### PR TITLE
Adaptive CRT shader compatibility fixes for really old GPUs

### DIFF
--- a/contrib/resources/glshaders/crt/arcade-1080p.glsl
+++ b/contrib/resources/glshaders/crt/arcade-1080p.glsl
@@ -169,10 +169,10 @@ uniform PRECISION float BLUE_SHIFT;
 
 #define WP_ADJUST           0.00
 #define TEMPERATURE      9300.00
-#define LUMA_PRESERVE 		1.00
-#define RED_SHIFT 			0.00
-#define GREEN_SHIFT 		0.00
-#define BLUE_SHIFT 			0.00
+#define LUMA_PRESERVE       1.00
+#define RED_SHIFT           0.00
+#define GREEN_SHIFT         0.00
+#define BLUE_SHIFT          0.00
 #endif
 // END PARAMETERS //
 
@@ -275,10 +275,10 @@ vec3 YxytoXYZ(vec3 Yxy) {
     Many of these mask arrays are adapted from cgwg's crt-geom-deluxe LUTs, and
     those have their filenames included for easy identification
 
-	NOTE: Having too many branches result in a black screen (but no
-	compilation errors) on some older GPUs such as the Intel HD 4000 iGPU. So
-	we're commenting out the branches that are not used by the adaptive CRT
-	shaders.
+    NOTE: Having too many branches result in a black screen (but no
+    compilation errors) on some older GPUs such as the Intel HD 4000 iGPU. So
+    we're commenting out the branches that are not used by the adaptive CRT
+    shaders.
 */
 vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
     vec3 weights = vec3(1.,1.,1.);
@@ -302,14 +302,14 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
     if (phosphor_layout == 0) {
         return weights;
-	}
+    }
 
     else if (phosphor_layout == 1) {
-    	// classic aperture for RGB panels; good for 1080p, too small for 4K+
+        // classic aperture for RGB panels; good for 1080p, too small for 4K+
         // aka aperture_1_2_bgr
         weights  = aperture_weights;
         return weights;
-	}
+    }
 
     else if (phosphor_layout == 2) {
         // 2x2 shadow mask for RGB panels; good for 1080p, too small for 4K+
@@ -317,7 +317,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
         vec3 inverse_aperture = mix(green, magenta, floor(mod(coord.x, 2.0)));
         weights               = mix(aperture_weights, inverse_aperture, floor(mod(coord.y, 2.0)));
         return weights;
-	}
+    }
 
 /*
     else if (phosphor_layout == 3) {
@@ -340,14 +340,14 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         // do a big, dumb comparison in place of a 2D array
         weights = (w == 1) ? slotmask_x1[z] : (w == 2) ? slotmask_x2[z] :  slotmask_x3[z];
-		return weights;
+        return weights;
     }
 */
     else if (phosphor_layout == 4) {
         // classic aperture for RBG panels; good for 1080p, too small for 4K+
         weights  = mix(yellow, blue, floor(mod(coord.x, 2.0)));
         return weights;
-	}
+    }
 /*
     else if (phosphor_layout == 5) {
         // 2x2 shadow mask for RBG panels; good for 1080p, too small for 4K+
@@ -359,7 +359,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
             floor(mod(coord.y, 2.0))
         );
         return weights;
-	}
+    }
 */
 /*
     else if (phosphor_layout == 6) {
@@ -370,7 +370,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = ap4[z];
         return weights;
-	}
+    }
 */
 /*
     else if (phosphor_layout == 7) {
@@ -391,7 +391,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap[w];
         return weights;
-	}
+    }
 */
     else if (phosphor_layout == 9) {
         // reduced TVL aperture for RGB panels
@@ -402,7 +402,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rgb[w];
         return weights;
-	}
+    }
 /*
     else if (phosphor_layout == 10) {
         // reduced TVL aperture for RBG panels
@@ -412,7 +412,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rbg[w];
         return weights;
-	}
+    }
 */
     else if(phosphor_layout == 11) {
         // delta_1_4x1_rgb; dunno why this is called 4x1 when it's obviously 4x2 /shrug
@@ -435,7 +435,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = (w == 1) ? delta_2_1[z] : delta_2_2[z];
         return weights;
-	}
+    }
 */
 /*
     else if (phosphor_layout == 13) {
@@ -487,10 +487,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = (w == 1) ? slotmask_RBG_x1[z] : (w == 2) ? slotmask_RBG_x2[z] : (w == 3) ? slotmask_RBG_x3[z] : slotmask_RBG_x4[z];
         return weights;
-	}
+    }
 */
 /*
-	else if(phosphor_layout == 16) {
+    else if(phosphor_layout == 16) {
         // slot mask for RBG panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
         // {yellow, blue,  black,  black},
         // {yellow, blue,  yellow, blue},
@@ -506,7 +506,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
         return weights;
     }
 */
-	else if (phosphor_layout == 17) {
+    else if (phosphor_layout == 17) {
         // slot_2_5x4_bgr
         // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
         // {black, blue,    blue,  green, green, red,   red,     black, black, black},
@@ -566,7 +566,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
         return weights;
      }
 */
-	else {
+    else {
         return weights;
     }
 }
@@ -586,10 +586,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 // For more info, see: http://www.imagemagick.org/Usage/img_diagrams/cubic_survey.gif
 mat4x4 get_hfilter_profile()
 {
-	float bf = 0.0;
-	float cf = 0.0;
+    float bf = 0.0;
+    float cf = 0.0;
 
-	if (HFILTER_PROFILE == 1) {
+    if (HFILTER_PROFILE == 1) {
         bf = 0.0;
         cf = 0.5;
     }
@@ -691,14 +691,14 @@ void main()
     mask_coords = mix(mask_coords.xy, mask_coords.yx, VSCANLINES);
     color.rgb *= mask_weights(mask_coords, MASK_INTENSITY, int(PHOSPHOR_LAYOUT));
 
-	// Colour temperature
-	if (WP_ADJUST == 1.0) {
-		vec3 wp_adjusted = wp_adjust(color.rgb);
-		vec3 base_luma = XYZtoYxy(sRGB_to_XYZ(color.rgb));
-		vec3 adjusted_luma = XYZtoYxy(sRGB_to_XYZ(wp_adjusted));
-		wp_adjusted = (LUMA_PRESERVE == 1.0) ? adjusted_luma + (vec3(base_luma.r,0.,0.) - vec3(adjusted_luma.r,0.,0.)) : adjusted_luma;
-		color = vec4(XYZ_to_sRGB(YxytoXYZ(wp_adjusted)), 1.0);
-	}
+    // Colour temperature
+    if (WP_ADJUST == 1.0) {
+        vec3 wp_adjusted = wp_adjust(color.rgb);
+        vec3 base_luma = XYZtoYxy(sRGB_to_XYZ(color.rgb));
+        vec3 adjusted_luma = XYZtoYxy(sRGB_to_XYZ(wp_adjusted));
+        wp_adjusted = (LUMA_PRESERVE == 1.0) ? adjusted_luma + (vec3(base_luma.r,0.,0.) - vec3(adjusted_luma.r,0.,0.)) : adjusted_luma;
+        color = vec4(XYZ_to_sRGB(YxytoXYZ(wp_adjusted)), 1.0);
+    }
 
     // Output gamma
     color = clamp(GAMMA_OUT(color), 0.0, 1.0);

--- a/contrib/resources/glshaders/crt/arcade-1080p.glsl
+++ b/contrib/resources/glshaders/crt/arcade-1080p.glsl
@@ -248,7 +248,6 @@ vec3 YxytoXYZ(vec3 Yxy) {
     return XYZ;
 }
 
-
 /*
     A collection of CRT mask effects that work with LCD subpixel structures for
     small details
@@ -275,11 +274,18 @@ vec3 YxytoXYZ(vec3 Yxy) {
 
     Many of these mask arrays are adapted from cgwg's crt-geom-deluxe LUTs, and
     those have their filenames included for easy identification
+
+	NOTE: Having too many branches result in a black screen (but no
+	compilation errors) on some older GPUs such as the Intel HD 4000 iGPU. So
+	we're commenting out the branches that are not used by the adaptive CRT
+	shaders.
 */
 vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
     vec3 weights = vec3(1.,1.,1.);
+
     float on = 1.;
     float off = 1.-mask_intensity;
+
     vec3 red     = vec3(on,  off, off);
     vec3 green   = vec3(off, on,  off);
     vec3 blue    = vec3(off, off, on );
@@ -288,6 +294,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
     vec3 cyan    = vec3(off, on,  on );
     vec3 black   = vec3(off, off, off);
     vec3 white   = vec3(on,  on,  on );
+
     int w, z = 0;
 
     // This pattern is used by a few layouts, so we'll define it here
@@ -295,21 +302,25 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
     if (phosphor_layout == 0) {
         return weights;
+	}
 
-    } else if (phosphor_layout == 1) {
-        // classic aperture for RGB panels; good for 1080p, too small for 4K+
+    else if (phosphor_layout == 1) {
+    	// classic aperture for RGB panels; good for 1080p, too small for 4K+
         // aka aperture_1_2_bgr
         weights  = aperture_weights;
         return weights;
+	}
 
-    } else if (phosphor_layout == 2) {
+    else if (phosphor_layout == 2) {
         // 2x2 shadow mask for RGB panels; good for 1080p, too small for 4K+
         // aka delta_1_2x1_bgr
         vec3 inverse_aperture = mix(green, magenta, floor(mod(coord.x, 2.0)));
         weights               = mix(aperture_weights, inverse_aperture, floor(mod(coord.y, 2.0)));
         return weights;
+	}
 
-    } else if (phosphor_layout == 3) {
+/*
+    else if (phosphor_layout == 3) {
         // slot mask for RGB panels; looks okay at 1080p, looks better at 4K
         // {magenta, green, black,   black},
         // {magenta, green, magenta, green},
@@ -329,14 +340,16 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         // do a big, dumb comparison in place of a 2D array
         weights = (w == 1) ? slotmask_x1[z] : (w == 2) ? slotmask_x2[z] :  slotmask_x3[z];
+		return weights;
     }
-
-    if (phosphor_layout == 4) {
+*/
+    else if (phosphor_layout == 4) {
         // classic aperture for RBG panels; good for 1080p, too small for 4K+
         weights  = mix(yellow, blue, floor(mod(coord.x, 2.0)));
         return weights;
-
-    } else if (phosphor_layout == 5) {
+	}
+/*
+    else if (phosphor_layout == 5) {
         // 2x2 shadow mask for RBG panels; good for 1080p, too small for 4K+
         vec3 inverse_aperture = mix(blue, yellow, floor(mod(coord.x, 2.0)));
 
@@ -346,8 +359,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
             floor(mod(coord.y, 2.0))
         );
         return weights;
-
-    } else if (phosphor_layout == 6) {
+	}
+*/
+/*
+    else if (phosphor_layout == 6) {
         // aperture_1_4_rgb; good for simulating lower
         vec3 ap4[4] = vec3[](red, green, blue, black);
 
@@ -355,8 +370,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = ap4[z];
         return weights;
-
-    } else if (phosphor_layout == 7) {
+	}
+*/
+/*
+    else if (phosphor_layout == 7) {
         // aperture_2_5_bgr
         vec3 ap3[5] = vec3[](red, magenta, blue, green, green);
 
@@ -364,8 +381,9 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = ap3[z];
         return weights;
-
-    } else if (phosphor_layout == 8){
+*/
+/*
+    else if (phosphor_layout == 8) {
         // aperture_3_6_rgb
         vec3 big_ap[7] = vec3[](red, red, yellow, green, cyan, blue, blue);
 
@@ -373,8 +391,9 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap[w];
         return weights;
-
-    } else if (phosphor_layout == 9) {
+	}
+*/
+    else if (phosphor_layout == 9) {
         // reduced TVL aperture for RGB panels
         // aperture_2_4_rgb
         vec3 big_ap_rgb[4] = vec3[](red, yellow, cyan, blue);
@@ -383,8 +402,9 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rgb[w];
         return weights;
-
-    } else if (phosphor_layout == 10) {
+	}
+/*
+    else if (phosphor_layout == 10) {
         // reduced TVL aperture for RBG panels
         vec3 big_ap_rbg[4] = vec3[](red, magenta, cyan, green);
 
@@ -392,148 +412,161 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rbg[w];
         return weights;
+	}
+*/
+    else if(phosphor_layout == 11) {
+        // delta_1_4x1_rgb; dunno why this is called 4x1 when it's obviously 4x2 /shrug
+        vec3 delta_1_1[4] = vec3[](red, green, blue, black);
+        vec3 delta_1_2[4] = vec3[](blue, black, red, green);
 
-    } else if(phosphor_layout == 11){
-       // delta_1_4x1_rgb; dunno why this is called 4x1 when it's obviously 4x2 /shrug
-       vec3 delta_1_1[4] = vec3[](red, green, blue, black);
-       vec3 delta_1_2[4] = vec3[](blue, black, red, green);
+        w = int(floor(mod(coord.y, 2.0)));
+        z = int(floor(mod(coord.x, 4.0)));
 
-       w = int(floor(mod(coord.y, 2.0)));
-       z = int(floor(mod(coord.x, 4.0)));
+        weights = (w == 1) ? delta_1_1[z] : delta_1_2[z];
+        return weights;
+    }
+/*
+    else if (phosphor_layout == 12) {
+        // delta_2_4x1_rgb
+        vec3 delta_2_1[4] = vec3[](red, yellow, cyan, blue);
+        vec3 delta_2_2[4] = vec3[](cyan, blue, red, yellow);
 
-       weights = (w == 1) ? delta_1_1[z] : delta_1_2[z];
-       return weights;
+        z = int(floor(mod(coord.x, 4.0)));
 
-    } else if(phosphor_layout == 12){
-       // delta_2_4x1_rgb
-       vec3 delta_2_1[4] = vec3[](red, yellow, cyan, blue);
-       vec3 delta_2_2[4] = vec3[](cyan, blue, red, yellow);
+        weights = (w == 1) ? delta_2_1[z] : delta_2_2[z];
+        return weights;
+	}
+*/
+/*
+    else if (phosphor_layout == 13) {
+        // delta_2_4x2_rgb
+        vec3 delta_1[4] = vec3[](red, yellow, cyan, blue);
+        vec3 delta_2[4] = vec3[](red, yellow, cyan, blue);
+        vec3 delta_3[4] = vec3[](cyan, blue, red, yellow);
+        vec3 delta_4[4] = vec3[](cyan, blue, red, yellow);
 
-       z = int(floor(mod(coord.x, 4.0)));
+        w = int(floor(mod(coord.y, 4.0)));
+        z = int(floor(mod(coord.x, 4.0)));
 
-       weights = (w == 1) ? delta_2_1[z] : delta_2_2[z];
-       return weights;
+        weights = (w == 1) ? delta_1[z] : (w == 2) ? delta_2[z] : (w == 3) ? delta_3[z] : delta_4[z];
+        return weights;
+    }
+*/
+    else if (phosphor_layout == 14) {
+        // slot mask for RGB panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
+        // {magenta, green, black, black,   black, black},
+        // {magenta, green, black, magenta, green, black},
+        // {black,   black, black, magenta, green, black}
+        vec3 slot2_1[6] = vec3[](magenta, green, black, black,   black, black);
+        vec3 slot2_2[6] = vec3[](magenta, green, black, magenta, green, black);
+        vec3 slot2_3[6] = vec3[](black,   black, black, magenta, green, black);
 
-    } else if(phosphor_layout == 13){
-       // delta_2_4x2_rgb
-       vec3 delta_1[4] = vec3[](red, yellow, cyan, blue);
-       vec3 delta_2[4] = vec3[](red, yellow, cyan, blue);
-       vec3 delta_3[4] = vec3[](cyan, blue, red, yellow);
-       vec3 delta_4[4] = vec3[](cyan, blue, red, yellow);
+        w = int(floor(mod(coord.y, 3.0)));
+        z = int(floor(mod(coord.x, 6.0)));
 
-       w = int(floor(mod(coord.y, 4.0)));
-       z = int(floor(mod(coord.x, 4.0)));
+        weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
+        return weights;
+    }
+/*
+    else if(phosphor_layout == 15) {
+        // slot_2_4x4_rgb
+        // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
+        // {red,   yellow, cyan,  blue,  black, black,  black, black},
+        // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
+        // {black, black,  black, black, red,   yellow, cyan,  blue }
+        vec3 slotmask_RBG_x1[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
+        vec3 slotmask_RBG_x2[8] = vec3[](red,   yellow, cyan,  blue,  black, black,  black, black);
+        vec3 slotmask_RBG_x3[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
+        vec3 slotmask_RBG_x4[8] = vec3[](black, black,  black, black, red,   yellow, cyan,  blue );
 
-       weights = (w == 1) ? delta_1[z] : (w == 2) ? delta_2[z] : (w == 3) ? delta_3[z] : delta_4[z];
-       return weights;
+        // find the vertical index
+        w = int(floor(mod(coord.y, 4.0)));
 
-    } else if(phosphor_layout == 14){
-       // slot mask for RGB panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
-       // {magenta, green, black, black,   black, black},
-       // {magenta, green, black, magenta, green, black},
-       // {black,   black, black, magenta, green, black}
-       vec3 slot2_1[6] = vec3[](magenta, green, black, black,   black, black);
-       vec3 slot2_2[6] = vec3[](magenta, green, black, magenta, green, black);
-       vec3 slot2_3[6] = vec3[](black,   black, black, magenta, green, black);
+        // find the horizontal index
+        z = int(floor(mod(coord.x, 8.0)));
 
-       w = int(floor(mod(coord.y, 3.0)));
-       z = int(floor(mod(coord.x, 6.0)));
+        weights = (w == 1) ? slotmask_RBG_x1[z] : (w == 2) ? slotmask_RBG_x2[z] : (w == 3) ? slotmask_RBG_x3[z] : slotmask_RBG_x4[z];
+        return weights;
+	}
+*/
+/*
+	else if(phosphor_layout == 16) {
+        // slot mask for RBG panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
+        // {yellow, blue,  black,  black},
+        // {yellow, blue,  yellow, blue},
+        // {black,  black, yellow, blue}
+        vec3 slot2_1[4] = vec3[](yellow, blue,  black,  black);
+        vec3 slot2_2[4] = vec3[](yellow, blue,  yellow, blue);
+        vec3 slot2_3[4] = vec3[](black,  black, yellow, blue);
 
-       weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
-       return weights;
+        w = int(floor(mod(coord.y, 3.0)));
+        z = int(floor(mod(coord.x, 4.0)));
 
-    } else if(phosphor_layout == 15){
-       // slot_2_4x4_rgb
-       // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
-       // {red,   yellow, cyan,  blue,  black, black,  black, black},
-       // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
-       // {black, black,  black, black, red,   yellow, cyan,  blue }
-       vec3 slotmask_RBG_x1[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
-       vec3 slotmask_RBG_x2[8] = vec3[](red,   yellow, cyan,  blue,  black, black,  black, black);
-       vec3 slotmask_RBG_x3[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
-       vec3 slotmask_RBG_x4[8] = vec3[](black, black,  black, black, red,   yellow, cyan,  blue );
+        weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
+        return weights;
+    }
+*/
+	else if (phosphor_layout == 17) {
+        // slot_2_5x4_bgr
+        // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
+        // {black, blue,    blue,  green, green, red,   red,     black, black, black},
+        // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
+        // {red,   red,     black, black, black, black, blue,    blue,  green, green}
+        vec3 slot_1[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
+        vec3 slot_2[10] = vec3[](black, blue,    blue,  green, green, red,   red,     black, black, black);
+        vec3 slot_3[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
+        vec3 slot_4[10] = vec3[](red,   red,     black, black, black, black, blue,    blue,  green, green);
 
-       // find the vertical index
-       w = int(floor(mod(coord.y, 4.0)));
+        w = int(floor(mod(coord.y, 4.0)));
+        z = int(floor(mod(coord.x, 10.0)));
 
-       // find the horizontal index
-       z = int(floor(mod(coord.x, 8.0)));
+        weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
+        return weights;
+    }
+/*
+    else if (phosphor_layout == 18) {
+        // same as above but for RBG panels
+        // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
+        // {black, green,  green, blue,  blue,  red,   red,    black, black, black},
+        // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
+        // {red,   red,    black, black, black, black, green,  green, blue,  blue }
+        vec3 slot_1[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
+        vec3 slot_2[10] = vec3[](black, green,  green, blue,  blue,  red,   red,    black, black, black);
+        vec3 slot_3[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
+        vec3 slot_4[10] = vec3[](red,   red,    black, black, black, black, green,  green, blue,  blue );
 
-       weights = (w == 1) ? slotmask_RBG_x1[z] : (w == 2) ? slotmask_RBG_x2[z] : (w == 3) ? slotmask_RBG_x3[z] : slotmask_RBG_x4[z];
-       return weights;
+        w = int(floor(mod(coord.y, 4.0)));
+        z = int(floor(mod(coord.x, 10.0)));
 
-     } else if(phosphor_layout == 16){
-       // slot mask for RBG panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
-       // {yellow, blue,  black,  black},
-       // {yellow, blue,  yellow, blue},
-       // {black,  black, yellow, blue}
-       vec3 slot2_1[4] = vec3[](yellow, blue,  black,  black);
-       vec3 slot2_2[4] = vec3[](yellow, blue,  yellow, blue);
-       vec3 slot2_3[4] = vec3[](black,  black, yellow, blue);
+        weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
+        return weights;
+    }
+*/
+/*
+    else if(phosphor_layout == 19) {
+        // slot_3_7x6_rgb
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue}
 
-       w = int(floor(mod(coord.y, 3.0)));
-       z = int(floor(mod(coord.x, 4.0)));
+        vec3 slot_1[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_2[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_3[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black);
+        vec3 slot_4[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_5[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_6[14] = vec3[](black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue);
 
-       weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
-       return weights;
+        w = int(floor(mod(coord.y, 6.0)));
+        z = int(floor(mod(coord.x, 14.0)));
 
-    } else if (phosphor_layout == 17) {
-       // slot_2_5x4_bgr
-       // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
-       // {black, blue,    blue,  green, green, red,   red,     black, black, black},
-       // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
-       // {red,   red,     black, black, black, black, blue,    blue,  green, green}
-       vec3 slot_1[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
-       vec3 slot_2[10] = vec3[](black, blue,    blue,  green, green, red,   red,     black, black, black);
-       vec3 slot_3[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
-       vec3 slot_4[10] = vec3[](red,   red,     black, black, black, black, blue,    blue,  green, green);
-
-       w = int(floor(mod(coord.y, 4.0)));
-       z = int(floor(mod(coord.x, 10.0)));
-
-       weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
-       return weights;
-
-    } else if (phosphor_layout == 18) {
-       // same as above but for RBG panels
-       // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
-       // {black, green,  green, blue,  blue,  red,   red,    black, black, black},
-       // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
-       // {red,   red,    black, black, black, black, green,  green, blue,  blue }
-       vec3 slot_1[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
-       vec3 slot_2[10] = vec3[](black, green,  green, blue,  blue,  red,   red,    black, black, black);
-       vec3 slot_3[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
-       vec3 slot_4[10] = vec3[](red,   red,    black, black, black, black, green,  green, blue,  blue );
-
-       w = int(floor(mod(coord.y, 4.0)));
-       z = int(floor(mod(coord.x, 10.0)));
-
-       weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
-       return weights;
-
-    } else if(phosphor_layout == 19) {
-       // slot_3_7x6_rgb
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue}
-
-       vec3 slot_1[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_2[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_3[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black);
-       vec3 slot_4[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_5[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_6[14] = vec3[](black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue);
-
-       w = int(floor(mod(coord.y, 6.0)));
-       z = int(floor(mod(coord.x, 14.0)));
-
-       weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : (w == 4) ? slot_4[z] : (w == 5) ? slot_5[z] : slot_6[z];
-       return weights;
-
-    } else {
+        weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : (w == 4) ? slot_4[z] : (w == 5) ? slot_5[z] : slot_6[z];
+        return weights;
+     }
+*/
+	else {
         return weights;
     }
 }

--- a/contrib/resources/glshaders/crt/arcade-1440p.glsl
+++ b/contrib/resources/glshaders/crt/arcade-1440p.glsl
@@ -169,10 +169,10 @@ uniform PRECISION float BLUE_SHIFT;
 
 #define WP_ADJUST           0.00
 #define TEMPERATURE      9300.00
-#define LUMA_PRESERVE 		1.00
-#define RED_SHIFT 			0.00
-#define GREEN_SHIFT 		0.00
-#define BLUE_SHIFT 			0.00
+#define LUMA_PRESERVE       1.00
+#define RED_SHIFT           0.00
+#define GREEN_SHIFT         0.00
+#define BLUE_SHIFT          0.00
 #endif
 // END PARAMETERS //
 
@@ -275,10 +275,10 @@ vec3 YxytoXYZ(vec3 Yxy) {
     Many of these mask arrays are adapted from cgwg's crt-geom-deluxe LUTs, and
     those have their filenames included for easy identification
 
-	NOTE: Having too many branches result in a black screen (but no
-	compilation errors) on some older GPUs such as the Intel HD 4000 iGPU. So
-	we're commenting out the branches that are not used by the adaptive CRT
-	shaders.
+    NOTE: Having too many branches result in a black screen (but no
+    compilation errors) on some older GPUs such as the Intel HD 4000 iGPU. So
+    we're commenting out the branches that are not used by the adaptive CRT
+    shaders.
 */
 vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
     vec3 weights = vec3(1.,1.,1.);
@@ -302,14 +302,14 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
     if (phosphor_layout == 0) {
         return weights;
-	}
+    }
 
     else if (phosphor_layout == 1) {
-    	// classic aperture for RGB panels; good for 1080p, too small for 4K+
+        // classic aperture for RGB panels; good for 1080p, too small for 4K+
         // aka aperture_1_2_bgr
         weights  = aperture_weights;
         return weights;
-	}
+    }
 
     else if (phosphor_layout == 2) {
         // 2x2 shadow mask for RGB panels; good for 1080p, too small for 4K+
@@ -317,7 +317,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
         vec3 inverse_aperture = mix(green, magenta, floor(mod(coord.x, 2.0)));
         weights               = mix(aperture_weights, inverse_aperture, floor(mod(coord.y, 2.0)));
         return weights;
-	}
+    }
 
 /*
     else if (phosphor_layout == 3) {
@@ -340,14 +340,14 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         // do a big, dumb comparison in place of a 2D array
         weights = (w == 1) ? slotmask_x1[z] : (w == 2) ? slotmask_x2[z] :  slotmask_x3[z];
-		return weights;
+        return weights;
     }
 */
     else if (phosphor_layout == 4) {
         // classic aperture for RBG panels; good for 1080p, too small for 4K+
         weights  = mix(yellow, blue, floor(mod(coord.x, 2.0)));
         return weights;
-	}
+    }
 /*
     else if (phosphor_layout == 5) {
         // 2x2 shadow mask for RBG panels; good for 1080p, too small for 4K+
@@ -359,7 +359,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
             floor(mod(coord.y, 2.0))
         );
         return weights;
-	}
+    }
 */
 /*
     else if (phosphor_layout == 6) {
@@ -370,7 +370,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = ap4[z];
         return weights;
-	}
+    }
 */
 /*
     else if (phosphor_layout == 7) {
@@ -391,7 +391,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap[w];
         return weights;
-	}
+    }
 */
     else if (phosphor_layout == 9) {
         // reduced TVL aperture for RGB panels
@@ -402,7 +402,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rgb[w];
         return weights;
-	}
+    }
 /*
     else if (phosphor_layout == 10) {
         // reduced TVL aperture for RBG panels
@@ -412,7 +412,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rbg[w];
         return weights;
-	}
+    }
 */
     else if(phosphor_layout == 11) {
         // delta_1_4x1_rgb; dunno why this is called 4x1 when it's obviously 4x2 /shrug
@@ -435,7 +435,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = (w == 1) ? delta_2_1[z] : delta_2_2[z];
         return weights;
-	}
+    }
 */
 /*
     else if (phosphor_layout == 13) {
@@ -487,10 +487,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = (w == 1) ? slotmask_RBG_x1[z] : (w == 2) ? slotmask_RBG_x2[z] : (w == 3) ? slotmask_RBG_x3[z] : slotmask_RBG_x4[z];
         return weights;
-	}
+    }
 */
 /*
-	else if(phosphor_layout == 16) {
+    else if(phosphor_layout == 16) {
         // slot mask for RBG panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
         // {yellow, blue,  black,  black},
         // {yellow, blue,  yellow, blue},
@@ -506,7 +506,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
         return weights;
     }
 */
-	else if (phosphor_layout == 17) {
+    else if (phosphor_layout == 17) {
         // slot_2_5x4_bgr
         // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
         // {black, blue,    blue,  green, green, red,   red,     black, black, black},
@@ -566,7 +566,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
         return weights;
      }
 */
-	else {
+    else {
         return weights;
     }
 }
@@ -586,10 +586,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 // For more info, see: http://www.imagemagick.org/Usage/img_diagrams/cubic_survey.gif
 mat4x4 get_hfilter_profile()
 {
-	float bf = 0.0;
-	float cf = 0.0;
+    float bf = 0.0;
+    float cf = 0.0;
 
-	if (HFILTER_PROFILE == 1) {
+    if (HFILTER_PROFILE == 1) {
         bf = 0.0;
         cf = 0.5;
     }
@@ -691,14 +691,14 @@ void main()
     mask_coords = mix(mask_coords.xy, mask_coords.yx, VSCANLINES);
     color.rgb *= mask_weights(mask_coords, MASK_INTENSITY, int(PHOSPHOR_LAYOUT));
 
-	// Colour temperature
-	if (WP_ADJUST == 1.0) {
-		vec3 wp_adjusted = wp_adjust(color.rgb);
-		vec3 base_luma = XYZtoYxy(sRGB_to_XYZ(color.rgb));
-		vec3 adjusted_luma = XYZtoYxy(sRGB_to_XYZ(wp_adjusted));
-		wp_adjusted = (LUMA_PRESERVE == 1.0) ? adjusted_luma + (vec3(base_luma.r,0.,0.) - vec3(adjusted_luma.r,0.,0.)) : adjusted_luma;
-		color = vec4(XYZ_to_sRGB(YxytoXYZ(wp_adjusted)), 1.0);
-	}
+    // Colour temperature
+    if (WP_ADJUST == 1.0) {
+        vec3 wp_adjusted = wp_adjust(color.rgb);
+        vec3 base_luma = XYZtoYxy(sRGB_to_XYZ(color.rgb));
+        vec3 adjusted_luma = XYZtoYxy(sRGB_to_XYZ(wp_adjusted));
+        wp_adjusted = (LUMA_PRESERVE == 1.0) ? adjusted_luma + (vec3(base_luma.r,0.,0.) - vec3(adjusted_luma.r,0.,0.)) : adjusted_luma;
+        color = vec4(XYZ_to_sRGB(YxytoXYZ(wp_adjusted)), 1.0);
+    }
 
     // Output gamma
     color = clamp(GAMMA_OUT(color), 0.0, 1.0);

--- a/contrib/resources/glshaders/crt/arcade-1440p.glsl
+++ b/contrib/resources/glshaders/crt/arcade-1440p.glsl
@@ -248,7 +248,6 @@ vec3 YxytoXYZ(vec3 Yxy) {
     return XYZ;
 }
 
-
 /*
     A collection of CRT mask effects that work with LCD subpixel structures for
     small details
@@ -275,11 +274,18 @@ vec3 YxytoXYZ(vec3 Yxy) {
 
     Many of these mask arrays are adapted from cgwg's crt-geom-deluxe LUTs, and
     those have their filenames included for easy identification
+
+	NOTE: Having too many branches result in a black screen (but no
+	compilation errors) on some older GPUs such as the Intel HD 4000 iGPU. So
+	we're commenting out the branches that are not used by the adaptive CRT
+	shaders.
 */
 vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
     vec3 weights = vec3(1.,1.,1.);
+
     float on = 1.;
     float off = 1.-mask_intensity;
+
     vec3 red     = vec3(on,  off, off);
     vec3 green   = vec3(off, on,  off);
     vec3 blue    = vec3(off, off, on );
@@ -288,6 +294,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
     vec3 cyan    = vec3(off, on,  on );
     vec3 black   = vec3(off, off, off);
     vec3 white   = vec3(on,  on,  on );
+
     int w, z = 0;
 
     // This pattern is used by a few layouts, so we'll define it here
@@ -295,21 +302,25 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
     if (phosphor_layout == 0) {
         return weights;
+	}
 
-    } else if (phosphor_layout == 1) {
-        // classic aperture for RGB panels; good for 1080p, too small for 4K+
+    else if (phosphor_layout == 1) {
+    	// classic aperture for RGB panels; good for 1080p, too small for 4K+
         // aka aperture_1_2_bgr
         weights  = aperture_weights;
         return weights;
+	}
 
-    } else if (phosphor_layout == 2) {
+    else if (phosphor_layout == 2) {
         // 2x2 shadow mask for RGB panels; good for 1080p, too small for 4K+
         // aka delta_1_2x1_bgr
         vec3 inverse_aperture = mix(green, magenta, floor(mod(coord.x, 2.0)));
         weights               = mix(aperture_weights, inverse_aperture, floor(mod(coord.y, 2.0)));
         return weights;
+	}
 
-    } else if (phosphor_layout == 3) {
+/*
+    else if (phosphor_layout == 3) {
         // slot mask for RGB panels; looks okay at 1080p, looks better at 4K
         // {magenta, green, black,   black},
         // {magenta, green, magenta, green},
@@ -329,14 +340,16 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         // do a big, dumb comparison in place of a 2D array
         weights = (w == 1) ? slotmask_x1[z] : (w == 2) ? slotmask_x2[z] :  slotmask_x3[z];
+		return weights;
     }
-
-    if (phosphor_layout == 4) {
+*/
+    else if (phosphor_layout == 4) {
         // classic aperture for RBG panels; good for 1080p, too small for 4K+
         weights  = mix(yellow, blue, floor(mod(coord.x, 2.0)));
         return weights;
-
-    } else if (phosphor_layout == 5) {
+	}
+/*
+    else if (phosphor_layout == 5) {
         // 2x2 shadow mask for RBG panels; good for 1080p, too small for 4K+
         vec3 inverse_aperture = mix(blue, yellow, floor(mod(coord.x, 2.0)));
 
@@ -346,8 +359,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
             floor(mod(coord.y, 2.0))
         );
         return weights;
-
-    } else if (phosphor_layout == 6) {
+	}
+*/
+/*
+    else if (phosphor_layout == 6) {
         // aperture_1_4_rgb; good for simulating lower
         vec3 ap4[4] = vec3[](red, green, blue, black);
 
@@ -355,8 +370,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = ap4[z];
         return weights;
-
-    } else if (phosphor_layout == 7) {
+	}
+*/
+/*
+    else if (phosphor_layout == 7) {
         // aperture_2_5_bgr
         vec3 ap3[5] = vec3[](red, magenta, blue, green, green);
 
@@ -364,8 +381,9 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = ap3[z];
         return weights;
-
-    } else if (phosphor_layout == 8){
+*/
+/*
+    else if (phosphor_layout == 8) {
         // aperture_3_6_rgb
         vec3 big_ap[7] = vec3[](red, red, yellow, green, cyan, blue, blue);
 
@@ -373,8 +391,9 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap[w];
         return weights;
-
-    } else if (phosphor_layout == 9) {
+	}
+*/
+    else if (phosphor_layout == 9) {
         // reduced TVL aperture for RGB panels
         // aperture_2_4_rgb
         vec3 big_ap_rgb[4] = vec3[](red, yellow, cyan, blue);
@@ -383,8 +402,9 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rgb[w];
         return weights;
-
-    } else if (phosphor_layout == 10) {
+	}
+/*
+    else if (phosphor_layout == 10) {
         // reduced TVL aperture for RBG panels
         vec3 big_ap_rbg[4] = vec3[](red, magenta, cyan, green);
 
@@ -392,148 +412,161 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rbg[w];
         return weights;
+	}
+*/
+    else if(phosphor_layout == 11) {
+        // delta_1_4x1_rgb; dunno why this is called 4x1 when it's obviously 4x2 /shrug
+        vec3 delta_1_1[4] = vec3[](red, green, blue, black);
+        vec3 delta_1_2[4] = vec3[](blue, black, red, green);
 
-    } else if(phosphor_layout == 11){
-       // delta_1_4x1_rgb; dunno why this is called 4x1 when it's obviously 4x2 /shrug
-       vec3 delta_1_1[4] = vec3[](red, green, blue, black);
-       vec3 delta_1_2[4] = vec3[](blue, black, red, green);
+        w = int(floor(mod(coord.y, 2.0)));
+        z = int(floor(mod(coord.x, 4.0)));
 
-       w = int(floor(mod(coord.y, 2.0)));
-       z = int(floor(mod(coord.x, 4.0)));
+        weights = (w == 1) ? delta_1_1[z] : delta_1_2[z];
+        return weights;
+    }
+/*
+    else if (phosphor_layout == 12) {
+        // delta_2_4x1_rgb
+        vec3 delta_2_1[4] = vec3[](red, yellow, cyan, blue);
+        vec3 delta_2_2[4] = vec3[](cyan, blue, red, yellow);
 
-       weights = (w == 1) ? delta_1_1[z] : delta_1_2[z];
-       return weights;
+        z = int(floor(mod(coord.x, 4.0)));
 
-    } else if(phosphor_layout == 12){
-       // delta_2_4x1_rgb
-       vec3 delta_2_1[4] = vec3[](red, yellow, cyan, blue);
-       vec3 delta_2_2[4] = vec3[](cyan, blue, red, yellow);
+        weights = (w == 1) ? delta_2_1[z] : delta_2_2[z];
+        return weights;
+	}
+*/
+/*
+    else if (phosphor_layout == 13) {
+        // delta_2_4x2_rgb
+        vec3 delta_1[4] = vec3[](red, yellow, cyan, blue);
+        vec3 delta_2[4] = vec3[](red, yellow, cyan, blue);
+        vec3 delta_3[4] = vec3[](cyan, blue, red, yellow);
+        vec3 delta_4[4] = vec3[](cyan, blue, red, yellow);
 
-       z = int(floor(mod(coord.x, 4.0)));
+        w = int(floor(mod(coord.y, 4.0)));
+        z = int(floor(mod(coord.x, 4.0)));
 
-       weights = (w == 1) ? delta_2_1[z] : delta_2_2[z];
-       return weights;
+        weights = (w == 1) ? delta_1[z] : (w == 2) ? delta_2[z] : (w == 3) ? delta_3[z] : delta_4[z];
+        return weights;
+    }
+*/
+    else if (phosphor_layout == 14) {
+        // slot mask for RGB panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
+        // {magenta, green, black, black,   black, black},
+        // {magenta, green, black, magenta, green, black},
+        // {black,   black, black, magenta, green, black}
+        vec3 slot2_1[6] = vec3[](magenta, green, black, black,   black, black);
+        vec3 slot2_2[6] = vec3[](magenta, green, black, magenta, green, black);
+        vec3 slot2_3[6] = vec3[](black,   black, black, magenta, green, black);
 
-    } else if(phosphor_layout == 13){
-       // delta_2_4x2_rgb
-       vec3 delta_1[4] = vec3[](red, yellow, cyan, blue);
-       vec3 delta_2[4] = vec3[](red, yellow, cyan, blue);
-       vec3 delta_3[4] = vec3[](cyan, blue, red, yellow);
-       vec3 delta_4[4] = vec3[](cyan, blue, red, yellow);
+        w = int(floor(mod(coord.y, 3.0)));
+        z = int(floor(mod(coord.x, 6.0)));
 
-       w = int(floor(mod(coord.y, 4.0)));
-       z = int(floor(mod(coord.x, 4.0)));
+        weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
+        return weights;
+    }
+/*
+    else if(phosphor_layout == 15) {
+        // slot_2_4x4_rgb
+        // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
+        // {red,   yellow, cyan,  blue,  black, black,  black, black},
+        // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
+        // {black, black,  black, black, red,   yellow, cyan,  blue }
+        vec3 slotmask_RBG_x1[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
+        vec3 slotmask_RBG_x2[8] = vec3[](red,   yellow, cyan,  blue,  black, black,  black, black);
+        vec3 slotmask_RBG_x3[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
+        vec3 slotmask_RBG_x4[8] = vec3[](black, black,  black, black, red,   yellow, cyan,  blue );
 
-       weights = (w == 1) ? delta_1[z] : (w == 2) ? delta_2[z] : (w == 3) ? delta_3[z] : delta_4[z];
-       return weights;
+        // find the vertical index
+        w = int(floor(mod(coord.y, 4.0)));
 
-    } else if(phosphor_layout == 14){
-       // slot mask for RGB panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
-       // {magenta, green, black, black,   black, black},
-       // {magenta, green, black, magenta, green, black},
-       // {black,   black, black, magenta, green, black}
-       vec3 slot2_1[6] = vec3[](magenta, green, black, black,   black, black);
-       vec3 slot2_2[6] = vec3[](magenta, green, black, magenta, green, black);
-       vec3 slot2_3[6] = vec3[](black,   black, black, magenta, green, black);
+        // find the horizontal index
+        z = int(floor(mod(coord.x, 8.0)));
 
-       w = int(floor(mod(coord.y, 3.0)));
-       z = int(floor(mod(coord.x, 6.0)));
+        weights = (w == 1) ? slotmask_RBG_x1[z] : (w == 2) ? slotmask_RBG_x2[z] : (w == 3) ? slotmask_RBG_x3[z] : slotmask_RBG_x4[z];
+        return weights;
+	}
+*/
+/*
+	else if(phosphor_layout == 16) {
+        // slot mask for RBG panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
+        // {yellow, blue,  black,  black},
+        // {yellow, blue,  yellow, blue},
+        // {black,  black, yellow, blue}
+        vec3 slot2_1[4] = vec3[](yellow, blue,  black,  black);
+        vec3 slot2_2[4] = vec3[](yellow, blue,  yellow, blue);
+        vec3 slot2_3[4] = vec3[](black,  black, yellow, blue);
 
-       weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
-       return weights;
+        w = int(floor(mod(coord.y, 3.0)));
+        z = int(floor(mod(coord.x, 4.0)));
 
-    } else if(phosphor_layout == 15){
-       // slot_2_4x4_rgb
-       // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
-       // {red,   yellow, cyan,  blue,  black, black,  black, black},
-       // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
-       // {black, black,  black, black, red,   yellow, cyan,  blue }
-       vec3 slotmask_RBG_x1[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
-       vec3 slotmask_RBG_x2[8] = vec3[](red,   yellow, cyan,  blue,  black, black,  black, black);
-       vec3 slotmask_RBG_x3[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
-       vec3 slotmask_RBG_x4[8] = vec3[](black, black,  black, black, red,   yellow, cyan,  blue );
+        weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
+        return weights;
+    }
+*/
+	else if (phosphor_layout == 17) {
+        // slot_2_5x4_bgr
+        // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
+        // {black, blue,    blue,  green, green, red,   red,     black, black, black},
+        // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
+        // {red,   red,     black, black, black, black, blue,    blue,  green, green}
+        vec3 slot_1[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
+        vec3 slot_2[10] = vec3[](black, blue,    blue,  green, green, red,   red,     black, black, black);
+        vec3 slot_3[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
+        vec3 slot_4[10] = vec3[](red,   red,     black, black, black, black, blue,    blue,  green, green);
 
-       // find the vertical index
-       w = int(floor(mod(coord.y, 4.0)));
+        w = int(floor(mod(coord.y, 4.0)));
+        z = int(floor(mod(coord.x, 10.0)));
 
-       // find the horizontal index
-       z = int(floor(mod(coord.x, 8.0)));
+        weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
+        return weights;
+    }
+/*
+    else if (phosphor_layout == 18) {
+        // same as above but for RBG panels
+        // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
+        // {black, green,  green, blue,  blue,  red,   red,    black, black, black},
+        // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
+        // {red,   red,    black, black, black, black, green,  green, blue,  blue }
+        vec3 slot_1[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
+        vec3 slot_2[10] = vec3[](black, green,  green, blue,  blue,  red,   red,    black, black, black);
+        vec3 slot_3[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
+        vec3 slot_4[10] = vec3[](red,   red,    black, black, black, black, green,  green, blue,  blue );
 
-       weights = (w == 1) ? slotmask_RBG_x1[z] : (w == 2) ? slotmask_RBG_x2[z] : (w == 3) ? slotmask_RBG_x3[z] : slotmask_RBG_x4[z];
-       return weights;
+        w = int(floor(mod(coord.y, 4.0)));
+        z = int(floor(mod(coord.x, 10.0)));
 
-     } else if(phosphor_layout == 16){
-       // slot mask for RBG panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
-       // {yellow, blue,  black,  black},
-       // {yellow, blue,  yellow, blue},
-       // {black,  black, yellow, blue}
-       vec3 slot2_1[4] = vec3[](yellow, blue,  black,  black);
-       vec3 slot2_2[4] = vec3[](yellow, blue,  yellow, blue);
-       vec3 slot2_3[4] = vec3[](black,  black, yellow, blue);
+        weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
+        return weights;
+    }
+*/
+/*
+    else if(phosphor_layout == 19) {
+        // slot_3_7x6_rgb
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue}
 
-       w = int(floor(mod(coord.y, 3.0)));
-       z = int(floor(mod(coord.x, 4.0)));
+        vec3 slot_1[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_2[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_3[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black);
+        vec3 slot_4[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_5[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_6[14] = vec3[](black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue);
 
-       weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
-       return weights;
+        w = int(floor(mod(coord.y, 6.0)));
+        z = int(floor(mod(coord.x, 14.0)));
 
-    } else if (phosphor_layout == 17) {
-       // slot_2_5x4_bgr
-       // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
-       // {black, blue,    blue,  green, green, red,   red,     black, black, black},
-       // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
-       // {red,   red,     black, black, black, black, blue,    blue,  green, green}
-       vec3 slot_1[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
-       vec3 slot_2[10] = vec3[](black, blue,    blue,  green, green, red,   red,     black, black, black);
-       vec3 slot_3[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
-       vec3 slot_4[10] = vec3[](red,   red,     black, black, black, black, blue,    blue,  green, green);
-
-       w = int(floor(mod(coord.y, 4.0)));
-       z = int(floor(mod(coord.x, 10.0)));
-
-       weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
-       return weights;
-
-    } else if (phosphor_layout == 18) {
-       // same as above but for RBG panels
-       // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
-       // {black, green,  green, blue,  blue,  red,   red,    black, black, black},
-       // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
-       // {red,   red,    black, black, black, black, green,  green, blue,  blue }
-       vec3 slot_1[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
-       vec3 slot_2[10] = vec3[](black, green,  green, blue,  blue,  red,   red,    black, black, black);
-       vec3 slot_3[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
-       vec3 slot_4[10] = vec3[](red,   red,    black, black, black, black, green,  green, blue,  blue );
-
-       w = int(floor(mod(coord.y, 4.0)));
-       z = int(floor(mod(coord.x, 10.0)));
-
-       weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
-       return weights;
-
-    } else if(phosphor_layout == 19) {
-       // slot_3_7x6_rgb
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue}
-
-       vec3 slot_1[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_2[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_3[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black);
-       vec3 slot_4[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_5[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_6[14] = vec3[](black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue);
-
-       w = int(floor(mod(coord.y, 6.0)));
-       z = int(floor(mod(coord.x, 14.0)));
-
-       weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : (w == 4) ? slot_4[z] : (w == 5) ? slot_5[z] : slot_6[z];
-       return weights;
-
-    } else {
+        weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : (w == 4) ? slot_4[z] : (w == 5) ? slot_5[z] : slot_6[z];
+        return weights;
+     }
+*/
+	else {
         return weights;
     }
 }

--- a/contrib/resources/glshaders/crt/arcade-4k.glsl
+++ b/contrib/resources/glshaders/crt/arcade-4k.glsl
@@ -169,10 +169,10 @@ uniform PRECISION float BLUE_SHIFT;
 
 #define WP_ADJUST           0.00
 #define TEMPERATURE      9300.00
-#define LUMA_PRESERVE 		1.00
-#define RED_SHIFT 			0.00
-#define GREEN_SHIFT 		0.00
-#define BLUE_SHIFT 			0.00
+#define LUMA_PRESERVE       1.00
+#define RED_SHIFT           0.00
+#define GREEN_SHIFT         0.00
+#define BLUE_SHIFT          0.00
 #endif
 // END PARAMETERS //
 
@@ -275,10 +275,10 @@ vec3 YxytoXYZ(vec3 Yxy) {
     Many of these mask arrays are adapted from cgwg's crt-geom-deluxe LUTs, and
     those have their filenames included for easy identification
 
-	NOTE: Having too many branches result in a black screen (but no
-	compilation errors) on some older GPUs such as the Intel HD 4000 iGPU. So
-	we're commenting out the branches that are not used by the adaptive CRT
-	shaders.
+    NOTE: Having too many branches result in a black screen (but no
+    compilation errors) on some older GPUs such as the Intel HD 4000 iGPU. So
+    we're commenting out the branches that are not used by the adaptive CRT
+    shaders.
 */
 vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
     vec3 weights = vec3(1.,1.,1.);
@@ -302,14 +302,14 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
     if (phosphor_layout == 0) {
         return weights;
-	}
+    }
 
     else if (phosphor_layout == 1) {
-    	// classic aperture for RGB panels; good for 1080p, too small for 4K+
+        // classic aperture for RGB panels; good for 1080p, too small for 4K+
         // aka aperture_1_2_bgr
         weights  = aperture_weights;
         return weights;
-	}
+    }
 
     else if (phosphor_layout == 2) {
         // 2x2 shadow mask for RGB panels; good for 1080p, too small for 4K+
@@ -317,7 +317,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
         vec3 inverse_aperture = mix(green, magenta, floor(mod(coord.x, 2.0)));
         weights               = mix(aperture_weights, inverse_aperture, floor(mod(coord.y, 2.0)));
         return weights;
-	}
+    }
 
 /*
     else if (phosphor_layout == 3) {
@@ -340,14 +340,14 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         // do a big, dumb comparison in place of a 2D array
         weights = (w == 1) ? slotmask_x1[z] : (w == 2) ? slotmask_x2[z] :  slotmask_x3[z];
-		return weights;
+        return weights;
     }
 */
     else if (phosphor_layout == 4) {
         // classic aperture for RBG panels; good for 1080p, too small for 4K+
         weights  = mix(yellow, blue, floor(mod(coord.x, 2.0)));
         return weights;
-	}
+    }
 /*
     else if (phosphor_layout == 5) {
         // 2x2 shadow mask for RBG panels; good for 1080p, too small for 4K+
@@ -359,7 +359,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
             floor(mod(coord.y, 2.0))
         );
         return weights;
-	}
+    }
 */
 /*
     else if (phosphor_layout == 6) {
@@ -370,7 +370,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = ap4[z];
         return weights;
-	}
+    }
 */
 /*
     else if (phosphor_layout == 7) {
@@ -391,7 +391,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap[w];
         return weights;
-	}
+    }
 */
     else if (phosphor_layout == 9) {
         // reduced TVL aperture for RGB panels
@@ -402,7 +402,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rgb[w];
         return weights;
-	}
+    }
 /*
     else if (phosphor_layout == 10) {
         // reduced TVL aperture for RBG panels
@@ -412,7 +412,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rbg[w];
         return weights;
-	}
+    }
 */
     else if(phosphor_layout == 11) {
         // delta_1_4x1_rgb; dunno why this is called 4x1 when it's obviously 4x2 /shrug
@@ -435,7 +435,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = (w == 1) ? delta_2_1[z] : delta_2_2[z];
         return weights;
-	}
+    }
 */
 /*
     else if (phosphor_layout == 13) {
@@ -487,10 +487,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = (w == 1) ? slotmask_RBG_x1[z] : (w == 2) ? slotmask_RBG_x2[z] : (w == 3) ? slotmask_RBG_x3[z] : slotmask_RBG_x4[z];
         return weights;
-	}
+    }
 */
 /*
-	else if(phosphor_layout == 16) {
+    else if(phosphor_layout == 16) {
         // slot mask for RBG panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
         // {yellow, blue,  black,  black},
         // {yellow, blue,  yellow, blue},
@@ -506,7 +506,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
         return weights;
     }
 */
-	else if (phosphor_layout == 17) {
+    else if (phosphor_layout == 17) {
         // slot_2_5x4_bgr
         // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
         // {black, blue,    blue,  green, green, red,   red,     black, black, black},
@@ -566,7 +566,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
         return weights;
      }
 */
-	else {
+    else {
         return weights;
     }
 }
@@ -586,10 +586,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 // For more info, see: http://www.imagemagick.org/Usage/img_diagrams/cubic_survey.gif
 mat4x4 get_hfilter_profile()
 {
-	float bf = 0.0;
-	float cf = 0.0;
+    float bf = 0.0;
+    float cf = 0.0;
 
-	if (HFILTER_PROFILE == 1) {
+    if (HFILTER_PROFILE == 1) {
         bf = 0.0;
         cf = 0.5;
     }
@@ -691,14 +691,14 @@ void main()
     mask_coords = mix(mask_coords.xy, mask_coords.yx, VSCANLINES);
     color.rgb *= mask_weights(mask_coords, MASK_INTENSITY, int(PHOSPHOR_LAYOUT));
 
-	// Colour temperature
-	if (WP_ADJUST == 1.0) {
-		vec3 wp_adjusted = wp_adjust(color.rgb);
-		vec3 base_luma = XYZtoYxy(sRGB_to_XYZ(color.rgb));
-		vec3 adjusted_luma = XYZtoYxy(sRGB_to_XYZ(wp_adjusted));
-		wp_adjusted = (LUMA_PRESERVE == 1.0) ? adjusted_luma + (vec3(base_luma.r,0.,0.) - vec3(adjusted_luma.r,0.,0.)) : adjusted_luma;
-		color = vec4(XYZ_to_sRGB(YxytoXYZ(wp_adjusted)), 1.0);
-	}
+    // Colour temperature
+    if (WP_ADJUST == 1.0) {
+        vec3 wp_adjusted = wp_adjust(color.rgb);
+        vec3 base_luma = XYZtoYxy(sRGB_to_XYZ(color.rgb));
+        vec3 adjusted_luma = XYZtoYxy(sRGB_to_XYZ(wp_adjusted));
+        wp_adjusted = (LUMA_PRESERVE == 1.0) ? adjusted_luma + (vec3(base_luma.r,0.,0.) - vec3(adjusted_luma.r,0.,0.)) : adjusted_luma;
+        color = vec4(XYZ_to_sRGB(YxytoXYZ(wp_adjusted)), 1.0);
+    }
 
     // Output gamma
     color = clamp(GAMMA_OUT(color), 0.0, 1.0);

--- a/contrib/resources/glshaders/crt/arcade-4k.glsl
+++ b/contrib/resources/glshaders/crt/arcade-4k.glsl
@@ -248,7 +248,6 @@ vec3 YxytoXYZ(vec3 Yxy) {
     return XYZ;
 }
 
-
 /*
     A collection of CRT mask effects that work with LCD subpixel structures for
     small details
@@ -275,11 +274,18 @@ vec3 YxytoXYZ(vec3 Yxy) {
 
     Many of these mask arrays are adapted from cgwg's crt-geom-deluxe LUTs, and
     those have their filenames included for easy identification
+
+	NOTE: Having too many branches result in a black screen (but no
+	compilation errors) on some older GPUs such as the Intel HD 4000 iGPU. So
+	we're commenting out the branches that are not used by the adaptive CRT
+	shaders.
 */
 vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
     vec3 weights = vec3(1.,1.,1.);
+
     float on = 1.;
     float off = 1.-mask_intensity;
+
     vec3 red     = vec3(on,  off, off);
     vec3 green   = vec3(off, on,  off);
     vec3 blue    = vec3(off, off, on );
@@ -288,6 +294,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
     vec3 cyan    = vec3(off, on,  on );
     vec3 black   = vec3(off, off, off);
     vec3 white   = vec3(on,  on,  on );
+
     int w, z = 0;
 
     // This pattern is used by a few layouts, so we'll define it here
@@ -295,21 +302,25 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
     if (phosphor_layout == 0) {
         return weights;
+	}
 
-    } else if (phosphor_layout == 1) {
-        // classic aperture for RGB panels; good for 1080p, too small for 4K+
+    else if (phosphor_layout == 1) {
+    	// classic aperture for RGB panels; good for 1080p, too small for 4K+
         // aka aperture_1_2_bgr
         weights  = aperture_weights;
         return weights;
+	}
 
-    } else if (phosphor_layout == 2) {
+    else if (phosphor_layout == 2) {
         // 2x2 shadow mask for RGB panels; good for 1080p, too small for 4K+
         // aka delta_1_2x1_bgr
         vec3 inverse_aperture = mix(green, magenta, floor(mod(coord.x, 2.0)));
         weights               = mix(aperture_weights, inverse_aperture, floor(mod(coord.y, 2.0)));
         return weights;
+	}
 
-    } else if (phosphor_layout == 3) {
+/*
+    else if (phosphor_layout == 3) {
         // slot mask for RGB panels; looks okay at 1080p, looks better at 4K
         // {magenta, green, black,   black},
         // {magenta, green, magenta, green},
@@ -329,14 +340,16 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         // do a big, dumb comparison in place of a 2D array
         weights = (w == 1) ? slotmask_x1[z] : (w == 2) ? slotmask_x2[z] :  slotmask_x3[z];
+		return weights;
     }
-
-    if (phosphor_layout == 4) {
+*/
+    else if (phosphor_layout == 4) {
         // classic aperture for RBG panels; good for 1080p, too small for 4K+
         weights  = mix(yellow, blue, floor(mod(coord.x, 2.0)));
         return weights;
-
-    } else if (phosphor_layout == 5) {
+	}
+/*
+    else if (phosphor_layout == 5) {
         // 2x2 shadow mask for RBG panels; good for 1080p, too small for 4K+
         vec3 inverse_aperture = mix(blue, yellow, floor(mod(coord.x, 2.0)));
 
@@ -346,8 +359,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
             floor(mod(coord.y, 2.0))
         );
         return weights;
-
-    } else if (phosphor_layout == 6) {
+	}
+*/
+/*
+    else if (phosphor_layout == 6) {
         // aperture_1_4_rgb; good for simulating lower
         vec3 ap4[4] = vec3[](red, green, blue, black);
 
@@ -355,8 +370,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = ap4[z];
         return weights;
-
-    } else if (phosphor_layout == 7) {
+	}
+*/
+/*
+    else if (phosphor_layout == 7) {
         // aperture_2_5_bgr
         vec3 ap3[5] = vec3[](red, magenta, blue, green, green);
 
@@ -364,8 +381,9 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = ap3[z];
         return weights;
-
-    } else if (phosphor_layout == 8){
+*/
+/*
+    else if (phosphor_layout == 8) {
         // aperture_3_6_rgb
         vec3 big_ap[7] = vec3[](red, red, yellow, green, cyan, blue, blue);
 
@@ -373,8 +391,9 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap[w];
         return weights;
-
-    } else if (phosphor_layout == 9) {
+	}
+*/
+    else if (phosphor_layout == 9) {
         // reduced TVL aperture for RGB panels
         // aperture_2_4_rgb
         vec3 big_ap_rgb[4] = vec3[](red, yellow, cyan, blue);
@@ -383,8 +402,9 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rgb[w];
         return weights;
-
-    } else if (phosphor_layout == 10) {
+	}
+/*
+    else if (phosphor_layout == 10) {
         // reduced TVL aperture for RBG panels
         vec3 big_ap_rbg[4] = vec3[](red, magenta, cyan, green);
 
@@ -392,148 +412,161 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rbg[w];
         return weights;
+	}
+*/
+    else if(phosphor_layout == 11) {
+        // delta_1_4x1_rgb; dunno why this is called 4x1 when it's obviously 4x2 /shrug
+        vec3 delta_1_1[4] = vec3[](red, green, blue, black);
+        vec3 delta_1_2[4] = vec3[](blue, black, red, green);
 
-    } else if(phosphor_layout == 11){
-       // delta_1_4x1_rgb; dunno why this is called 4x1 when it's obviously 4x2 /shrug
-       vec3 delta_1_1[4] = vec3[](red, green, blue, black);
-       vec3 delta_1_2[4] = vec3[](blue, black, red, green);
+        w = int(floor(mod(coord.y, 2.0)));
+        z = int(floor(mod(coord.x, 4.0)));
 
-       w = int(floor(mod(coord.y, 2.0)));
-       z = int(floor(mod(coord.x, 4.0)));
+        weights = (w == 1) ? delta_1_1[z] : delta_1_2[z];
+        return weights;
+    }
+/*
+    else if (phosphor_layout == 12) {
+        // delta_2_4x1_rgb
+        vec3 delta_2_1[4] = vec3[](red, yellow, cyan, blue);
+        vec3 delta_2_2[4] = vec3[](cyan, blue, red, yellow);
 
-       weights = (w == 1) ? delta_1_1[z] : delta_1_2[z];
-       return weights;
+        z = int(floor(mod(coord.x, 4.0)));
 
-    } else if(phosphor_layout == 12){
-       // delta_2_4x1_rgb
-       vec3 delta_2_1[4] = vec3[](red, yellow, cyan, blue);
-       vec3 delta_2_2[4] = vec3[](cyan, blue, red, yellow);
+        weights = (w == 1) ? delta_2_1[z] : delta_2_2[z];
+        return weights;
+	}
+*/
+/*
+    else if (phosphor_layout == 13) {
+        // delta_2_4x2_rgb
+        vec3 delta_1[4] = vec3[](red, yellow, cyan, blue);
+        vec3 delta_2[4] = vec3[](red, yellow, cyan, blue);
+        vec3 delta_3[4] = vec3[](cyan, blue, red, yellow);
+        vec3 delta_4[4] = vec3[](cyan, blue, red, yellow);
 
-       z = int(floor(mod(coord.x, 4.0)));
+        w = int(floor(mod(coord.y, 4.0)));
+        z = int(floor(mod(coord.x, 4.0)));
 
-       weights = (w == 1) ? delta_2_1[z] : delta_2_2[z];
-       return weights;
+        weights = (w == 1) ? delta_1[z] : (w == 2) ? delta_2[z] : (w == 3) ? delta_3[z] : delta_4[z];
+        return weights;
+    }
+*/
+    else if (phosphor_layout == 14) {
+        // slot mask for RGB panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
+        // {magenta, green, black, black,   black, black},
+        // {magenta, green, black, magenta, green, black},
+        // {black,   black, black, magenta, green, black}
+        vec3 slot2_1[6] = vec3[](magenta, green, black, black,   black, black);
+        vec3 slot2_2[6] = vec3[](magenta, green, black, magenta, green, black);
+        vec3 slot2_3[6] = vec3[](black,   black, black, magenta, green, black);
 
-    } else if(phosphor_layout == 13){
-       // delta_2_4x2_rgb
-       vec3 delta_1[4] = vec3[](red, yellow, cyan, blue);
-       vec3 delta_2[4] = vec3[](red, yellow, cyan, blue);
-       vec3 delta_3[4] = vec3[](cyan, blue, red, yellow);
-       vec3 delta_4[4] = vec3[](cyan, blue, red, yellow);
+        w = int(floor(mod(coord.y, 3.0)));
+        z = int(floor(mod(coord.x, 6.0)));
 
-       w = int(floor(mod(coord.y, 4.0)));
-       z = int(floor(mod(coord.x, 4.0)));
+        weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
+        return weights;
+    }
+/*
+    else if(phosphor_layout == 15) {
+        // slot_2_4x4_rgb
+        // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
+        // {red,   yellow, cyan,  blue,  black, black,  black, black},
+        // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
+        // {black, black,  black, black, red,   yellow, cyan,  blue }
+        vec3 slotmask_RBG_x1[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
+        vec3 slotmask_RBG_x2[8] = vec3[](red,   yellow, cyan,  blue,  black, black,  black, black);
+        vec3 slotmask_RBG_x3[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
+        vec3 slotmask_RBG_x4[8] = vec3[](black, black,  black, black, red,   yellow, cyan,  blue );
 
-       weights = (w == 1) ? delta_1[z] : (w == 2) ? delta_2[z] : (w == 3) ? delta_3[z] : delta_4[z];
-       return weights;
+        // find the vertical index
+        w = int(floor(mod(coord.y, 4.0)));
 
-    } else if(phosphor_layout == 14){
-       // slot mask for RGB panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
-       // {magenta, green, black, black,   black, black},
-       // {magenta, green, black, magenta, green, black},
-       // {black,   black, black, magenta, green, black}
-       vec3 slot2_1[6] = vec3[](magenta, green, black, black,   black, black);
-       vec3 slot2_2[6] = vec3[](magenta, green, black, magenta, green, black);
-       vec3 slot2_3[6] = vec3[](black,   black, black, magenta, green, black);
+        // find the horizontal index
+        z = int(floor(mod(coord.x, 8.0)));
 
-       w = int(floor(mod(coord.y, 3.0)));
-       z = int(floor(mod(coord.x, 6.0)));
+        weights = (w == 1) ? slotmask_RBG_x1[z] : (w == 2) ? slotmask_RBG_x2[z] : (w == 3) ? slotmask_RBG_x3[z] : slotmask_RBG_x4[z];
+        return weights;
+	}
+*/
+/*
+	else if(phosphor_layout == 16) {
+        // slot mask for RBG panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
+        // {yellow, blue,  black,  black},
+        // {yellow, blue,  yellow, blue},
+        // {black,  black, yellow, blue}
+        vec3 slot2_1[4] = vec3[](yellow, blue,  black,  black);
+        vec3 slot2_2[4] = vec3[](yellow, blue,  yellow, blue);
+        vec3 slot2_3[4] = vec3[](black,  black, yellow, blue);
 
-       weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
-       return weights;
+        w = int(floor(mod(coord.y, 3.0)));
+        z = int(floor(mod(coord.x, 4.0)));
 
-    } else if(phosphor_layout == 15){
-       // slot_2_4x4_rgb
-       // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
-       // {red,   yellow, cyan,  blue,  black, black,  black, black},
-       // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
-       // {black, black,  black, black, red,   yellow, cyan,  blue }
-       vec3 slotmask_RBG_x1[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
-       vec3 slotmask_RBG_x2[8] = vec3[](red,   yellow, cyan,  blue,  black, black,  black, black);
-       vec3 slotmask_RBG_x3[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
-       vec3 slotmask_RBG_x4[8] = vec3[](black, black,  black, black, red,   yellow, cyan,  blue );
+        weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
+        return weights;
+    }
+*/
+	else if (phosphor_layout == 17) {
+        // slot_2_5x4_bgr
+        // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
+        // {black, blue,    blue,  green, green, red,   red,     black, black, black},
+        // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
+        // {red,   red,     black, black, black, black, blue,    blue,  green, green}
+        vec3 slot_1[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
+        vec3 slot_2[10] = vec3[](black, blue,    blue,  green, green, red,   red,     black, black, black);
+        vec3 slot_3[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
+        vec3 slot_4[10] = vec3[](red,   red,     black, black, black, black, blue,    blue,  green, green);
 
-       // find the vertical index
-       w = int(floor(mod(coord.y, 4.0)));
+        w = int(floor(mod(coord.y, 4.0)));
+        z = int(floor(mod(coord.x, 10.0)));
 
-       // find the horizontal index
-       z = int(floor(mod(coord.x, 8.0)));
+        weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
+        return weights;
+    }
+/*
+    else if (phosphor_layout == 18) {
+        // same as above but for RBG panels
+        // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
+        // {black, green,  green, blue,  blue,  red,   red,    black, black, black},
+        // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
+        // {red,   red,    black, black, black, black, green,  green, blue,  blue }
+        vec3 slot_1[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
+        vec3 slot_2[10] = vec3[](black, green,  green, blue,  blue,  red,   red,    black, black, black);
+        vec3 slot_3[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
+        vec3 slot_4[10] = vec3[](red,   red,    black, black, black, black, green,  green, blue,  blue );
 
-       weights = (w == 1) ? slotmask_RBG_x1[z] : (w == 2) ? slotmask_RBG_x2[z] : (w == 3) ? slotmask_RBG_x3[z] : slotmask_RBG_x4[z];
-       return weights;
+        w = int(floor(mod(coord.y, 4.0)));
+        z = int(floor(mod(coord.x, 10.0)));
 
-     } else if(phosphor_layout == 16){
-       // slot mask for RBG panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
-       // {yellow, blue,  black,  black},
-       // {yellow, blue,  yellow, blue},
-       // {black,  black, yellow, blue}
-       vec3 slot2_1[4] = vec3[](yellow, blue,  black,  black);
-       vec3 slot2_2[4] = vec3[](yellow, blue,  yellow, blue);
-       vec3 slot2_3[4] = vec3[](black,  black, yellow, blue);
+        weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
+        return weights;
+    }
+*/
+/*
+    else if(phosphor_layout == 19) {
+        // slot_3_7x6_rgb
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue}
 
-       w = int(floor(mod(coord.y, 3.0)));
-       z = int(floor(mod(coord.x, 4.0)));
+        vec3 slot_1[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_2[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_3[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black);
+        vec3 slot_4[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_5[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_6[14] = vec3[](black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue);
 
-       weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
-       return weights;
+        w = int(floor(mod(coord.y, 6.0)));
+        z = int(floor(mod(coord.x, 14.0)));
 
-    } else if (phosphor_layout == 17) {
-       // slot_2_5x4_bgr
-       // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
-       // {black, blue,    blue,  green, green, red,   red,     black, black, black},
-       // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
-       // {red,   red,     black, black, black, black, blue,    blue,  green, green}
-       vec3 slot_1[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
-       vec3 slot_2[10] = vec3[](black, blue,    blue,  green, green, red,   red,     black, black, black);
-       vec3 slot_3[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
-       vec3 slot_4[10] = vec3[](red,   red,     black, black, black, black, blue,    blue,  green, green);
-
-       w = int(floor(mod(coord.y, 4.0)));
-       z = int(floor(mod(coord.x, 10.0)));
-
-       weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
-       return weights;
-
-    } else if (phosphor_layout == 18) {
-       // same as above but for RBG panels
-       // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
-       // {black, green,  green, blue,  blue,  red,   red,    black, black, black},
-       // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
-       // {red,   red,    black, black, black, black, green,  green, blue,  blue }
-       vec3 slot_1[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
-       vec3 slot_2[10] = vec3[](black, green,  green, blue,  blue,  red,   red,    black, black, black);
-       vec3 slot_3[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
-       vec3 slot_4[10] = vec3[](red,   red,    black, black, black, black, green,  green, blue,  blue );
-
-       w = int(floor(mod(coord.y, 4.0)));
-       z = int(floor(mod(coord.x, 10.0)));
-
-       weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
-       return weights;
-
-    } else if(phosphor_layout == 19) {
-       // slot_3_7x6_rgb
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue}
-
-       vec3 slot_1[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_2[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_3[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black);
-       vec3 slot_4[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_5[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_6[14] = vec3[](black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue);
-
-       w = int(floor(mod(coord.y, 6.0)));
-       z = int(floor(mod(coord.x, 14.0)));
-
-       weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : (w == 4) ? slot_4[z] : (w == 5) ? slot_5[z] : slot_6[z];
-       return weights;
-
-    } else {
+        weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : (w == 4) ? slot_4[z] : (w == 5) ? slot_5[z] : slot_6[z];
+        return weights;
+     }
+*/
+	else {
         return weights;
     }
 }

--- a/contrib/resources/glshaders/crt/arcade-sharp-1080p.glsl
+++ b/contrib/resources/glshaders/crt/arcade-sharp-1080p.glsl
@@ -168,10 +168,10 @@ uniform PRECISION float BLUE_SHIFT;
 
 #define WP_ADJUST           0.00
 #define TEMPERATURE      9300.00
-#define LUMA_PRESERVE 		1.00
-#define RED_SHIFT 			0.00
-#define GREEN_SHIFT 		0.00
-#define BLUE_SHIFT 			0.00
+#define LUMA_PRESERVE       1.00
+#define RED_SHIFT           0.00
+#define GREEN_SHIFT         0.00
+#define BLUE_SHIFT          0.00
 #endif
 // END PARAMETERS //
 
@@ -274,10 +274,10 @@ vec3 YxytoXYZ(vec3 Yxy) {
     Many of these mask arrays are adapted from cgwg's crt-geom-deluxe LUTs, and
     those have their filenames included for easy identification
 
-	NOTE: Having too many branches result in a black screen (but no
-	compilation errors) on some older GPUs such as the Intel HD 4000 iGPU. So
-	we're commenting out the branches that are not used by the adaptive CRT
-	shaders.
+    NOTE: Having too many branches result in a black screen (but no
+    compilation errors) on some older GPUs such as the Intel HD 4000 iGPU. So
+    we're commenting out the branches that are not used by the adaptive CRT
+    shaders.
 */
 vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
     vec3 weights = vec3(1.,1.,1.);
@@ -301,14 +301,14 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
     if (phosphor_layout == 0) {
         return weights;
-	}
+    }
 
     else if (phosphor_layout == 1) {
-    	// classic aperture for RGB panels; good for 1080p, too small for 4K+
+        // classic aperture for RGB panels; good for 1080p, too small for 4K+
         // aka aperture_1_2_bgr
         weights  = aperture_weights;
         return weights;
-	}
+    }
 
     else if (phosphor_layout == 2) {
         // 2x2 shadow mask for RGB panels; good for 1080p, too small for 4K+
@@ -316,7 +316,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
         vec3 inverse_aperture = mix(green, magenta, floor(mod(coord.x, 2.0)));
         weights               = mix(aperture_weights, inverse_aperture, floor(mod(coord.y, 2.0)));
         return weights;
-	}
+    }
 
 /*
     else if (phosphor_layout == 3) {
@@ -339,14 +339,14 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         // do a big, dumb comparison in place of a 2D array
         weights = (w == 1) ? slotmask_x1[z] : (w == 2) ? slotmask_x2[z] :  slotmask_x3[z];
-		return weights;
+        return weights;
     }
 */
     else if (phosphor_layout == 4) {
         // classic aperture for RBG panels; good for 1080p, too small for 4K+
         weights  = mix(yellow, blue, floor(mod(coord.x, 2.0)));
         return weights;
-	}
+    }
 /*
     else if (phosphor_layout == 5) {
         // 2x2 shadow mask for RBG panels; good for 1080p, too small for 4K+
@@ -358,7 +358,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
             floor(mod(coord.y, 2.0))
         );
         return weights;
-	}
+    }
 */
 /*
     else if (phosphor_layout == 6) {
@@ -369,7 +369,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = ap4[z];
         return weights;
-	}
+    }
 */
 /*
     else if (phosphor_layout == 7) {
@@ -390,7 +390,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap[w];
         return weights;
-	}
+    }
 */
     else if (phosphor_layout == 9) {
         // reduced TVL aperture for RGB panels
@@ -401,7 +401,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rgb[w];
         return weights;
-	}
+    }
 /*
     else if (phosphor_layout == 10) {
         // reduced TVL aperture for RBG panels
@@ -411,7 +411,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rbg[w];
         return weights;
-	}
+    }
 */
     else if(phosphor_layout == 11) {
         // delta_1_4x1_rgb; dunno why this is called 4x1 when it's obviously 4x2 /shrug
@@ -434,7 +434,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = (w == 1) ? delta_2_1[z] : delta_2_2[z];
         return weights;
-	}
+    }
 */
 /*
     else if (phosphor_layout == 13) {
@@ -486,10 +486,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = (w == 1) ? slotmask_RBG_x1[z] : (w == 2) ? slotmask_RBG_x2[z] : (w == 3) ? slotmask_RBG_x3[z] : slotmask_RBG_x4[z];
         return weights;
-	}
+    }
 */
 /*
-	else if(phosphor_layout == 16) {
+    else if(phosphor_layout == 16) {
         // slot mask for RBG panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
         // {yellow, blue,  black,  black},
         // {yellow, blue,  yellow, blue},
@@ -505,7 +505,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
         return weights;
     }
 */
-	else if (phosphor_layout == 17) {
+    else if (phosphor_layout == 17) {
         // slot_2_5x4_bgr
         // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
         // {black, blue,    blue,  green, green, red,   red,     black, black, black},
@@ -565,7 +565,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
         return weights;
      }
 */
-	else {
+    else {
         return weights;
     }
 }
@@ -585,10 +585,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 // For more info, see: http://www.imagemagick.org/Usage/img_diagrams/cubic_survey.gif
 mat4x4 get_hfilter_profile()
 {
-	float bf = 0.0;
-	float cf = 0.0;
+    float bf = 0.0;
+    float cf = 0.0;
 
-	if (HFILTER_PROFILE == 1) {
+    if (HFILTER_PROFILE == 1) {
         bf = 0.0;
         cf = 0.5;
     }
@@ -690,14 +690,14 @@ void main()
     mask_coords = mix(mask_coords.xy, mask_coords.yx, VSCANLINES);
     color.rgb *= mask_weights(mask_coords, MASK_INTENSITY, int(PHOSPHOR_LAYOUT));
 
-	// Colour temperature
-	if (WP_ADJUST == 1.0) {
-		vec3 wp_adjusted = wp_adjust(color.rgb);
-		vec3 base_luma = XYZtoYxy(sRGB_to_XYZ(color.rgb));
-		vec3 adjusted_luma = XYZtoYxy(sRGB_to_XYZ(wp_adjusted));
-		wp_adjusted = (LUMA_PRESERVE == 1.0) ? adjusted_luma + (vec3(base_luma.r,0.,0.) - vec3(adjusted_luma.r,0.,0.)) : adjusted_luma;
-		color = vec4(XYZ_to_sRGB(YxytoXYZ(wp_adjusted)), 1.0);
-	}
+    // Colour temperature
+    if (WP_ADJUST == 1.0) {
+        vec3 wp_adjusted = wp_adjust(color.rgb);
+        vec3 base_luma = XYZtoYxy(sRGB_to_XYZ(color.rgb));
+        vec3 adjusted_luma = XYZtoYxy(sRGB_to_XYZ(wp_adjusted));
+        wp_adjusted = (LUMA_PRESERVE == 1.0) ? adjusted_luma + (vec3(base_luma.r,0.,0.) - vec3(adjusted_luma.r,0.,0.)) : adjusted_luma;
+        color = vec4(XYZ_to_sRGB(YxytoXYZ(wp_adjusted)), 1.0);
+    }
 
     // Output gamma
     color = clamp(GAMMA_OUT(color), 0.0, 1.0);

--- a/contrib/resources/glshaders/crt/arcade-sharp-1080p.glsl
+++ b/contrib/resources/glshaders/crt/arcade-sharp-1080p.glsl
@@ -247,7 +247,6 @@ vec3 YxytoXYZ(vec3 Yxy) {
     return XYZ;
 }
 
-
 /*
     A collection of CRT mask effects that work with LCD subpixel structures for
     small details
@@ -274,11 +273,18 @@ vec3 YxytoXYZ(vec3 Yxy) {
 
     Many of these mask arrays are adapted from cgwg's crt-geom-deluxe LUTs, and
     those have their filenames included for easy identification
+
+	NOTE: Having too many branches result in a black screen (but no
+	compilation errors) on some older GPUs such as the Intel HD 4000 iGPU. So
+	we're commenting out the branches that are not used by the adaptive CRT
+	shaders.
 */
 vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
     vec3 weights = vec3(1.,1.,1.);
+
     float on = 1.;
     float off = 1.-mask_intensity;
+
     vec3 red     = vec3(on,  off, off);
     vec3 green   = vec3(off, on,  off);
     vec3 blue    = vec3(off, off, on );
@@ -287,6 +293,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
     vec3 cyan    = vec3(off, on,  on );
     vec3 black   = vec3(off, off, off);
     vec3 white   = vec3(on,  on,  on );
+
     int w, z = 0;
 
     // This pattern is used by a few layouts, so we'll define it here
@@ -294,21 +301,25 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
     if (phosphor_layout == 0) {
         return weights;
+	}
 
-    } else if (phosphor_layout == 1) {
-        // classic aperture for RGB panels; good for 1080p, too small for 4K+
+    else if (phosphor_layout == 1) {
+    	// classic aperture for RGB panels; good for 1080p, too small for 4K+
         // aka aperture_1_2_bgr
         weights  = aperture_weights;
         return weights;
+	}
 
-    } else if (phosphor_layout == 2) {
+    else if (phosphor_layout == 2) {
         // 2x2 shadow mask for RGB panels; good for 1080p, too small for 4K+
         // aka delta_1_2x1_bgr
         vec3 inverse_aperture = mix(green, magenta, floor(mod(coord.x, 2.0)));
         weights               = mix(aperture_weights, inverse_aperture, floor(mod(coord.y, 2.0)));
         return weights;
+	}
 
-    } else if (phosphor_layout == 3) {
+/*
+    else if (phosphor_layout == 3) {
         // slot mask for RGB panels; looks okay at 1080p, looks better at 4K
         // {magenta, green, black,   black},
         // {magenta, green, magenta, green},
@@ -328,14 +339,16 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         // do a big, dumb comparison in place of a 2D array
         weights = (w == 1) ? slotmask_x1[z] : (w == 2) ? slotmask_x2[z] :  slotmask_x3[z];
+		return weights;
     }
-
-    if (phosphor_layout == 4) {
+*/
+    else if (phosphor_layout == 4) {
         // classic aperture for RBG panels; good for 1080p, too small for 4K+
         weights  = mix(yellow, blue, floor(mod(coord.x, 2.0)));
         return weights;
-
-    } else if (phosphor_layout == 5) {
+	}
+/*
+    else if (phosphor_layout == 5) {
         // 2x2 shadow mask for RBG panels; good for 1080p, too small for 4K+
         vec3 inverse_aperture = mix(blue, yellow, floor(mod(coord.x, 2.0)));
 
@@ -345,8 +358,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
             floor(mod(coord.y, 2.0))
         );
         return weights;
-
-    } else if (phosphor_layout == 6) {
+	}
+*/
+/*
+    else if (phosphor_layout == 6) {
         // aperture_1_4_rgb; good for simulating lower
         vec3 ap4[4] = vec3[](red, green, blue, black);
 
@@ -354,8 +369,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = ap4[z];
         return weights;
-
-    } else if (phosphor_layout == 7) {
+	}
+*/
+/*
+    else if (phosphor_layout == 7) {
         // aperture_2_5_bgr
         vec3 ap3[5] = vec3[](red, magenta, blue, green, green);
 
@@ -363,8 +380,9 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = ap3[z];
         return weights;
-
-    } else if (phosphor_layout == 8){
+*/
+/*
+    else if (phosphor_layout == 8) {
         // aperture_3_6_rgb
         vec3 big_ap[7] = vec3[](red, red, yellow, green, cyan, blue, blue);
 
@@ -372,8 +390,9 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap[w];
         return weights;
-
-    } else if (phosphor_layout == 9) {
+	}
+*/
+    else if (phosphor_layout == 9) {
         // reduced TVL aperture for RGB panels
         // aperture_2_4_rgb
         vec3 big_ap_rgb[4] = vec3[](red, yellow, cyan, blue);
@@ -382,8 +401,9 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rgb[w];
         return weights;
-
-    } else if (phosphor_layout == 10) {
+	}
+/*
+    else if (phosphor_layout == 10) {
         // reduced TVL aperture for RBG panels
         vec3 big_ap_rbg[4] = vec3[](red, magenta, cyan, green);
 
@@ -391,148 +411,161 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rbg[w];
         return weights;
+	}
+*/
+    else if(phosphor_layout == 11) {
+        // delta_1_4x1_rgb; dunno why this is called 4x1 when it's obviously 4x2 /shrug
+        vec3 delta_1_1[4] = vec3[](red, green, blue, black);
+        vec3 delta_1_2[4] = vec3[](blue, black, red, green);
 
-    } else if(phosphor_layout == 11){
-       // delta_1_4x1_rgb; dunno why this is called 4x1 when it's obviously 4x2 /shrug
-       vec3 delta_1_1[4] = vec3[](red, green, blue, black);
-       vec3 delta_1_2[4] = vec3[](blue, black, red, green);
+        w = int(floor(mod(coord.y, 2.0)));
+        z = int(floor(mod(coord.x, 4.0)));
 
-       w = int(floor(mod(coord.y, 2.0)));
-       z = int(floor(mod(coord.x, 4.0)));
+        weights = (w == 1) ? delta_1_1[z] : delta_1_2[z];
+        return weights;
+    }
+/*
+    else if (phosphor_layout == 12) {
+        // delta_2_4x1_rgb
+        vec3 delta_2_1[4] = vec3[](red, yellow, cyan, blue);
+        vec3 delta_2_2[4] = vec3[](cyan, blue, red, yellow);
 
-       weights = (w == 1) ? delta_1_1[z] : delta_1_2[z];
-       return weights;
+        z = int(floor(mod(coord.x, 4.0)));
 
-    } else if(phosphor_layout == 12){
-       // delta_2_4x1_rgb
-       vec3 delta_2_1[4] = vec3[](red, yellow, cyan, blue);
-       vec3 delta_2_2[4] = vec3[](cyan, blue, red, yellow);
+        weights = (w == 1) ? delta_2_1[z] : delta_2_2[z];
+        return weights;
+	}
+*/
+/*
+    else if (phosphor_layout == 13) {
+        // delta_2_4x2_rgb
+        vec3 delta_1[4] = vec3[](red, yellow, cyan, blue);
+        vec3 delta_2[4] = vec3[](red, yellow, cyan, blue);
+        vec3 delta_3[4] = vec3[](cyan, blue, red, yellow);
+        vec3 delta_4[4] = vec3[](cyan, blue, red, yellow);
 
-       z = int(floor(mod(coord.x, 4.0)));
+        w = int(floor(mod(coord.y, 4.0)));
+        z = int(floor(mod(coord.x, 4.0)));
 
-       weights = (w == 1) ? delta_2_1[z] : delta_2_2[z];
-       return weights;
+        weights = (w == 1) ? delta_1[z] : (w == 2) ? delta_2[z] : (w == 3) ? delta_3[z] : delta_4[z];
+        return weights;
+    }
+*/
+    else if (phosphor_layout == 14) {
+        // slot mask for RGB panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
+        // {magenta, green, black, black,   black, black},
+        // {magenta, green, black, magenta, green, black},
+        // {black,   black, black, magenta, green, black}
+        vec3 slot2_1[6] = vec3[](magenta, green, black, black,   black, black);
+        vec3 slot2_2[6] = vec3[](magenta, green, black, magenta, green, black);
+        vec3 slot2_3[6] = vec3[](black,   black, black, magenta, green, black);
 
-    } else if(phosphor_layout == 13){
-       // delta_2_4x2_rgb
-       vec3 delta_1[4] = vec3[](red, yellow, cyan, blue);
-       vec3 delta_2[4] = vec3[](red, yellow, cyan, blue);
-       vec3 delta_3[4] = vec3[](cyan, blue, red, yellow);
-       vec3 delta_4[4] = vec3[](cyan, blue, red, yellow);
+        w = int(floor(mod(coord.y, 3.0)));
+        z = int(floor(mod(coord.x, 6.0)));
 
-       w = int(floor(mod(coord.y, 4.0)));
-       z = int(floor(mod(coord.x, 4.0)));
+        weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
+        return weights;
+    }
+/*
+    else if(phosphor_layout == 15) {
+        // slot_2_4x4_rgb
+        // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
+        // {red,   yellow, cyan,  blue,  black, black,  black, black},
+        // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
+        // {black, black,  black, black, red,   yellow, cyan,  blue }
+        vec3 slotmask_RBG_x1[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
+        vec3 slotmask_RBG_x2[8] = vec3[](red,   yellow, cyan,  blue,  black, black,  black, black);
+        vec3 slotmask_RBG_x3[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
+        vec3 slotmask_RBG_x4[8] = vec3[](black, black,  black, black, red,   yellow, cyan,  blue );
 
-       weights = (w == 1) ? delta_1[z] : (w == 2) ? delta_2[z] : (w == 3) ? delta_3[z] : delta_4[z];
-       return weights;
+        // find the vertical index
+        w = int(floor(mod(coord.y, 4.0)));
 
-    } else if(phosphor_layout == 14){
-       // slot mask for RGB panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
-       // {magenta, green, black, black,   black, black},
-       // {magenta, green, black, magenta, green, black},
-       // {black,   black, black, magenta, green, black}
-       vec3 slot2_1[6] = vec3[](magenta, green, black, black,   black, black);
-       vec3 slot2_2[6] = vec3[](magenta, green, black, magenta, green, black);
-       vec3 slot2_3[6] = vec3[](black,   black, black, magenta, green, black);
+        // find the horizontal index
+        z = int(floor(mod(coord.x, 8.0)));
 
-       w = int(floor(mod(coord.y, 3.0)));
-       z = int(floor(mod(coord.x, 6.0)));
+        weights = (w == 1) ? slotmask_RBG_x1[z] : (w == 2) ? slotmask_RBG_x2[z] : (w == 3) ? slotmask_RBG_x3[z] : slotmask_RBG_x4[z];
+        return weights;
+	}
+*/
+/*
+	else if(phosphor_layout == 16) {
+        // slot mask for RBG panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
+        // {yellow, blue,  black,  black},
+        // {yellow, blue,  yellow, blue},
+        // {black,  black, yellow, blue}
+        vec3 slot2_1[4] = vec3[](yellow, blue,  black,  black);
+        vec3 slot2_2[4] = vec3[](yellow, blue,  yellow, blue);
+        vec3 slot2_3[4] = vec3[](black,  black, yellow, blue);
 
-       weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
-       return weights;
+        w = int(floor(mod(coord.y, 3.0)));
+        z = int(floor(mod(coord.x, 4.0)));
 
-    } else if(phosphor_layout == 15){
-       // slot_2_4x4_rgb
-       // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
-       // {red,   yellow, cyan,  blue,  black, black,  black, black},
-       // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
-       // {black, black,  black, black, red,   yellow, cyan,  blue }
-       vec3 slotmask_RBG_x1[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
-       vec3 slotmask_RBG_x2[8] = vec3[](red,   yellow, cyan,  blue,  black, black,  black, black);
-       vec3 slotmask_RBG_x3[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
-       vec3 slotmask_RBG_x4[8] = vec3[](black, black,  black, black, red,   yellow, cyan,  blue );
+        weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
+        return weights;
+    }
+*/
+	else if (phosphor_layout == 17) {
+        // slot_2_5x4_bgr
+        // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
+        // {black, blue,    blue,  green, green, red,   red,     black, black, black},
+        // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
+        // {red,   red,     black, black, black, black, blue,    blue,  green, green}
+        vec3 slot_1[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
+        vec3 slot_2[10] = vec3[](black, blue,    blue,  green, green, red,   red,     black, black, black);
+        vec3 slot_3[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
+        vec3 slot_4[10] = vec3[](red,   red,     black, black, black, black, blue,    blue,  green, green);
 
-       // find the vertical index
-       w = int(floor(mod(coord.y, 4.0)));
+        w = int(floor(mod(coord.y, 4.0)));
+        z = int(floor(mod(coord.x, 10.0)));
 
-       // find the horizontal index
-       z = int(floor(mod(coord.x, 8.0)));
+        weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
+        return weights;
+    }
+/*
+    else if (phosphor_layout == 18) {
+        // same as above but for RBG panels
+        // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
+        // {black, green,  green, blue,  blue,  red,   red,    black, black, black},
+        // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
+        // {red,   red,    black, black, black, black, green,  green, blue,  blue }
+        vec3 slot_1[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
+        vec3 slot_2[10] = vec3[](black, green,  green, blue,  blue,  red,   red,    black, black, black);
+        vec3 slot_3[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
+        vec3 slot_4[10] = vec3[](red,   red,    black, black, black, black, green,  green, blue,  blue );
 
-       weights = (w == 1) ? slotmask_RBG_x1[z] : (w == 2) ? slotmask_RBG_x2[z] : (w == 3) ? slotmask_RBG_x3[z] : slotmask_RBG_x4[z];
-       return weights;
+        w = int(floor(mod(coord.y, 4.0)));
+        z = int(floor(mod(coord.x, 10.0)));
 
-     } else if(phosphor_layout == 16){
-       // slot mask for RBG panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
-       // {yellow, blue,  black,  black},
-       // {yellow, blue,  yellow, blue},
-       // {black,  black, yellow, blue}
-       vec3 slot2_1[4] = vec3[](yellow, blue,  black,  black);
-       vec3 slot2_2[4] = vec3[](yellow, blue,  yellow, blue);
-       vec3 slot2_3[4] = vec3[](black,  black, yellow, blue);
+        weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
+        return weights;
+    }
+*/
+/*
+    else if(phosphor_layout == 19) {
+        // slot_3_7x6_rgb
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue}
 
-       w = int(floor(mod(coord.y, 3.0)));
-       z = int(floor(mod(coord.x, 4.0)));
+        vec3 slot_1[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_2[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_3[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black);
+        vec3 slot_4[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_5[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_6[14] = vec3[](black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue);
 
-       weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
-       return weights;
+        w = int(floor(mod(coord.y, 6.0)));
+        z = int(floor(mod(coord.x, 14.0)));
 
-    } else if (phosphor_layout == 17) {
-       // slot_2_5x4_bgr
-       // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
-       // {black, blue,    blue,  green, green, red,   red,     black, black, black},
-       // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
-       // {red,   red,     black, black, black, black, blue,    blue,  green, green}
-       vec3 slot_1[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
-       vec3 slot_2[10] = vec3[](black, blue,    blue,  green, green, red,   red,     black, black, black);
-       vec3 slot_3[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
-       vec3 slot_4[10] = vec3[](red,   red,     black, black, black, black, blue,    blue,  green, green);
-
-       w = int(floor(mod(coord.y, 4.0)));
-       z = int(floor(mod(coord.x, 10.0)));
-
-       weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
-       return weights;
-
-    } else if (phosphor_layout == 18) {
-       // same as above but for RBG panels
-       // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
-       // {black, green,  green, blue,  blue,  red,   red,    black, black, black},
-       // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
-       // {red,   red,    black, black, black, black, green,  green, blue,  blue }
-       vec3 slot_1[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
-       vec3 slot_2[10] = vec3[](black, green,  green, blue,  blue,  red,   red,    black, black, black);
-       vec3 slot_3[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
-       vec3 slot_4[10] = vec3[](red,   red,    black, black, black, black, green,  green, blue,  blue );
-
-       w = int(floor(mod(coord.y, 4.0)));
-       z = int(floor(mod(coord.x, 10.0)));
-
-       weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
-       return weights;
-
-    } else if(phosphor_layout == 19) {
-       // slot_3_7x6_rgb
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue}
-
-       vec3 slot_1[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_2[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_3[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black);
-       vec3 slot_4[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_5[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_6[14] = vec3[](black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue);
-
-       w = int(floor(mod(coord.y, 6.0)));
-       z = int(floor(mod(coord.x, 14.0)));
-
-       weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : (w == 4) ? slot_4[z] : (w == 5) ? slot_5[z] : slot_6[z];
-       return weights;
-
-    } else {
+        weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : (w == 4) ? slot_4[z] : (w == 5) ? slot_5[z] : slot_6[z];
+        return weights;
+     }
+*/
+	else {
         return weights;
     }
 }

--- a/contrib/resources/glshaders/crt/arcade-sharp-1440p.glsl
+++ b/contrib/resources/glshaders/crt/arcade-sharp-1440p.glsl
@@ -168,10 +168,10 @@ uniform PRECISION float BLUE_SHIFT;
 
 #define WP_ADJUST           0.00
 #define TEMPERATURE      9300.00
-#define LUMA_PRESERVE 		1.00
-#define RED_SHIFT 			0.00
-#define GREEN_SHIFT 		0.00
-#define BLUE_SHIFT 			0.00
+#define LUMA_PRESERVE       1.00
+#define RED_SHIFT           0.00
+#define GREEN_SHIFT         0.00
+#define BLUE_SHIFT          0.00
 #endif
 // END PARAMETERS //
 
@@ -274,10 +274,10 @@ vec3 YxytoXYZ(vec3 Yxy) {
     Many of these mask arrays are adapted from cgwg's crt-geom-deluxe LUTs, and
     those have their filenames included for easy identification
 
-	NOTE: Having too many branches result in a black screen (but no
-	compilation errors) on some older GPUs such as the Intel HD 4000 iGPU. So
-	we're commenting out the branches that are not used by the adaptive CRT
-	shaders.
+    NOTE: Having too many branches result in a black screen (but no
+    compilation errors) on some older GPUs such as the Intel HD 4000 iGPU. So
+    we're commenting out the branches that are not used by the adaptive CRT
+    shaders.
 */
 vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
     vec3 weights = vec3(1.,1.,1.);
@@ -301,14 +301,14 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
     if (phosphor_layout == 0) {
         return weights;
-	}
+    }
 
     else if (phosphor_layout == 1) {
-    	// classic aperture for RGB panels; good for 1080p, too small for 4K+
+        // classic aperture for RGB panels; good for 1080p, too small for 4K+
         // aka aperture_1_2_bgr
         weights  = aperture_weights;
         return weights;
-	}
+    }
 
     else if (phosphor_layout == 2) {
         // 2x2 shadow mask for RGB panels; good for 1080p, too small for 4K+
@@ -316,7 +316,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
         vec3 inverse_aperture = mix(green, magenta, floor(mod(coord.x, 2.0)));
         weights               = mix(aperture_weights, inverse_aperture, floor(mod(coord.y, 2.0)));
         return weights;
-	}
+    }
 
 /*
     else if (phosphor_layout == 3) {
@@ -339,14 +339,14 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         // do a big, dumb comparison in place of a 2D array
         weights = (w == 1) ? slotmask_x1[z] : (w == 2) ? slotmask_x2[z] :  slotmask_x3[z];
-		return weights;
+        return weights;
     }
 */
     else if (phosphor_layout == 4) {
         // classic aperture for RBG panels; good for 1080p, too small for 4K+
         weights  = mix(yellow, blue, floor(mod(coord.x, 2.0)));
         return weights;
-	}
+    }
 /*
     else if (phosphor_layout == 5) {
         // 2x2 shadow mask for RBG panels; good for 1080p, too small for 4K+
@@ -358,7 +358,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
             floor(mod(coord.y, 2.0))
         );
         return weights;
-	}
+    }
 */
 /*
     else if (phosphor_layout == 6) {
@@ -369,7 +369,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = ap4[z];
         return weights;
-	}
+    }
 */
 /*
     else if (phosphor_layout == 7) {
@@ -390,7 +390,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap[w];
         return weights;
-	}
+    }
 */
     else if (phosphor_layout == 9) {
         // reduced TVL aperture for RGB panels
@@ -401,7 +401,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rgb[w];
         return weights;
-	}
+    }
 /*
     else if (phosphor_layout == 10) {
         // reduced TVL aperture for RBG panels
@@ -411,7 +411,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rbg[w];
         return weights;
-	}
+    }
 */
     else if(phosphor_layout == 11) {
         // delta_1_4x1_rgb; dunno why this is called 4x1 when it's obviously 4x2 /shrug
@@ -434,7 +434,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = (w == 1) ? delta_2_1[z] : delta_2_2[z];
         return weights;
-	}
+    }
 */
 /*
     else if (phosphor_layout == 13) {
@@ -486,10 +486,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = (w == 1) ? slotmask_RBG_x1[z] : (w == 2) ? slotmask_RBG_x2[z] : (w == 3) ? slotmask_RBG_x3[z] : slotmask_RBG_x4[z];
         return weights;
-	}
+    }
 */
 /*
-	else if(phosphor_layout == 16) {
+    else if(phosphor_layout == 16) {
         // slot mask for RBG panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
         // {yellow, blue,  black,  black},
         // {yellow, blue,  yellow, blue},
@@ -505,7 +505,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
         return weights;
     }
 */
-	else if (phosphor_layout == 17) {
+    else if (phosphor_layout == 17) {
         // slot_2_5x4_bgr
         // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
         // {black, blue,    blue,  green, green, red,   red,     black, black, black},
@@ -565,7 +565,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
         return weights;
      }
 */
-	else {
+    else {
         return weights;
     }
 }
@@ -585,10 +585,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 // For more info, see: http://www.imagemagick.org/Usage/img_diagrams/cubic_survey.gif
 mat4x4 get_hfilter_profile()
 {
-	float bf = 0.0;
-	float cf = 0.0;
+    float bf = 0.0;
+    float cf = 0.0;
 
-	if (HFILTER_PROFILE == 1) {
+    if (HFILTER_PROFILE == 1) {
         bf = 0.0;
         cf = 0.5;
     }
@@ -690,14 +690,14 @@ void main()
     mask_coords = mix(mask_coords.xy, mask_coords.yx, VSCANLINES);
     color.rgb *= mask_weights(mask_coords, MASK_INTENSITY, int(PHOSPHOR_LAYOUT));
 
-	// Colour temperature
-	if (WP_ADJUST == 1.0) {
-		vec3 wp_adjusted = wp_adjust(color.rgb);
-		vec3 base_luma = XYZtoYxy(sRGB_to_XYZ(color.rgb));
-		vec3 adjusted_luma = XYZtoYxy(sRGB_to_XYZ(wp_adjusted));
-		wp_adjusted = (LUMA_PRESERVE == 1.0) ? adjusted_luma + (vec3(base_luma.r,0.,0.) - vec3(adjusted_luma.r,0.,0.)) : adjusted_luma;
-		color = vec4(XYZ_to_sRGB(YxytoXYZ(wp_adjusted)), 1.0);
-	}
+    // Colour temperature
+    if (WP_ADJUST == 1.0) {
+        vec3 wp_adjusted = wp_adjust(color.rgb);
+        vec3 base_luma = XYZtoYxy(sRGB_to_XYZ(color.rgb));
+        vec3 adjusted_luma = XYZtoYxy(sRGB_to_XYZ(wp_adjusted));
+        wp_adjusted = (LUMA_PRESERVE == 1.0) ? adjusted_luma + (vec3(base_luma.r,0.,0.) - vec3(adjusted_luma.r,0.,0.)) : adjusted_luma;
+        color = vec4(XYZ_to_sRGB(YxytoXYZ(wp_adjusted)), 1.0);
+    }
 
     // Output gamma
     color = clamp(GAMMA_OUT(color), 0.0, 1.0);

--- a/contrib/resources/glshaders/crt/arcade-sharp-1440p.glsl
+++ b/contrib/resources/glshaders/crt/arcade-sharp-1440p.glsl
@@ -247,7 +247,6 @@ vec3 YxytoXYZ(vec3 Yxy) {
     return XYZ;
 }
 
-
 /*
     A collection of CRT mask effects that work with LCD subpixel structures for
     small details
@@ -274,11 +273,18 @@ vec3 YxytoXYZ(vec3 Yxy) {
 
     Many of these mask arrays are adapted from cgwg's crt-geom-deluxe LUTs, and
     those have their filenames included for easy identification
+
+	NOTE: Having too many branches result in a black screen (but no
+	compilation errors) on some older GPUs such as the Intel HD 4000 iGPU. So
+	we're commenting out the branches that are not used by the adaptive CRT
+	shaders.
 */
 vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
     vec3 weights = vec3(1.,1.,1.);
+
     float on = 1.;
     float off = 1.-mask_intensity;
+
     vec3 red     = vec3(on,  off, off);
     vec3 green   = vec3(off, on,  off);
     vec3 blue    = vec3(off, off, on );
@@ -287,6 +293,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
     vec3 cyan    = vec3(off, on,  on );
     vec3 black   = vec3(off, off, off);
     vec3 white   = vec3(on,  on,  on );
+
     int w, z = 0;
 
     // This pattern is used by a few layouts, so we'll define it here
@@ -294,21 +301,25 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
     if (phosphor_layout == 0) {
         return weights;
+	}
 
-    } else if (phosphor_layout == 1) {
-        // classic aperture for RGB panels; good for 1080p, too small for 4K+
+    else if (phosphor_layout == 1) {
+    	// classic aperture for RGB panels; good for 1080p, too small for 4K+
         // aka aperture_1_2_bgr
         weights  = aperture_weights;
         return weights;
+	}
 
-    } else if (phosphor_layout == 2) {
+    else if (phosphor_layout == 2) {
         // 2x2 shadow mask for RGB panels; good for 1080p, too small for 4K+
         // aka delta_1_2x1_bgr
         vec3 inverse_aperture = mix(green, magenta, floor(mod(coord.x, 2.0)));
         weights               = mix(aperture_weights, inverse_aperture, floor(mod(coord.y, 2.0)));
         return weights;
+	}
 
-    } else if (phosphor_layout == 3) {
+/*
+    else if (phosphor_layout == 3) {
         // slot mask for RGB panels; looks okay at 1080p, looks better at 4K
         // {magenta, green, black,   black},
         // {magenta, green, magenta, green},
@@ -328,14 +339,16 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         // do a big, dumb comparison in place of a 2D array
         weights = (w == 1) ? slotmask_x1[z] : (w == 2) ? slotmask_x2[z] :  slotmask_x3[z];
+		return weights;
     }
-
-    if (phosphor_layout == 4) {
+*/
+    else if (phosphor_layout == 4) {
         // classic aperture for RBG panels; good for 1080p, too small for 4K+
         weights  = mix(yellow, blue, floor(mod(coord.x, 2.0)));
         return weights;
-
-    } else if (phosphor_layout == 5) {
+	}
+/*
+    else if (phosphor_layout == 5) {
         // 2x2 shadow mask for RBG panels; good for 1080p, too small for 4K+
         vec3 inverse_aperture = mix(blue, yellow, floor(mod(coord.x, 2.0)));
 
@@ -345,8 +358,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
             floor(mod(coord.y, 2.0))
         );
         return weights;
-
-    } else if (phosphor_layout == 6) {
+	}
+*/
+/*
+    else if (phosphor_layout == 6) {
         // aperture_1_4_rgb; good for simulating lower
         vec3 ap4[4] = vec3[](red, green, blue, black);
 
@@ -354,8 +369,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = ap4[z];
         return weights;
-
-    } else if (phosphor_layout == 7) {
+	}
+*/
+/*
+    else if (phosphor_layout == 7) {
         // aperture_2_5_bgr
         vec3 ap3[5] = vec3[](red, magenta, blue, green, green);
 
@@ -363,8 +380,9 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = ap3[z];
         return weights;
-
-    } else if (phosphor_layout == 8){
+*/
+/*
+    else if (phosphor_layout == 8) {
         // aperture_3_6_rgb
         vec3 big_ap[7] = vec3[](red, red, yellow, green, cyan, blue, blue);
 
@@ -372,8 +390,9 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap[w];
         return weights;
-
-    } else if (phosphor_layout == 9) {
+	}
+*/
+    else if (phosphor_layout == 9) {
         // reduced TVL aperture for RGB panels
         // aperture_2_4_rgb
         vec3 big_ap_rgb[4] = vec3[](red, yellow, cyan, blue);
@@ -382,8 +401,9 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rgb[w];
         return weights;
-
-    } else if (phosphor_layout == 10) {
+	}
+/*
+    else if (phosphor_layout == 10) {
         // reduced TVL aperture for RBG panels
         vec3 big_ap_rbg[4] = vec3[](red, magenta, cyan, green);
 
@@ -391,148 +411,161 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rbg[w];
         return weights;
+	}
+*/
+    else if(phosphor_layout == 11) {
+        // delta_1_4x1_rgb; dunno why this is called 4x1 when it's obviously 4x2 /shrug
+        vec3 delta_1_1[4] = vec3[](red, green, blue, black);
+        vec3 delta_1_2[4] = vec3[](blue, black, red, green);
 
-    } else if(phosphor_layout == 11){
-       // delta_1_4x1_rgb; dunno why this is called 4x1 when it's obviously 4x2 /shrug
-       vec3 delta_1_1[4] = vec3[](red, green, blue, black);
-       vec3 delta_1_2[4] = vec3[](blue, black, red, green);
+        w = int(floor(mod(coord.y, 2.0)));
+        z = int(floor(mod(coord.x, 4.0)));
 
-       w = int(floor(mod(coord.y, 2.0)));
-       z = int(floor(mod(coord.x, 4.0)));
+        weights = (w == 1) ? delta_1_1[z] : delta_1_2[z];
+        return weights;
+    }
+/*
+    else if (phosphor_layout == 12) {
+        // delta_2_4x1_rgb
+        vec3 delta_2_1[4] = vec3[](red, yellow, cyan, blue);
+        vec3 delta_2_2[4] = vec3[](cyan, blue, red, yellow);
 
-       weights = (w == 1) ? delta_1_1[z] : delta_1_2[z];
-       return weights;
+        z = int(floor(mod(coord.x, 4.0)));
 
-    } else if(phosphor_layout == 12){
-       // delta_2_4x1_rgb
-       vec3 delta_2_1[4] = vec3[](red, yellow, cyan, blue);
-       vec3 delta_2_2[4] = vec3[](cyan, blue, red, yellow);
+        weights = (w == 1) ? delta_2_1[z] : delta_2_2[z];
+        return weights;
+	}
+*/
+/*
+    else if (phosphor_layout == 13) {
+        // delta_2_4x2_rgb
+        vec3 delta_1[4] = vec3[](red, yellow, cyan, blue);
+        vec3 delta_2[4] = vec3[](red, yellow, cyan, blue);
+        vec3 delta_3[4] = vec3[](cyan, blue, red, yellow);
+        vec3 delta_4[4] = vec3[](cyan, blue, red, yellow);
 
-       z = int(floor(mod(coord.x, 4.0)));
+        w = int(floor(mod(coord.y, 4.0)));
+        z = int(floor(mod(coord.x, 4.0)));
 
-       weights = (w == 1) ? delta_2_1[z] : delta_2_2[z];
-       return weights;
+        weights = (w == 1) ? delta_1[z] : (w == 2) ? delta_2[z] : (w == 3) ? delta_3[z] : delta_4[z];
+        return weights;
+    }
+*/
+    else if (phosphor_layout == 14) {
+        // slot mask for RGB panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
+        // {magenta, green, black, black,   black, black},
+        // {magenta, green, black, magenta, green, black},
+        // {black,   black, black, magenta, green, black}
+        vec3 slot2_1[6] = vec3[](magenta, green, black, black,   black, black);
+        vec3 slot2_2[6] = vec3[](magenta, green, black, magenta, green, black);
+        vec3 slot2_3[6] = vec3[](black,   black, black, magenta, green, black);
 
-    } else if(phosphor_layout == 13){
-       // delta_2_4x2_rgb
-       vec3 delta_1[4] = vec3[](red, yellow, cyan, blue);
-       vec3 delta_2[4] = vec3[](red, yellow, cyan, blue);
-       vec3 delta_3[4] = vec3[](cyan, blue, red, yellow);
-       vec3 delta_4[4] = vec3[](cyan, blue, red, yellow);
+        w = int(floor(mod(coord.y, 3.0)));
+        z = int(floor(mod(coord.x, 6.0)));
 
-       w = int(floor(mod(coord.y, 4.0)));
-       z = int(floor(mod(coord.x, 4.0)));
+        weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
+        return weights;
+    }
+/*
+    else if(phosphor_layout == 15) {
+        // slot_2_4x4_rgb
+        // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
+        // {red,   yellow, cyan,  blue,  black, black,  black, black},
+        // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
+        // {black, black,  black, black, red,   yellow, cyan,  blue }
+        vec3 slotmask_RBG_x1[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
+        vec3 slotmask_RBG_x2[8] = vec3[](red,   yellow, cyan,  blue,  black, black,  black, black);
+        vec3 slotmask_RBG_x3[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
+        vec3 slotmask_RBG_x4[8] = vec3[](black, black,  black, black, red,   yellow, cyan,  blue );
 
-       weights = (w == 1) ? delta_1[z] : (w == 2) ? delta_2[z] : (w == 3) ? delta_3[z] : delta_4[z];
-       return weights;
+        // find the vertical index
+        w = int(floor(mod(coord.y, 4.0)));
 
-    } else if(phosphor_layout == 14){
-       // slot mask for RGB panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
-       // {magenta, green, black, black,   black, black},
-       // {magenta, green, black, magenta, green, black},
-       // {black,   black, black, magenta, green, black}
-       vec3 slot2_1[6] = vec3[](magenta, green, black, black,   black, black);
-       vec3 slot2_2[6] = vec3[](magenta, green, black, magenta, green, black);
-       vec3 slot2_3[6] = vec3[](black,   black, black, magenta, green, black);
+        // find the horizontal index
+        z = int(floor(mod(coord.x, 8.0)));
 
-       w = int(floor(mod(coord.y, 3.0)));
-       z = int(floor(mod(coord.x, 6.0)));
+        weights = (w == 1) ? slotmask_RBG_x1[z] : (w == 2) ? slotmask_RBG_x2[z] : (w == 3) ? slotmask_RBG_x3[z] : slotmask_RBG_x4[z];
+        return weights;
+	}
+*/
+/*
+	else if(phosphor_layout == 16) {
+        // slot mask for RBG panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
+        // {yellow, blue,  black,  black},
+        // {yellow, blue,  yellow, blue},
+        // {black,  black, yellow, blue}
+        vec3 slot2_1[4] = vec3[](yellow, blue,  black,  black);
+        vec3 slot2_2[4] = vec3[](yellow, blue,  yellow, blue);
+        vec3 slot2_3[4] = vec3[](black,  black, yellow, blue);
 
-       weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
-       return weights;
+        w = int(floor(mod(coord.y, 3.0)));
+        z = int(floor(mod(coord.x, 4.0)));
 
-    } else if(phosphor_layout == 15){
-       // slot_2_4x4_rgb
-       // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
-       // {red,   yellow, cyan,  blue,  black, black,  black, black},
-       // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
-       // {black, black,  black, black, red,   yellow, cyan,  blue }
-       vec3 slotmask_RBG_x1[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
-       vec3 slotmask_RBG_x2[8] = vec3[](red,   yellow, cyan,  blue,  black, black,  black, black);
-       vec3 slotmask_RBG_x3[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
-       vec3 slotmask_RBG_x4[8] = vec3[](black, black,  black, black, red,   yellow, cyan,  blue );
+        weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
+        return weights;
+    }
+*/
+	else if (phosphor_layout == 17) {
+        // slot_2_5x4_bgr
+        // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
+        // {black, blue,    blue,  green, green, red,   red,     black, black, black},
+        // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
+        // {red,   red,     black, black, black, black, blue,    blue,  green, green}
+        vec3 slot_1[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
+        vec3 slot_2[10] = vec3[](black, blue,    blue,  green, green, red,   red,     black, black, black);
+        vec3 slot_3[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
+        vec3 slot_4[10] = vec3[](red,   red,     black, black, black, black, blue,    blue,  green, green);
 
-       // find the vertical index
-       w = int(floor(mod(coord.y, 4.0)));
+        w = int(floor(mod(coord.y, 4.0)));
+        z = int(floor(mod(coord.x, 10.0)));
 
-       // find the horizontal index
-       z = int(floor(mod(coord.x, 8.0)));
+        weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
+        return weights;
+    }
+/*
+    else if (phosphor_layout == 18) {
+        // same as above but for RBG panels
+        // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
+        // {black, green,  green, blue,  blue,  red,   red,    black, black, black},
+        // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
+        // {red,   red,    black, black, black, black, green,  green, blue,  blue }
+        vec3 slot_1[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
+        vec3 slot_2[10] = vec3[](black, green,  green, blue,  blue,  red,   red,    black, black, black);
+        vec3 slot_3[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
+        vec3 slot_4[10] = vec3[](red,   red,    black, black, black, black, green,  green, blue,  blue );
 
-       weights = (w == 1) ? slotmask_RBG_x1[z] : (w == 2) ? slotmask_RBG_x2[z] : (w == 3) ? slotmask_RBG_x3[z] : slotmask_RBG_x4[z];
-       return weights;
+        w = int(floor(mod(coord.y, 4.0)));
+        z = int(floor(mod(coord.x, 10.0)));
 
-     } else if(phosphor_layout == 16){
-       // slot mask for RBG panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
-       // {yellow, blue,  black,  black},
-       // {yellow, blue,  yellow, blue},
-       // {black,  black, yellow, blue}
-       vec3 slot2_1[4] = vec3[](yellow, blue,  black,  black);
-       vec3 slot2_2[4] = vec3[](yellow, blue,  yellow, blue);
-       vec3 slot2_3[4] = vec3[](black,  black, yellow, blue);
+        weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
+        return weights;
+    }
+*/
+/*
+    else if(phosphor_layout == 19) {
+        // slot_3_7x6_rgb
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue}
 
-       w = int(floor(mod(coord.y, 3.0)));
-       z = int(floor(mod(coord.x, 4.0)));
+        vec3 slot_1[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_2[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_3[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black);
+        vec3 slot_4[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_5[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_6[14] = vec3[](black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue);
 
-       weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
-       return weights;
+        w = int(floor(mod(coord.y, 6.0)));
+        z = int(floor(mod(coord.x, 14.0)));
 
-    } else if (phosphor_layout == 17) {
-       // slot_2_5x4_bgr
-       // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
-       // {black, blue,    blue,  green, green, red,   red,     black, black, black},
-       // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
-       // {red,   red,     black, black, black, black, blue,    blue,  green, green}
-       vec3 slot_1[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
-       vec3 slot_2[10] = vec3[](black, blue,    blue,  green, green, red,   red,     black, black, black);
-       vec3 slot_3[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
-       vec3 slot_4[10] = vec3[](red,   red,     black, black, black, black, blue,    blue,  green, green);
-
-       w = int(floor(mod(coord.y, 4.0)));
-       z = int(floor(mod(coord.x, 10.0)));
-
-       weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
-       return weights;
-
-    } else if (phosphor_layout == 18) {
-       // same as above but for RBG panels
-       // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
-       // {black, green,  green, blue,  blue,  red,   red,    black, black, black},
-       // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
-       // {red,   red,    black, black, black, black, green,  green, blue,  blue }
-       vec3 slot_1[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
-       vec3 slot_2[10] = vec3[](black, green,  green, blue,  blue,  red,   red,    black, black, black);
-       vec3 slot_3[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
-       vec3 slot_4[10] = vec3[](red,   red,    black, black, black, black, green,  green, blue,  blue );
-
-       w = int(floor(mod(coord.y, 4.0)));
-       z = int(floor(mod(coord.x, 10.0)));
-
-       weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
-       return weights;
-
-    } else if(phosphor_layout == 19) {
-       // slot_3_7x6_rgb
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue}
-
-       vec3 slot_1[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_2[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_3[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black);
-       vec3 slot_4[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_5[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_6[14] = vec3[](black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue);
-
-       w = int(floor(mod(coord.y, 6.0)));
-       z = int(floor(mod(coord.x, 14.0)));
-
-       weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : (w == 4) ? slot_4[z] : (w == 5) ? slot_5[z] : slot_6[z];
-       return weights;
-
-    } else {
+        weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : (w == 4) ? slot_4[z] : (w == 5) ? slot_5[z] : slot_6[z];
+        return weights;
+     }
+*/
+	else {
         return weights;
     }
 }

--- a/contrib/resources/glshaders/crt/arcade-sharp-4k.glsl
+++ b/contrib/resources/glshaders/crt/arcade-sharp-4k.glsl
@@ -168,10 +168,10 @@ uniform PRECISION float BLUE_SHIFT;
 
 #define WP_ADJUST           0.00
 #define TEMPERATURE      9300.00
-#define LUMA_PRESERVE 		1.00
-#define RED_SHIFT 			0.00
-#define GREEN_SHIFT 		0.00
-#define BLUE_SHIFT 			0.00
+#define LUMA_PRESERVE       1.00
+#define RED_SHIFT           0.00
+#define GREEN_SHIFT         0.00
+#define BLUE_SHIFT          0.00
 #endif
 // END PARAMETERS //
 
@@ -274,10 +274,10 @@ vec3 YxytoXYZ(vec3 Yxy) {
     Many of these mask arrays are adapted from cgwg's crt-geom-deluxe LUTs, and
     those have their filenames included for easy identification
 
-	NOTE: Having too many branches result in a black screen (but no
-	compilation errors) on some older GPUs such as the Intel HD 4000 iGPU. So
-	we're commenting out the branches that are not used by the adaptive CRT
-	shaders.
+    NOTE: Having too many branches result in a black screen (but no
+    compilation errors) on some older GPUs such as the Intel HD 4000 iGPU. So
+    we're commenting out the branches that are not used by the adaptive CRT
+    shaders.
 */
 vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
     vec3 weights = vec3(1.,1.,1.);
@@ -301,14 +301,14 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
     if (phosphor_layout == 0) {
         return weights;
-	}
+    }
 
     else if (phosphor_layout == 1) {
-    	// classic aperture for RGB panels; good for 1080p, too small for 4K+
+        // classic aperture for RGB panels; good for 1080p, too small for 4K+
         // aka aperture_1_2_bgr
         weights  = aperture_weights;
         return weights;
-	}
+    }
 
     else if (phosphor_layout == 2) {
         // 2x2 shadow mask for RGB panels; good for 1080p, too small for 4K+
@@ -316,7 +316,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
         vec3 inverse_aperture = mix(green, magenta, floor(mod(coord.x, 2.0)));
         weights               = mix(aperture_weights, inverse_aperture, floor(mod(coord.y, 2.0)));
         return weights;
-	}
+    }
 
 /*
     else if (phosphor_layout == 3) {
@@ -339,14 +339,14 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         // do a big, dumb comparison in place of a 2D array
         weights = (w == 1) ? slotmask_x1[z] : (w == 2) ? slotmask_x2[z] :  slotmask_x3[z];
-		return weights;
+        return weights;
     }
 */
     else if (phosphor_layout == 4) {
         // classic aperture for RBG panels; good for 1080p, too small for 4K+
         weights  = mix(yellow, blue, floor(mod(coord.x, 2.0)));
         return weights;
-	}
+    }
 /*
     else if (phosphor_layout == 5) {
         // 2x2 shadow mask for RBG panels; good for 1080p, too small for 4K+
@@ -358,7 +358,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
             floor(mod(coord.y, 2.0))
         );
         return weights;
-	}
+    }
 */
 /*
     else if (phosphor_layout == 6) {
@@ -369,7 +369,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = ap4[z];
         return weights;
-	}
+    }
 */
 /*
     else if (phosphor_layout == 7) {
@@ -390,7 +390,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap[w];
         return weights;
-	}
+    }
 */
     else if (phosphor_layout == 9) {
         // reduced TVL aperture for RGB panels
@@ -401,7 +401,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rgb[w];
         return weights;
-	}
+    }
 /*
     else if (phosphor_layout == 10) {
         // reduced TVL aperture for RBG panels
@@ -411,7 +411,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rbg[w];
         return weights;
-	}
+    }
 */
     else if(phosphor_layout == 11) {
         // delta_1_4x1_rgb; dunno why this is called 4x1 when it's obviously 4x2 /shrug
@@ -434,7 +434,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = (w == 1) ? delta_2_1[z] : delta_2_2[z];
         return weights;
-	}
+    }
 */
 /*
     else if (phosphor_layout == 13) {
@@ -486,10 +486,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = (w == 1) ? slotmask_RBG_x1[z] : (w == 2) ? slotmask_RBG_x2[z] : (w == 3) ? slotmask_RBG_x3[z] : slotmask_RBG_x4[z];
         return weights;
-	}
+    }
 */
 /*
-	else if(phosphor_layout == 16) {
+    else if(phosphor_layout == 16) {
         // slot mask for RBG panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
         // {yellow, blue,  black,  black},
         // {yellow, blue,  yellow, blue},
@@ -505,7 +505,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
         return weights;
     }
 */
-	else if (phosphor_layout == 17) {
+    else if (phosphor_layout == 17) {
         // slot_2_5x4_bgr
         // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
         // {black, blue,    blue,  green, green, red,   red,     black, black, black},
@@ -565,7 +565,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
         return weights;
      }
 */
-	else {
+    else {
         return weights;
     }
 }
@@ -585,10 +585,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 // For more info, see: http://www.imagemagick.org/Usage/img_diagrams/cubic_survey.gif
 mat4x4 get_hfilter_profile()
 {
-	float bf = 0.0;
-	float cf = 0.0;
+    float bf = 0.0;
+    float cf = 0.0;
 
-	if (HFILTER_PROFILE == 1) {
+    if (HFILTER_PROFILE == 1) {
         bf = 0.0;
         cf = 0.5;
     }
@@ -690,14 +690,14 @@ void main()
     mask_coords = mix(mask_coords.xy, mask_coords.yx, VSCANLINES);
     color.rgb *= mask_weights(mask_coords, MASK_INTENSITY, int(PHOSPHOR_LAYOUT));
 
-	// Colour temperature
-	if (WP_ADJUST == 1.0) {
-		vec3 wp_adjusted = wp_adjust(color.rgb);
-		vec3 base_luma = XYZtoYxy(sRGB_to_XYZ(color.rgb));
-		vec3 adjusted_luma = XYZtoYxy(sRGB_to_XYZ(wp_adjusted));
-		wp_adjusted = (LUMA_PRESERVE == 1.0) ? adjusted_luma + (vec3(base_luma.r,0.,0.) - vec3(adjusted_luma.r,0.,0.)) : adjusted_luma;
-		color = vec4(XYZ_to_sRGB(YxytoXYZ(wp_adjusted)), 1.0);
-	}
+    // Colour temperature
+    if (WP_ADJUST == 1.0) {
+        vec3 wp_adjusted = wp_adjust(color.rgb);
+        vec3 base_luma = XYZtoYxy(sRGB_to_XYZ(color.rgb));
+        vec3 adjusted_luma = XYZtoYxy(sRGB_to_XYZ(wp_adjusted));
+        wp_adjusted = (LUMA_PRESERVE == 1.0) ? adjusted_luma + (vec3(base_luma.r,0.,0.) - vec3(adjusted_luma.r,0.,0.)) : adjusted_luma;
+        color = vec4(XYZ_to_sRGB(YxytoXYZ(wp_adjusted)), 1.0);
+    }
 
     // Output gamma
     color = clamp(GAMMA_OUT(color), 0.0, 1.0);

--- a/contrib/resources/glshaders/crt/arcade-sharp-4k.glsl
+++ b/contrib/resources/glshaders/crt/arcade-sharp-4k.glsl
@@ -247,7 +247,6 @@ vec3 YxytoXYZ(vec3 Yxy) {
     return XYZ;
 }
 
-
 /*
     A collection of CRT mask effects that work with LCD subpixel structures for
     small details
@@ -274,11 +273,18 @@ vec3 YxytoXYZ(vec3 Yxy) {
 
     Many of these mask arrays are adapted from cgwg's crt-geom-deluxe LUTs, and
     those have their filenames included for easy identification
+
+	NOTE: Having too many branches result in a black screen (but no
+	compilation errors) on some older GPUs such as the Intel HD 4000 iGPU. So
+	we're commenting out the branches that are not used by the adaptive CRT
+	shaders.
 */
 vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
     vec3 weights = vec3(1.,1.,1.);
+
     float on = 1.;
     float off = 1.-mask_intensity;
+
     vec3 red     = vec3(on,  off, off);
     vec3 green   = vec3(off, on,  off);
     vec3 blue    = vec3(off, off, on );
@@ -287,6 +293,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
     vec3 cyan    = vec3(off, on,  on );
     vec3 black   = vec3(off, off, off);
     vec3 white   = vec3(on,  on,  on );
+
     int w, z = 0;
 
     // This pattern is used by a few layouts, so we'll define it here
@@ -294,21 +301,25 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
     if (phosphor_layout == 0) {
         return weights;
+	}
 
-    } else if (phosphor_layout == 1) {
-        // classic aperture for RGB panels; good for 1080p, too small for 4K+
+    else if (phosphor_layout == 1) {
+    	// classic aperture for RGB panels; good for 1080p, too small for 4K+
         // aka aperture_1_2_bgr
         weights  = aperture_weights;
         return weights;
+	}
 
-    } else if (phosphor_layout == 2) {
+    else if (phosphor_layout == 2) {
         // 2x2 shadow mask for RGB panels; good for 1080p, too small for 4K+
         // aka delta_1_2x1_bgr
         vec3 inverse_aperture = mix(green, magenta, floor(mod(coord.x, 2.0)));
         weights               = mix(aperture_weights, inverse_aperture, floor(mod(coord.y, 2.0)));
         return weights;
+	}
 
-    } else if (phosphor_layout == 3) {
+/*
+    else if (phosphor_layout == 3) {
         // slot mask for RGB panels; looks okay at 1080p, looks better at 4K
         // {magenta, green, black,   black},
         // {magenta, green, magenta, green},
@@ -328,14 +339,16 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         // do a big, dumb comparison in place of a 2D array
         weights = (w == 1) ? slotmask_x1[z] : (w == 2) ? slotmask_x2[z] :  slotmask_x3[z];
+		return weights;
     }
-
-    if (phosphor_layout == 4) {
+*/
+    else if (phosphor_layout == 4) {
         // classic aperture for RBG panels; good for 1080p, too small for 4K+
         weights  = mix(yellow, blue, floor(mod(coord.x, 2.0)));
         return weights;
-
-    } else if (phosphor_layout == 5) {
+	}
+/*
+    else if (phosphor_layout == 5) {
         // 2x2 shadow mask for RBG panels; good for 1080p, too small for 4K+
         vec3 inverse_aperture = mix(blue, yellow, floor(mod(coord.x, 2.0)));
 
@@ -345,8 +358,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
             floor(mod(coord.y, 2.0))
         );
         return weights;
-
-    } else if (phosphor_layout == 6) {
+	}
+*/
+/*
+    else if (phosphor_layout == 6) {
         // aperture_1_4_rgb; good for simulating lower
         vec3 ap4[4] = vec3[](red, green, blue, black);
 
@@ -354,8 +369,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = ap4[z];
         return weights;
-
-    } else if (phosphor_layout == 7) {
+	}
+*/
+/*
+    else if (phosphor_layout == 7) {
         // aperture_2_5_bgr
         vec3 ap3[5] = vec3[](red, magenta, blue, green, green);
 
@@ -363,8 +380,9 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = ap3[z];
         return weights;
-
-    } else if (phosphor_layout == 8){
+*/
+/*
+    else if (phosphor_layout == 8) {
         // aperture_3_6_rgb
         vec3 big_ap[7] = vec3[](red, red, yellow, green, cyan, blue, blue);
 
@@ -372,8 +390,9 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap[w];
         return weights;
-
-    } else if (phosphor_layout == 9) {
+	}
+*/
+    else if (phosphor_layout == 9) {
         // reduced TVL aperture for RGB panels
         // aperture_2_4_rgb
         vec3 big_ap_rgb[4] = vec3[](red, yellow, cyan, blue);
@@ -382,8 +401,9 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rgb[w];
         return weights;
-
-    } else if (phosphor_layout == 10) {
+	}
+/*
+    else if (phosphor_layout == 10) {
         // reduced TVL aperture for RBG panels
         vec3 big_ap_rbg[4] = vec3[](red, magenta, cyan, green);
 
@@ -391,148 +411,161 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rbg[w];
         return weights;
+	}
+*/
+    else if(phosphor_layout == 11) {
+        // delta_1_4x1_rgb; dunno why this is called 4x1 when it's obviously 4x2 /shrug
+        vec3 delta_1_1[4] = vec3[](red, green, blue, black);
+        vec3 delta_1_2[4] = vec3[](blue, black, red, green);
 
-    } else if(phosphor_layout == 11){
-       // delta_1_4x1_rgb; dunno why this is called 4x1 when it's obviously 4x2 /shrug
-       vec3 delta_1_1[4] = vec3[](red, green, blue, black);
-       vec3 delta_1_2[4] = vec3[](blue, black, red, green);
+        w = int(floor(mod(coord.y, 2.0)));
+        z = int(floor(mod(coord.x, 4.0)));
 
-       w = int(floor(mod(coord.y, 2.0)));
-       z = int(floor(mod(coord.x, 4.0)));
+        weights = (w == 1) ? delta_1_1[z] : delta_1_2[z];
+        return weights;
+    }
+/*
+    else if (phosphor_layout == 12) {
+        // delta_2_4x1_rgb
+        vec3 delta_2_1[4] = vec3[](red, yellow, cyan, blue);
+        vec3 delta_2_2[4] = vec3[](cyan, blue, red, yellow);
 
-       weights = (w == 1) ? delta_1_1[z] : delta_1_2[z];
-       return weights;
+        z = int(floor(mod(coord.x, 4.0)));
 
-    } else if(phosphor_layout == 12){
-       // delta_2_4x1_rgb
-       vec3 delta_2_1[4] = vec3[](red, yellow, cyan, blue);
-       vec3 delta_2_2[4] = vec3[](cyan, blue, red, yellow);
+        weights = (w == 1) ? delta_2_1[z] : delta_2_2[z];
+        return weights;
+	}
+*/
+/*
+    else if (phosphor_layout == 13) {
+        // delta_2_4x2_rgb
+        vec3 delta_1[4] = vec3[](red, yellow, cyan, blue);
+        vec3 delta_2[4] = vec3[](red, yellow, cyan, blue);
+        vec3 delta_3[4] = vec3[](cyan, blue, red, yellow);
+        vec3 delta_4[4] = vec3[](cyan, blue, red, yellow);
 
-       z = int(floor(mod(coord.x, 4.0)));
+        w = int(floor(mod(coord.y, 4.0)));
+        z = int(floor(mod(coord.x, 4.0)));
 
-       weights = (w == 1) ? delta_2_1[z] : delta_2_2[z];
-       return weights;
+        weights = (w == 1) ? delta_1[z] : (w == 2) ? delta_2[z] : (w == 3) ? delta_3[z] : delta_4[z];
+        return weights;
+    }
+*/
+    else if (phosphor_layout == 14) {
+        // slot mask for RGB panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
+        // {magenta, green, black, black,   black, black},
+        // {magenta, green, black, magenta, green, black},
+        // {black,   black, black, magenta, green, black}
+        vec3 slot2_1[6] = vec3[](magenta, green, black, black,   black, black);
+        vec3 slot2_2[6] = vec3[](magenta, green, black, magenta, green, black);
+        vec3 slot2_3[6] = vec3[](black,   black, black, magenta, green, black);
 
-    } else if(phosphor_layout == 13){
-       // delta_2_4x2_rgb
-       vec3 delta_1[4] = vec3[](red, yellow, cyan, blue);
-       vec3 delta_2[4] = vec3[](red, yellow, cyan, blue);
-       vec3 delta_3[4] = vec3[](cyan, blue, red, yellow);
-       vec3 delta_4[4] = vec3[](cyan, blue, red, yellow);
+        w = int(floor(mod(coord.y, 3.0)));
+        z = int(floor(mod(coord.x, 6.0)));
 
-       w = int(floor(mod(coord.y, 4.0)));
-       z = int(floor(mod(coord.x, 4.0)));
+        weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
+        return weights;
+    }
+/*
+    else if(phosphor_layout == 15) {
+        // slot_2_4x4_rgb
+        // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
+        // {red,   yellow, cyan,  blue,  black, black,  black, black},
+        // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
+        // {black, black,  black, black, red,   yellow, cyan,  blue }
+        vec3 slotmask_RBG_x1[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
+        vec3 slotmask_RBG_x2[8] = vec3[](red,   yellow, cyan,  blue,  black, black,  black, black);
+        vec3 slotmask_RBG_x3[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
+        vec3 slotmask_RBG_x4[8] = vec3[](black, black,  black, black, red,   yellow, cyan,  blue );
 
-       weights = (w == 1) ? delta_1[z] : (w == 2) ? delta_2[z] : (w == 3) ? delta_3[z] : delta_4[z];
-       return weights;
+        // find the vertical index
+        w = int(floor(mod(coord.y, 4.0)));
 
-    } else if(phosphor_layout == 14){
-       // slot mask for RGB panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
-       // {magenta, green, black, black,   black, black},
-       // {magenta, green, black, magenta, green, black},
-       // {black,   black, black, magenta, green, black}
-       vec3 slot2_1[6] = vec3[](magenta, green, black, black,   black, black);
-       vec3 slot2_2[6] = vec3[](magenta, green, black, magenta, green, black);
-       vec3 slot2_3[6] = vec3[](black,   black, black, magenta, green, black);
+        // find the horizontal index
+        z = int(floor(mod(coord.x, 8.0)));
 
-       w = int(floor(mod(coord.y, 3.0)));
-       z = int(floor(mod(coord.x, 6.0)));
+        weights = (w == 1) ? slotmask_RBG_x1[z] : (w == 2) ? slotmask_RBG_x2[z] : (w == 3) ? slotmask_RBG_x3[z] : slotmask_RBG_x4[z];
+        return weights;
+	}
+*/
+/*
+	else if(phosphor_layout == 16) {
+        // slot mask for RBG panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
+        // {yellow, blue,  black,  black},
+        // {yellow, blue,  yellow, blue},
+        // {black,  black, yellow, blue}
+        vec3 slot2_1[4] = vec3[](yellow, blue,  black,  black);
+        vec3 slot2_2[4] = vec3[](yellow, blue,  yellow, blue);
+        vec3 slot2_3[4] = vec3[](black,  black, yellow, blue);
 
-       weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
-       return weights;
+        w = int(floor(mod(coord.y, 3.0)));
+        z = int(floor(mod(coord.x, 4.0)));
 
-    } else if(phosphor_layout == 15){
-       // slot_2_4x4_rgb
-       // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
-       // {red,   yellow, cyan,  blue,  black, black,  black, black},
-       // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
-       // {black, black,  black, black, red,   yellow, cyan,  blue }
-       vec3 slotmask_RBG_x1[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
-       vec3 slotmask_RBG_x2[8] = vec3[](red,   yellow, cyan,  blue,  black, black,  black, black);
-       vec3 slotmask_RBG_x3[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
-       vec3 slotmask_RBG_x4[8] = vec3[](black, black,  black, black, red,   yellow, cyan,  blue );
+        weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
+        return weights;
+    }
+*/
+	else if (phosphor_layout == 17) {
+        // slot_2_5x4_bgr
+        // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
+        // {black, blue,    blue,  green, green, red,   red,     black, black, black},
+        // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
+        // {red,   red,     black, black, black, black, blue,    blue,  green, green}
+        vec3 slot_1[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
+        vec3 slot_2[10] = vec3[](black, blue,    blue,  green, green, red,   red,     black, black, black);
+        vec3 slot_3[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
+        vec3 slot_4[10] = vec3[](red,   red,     black, black, black, black, blue,    blue,  green, green);
 
-       // find the vertical index
-       w = int(floor(mod(coord.y, 4.0)));
+        w = int(floor(mod(coord.y, 4.0)));
+        z = int(floor(mod(coord.x, 10.0)));
 
-       // find the horizontal index
-       z = int(floor(mod(coord.x, 8.0)));
+        weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
+        return weights;
+    }
+/*
+    else if (phosphor_layout == 18) {
+        // same as above but for RBG panels
+        // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
+        // {black, green,  green, blue,  blue,  red,   red,    black, black, black},
+        // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
+        // {red,   red,    black, black, black, black, green,  green, blue,  blue }
+        vec3 slot_1[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
+        vec3 slot_2[10] = vec3[](black, green,  green, blue,  blue,  red,   red,    black, black, black);
+        vec3 slot_3[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
+        vec3 slot_4[10] = vec3[](red,   red,    black, black, black, black, green,  green, blue,  blue );
 
-       weights = (w == 1) ? slotmask_RBG_x1[z] : (w == 2) ? slotmask_RBG_x2[z] : (w == 3) ? slotmask_RBG_x3[z] : slotmask_RBG_x4[z];
-       return weights;
+        w = int(floor(mod(coord.y, 4.0)));
+        z = int(floor(mod(coord.x, 10.0)));
 
-     } else if(phosphor_layout == 16){
-       // slot mask for RBG panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
-       // {yellow, blue,  black,  black},
-       // {yellow, blue,  yellow, blue},
-       // {black,  black, yellow, blue}
-       vec3 slot2_1[4] = vec3[](yellow, blue,  black,  black);
-       vec3 slot2_2[4] = vec3[](yellow, blue,  yellow, blue);
-       vec3 slot2_3[4] = vec3[](black,  black, yellow, blue);
+        weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
+        return weights;
+    }
+*/
+/*
+    else if(phosphor_layout == 19) {
+        // slot_3_7x6_rgb
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue}
 
-       w = int(floor(mod(coord.y, 3.0)));
-       z = int(floor(mod(coord.x, 4.0)));
+        vec3 slot_1[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_2[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_3[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black);
+        vec3 slot_4[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_5[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_6[14] = vec3[](black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue);
 
-       weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
-       return weights;
+        w = int(floor(mod(coord.y, 6.0)));
+        z = int(floor(mod(coord.x, 14.0)));
 
-    } else if (phosphor_layout == 17) {
-       // slot_2_5x4_bgr
-       // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
-       // {black, blue,    blue,  green, green, red,   red,     black, black, black},
-       // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
-       // {red,   red,     black, black, black, black, blue,    blue,  green, green}
-       vec3 slot_1[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
-       vec3 slot_2[10] = vec3[](black, blue,    blue,  green, green, red,   red,     black, black, black);
-       vec3 slot_3[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
-       vec3 slot_4[10] = vec3[](red,   red,     black, black, black, black, blue,    blue,  green, green);
-
-       w = int(floor(mod(coord.y, 4.0)));
-       z = int(floor(mod(coord.x, 10.0)));
-
-       weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
-       return weights;
-
-    } else if (phosphor_layout == 18) {
-       // same as above but for RBG panels
-       // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
-       // {black, green,  green, blue,  blue,  red,   red,    black, black, black},
-       // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
-       // {red,   red,    black, black, black, black, green,  green, blue,  blue }
-       vec3 slot_1[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
-       vec3 slot_2[10] = vec3[](black, green,  green, blue,  blue,  red,   red,    black, black, black);
-       vec3 slot_3[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
-       vec3 slot_4[10] = vec3[](red,   red,    black, black, black, black, green,  green, blue,  blue );
-
-       w = int(floor(mod(coord.y, 4.0)));
-       z = int(floor(mod(coord.x, 10.0)));
-
-       weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
-       return weights;
-
-    } else if(phosphor_layout == 19) {
-       // slot_3_7x6_rgb
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue}
-
-       vec3 slot_1[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_2[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_3[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black);
-       vec3 slot_4[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_5[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_6[14] = vec3[](black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue);
-
-       w = int(floor(mod(coord.y, 6.0)));
-       z = int(floor(mod(coord.x, 14.0)));
-
-       weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : (w == 4) ? slot_4[z] : (w == 5) ? slot_5[z] : slot_6[z];
-       return weights;
-
-    } else {
+        weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : (w == 4) ? slot_4[z] : (w == 5) ? slot_5[z] : slot_6[z];
+        return weights;
+     }
+*/
+	else {
         return weights;
     }
 }

--- a/contrib/resources/glshaders/crt/cga-1080p.glsl
+++ b/contrib/resources/glshaders/crt/cga-1080p.glsl
@@ -169,10 +169,10 @@ uniform PRECISION float BLUE_SHIFT;
 
 #define WP_ADJUST           0.00
 #define TEMPERATURE      9300.00
-#define LUMA_PRESERVE 		1.00
-#define RED_SHIFT 			0.00
-#define GREEN_SHIFT 		0.00
-#define BLUE_SHIFT 			0.00
+#define LUMA_PRESERVE       1.00
+#define RED_SHIFT           0.00
+#define GREEN_SHIFT         0.00
+#define BLUE_SHIFT          0.00
 #endif
 // END PARAMETERS //
 
@@ -275,10 +275,10 @@ vec3 YxytoXYZ(vec3 Yxy) {
     Many of these mask arrays are adapted from cgwg's crt-geom-deluxe LUTs, and
     those have their filenames included for easy identification
 
-	NOTE: Having too many branches result in a black screen (but no
-	compilation errors) on some older GPUs such as the Intel HD 4000 iGPU. So
-	we're commenting out the branches that are not used by the adaptive CRT
-	shaders.
+    NOTE: Having too many branches result in a black screen (but no
+    compilation errors) on some older GPUs such as the Intel HD 4000 iGPU. So
+    we're commenting out the branches that are not used by the adaptive CRT
+    shaders.
 */
 vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
     vec3 weights = vec3(1.,1.,1.);
@@ -302,14 +302,14 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
     if (phosphor_layout == 0) {
         return weights;
-	}
+    }
 
     else if (phosphor_layout == 1) {
-    	// classic aperture for RGB panels; good for 1080p, too small for 4K+
+        // classic aperture for RGB panels; good for 1080p, too small for 4K+
         // aka aperture_1_2_bgr
         weights  = aperture_weights;
         return weights;
-	}
+    }
 
     else if (phosphor_layout == 2) {
         // 2x2 shadow mask for RGB panels; good for 1080p, too small for 4K+
@@ -317,7 +317,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
         vec3 inverse_aperture = mix(green, magenta, floor(mod(coord.x, 2.0)));
         weights               = mix(aperture_weights, inverse_aperture, floor(mod(coord.y, 2.0)));
         return weights;
-	}
+    }
 
 /*
     else if (phosphor_layout == 3) {
@@ -340,14 +340,14 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         // do a big, dumb comparison in place of a 2D array
         weights = (w == 1) ? slotmask_x1[z] : (w == 2) ? slotmask_x2[z] :  slotmask_x3[z];
-		return weights;
+        return weights;
     }
 */
     else if (phosphor_layout == 4) {
         // classic aperture for RBG panels; good for 1080p, too small for 4K+
         weights  = mix(yellow, blue, floor(mod(coord.x, 2.0)));
         return weights;
-	}
+    }
 /*
     else if (phosphor_layout == 5) {
         // 2x2 shadow mask for RBG panels; good for 1080p, too small for 4K+
@@ -359,7 +359,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
             floor(mod(coord.y, 2.0))
         );
         return weights;
-	}
+    }
 */
 /*
     else if (phosphor_layout == 6) {
@@ -370,7 +370,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = ap4[z];
         return weights;
-	}
+    }
 */
 /*
     else if (phosphor_layout == 7) {
@@ -391,7 +391,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap[w];
         return weights;
-	}
+    }
 */
     else if (phosphor_layout == 9) {
         // reduced TVL aperture for RGB panels
@@ -402,7 +402,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rgb[w];
         return weights;
-	}
+    }
 /*
     else if (phosphor_layout == 10) {
         // reduced TVL aperture for RBG panels
@@ -412,7 +412,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rbg[w];
         return weights;
-	}
+    }
 */
     else if(phosphor_layout == 11) {
         // delta_1_4x1_rgb; dunno why this is called 4x1 when it's obviously 4x2 /shrug
@@ -435,7 +435,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = (w == 1) ? delta_2_1[z] : delta_2_2[z];
         return weights;
-	}
+    }
 */
 /*
     else if (phosphor_layout == 13) {
@@ -487,10 +487,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = (w == 1) ? slotmask_RBG_x1[z] : (w == 2) ? slotmask_RBG_x2[z] : (w == 3) ? slotmask_RBG_x3[z] : slotmask_RBG_x4[z];
         return weights;
-	}
+    }
 */
 /*
-	else if(phosphor_layout == 16) {
+    else if(phosphor_layout == 16) {
         // slot mask for RBG panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
         // {yellow, blue,  black,  black},
         // {yellow, blue,  yellow, blue},
@@ -506,7 +506,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
         return weights;
     }
 */
-	else if (phosphor_layout == 17) {
+    else if (phosphor_layout == 17) {
         // slot_2_5x4_bgr
         // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
         // {black, blue,    blue,  green, green, red,   red,     black, black, black},
@@ -566,7 +566,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
         return weights;
      }
 */
-	else {
+    else {
         return weights;
     }
 }
@@ -587,10 +587,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 // For more info, see: http://www.imagemagick.org/Usage/img_diagrams/cubic_survey.gif
 mat4x4 get_hfilter_profile()
 {
-	float bf = 0.0;
-	float cf = 0.0;
+    float bf = 0.0;
+    float cf = 0.0;
 
-	if (HFILTER_PROFILE == 1) {
+    if (HFILTER_PROFILE == 1) {
         bf = 0.0;
         cf = 0.5;
     }
@@ -692,14 +692,14 @@ void main()
     mask_coords = mix(mask_coords.xy, mask_coords.yx, VSCANLINES);
     color.rgb *= mask_weights(mask_coords, MASK_INTENSITY, int(PHOSPHOR_LAYOUT));
 
-	// Colour temperature
-	if (WP_ADJUST == 1.0) {
-		vec3 wp_adjusted = wp_adjust(color.rgb);
-		vec3 base_luma = XYZtoYxy(sRGB_to_XYZ(color.rgb));
-		vec3 adjusted_luma = XYZtoYxy(sRGB_to_XYZ(wp_adjusted));
-		wp_adjusted = (LUMA_PRESERVE == 1.0) ? adjusted_luma + (vec3(base_luma.r,0.,0.) - vec3(adjusted_luma.r,0.,0.)) : adjusted_luma;
-		color = vec4(XYZ_to_sRGB(YxytoXYZ(wp_adjusted)), 1.0);
-	}
+    // Colour temperature
+    if (WP_ADJUST == 1.0) {
+        vec3 wp_adjusted = wp_adjust(color.rgb);
+        vec3 base_luma = XYZtoYxy(sRGB_to_XYZ(color.rgb));
+        vec3 adjusted_luma = XYZtoYxy(sRGB_to_XYZ(wp_adjusted));
+        wp_adjusted = (LUMA_PRESERVE == 1.0) ? adjusted_luma + (vec3(base_luma.r,0.,0.) - vec3(adjusted_luma.r,0.,0.)) : adjusted_luma;
+        color = vec4(XYZ_to_sRGB(YxytoXYZ(wp_adjusted)), 1.0);
+    }
 
     // Output gamma
     color = clamp(GAMMA_OUT(color), 0.0, 1.0);

--- a/contrib/resources/glshaders/crt/cga-1080p.glsl
+++ b/contrib/resources/glshaders/crt/cga-1080p.glsl
@@ -248,7 +248,6 @@ vec3 YxytoXYZ(vec3 Yxy) {
     return XYZ;
 }
 
-
 /*
     A collection of CRT mask effects that work with LCD subpixel structures for
     small details
@@ -275,11 +274,18 @@ vec3 YxytoXYZ(vec3 Yxy) {
 
     Many of these mask arrays are adapted from cgwg's crt-geom-deluxe LUTs, and
     those have their filenames included for easy identification
+
+	NOTE: Having too many branches result in a black screen (but no
+	compilation errors) on some older GPUs such as the Intel HD 4000 iGPU. So
+	we're commenting out the branches that are not used by the adaptive CRT
+	shaders.
 */
 vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
     vec3 weights = vec3(1.,1.,1.);
+
     float on = 1.;
     float off = 1.-mask_intensity;
+
     vec3 red     = vec3(on,  off, off);
     vec3 green   = vec3(off, on,  off);
     vec3 blue    = vec3(off, off, on );
@@ -288,6 +294,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
     vec3 cyan    = vec3(off, on,  on );
     vec3 black   = vec3(off, off, off);
     vec3 white   = vec3(on,  on,  on );
+
     int w, z = 0;
 
     // This pattern is used by a few layouts, so we'll define it here
@@ -295,21 +302,25 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
     if (phosphor_layout == 0) {
         return weights;
+	}
 
-    } else if (phosphor_layout == 1) {
-        // classic aperture for RGB panels; good for 1080p, too small for 4K+
+    else if (phosphor_layout == 1) {
+    	// classic aperture for RGB panels; good for 1080p, too small for 4K+
         // aka aperture_1_2_bgr
         weights  = aperture_weights;
         return weights;
+	}
 
-    } else if (phosphor_layout == 2) {
+    else if (phosphor_layout == 2) {
         // 2x2 shadow mask for RGB panels; good for 1080p, too small for 4K+
         // aka delta_1_2x1_bgr
         vec3 inverse_aperture = mix(green, magenta, floor(mod(coord.x, 2.0)));
         weights               = mix(aperture_weights, inverse_aperture, floor(mod(coord.y, 2.0)));
         return weights;
+	}
 
-    } else if (phosphor_layout == 3) {
+/*
+    else if (phosphor_layout == 3) {
         // slot mask for RGB panels; looks okay at 1080p, looks better at 4K
         // {magenta, green, black,   black},
         // {magenta, green, magenta, green},
@@ -329,14 +340,16 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         // do a big, dumb comparison in place of a 2D array
         weights = (w == 1) ? slotmask_x1[z] : (w == 2) ? slotmask_x2[z] :  slotmask_x3[z];
+		return weights;
     }
-
-    if (phosphor_layout == 4) {
+*/
+    else if (phosphor_layout == 4) {
         // classic aperture for RBG panels; good for 1080p, too small for 4K+
         weights  = mix(yellow, blue, floor(mod(coord.x, 2.0)));
         return weights;
-
-    } else if (phosphor_layout == 5) {
+	}
+/*
+    else if (phosphor_layout == 5) {
         // 2x2 shadow mask for RBG panels; good for 1080p, too small for 4K+
         vec3 inverse_aperture = mix(blue, yellow, floor(mod(coord.x, 2.0)));
 
@@ -346,8 +359,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
             floor(mod(coord.y, 2.0))
         );
         return weights;
-
-    } else if (phosphor_layout == 6) {
+	}
+*/
+/*
+    else if (phosphor_layout == 6) {
         // aperture_1_4_rgb; good for simulating lower
         vec3 ap4[4] = vec3[](red, green, blue, black);
 
@@ -355,8 +370,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = ap4[z];
         return weights;
-
-    } else if (phosphor_layout == 7) {
+	}
+*/
+/*
+    else if (phosphor_layout == 7) {
         // aperture_2_5_bgr
         vec3 ap3[5] = vec3[](red, magenta, blue, green, green);
 
@@ -364,8 +381,9 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = ap3[z];
         return weights;
-
-    } else if (phosphor_layout == 8){
+*/
+/*
+    else if (phosphor_layout == 8) {
         // aperture_3_6_rgb
         vec3 big_ap[7] = vec3[](red, red, yellow, green, cyan, blue, blue);
 
@@ -373,8 +391,9 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap[w];
         return weights;
-
-    } else if (phosphor_layout == 9) {
+	}
+*/
+    else if (phosphor_layout == 9) {
         // reduced TVL aperture for RGB panels
         // aperture_2_4_rgb
         vec3 big_ap_rgb[4] = vec3[](red, yellow, cyan, blue);
@@ -383,8 +402,9 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rgb[w];
         return weights;
-
-    } else if (phosphor_layout == 10) {
+	}
+/*
+    else if (phosphor_layout == 10) {
         // reduced TVL aperture for RBG panels
         vec3 big_ap_rbg[4] = vec3[](red, magenta, cyan, green);
 
@@ -392,151 +412,165 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rbg[w];
         return weights;
+	}
+*/
+    else if(phosphor_layout == 11) {
+        // delta_1_4x1_rgb; dunno why this is called 4x1 when it's obviously 4x2 /shrug
+        vec3 delta_1_1[4] = vec3[](red, green, blue, black);
+        vec3 delta_1_2[4] = vec3[](blue, black, red, green);
 
-    } else if(phosphor_layout == 11){
-       // delta_1_4x1_rgb; dunno why this is called 4x1 when it's obviously 4x2 /shrug
-       vec3 delta_1_1[4] = vec3[](red, green, blue, black);
-       vec3 delta_1_2[4] = vec3[](blue, black, red, green);
+        w = int(floor(mod(coord.y, 2.0)));
+        z = int(floor(mod(coord.x, 4.0)));
 
-       w = int(floor(mod(coord.y, 2.0)));
-       z = int(floor(mod(coord.x, 4.0)));
+        weights = (w == 1) ? delta_1_1[z] : delta_1_2[z];
+        return weights;
+    }
+/*
+    else if (phosphor_layout == 12) {
+        // delta_2_4x1_rgb
+        vec3 delta_2_1[4] = vec3[](red, yellow, cyan, blue);
+        vec3 delta_2_2[4] = vec3[](cyan, blue, red, yellow);
 
-       weights = (w == 1) ? delta_1_1[z] : delta_1_2[z];
-       return weights;
+        z = int(floor(mod(coord.x, 4.0)));
 
-    } else if(phosphor_layout == 12){
-       // delta_2_4x1_rgb
-       vec3 delta_2_1[4] = vec3[](red, yellow, cyan, blue);
-       vec3 delta_2_2[4] = vec3[](cyan, blue, red, yellow);
+        weights = (w == 1) ? delta_2_1[z] : delta_2_2[z];
+        return weights;
+	}
+*/
+/*
+    else if (phosphor_layout == 13) {
+        // delta_2_4x2_rgb
+        vec3 delta_1[4] = vec3[](red, yellow, cyan, blue);
+        vec3 delta_2[4] = vec3[](red, yellow, cyan, blue);
+        vec3 delta_3[4] = vec3[](cyan, blue, red, yellow);
+        vec3 delta_4[4] = vec3[](cyan, blue, red, yellow);
 
-       z = int(floor(mod(coord.x, 4.0)));
+        w = int(floor(mod(coord.y, 4.0)));
+        z = int(floor(mod(coord.x, 4.0)));
 
-       weights = (w == 1) ? delta_2_1[z] : delta_2_2[z];
-       return weights;
+        weights = (w == 1) ? delta_1[z] : (w == 2) ? delta_2[z] : (w == 3) ? delta_3[z] : delta_4[z];
+        return weights;
+    }
+*/
+    else if (phosphor_layout == 14) {
+        // slot mask for RGB panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
+        // {magenta, green, black, black,   black, black},
+        // {magenta, green, black, magenta, green, black},
+        // {black,   black, black, magenta, green, black}
+        vec3 slot2_1[6] = vec3[](magenta, green, black, black,   black, black);
+        vec3 slot2_2[6] = vec3[](magenta, green, black, magenta, green, black);
+        vec3 slot2_3[6] = vec3[](black,   black, black, magenta, green, black);
 
-    } else if(phosphor_layout == 13){
-       // delta_2_4x2_rgb
-       vec3 delta_1[4] = vec3[](red, yellow, cyan, blue);
-       vec3 delta_2[4] = vec3[](red, yellow, cyan, blue);
-       vec3 delta_3[4] = vec3[](cyan, blue, red, yellow);
-       vec3 delta_4[4] = vec3[](cyan, blue, red, yellow);
+        w = int(floor(mod(coord.y, 3.0)));
+        z = int(floor(mod(coord.x, 6.0)));
 
-       w = int(floor(mod(coord.y, 4.0)));
-       z = int(floor(mod(coord.x, 4.0)));
+        weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
+        return weights;
+    }
+/*
+    else if(phosphor_layout == 15) {
+        // slot_2_4x4_rgb
+        // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
+        // {red,   yellow, cyan,  blue,  black, black,  black, black},
+        // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
+        // {black, black,  black, black, red,   yellow, cyan,  blue }
+        vec3 slotmask_RBG_x1[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
+        vec3 slotmask_RBG_x2[8] = vec3[](red,   yellow, cyan,  blue,  black, black,  black, black);
+        vec3 slotmask_RBG_x3[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
+        vec3 slotmask_RBG_x4[8] = vec3[](black, black,  black, black, red,   yellow, cyan,  blue );
 
-       weights = (w == 1) ? delta_1[z] : (w == 2) ? delta_2[z] : (w == 3) ? delta_3[z] : delta_4[z];
-       return weights;
+        // find the vertical index
+        w = int(floor(mod(coord.y, 4.0)));
 
-    } else if(phosphor_layout == 14){
-       // slot mask for RGB panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
-       // {magenta, green, black, black,   black, black},
-       // {magenta, green, black, magenta, green, black},
-       // {black,   black, black, magenta, green, black}
-       vec3 slot2_1[6] = vec3[](magenta, green, black, black,   black, black);
-       vec3 slot2_2[6] = vec3[](magenta, green, black, magenta, green, black);
-       vec3 slot2_3[6] = vec3[](black,   black, black, magenta, green, black);
+        // find the horizontal index
+        z = int(floor(mod(coord.x, 8.0)));
 
-       w = int(floor(mod(coord.y, 3.0)));
-       z = int(floor(mod(coord.x, 6.0)));
+        weights = (w == 1) ? slotmask_RBG_x1[z] : (w == 2) ? slotmask_RBG_x2[z] : (w == 3) ? slotmask_RBG_x3[z] : slotmask_RBG_x4[z];
+        return weights;
+	}
+*/
+/*
+	else if(phosphor_layout == 16) {
+        // slot mask for RBG panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
+        // {yellow, blue,  black,  black},
+        // {yellow, blue,  yellow, blue},
+        // {black,  black, yellow, blue}
+        vec3 slot2_1[4] = vec3[](yellow, blue,  black,  black);
+        vec3 slot2_2[4] = vec3[](yellow, blue,  yellow, blue);
+        vec3 slot2_3[4] = vec3[](black,  black, yellow, blue);
 
-       weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
-       return weights;
+        w = int(floor(mod(coord.y, 3.0)));
+        z = int(floor(mod(coord.x, 4.0)));
 
-    } else if(phosphor_layout == 15){
-       // slot_2_4x4_rgb
-       // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
-       // {red,   yellow, cyan,  blue,  black, black,  black, black},
-       // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
-       // {black, black,  black, black, red,   yellow, cyan,  blue }
-       vec3 slotmask_RBG_x1[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
-       vec3 slotmask_RBG_x2[8] = vec3[](red,   yellow, cyan,  blue,  black, black,  black, black);
-       vec3 slotmask_RBG_x3[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
-       vec3 slotmask_RBG_x4[8] = vec3[](black, black,  black, black, red,   yellow, cyan,  blue );
+        weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
+        return weights;
+    }
+*/
+	else if (phosphor_layout == 17) {
+        // slot_2_5x4_bgr
+        // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
+        // {black, blue,    blue,  green, green, red,   red,     black, black, black},
+        // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
+        // {red,   red,     black, black, black, black, blue,    blue,  green, green}
+        vec3 slot_1[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
+        vec3 slot_2[10] = vec3[](black, blue,    blue,  green, green, red,   red,     black, black, black);
+        vec3 slot_3[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
+        vec3 slot_4[10] = vec3[](red,   red,     black, black, black, black, blue,    blue,  green, green);
 
-       // find the vertical index
-       w = int(floor(mod(coord.y, 4.0)));
+        w = int(floor(mod(coord.y, 4.0)));
+        z = int(floor(mod(coord.x, 10.0)));
 
-       // find the horizontal index
-       z = int(floor(mod(coord.x, 8.0)));
+        weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
+        return weights;
+    }
+/*
+    else if (phosphor_layout == 18) {
+        // same as above but for RBG panels
+        // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
+        // {black, green,  green, blue,  blue,  red,   red,    black, black, black},
+        // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
+        // {red,   red,    black, black, black, black, green,  green, blue,  blue }
+        vec3 slot_1[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
+        vec3 slot_2[10] = vec3[](black, green,  green, blue,  blue,  red,   red,    black, black, black);
+        vec3 slot_3[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
+        vec3 slot_4[10] = vec3[](red,   red,    black, black, black, black, green,  green, blue,  blue );
 
-       weights = (w == 1) ? slotmask_RBG_x1[z] : (w == 2) ? slotmask_RBG_x2[z] : (w == 3) ? slotmask_RBG_x3[z] : slotmask_RBG_x4[z];
-       return weights;
+        w = int(floor(mod(coord.y, 4.0)));
+        z = int(floor(mod(coord.x, 10.0)));
 
-     } else if(phosphor_layout == 16){
-       // slot mask for RBG panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
-       // {yellow, blue,  black,  black},
-       // {yellow, blue,  yellow, blue},
-       // {black,  black, yellow, blue}
-       vec3 slot2_1[4] = vec3[](yellow, blue,  black,  black);
-       vec3 slot2_2[4] = vec3[](yellow, blue,  yellow, blue);
-       vec3 slot2_3[4] = vec3[](black,  black, yellow, blue);
+        weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
+        return weights;
+    }
+*/
+/*
+    else if(phosphor_layout == 19) {
+        // slot_3_7x6_rgb
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue}
 
-       w = int(floor(mod(coord.y, 3.0)));
-       z = int(floor(mod(coord.x, 4.0)));
+        vec3 slot_1[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_2[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_3[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black);
+        vec3 slot_4[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_5[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_6[14] = vec3[](black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue);
 
-       weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
-       return weights;
+        w = int(floor(mod(coord.y, 6.0)));
+        z = int(floor(mod(coord.x, 14.0)));
 
-    } else if (phosphor_layout == 17) {
-       // slot_2_5x4_bgr
-       // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
-       // {black, blue,    blue,  green, green, red,   red,     black, black, black},
-       // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
-       // {red,   red,     black, black, black, black, blue,    blue,  green, green}
-       vec3 slot_1[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
-       vec3 slot_2[10] = vec3[](black, blue,    blue,  green, green, red,   red,     black, black, black);
-       vec3 slot_3[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
-       vec3 slot_4[10] = vec3[](red,   red,     black, black, black, black, blue,    blue,  green, green);
-
-       w = int(floor(mod(coord.y, 4.0)));
-       z = int(floor(mod(coord.x, 10.0)));
-
-       weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
-       return weights;
-
-    } else if (phosphor_layout == 18) {
-       // same as above but for RBG panels
-       // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
-       // {black, green,  green, blue,  blue,  red,   red,    black, black, black},
-       // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
-       // {red,   red,    black, black, black, black, green,  green, blue,  blue }
-       vec3 slot_1[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
-       vec3 slot_2[10] = vec3[](black, green,  green, blue,  blue,  red,   red,    black, black, black);
-       vec3 slot_3[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
-       vec3 slot_4[10] = vec3[](red,   red,    black, black, black, black, green,  green, blue,  blue );
-
-       w = int(floor(mod(coord.y, 4.0)));
-       z = int(floor(mod(coord.x, 10.0)));
-
-       weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
-       return weights;
-
-    } else if(phosphor_layout == 19) {
-       // slot_3_7x6_rgb
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue}
-
-       vec3 slot_1[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_2[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_3[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black);
-       vec3 slot_4[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_5[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_6[14] = vec3[](black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue);
-
-       w = int(floor(mod(coord.y, 6.0)));
-       z = int(floor(mod(coord.x, 14.0)));
-
-       weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : (w == 4) ? slot_4[z] : (w == 5) ? slot_5[z] : slot_6[z];
-       return weights;
-
-    } else {
+        weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : (w == 4) ? slot_4[z] : (w == 5) ? slot_5[z] : slot_6[z];
+        return weights;
+     }
+*/
+	else {
         return weights;
     }
 }
+
 
 // Horizontal cubic filter.
 //

--- a/contrib/resources/glshaders/crt/cga-1440p.glsl
+++ b/contrib/resources/glshaders/crt/cga-1440p.glsl
@@ -169,10 +169,10 @@ uniform PRECISION float BLUE_SHIFT;
 
 #define WP_ADJUST           0.00
 #define TEMPERATURE      9300.00
-#define LUMA_PRESERVE 		1.00
-#define RED_SHIFT 			0.00
-#define GREEN_SHIFT 		0.00
-#define BLUE_SHIFT 			0.00
+#define LUMA_PRESERVE       1.00
+#define RED_SHIFT           0.00
+#define GREEN_SHIFT         0.00
+#define BLUE_SHIFT          0.00
 #endif
 // END PARAMETERS //
 
@@ -275,10 +275,10 @@ vec3 YxytoXYZ(vec3 Yxy) {
     Many of these mask arrays are adapted from cgwg's crt-geom-deluxe LUTs, and
     those have their filenames included for easy identification
 
-	NOTE: Having too many branches result in a black screen (but no
-	compilation errors) on some older GPUs such as the Intel HD 4000 iGPU. So
-	we're commenting out the branches that are not used by the adaptive CRT
-	shaders.
+    NOTE: Having too many branches result in a black screen (but no
+    compilation errors) on some older GPUs such as the Intel HD 4000 iGPU. So
+    we're commenting out the branches that are not used by the adaptive CRT
+    shaders.
 */
 vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
     vec3 weights = vec3(1.,1.,1.);
@@ -302,14 +302,14 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
     if (phosphor_layout == 0) {
         return weights;
-	}
+    }
 
     else if (phosphor_layout == 1) {
-    	// classic aperture for RGB panels; good for 1080p, too small for 4K+
+        // classic aperture for RGB panels; good for 1080p, too small for 4K+
         // aka aperture_1_2_bgr
         weights  = aperture_weights;
         return weights;
-	}
+    }
 
     else if (phosphor_layout == 2) {
         // 2x2 shadow mask for RGB panels; good for 1080p, too small for 4K+
@@ -317,7 +317,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
         vec3 inverse_aperture = mix(green, magenta, floor(mod(coord.x, 2.0)));
         weights               = mix(aperture_weights, inverse_aperture, floor(mod(coord.y, 2.0)));
         return weights;
-	}
+    }
 
 /*
     else if (phosphor_layout == 3) {
@@ -340,14 +340,14 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         // do a big, dumb comparison in place of a 2D array
         weights = (w == 1) ? slotmask_x1[z] : (w == 2) ? slotmask_x2[z] :  slotmask_x3[z];
-		return weights;
+        return weights;
     }
 */
     else if (phosphor_layout == 4) {
         // classic aperture for RBG panels; good for 1080p, too small for 4K+
         weights  = mix(yellow, blue, floor(mod(coord.x, 2.0)));
         return weights;
-	}
+    }
 /*
     else if (phosphor_layout == 5) {
         // 2x2 shadow mask for RBG panels; good for 1080p, too small for 4K+
@@ -359,7 +359,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
             floor(mod(coord.y, 2.0))
         );
         return weights;
-	}
+    }
 */
 /*
     else if (phosphor_layout == 6) {
@@ -370,7 +370,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = ap4[z];
         return weights;
-	}
+    }
 */
 /*
     else if (phosphor_layout == 7) {
@@ -391,7 +391,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap[w];
         return weights;
-	}
+    }
 */
     else if (phosphor_layout == 9) {
         // reduced TVL aperture for RGB panels
@@ -402,7 +402,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rgb[w];
         return weights;
-	}
+    }
 /*
     else if (phosphor_layout == 10) {
         // reduced TVL aperture for RBG panels
@@ -412,7 +412,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rbg[w];
         return weights;
-	}
+    }
 */
     else if(phosphor_layout == 11) {
         // delta_1_4x1_rgb; dunno why this is called 4x1 when it's obviously 4x2 /shrug
@@ -435,7 +435,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = (w == 1) ? delta_2_1[z] : delta_2_2[z];
         return weights;
-	}
+    }
 */
 /*
     else if (phosphor_layout == 13) {
@@ -487,10 +487,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = (w == 1) ? slotmask_RBG_x1[z] : (w == 2) ? slotmask_RBG_x2[z] : (w == 3) ? slotmask_RBG_x3[z] : slotmask_RBG_x4[z];
         return weights;
-	}
+    }
 */
 /*
-	else if(phosphor_layout == 16) {
+    else if(phosphor_layout == 16) {
         // slot mask for RBG panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
         // {yellow, blue,  black,  black},
         // {yellow, blue,  yellow, blue},
@@ -506,7 +506,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
         return weights;
     }
 */
-	else if (phosphor_layout == 17) {
+    else if (phosphor_layout == 17) {
         // slot_2_5x4_bgr
         // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
         // {black, blue,    blue,  green, green, red,   red,     black, black, black},
@@ -566,7 +566,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
         return weights;
      }
 */
-	else {
+    else {
         return weights;
     }
 }
@@ -586,10 +586,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 // For more info, see: http://www.imagemagick.org/Usage/img_diagrams/cubic_survey.gif
 mat4x4 get_hfilter_profile()
 {
-	float bf = 0.0;
-	float cf = 0.0;
+    float bf = 0.0;
+    float cf = 0.0;
 
-	if (HFILTER_PROFILE == 1) {
+    if (HFILTER_PROFILE == 1) {
         bf = 0.0;
         cf = 0.5;
     }
@@ -691,14 +691,14 @@ void main()
     mask_coords = mix(mask_coords.xy, mask_coords.yx, VSCANLINES);
     color.rgb *= mask_weights(mask_coords, MASK_INTENSITY, int(PHOSPHOR_LAYOUT));
 
-	// Colour temperature
-	if (WP_ADJUST == 1.0) {
-		vec3 wp_adjusted = wp_adjust(color.rgb);
-		vec3 base_luma = XYZtoYxy(sRGB_to_XYZ(color.rgb));
-		vec3 adjusted_luma = XYZtoYxy(sRGB_to_XYZ(wp_adjusted));
-		wp_adjusted = (LUMA_PRESERVE == 1.0) ? adjusted_luma + (vec3(base_luma.r,0.,0.) - vec3(adjusted_luma.r,0.,0.)) : adjusted_luma;
-		color = vec4(XYZ_to_sRGB(YxytoXYZ(wp_adjusted)), 1.0);
-	}
+    // Colour temperature
+    if (WP_ADJUST == 1.0) {
+        vec3 wp_adjusted = wp_adjust(color.rgb);
+        vec3 base_luma = XYZtoYxy(sRGB_to_XYZ(color.rgb));
+        vec3 adjusted_luma = XYZtoYxy(sRGB_to_XYZ(wp_adjusted));
+        wp_adjusted = (LUMA_PRESERVE == 1.0) ? adjusted_luma + (vec3(base_luma.r,0.,0.) - vec3(adjusted_luma.r,0.,0.)) : adjusted_luma;
+        color = vec4(XYZ_to_sRGB(YxytoXYZ(wp_adjusted)), 1.0);
+    }
 
     // Output gamma
     color = clamp(GAMMA_OUT(color), 0.0, 1.0);

--- a/contrib/resources/glshaders/crt/cga-1440p.glsl
+++ b/contrib/resources/glshaders/crt/cga-1440p.glsl
@@ -248,7 +248,6 @@ vec3 YxytoXYZ(vec3 Yxy) {
     return XYZ;
 }
 
-
 /*
     A collection of CRT mask effects that work with LCD subpixel structures for
     small details
@@ -275,11 +274,18 @@ vec3 YxytoXYZ(vec3 Yxy) {
 
     Many of these mask arrays are adapted from cgwg's crt-geom-deluxe LUTs, and
     those have their filenames included for easy identification
+
+	NOTE: Having too many branches result in a black screen (but no
+	compilation errors) on some older GPUs such as the Intel HD 4000 iGPU. So
+	we're commenting out the branches that are not used by the adaptive CRT
+	shaders.
 */
 vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
     vec3 weights = vec3(1.,1.,1.);
+
     float on = 1.;
     float off = 1.-mask_intensity;
+
     vec3 red     = vec3(on,  off, off);
     vec3 green   = vec3(off, on,  off);
     vec3 blue    = vec3(off, off, on );
@@ -288,6 +294,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
     vec3 cyan    = vec3(off, on,  on );
     vec3 black   = vec3(off, off, off);
     vec3 white   = vec3(on,  on,  on );
+
     int w, z = 0;
 
     // This pattern is used by a few layouts, so we'll define it here
@@ -295,21 +302,25 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
     if (phosphor_layout == 0) {
         return weights;
+	}
 
-    } else if (phosphor_layout == 1) {
-        // classic aperture for RGB panels; good for 1080p, too small for 4K+
+    else if (phosphor_layout == 1) {
+    	// classic aperture for RGB panels; good for 1080p, too small for 4K+
         // aka aperture_1_2_bgr
         weights  = aperture_weights;
         return weights;
+	}
 
-    } else if (phosphor_layout == 2) {
+    else if (phosphor_layout == 2) {
         // 2x2 shadow mask for RGB panels; good for 1080p, too small for 4K+
         // aka delta_1_2x1_bgr
         vec3 inverse_aperture = mix(green, magenta, floor(mod(coord.x, 2.0)));
         weights               = mix(aperture_weights, inverse_aperture, floor(mod(coord.y, 2.0)));
         return weights;
+	}
 
-    } else if (phosphor_layout == 3) {
+/*
+    else if (phosphor_layout == 3) {
         // slot mask for RGB panels; looks okay at 1080p, looks better at 4K
         // {magenta, green, black,   black},
         // {magenta, green, magenta, green},
@@ -329,14 +340,16 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         // do a big, dumb comparison in place of a 2D array
         weights = (w == 1) ? slotmask_x1[z] : (w == 2) ? slotmask_x2[z] :  slotmask_x3[z];
+		return weights;
     }
-
-    if (phosphor_layout == 4) {
+*/
+    else if (phosphor_layout == 4) {
         // classic aperture for RBG panels; good for 1080p, too small for 4K+
         weights  = mix(yellow, blue, floor(mod(coord.x, 2.0)));
         return weights;
-
-    } else if (phosphor_layout == 5) {
+	}
+/*
+    else if (phosphor_layout == 5) {
         // 2x2 shadow mask for RBG panels; good for 1080p, too small for 4K+
         vec3 inverse_aperture = mix(blue, yellow, floor(mod(coord.x, 2.0)));
 
@@ -346,8 +359,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
             floor(mod(coord.y, 2.0))
         );
         return weights;
-
-    } else if (phosphor_layout == 6) {
+	}
+*/
+/*
+    else if (phosphor_layout == 6) {
         // aperture_1_4_rgb; good for simulating lower
         vec3 ap4[4] = vec3[](red, green, blue, black);
 
@@ -355,8 +370,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = ap4[z];
         return weights;
-
-    } else if (phosphor_layout == 7) {
+	}
+*/
+/*
+    else if (phosphor_layout == 7) {
         // aperture_2_5_bgr
         vec3 ap3[5] = vec3[](red, magenta, blue, green, green);
 
@@ -364,8 +381,9 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = ap3[z];
         return weights;
-
-    } else if (phosphor_layout == 8){
+*/
+/*
+    else if (phosphor_layout == 8) {
         // aperture_3_6_rgb
         vec3 big_ap[7] = vec3[](red, red, yellow, green, cyan, blue, blue);
 
@@ -373,8 +391,9 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap[w];
         return weights;
-
-    } else if (phosphor_layout == 9) {
+	}
+*/
+    else if (phosphor_layout == 9) {
         // reduced TVL aperture for RGB panels
         // aperture_2_4_rgb
         vec3 big_ap_rgb[4] = vec3[](red, yellow, cyan, blue);
@@ -383,8 +402,9 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rgb[w];
         return weights;
-
-    } else if (phosphor_layout == 10) {
+	}
+/*
+    else if (phosphor_layout == 10) {
         // reduced TVL aperture for RBG panels
         vec3 big_ap_rbg[4] = vec3[](red, magenta, cyan, green);
 
@@ -392,148 +412,161 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rbg[w];
         return weights;
+	}
+*/
+    else if(phosphor_layout == 11) {
+        // delta_1_4x1_rgb; dunno why this is called 4x1 when it's obviously 4x2 /shrug
+        vec3 delta_1_1[4] = vec3[](red, green, blue, black);
+        vec3 delta_1_2[4] = vec3[](blue, black, red, green);
 
-    } else if(phosphor_layout == 11){
-       // delta_1_4x1_rgb; dunno why this is called 4x1 when it's obviously 4x2 /shrug
-       vec3 delta_1_1[4] = vec3[](red, green, blue, black);
-       vec3 delta_1_2[4] = vec3[](blue, black, red, green);
+        w = int(floor(mod(coord.y, 2.0)));
+        z = int(floor(mod(coord.x, 4.0)));
 
-       w = int(floor(mod(coord.y, 2.0)));
-       z = int(floor(mod(coord.x, 4.0)));
+        weights = (w == 1) ? delta_1_1[z] : delta_1_2[z];
+        return weights;
+    }
+/*
+    else if (phosphor_layout == 12) {
+        // delta_2_4x1_rgb
+        vec3 delta_2_1[4] = vec3[](red, yellow, cyan, blue);
+        vec3 delta_2_2[4] = vec3[](cyan, blue, red, yellow);
 
-       weights = (w == 1) ? delta_1_1[z] : delta_1_2[z];
-       return weights;
+        z = int(floor(mod(coord.x, 4.0)));
 
-    } else if(phosphor_layout == 12){
-       // delta_2_4x1_rgb
-       vec3 delta_2_1[4] = vec3[](red, yellow, cyan, blue);
-       vec3 delta_2_2[4] = vec3[](cyan, blue, red, yellow);
+        weights = (w == 1) ? delta_2_1[z] : delta_2_2[z];
+        return weights;
+	}
+*/
+/*
+    else if (phosphor_layout == 13) {
+        // delta_2_4x2_rgb
+        vec3 delta_1[4] = vec3[](red, yellow, cyan, blue);
+        vec3 delta_2[4] = vec3[](red, yellow, cyan, blue);
+        vec3 delta_3[4] = vec3[](cyan, blue, red, yellow);
+        vec3 delta_4[4] = vec3[](cyan, blue, red, yellow);
 
-       z = int(floor(mod(coord.x, 4.0)));
+        w = int(floor(mod(coord.y, 4.0)));
+        z = int(floor(mod(coord.x, 4.0)));
 
-       weights = (w == 1) ? delta_2_1[z] : delta_2_2[z];
-       return weights;
+        weights = (w == 1) ? delta_1[z] : (w == 2) ? delta_2[z] : (w == 3) ? delta_3[z] : delta_4[z];
+        return weights;
+    }
+*/
+    else if (phosphor_layout == 14) {
+        // slot mask for RGB panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
+        // {magenta, green, black, black,   black, black},
+        // {magenta, green, black, magenta, green, black},
+        // {black,   black, black, magenta, green, black}
+        vec3 slot2_1[6] = vec3[](magenta, green, black, black,   black, black);
+        vec3 slot2_2[6] = vec3[](magenta, green, black, magenta, green, black);
+        vec3 slot2_3[6] = vec3[](black,   black, black, magenta, green, black);
 
-    } else if(phosphor_layout == 13){
-       // delta_2_4x2_rgb
-       vec3 delta_1[4] = vec3[](red, yellow, cyan, blue);
-       vec3 delta_2[4] = vec3[](red, yellow, cyan, blue);
-       vec3 delta_3[4] = vec3[](cyan, blue, red, yellow);
-       vec3 delta_4[4] = vec3[](cyan, blue, red, yellow);
+        w = int(floor(mod(coord.y, 3.0)));
+        z = int(floor(mod(coord.x, 6.0)));
 
-       w = int(floor(mod(coord.y, 4.0)));
-       z = int(floor(mod(coord.x, 4.0)));
+        weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
+        return weights;
+    }
+/*
+    else if(phosphor_layout == 15) {
+        // slot_2_4x4_rgb
+        // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
+        // {red,   yellow, cyan,  blue,  black, black,  black, black},
+        // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
+        // {black, black,  black, black, red,   yellow, cyan,  blue }
+        vec3 slotmask_RBG_x1[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
+        vec3 slotmask_RBG_x2[8] = vec3[](red,   yellow, cyan,  blue,  black, black,  black, black);
+        vec3 slotmask_RBG_x3[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
+        vec3 slotmask_RBG_x4[8] = vec3[](black, black,  black, black, red,   yellow, cyan,  blue );
 
-       weights = (w == 1) ? delta_1[z] : (w == 2) ? delta_2[z] : (w == 3) ? delta_3[z] : delta_4[z];
-       return weights;
+        // find the vertical index
+        w = int(floor(mod(coord.y, 4.0)));
 
-    } else if(phosphor_layout == 14){
-       // slot mask for RGB panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
-       // {magenta, green, black, black,   black, black},
-       // {magenta, green, black, magenta, green, black},
-       // {black,   black, black, magenta, green, black}
-       vec3 slot2_1[6] = vec3[](magenta, green, black, black,   black, black);
-       vec3 slot2_2[6] = vec3[](magenta, green, black, magenta, green, black);
-       vec3 slot2_3[6] = vec3[](black,   black, black, magenta, green, black);
+        // find the horizontal index
+        z = int(floor(mod(coord.x, 8.0)));
 
-       w = int(floor(mod(coord.y, 3.0)));
-       z = int(floor(mod(coord.x, 6.0)));
+        weights = (w == 1) ? slotmask_RBG_x1[z] : (w == 2) ? slotmask_RBG_x2[z] : (w == 3) ? slotmask_RBG_x3[z] : slotmask_RBG_x4[z];
+        return weights;
+	}
+*/
+/*
+	else if(phosphor_layout == 16) {
+        // slot mask for RBG panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
+        // {yellow, blue,  black,  black},
+        // {yellow, blue,  yellow, blue},
+        // {black,  black, yellow, blue}
+        vec3 slot2_1[4] = vec3[](yellow, blue,  black,  black);
+        vec3 slot2_2[4] = vec3[](yellow, blue,  yellow, blue);
+        vec3 slot2_3[4] = vec3[](black,  black, yellow, blue);
 
-       weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
-       return weights;
+        w = int(floor(mod(coord.y, 3.0)));
+        z = int(floor(mod(coord.x, 4.0)));
 
-    } else if(phosphor_layout == 15){
-       // slot_2_4x4_rgb
-       // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
-       // {red,   yellow, cyan,  blue,  black, black,  black, black},
-       // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
-       // {black, black,  black, black, red,   yellow, cyan,  blue }
-       vec3 slotmask_RBG_x1[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
-       vec3 slotmask_RBG_x2[8] = vec3[](red,   yellow, cyan,  blue,  black, black,  black, black);
-       vec3 slotmask_RBG_x3[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
-       vec3 slotmask_RBG_x4[8] = vec3[](black, black,  black, black, red,   yellow, cyan,  blue );
+        weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
+        return weights;
+    }
+*/
+	else if (phosphor_layout == 17) {
+        // slot_2_5x4_bgr
+        // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
+        // {black, blue,    blue,  green, green, red,   red,     black, black, black},
+        // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
+        // {red,   red,     black, black, black, black, blue,    blue,  green, green}
+        vec3 slot_1[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
+        vec3 slot_2[10] = vec3[](black, blue,    blue,  green, green, red,   red,     black, black, black);
+        vec3 slot_3[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
+        vec3 slot_4[10] = vec3[](red,   red,     black, black, black, black, blue,    blue,  green, green);
 
-       // find the vertical index
-       w = int(floor(mod(coord.y, 4.0)));
+        w = int(floor(mod(coord.y, 4.0)));
+        z = int(floor(mod(coord.x, 10.0)));
 
-       // find the horizontal index
-       z = int(floor(mod(coord.x, 8.0)));
+        weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
+        return weights;
+    }
+/*
+    else if (phosphor_layout == 18) {
+        // same as above but for RBG panels
+        // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
+        // {black, green,  green, blue,  blue,  red,   red,    black, black, black},
+        // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
+        // {red,   red,    black, black, black, black, green,  green, blue,  blue }
+        vec3 slot_1[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
+        vec3 slot_2[10] = vec3[](black, green,  green, blue,  blue,  red,   red,    black, black, black);
+        vec3 slot_3[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
+        vec3 slot_4[10] = vec3[](red,   red,    black, black, black, black, green,  green, blue,  blue );
 
-       weights = (w == 1) ? slotmask_RBG_x1[z] : (w == 2) ? slotmask_RBG_x2[z] : (w == 3) ? slotmask_RBG_x3[z] : slotmask_RBG_x4[z];
-       return weights;
+        w = int(floor(mod(coord.y, 4.0)));
+        z = int(floor(mod(coord.x, 10.0)));
 
-     } else if(phosphor_layout == 16){
-       // slot mask for RBG panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
-       // {yellow, blue,  black,  black},
-       // {yellow, blue,  yellow, blue},
-       // {black,  black, yellow, blue}
-       vec3 slot2_1[4] = vec3[](yellow, blue,  black,  black);
-       vec3 slot2_2[4] = vec3[](yellow, blue,  yellow, blue);
-       vec3 slot2_3[4] = vec3[](black,  black, yellow, blue);
+        weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
+        return weights;
+    }
+*/
+/*
+    else if(phosphor_layout == 19) {
+        // slot_3_7x6_rgb
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue}
 
-       w = int(floor(mod(coord.y, 3.0)));
-       z = int(floor(mod(coord.x, 4.0)));
+        vec3 slot_1[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_2[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_3[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black);
+        vec3 slot_4[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_5[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_6[14] = vec3[](black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue);
 
-       weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
-       return weights;
+        w = int(floor(mod(coord.y, 6.0)));
+        z = int(floor(mod(coord.x, 14.0)));
 
-    } else if (phosphor_layout == 17) {
-       // slot_2_5x4_bgr
-       // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
-       // {black, blue,    blue,  green, green, red,   red,     black, black, black},
-       // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
-       // {red,   red,     black, black, black, black, blue,    blue,  green, green}
-       vec3 slot_1[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
-       vec3 slot_2[10] = vec3[](black, blue,    blue,  green, green, red,   red,     black, black, black);
-       vec3 slot_3[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
-       vec3 slot_4[10] = vec3[](red,   red,     black, black, black, black, blue,    blue,  green, green);
-
-       w = int(floor(mod(coord.y, 4.0)));
-       z = int(floor(mod(coord.x, 10.0)));
-
-       weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
-       return weights;
-
-    } else if (phosphor_layout == 18) {
-       // same as above but for RBG panels
-       // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
-       // {black, green,  green, blue,  blue,  red,   red,    black, black, black},
-       // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
-       // {red,   red,    black, black, black, black, green,  green, blue,  blue }
-       vec3 slot_1[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
-       vec3 slot_2[10] = vec3[](black, green,  green, blue,  blue,  red,   red,    black, black, black);
-       vec3 slot_3[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
-       vec3 slot_4[10] = vec3[](red,   red,    black, black, black, black, green,  green, blue,  blue );
-
-       w = int(floor(mod(coord.y, 4.0)));
-       z = int(floor(mod(coord.x, 10.0)));
-
-       weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
-       return weights;
-
-    } else if(phosphor_layout == 19) {
-       // slot_3_7x6_rgb
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue}
-
-       vec3 slot_1[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_2[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_3[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black);
-       vec3 slot_4[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_5[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_6[14] = vec3[](black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue);
-
-       w = int(floor(mod(coord.y, 6.0)));
-       z = int(floor(mod(coord.x, 14.0)));
-
-       weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : (w == 4) ? slot_4[z] : (w == 5) ? slot_5[z] : slot_6[z];
-       return weights;
-
-    } else {
+        weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : (w == 4) ? slot_4[z] : (w == 5) ? slot_5[z] : slot_6[z];
+        return weights;
+     }
+*/
+	else {
         return weights;
     }
 }

--- a/contrib/resources/glshaders/crt/cga-4k.glsl
+++ b/contrib/resources/glshaders/crt/cga-4k.glsl
@@ -169,10 +169,10 @@ uniform PRECISION float BLUE_SHIFT;
 
 #define WP_ADJUST           0.00
 #define TEMPERATURE      9300.00
-#define LUMA_PRESERVE 		1.00
-#define RED_SHIFT 			0.00
-#define GREEN_SHIFT 		0.00
-#define BLUE_SHIFT 			0.00
+#define LUMA_PRESERVE       1.00
+#define RED_SHIFT           0.00
+#define GREEN_SHIFT         0.00
+#define BLUE_SHIFT          0.00
 #endif
 // END PARAMETERS //
 
@@ -275,10 +275,10 @@ vec3 YxytoXYZ(vec3 Yxy) {
     Many of these mask arrays are adapted from cgwg's crt-geom-deluxe LUTs, and
     those have their filenames included for easy identification
 
-	NOTE: Having too many branches result in a black screen (but no
-	compilation errors) on some older GPUs such as the Intel HD 4000 iGPU. So
-	we're commenting out the branches that are not used by the adaptive CRT
-	shaders.
+    NOTE: Having too many branches result in a black screen (but no
+    compilation errors) on some older GPUs such as the Intel HD 4000 iGPU. So
+    we're commenting out the branches that are not used by the adaptive CRT
+    shaders.
 */
 vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
     vec3 weights = vec3(1.,1.,1.);
@@ -302,14 +302,14 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
     if (phosphor_layout == 0) {
         return weights;
-	}
+    }
 
     else if (phosphor_layout == 1) {
-    	// classic aperture for RGB panels; good for 1080p, too small for 4K+
+        // classic aperture for RGB panels; good for 1080p, too small for 4K+
         // aka aperture_1_2_bgr
         weights  = aperture_weights;
         return weights;
-	}
+    }
 
     else if (phosphor_layout == 2) {
         // 2x2 shadow mask for RGB panels; good for 1080p, too small for 4K+
@@ -317,7 +317,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
         vec3 inverse_aperture = mix(green, magenta, floor(mod(coord.x, 2.0)));
         weights               = mix(aperture_weights, inverse_aperture, floor(mod(coord.y, 2.0)));
         return weights;
-	}
+    }
 
 /*
     else if (phosphor_layout == 3) {
@@ -340,14 +340,14 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         // do a big, dumb comparison in place of a 2D array
         weights = (w == 1) ? slotmask_x1[z] : (w == 2) ? slotmask_x2[z] :  slotmask_x3[z];
-		return weights;
+        return weights;
     }
 */
     else if (phosphor_layout == 4) {
         // classic aperture for RBG panels; good for 1080p, too small for 4K+
         weights  = mix(yellow, blue, floor(mod(coord.x, 2.0)));
         return weights;
-	}
+    }
 /*
     else if (phosphor_layout == 5) {
         // 2x2 shadow mask for RBG panels; good for 1080p, too small for 4K+
@@ -359,7 +359,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
             floor(mod(coord.y, 2.0))
         );
         return weights;
-	}
+    }
 */
 /*
     else if (phosphor_layout == 6) {
@@ -370,7 +370,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = ap4[z];
         return weights;
-	}
+    }
 */
 /*
     else if (phosphor_layout == 7) {
@@ -391,7 +391,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap[w];
         return weights;
-	}
+    }
 */
     else if (phosphor_layout == 9) {
         // reduced TVL aperture for RGB panels
@@ -402,7 +402,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rgb[w];
         return weights;
-	}
+    }
 /*
     else if (phosphor_layout == 10) {
         // reduced TVL aperture for RBG panels
@@ -412,7 +412,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rbg[w];
         return weights;
-	}
+    }
 */
     else if(phosphor_layout == 11) {
         // delta_1_4x1_rgb; dunno why this is called 4x1 when it's obviously 4x2 /shrug
@@ -435,7 +435,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = (w == 1) ? delta_2_1[z] : delta_2_2[z];
         return weights;
-	}
+    }
 */
 /*
     else if (phosphor_layout == 13) {
@@ -487,10 +487,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = (w == 1) ? slotmask_RBG_x1[z] : (w == 2) ? slotmask_RBG_x2[z] : (w == 3) ? slotmask_RBG_x3[z] : slotmask_RBG_x4[z];
         return weights;
-	}
+    }
 */
 /*
-	else if(phosphor_layout == 16) {
+    else if(phosphor_layout == 16) {
         // slot mask for RBG panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
         // {yellow, blue,  black,  black},
         // {yellow, blue,  yellow, blue},
@@ -506,7 +506,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
         return weights;
     }
 */
-	else if (phosphor_layout == 17) {
+    else if (phosphor_layout == 17) {
         // slot_2_5x4_bgr
         // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
         // {black, blue,    blue,  green, green, red,   red,     black, black, black},
@@ -566,7 +566,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
         return weights;
      }
 */
-	else {
+    else {
         return weights;
     }
 }
@@ -586,10 +586,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 // For more info, see: http://www.imagemagick.org/Usage/img_diagrams/cubic_survey.gif
 mat4x4 get_hfilter_profile()
 {
-	float bf = 0.0;
-	float cf = 0.0;
+    float bf = 0.0;
+    float cf = 0.0;
 
-	if (HFILTER_PROFILE == 1) {
+    if (HFILTER_PROFILE == 1) {
         bf = 0.0;
         cf = 0.5;
     }
@@ -691,14 +691,14 @@ void main()
     mask_coords = mix(mask_coords.xy, mask_coords.yx, VSCANLINES);
     color.rgb *= mask_weights(mask_coords, MASK_INTENSITY, int(PHOSPHOR_LAYOUT));
 
-	// Colour temperature
-	if (WP_ADJUST == 1.0) {
-		vec3 wp_adjusted = wp_adjust(color.rgb);
-		vec3 base_luma = XYZtoYxy(sRGB_to_XYZ(color.rgb));
-		vec3 adjusted_luma = XYZtoYxy(sRGB_to_XYZ(wp_adjusted));
-		wp_adjusted = (LUMA_PRESERVE == 1.0) ? adjusted_luma + (vec3(base_luma.r,0.,0.) - vec3(adjusted_luma.r,0.,0.)) : adjusted_luma;
-		color = vec4(XYZ_to_sRGB(YxytoXYZ(wp_adjusted)), 1.0);
-	}
+    // Colour temperature
+    if (WP_ADJUST == 1.0) {
+        vec3 wp_adjusted = wp_adjust(color.rgb);
+        vec3 base_luma = XYZtoYxy(sRGB_to_XYZ(color.rgb));
+        vec3 adjusted_luma = XYZtoYxy(sRGB_to_XYZ(wp_adjusted));
+        wp_adjusted = (LUMA_PRESERVE == 1.0) ? adjusted_luma + (vec3(base_luma.r,0.,0.) - vec3(adjusted_luma.r,0.,0.)) : adjusted_luma;
+        color = vec4(XYZ_to_sRGB(YxytoXYZ(wp_adjusted)), 1.0);
+    }
 
     // Output gamma
     color = clamp(GAMMA_OUT(color), 0.0, 1.0);

--- a/contrib/resources/glshaders/crt/cga-4k.glsl
+++ b/contrib/resources/glshaders/crt/cga-4k.glsl
@@ -248,7 +248,6 @@ vec3 YxytoXYZ(vec3 Yxy) {
     return XYZ;
 }
 
-
 /*
     A collection of CRT mask effects that work with LCD subpixel structures for
     small details
@@ -275,11 +274,18 @@ vec3 YxytoXYZ(vec3 Yxy) {
 
     Many of these mask arrays are adapted from cgwg's crt-geom-deluxe LUTs, and
     those have their filenames included for easy identification
+
+	NOTE: Having too many branches result in a black screen (but no
+	compilation errors) on some older GPUs such as the Intel HD 4000 iGPU. So
+	we're commenting out the branches that are not used by the adaptive CRT
+	shaders.
 */
 vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
     vec3 weights = vec3(1.,1.,1.);
+
     float on = 1.;
     float off = 1.-mask_intensity;
+
     vec3 red     = vec3(on,  off, off);
     vec3 green   = vec3(off, on,  off);
     vec3 blue    = vec3(off, off, on );
@@ -288,6 +294,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
     vec3 cyan    = vec3(off, on,  on );
     vec3 black   = vec3(off, off, off);
     vec3 white   = vec3(on,  on,  on );
+
     int w, z = 0;
 
     // This pattern is used by a few layouts, so we'll define it here
@@ -295,21 +302,25 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
     if (phosphor_layout == 0) {
         return weights;
+	}
 
-    } else if (phosphor_layout == 1) {
-        // classic aperture for RGB panels; good for 1080p, too small for 4K+
+    else if (phosphor_layout == 1) {
+    	// classic aperture for RGB panels; good for 1080p, too small for 4K+
         // aka aperture_1_2_bgr
         weights  = aperture_weights;
         return weights;
+	}
 
-    } else if (phosphor_layout == 2) {
+    else if (phosphor_layout == 2) {
         // 2x2 shadow mask for RGB panels; good for 1080p, too small for 4K+
         // aka delta_1_2x1_bgr
         vec3 inverse_aperture = mix(green, magenta, floor(mod(coord.x, 2.0)));
         weights               = mix(aperture_weights, inverse_aperture, floor(mod(coord.y, 2.0)));
         return weights;
+	}
 
-    } else if (phosphor_layout == 3) {
+/*
+    else if (phosphor_layout == 3) {
         // slot mask for RGB panels; looks okay at 1080p, looks better at 4K
         // {magenta, green, black,   black},
         // {magenta, green, magenta, green},
@@ -329,14 +340,16 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         // do a big, dumb comparison in place of a 2D array
         weights = (w == 1) ? slotmask_x1[z] : (w == 2) ? slotmask_x2[z] :  slotmask_x3[z];
+		return weights;
     }
-
-    if (phosphor_layout == 4) {
+*/
+    else if (phosphor_layout == 4) {
         // classic aperture for RBG panels; good for 1080p, too small for 4K+
         weights  = mix(yellow, blue, floor(mod(coord.x, 2.0)));
         return weights;
-
-    } else if (phosphor_layout == 5) {
+	}
+/*
+    else if (phosphor_layout == 5) {
         // 2x2 shadow mask for RBG panels; good for 1080p, too small for 4K+
         vec3 inverse_aperture = mix(blue, yellow, floor(mod(coord.x, 2.0)));
 
@@ -346,8 +359,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
             floor(mod(coord.y, 2.0))
         );
         return weights;
-
-    } else if (phosphor_layout == 6) {
+	}
+*/
+/*
+    else if (phosphor_layout == 6) {
         // aperture_1_4_rgb; good for simulating lower
         vec3 ap4[4] = vec3[](red, green, blue, black);
 
@@ -355,8 +370,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = ap4[z];
         return weights;
-
-    } else if (phosphor_layout == 7) {
+	}
+*/
+/*
+    else if (phosphor_layout == 7) {
         // aperture_2_5_bgr
         vec3 ap3[5] = vec3[](red, magenta, blue, green, green);
 
@@ -364,8 +381,9 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = ap3[z];
         return weights;
-
-    } else if (phosphor_layout == 8){
+*/
+/*
+    else if (phosphor_layout == 8) {
         // aperture_3_6_rgb
         vec3 big_ap[7] = vec3[](red, red, yellow, green, cyan, blue, blue);
 
@@ -373,8 +391,9 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap[w];
         return weights;
-
-    } else if (phosphor_layout == 9) {
+	}
+*/
+    else if (phosphor_layout == 9) {
         // reduced TVL aperture for RGB panels
         // aperture_2_4_rgb
         vec3 big_ap_rgb[4] = vec3[](red, yellow, cyan, blue);
@@ -383,8 +402,9 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rgb[w];
         return weights;
-
-    } else if (phosphor_layout == 10) {
+	}
+/*
+    else if (phosphor_layout == 10) {
         // reduced TVL aperture for RBG panels
         vec3 big_ap_rbg[4] = vec3[](red, magenta, cyan, green);
 
@@ -392,148 +412,161 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rbg[w];
         return weights;
+	}
+*/
+    else if(phosphor_layout == 11) {
+        // delta_1_4x1_rgb; dunno why this is called 4x1 when it's obviously 4x2 /shrug
+        vec3 delta_1_1[4] = vec3[](red, green, blue, black);
+        vec3 delta_1_2[4] = vec3[](blue, black, red, green);
 
-    } else if(phosphor_layout == 11){
-       // delta_1_4x1_rgb; dunno why this is called 4x1 when it's obviously 4x2 /shrug
-       vec3 delta_1_1[4] = vec3[](red, green, blue, black);
-       vec3 delta_1_2[4] = vec3[](blue, black, red, green);
+        w = int(floor(mod(coord.y, 2.0)));
+        z = int(floor(mod(coord.x, 4.0)));
 
-       w = int(floor(mod(coord.y, 2.0)));
-       z = int(floor(mod(coord.x, 4.0)));
+        weights = (w == 1) ? delta_1_1[z] : delta_1_2[z];
+        return weights;
+    }
+/*
+    else if (phosphor_layout == 12) {
+        // delta_2_4x1_rgb
+        vec3 delta_2_1[4] = vec3[](red, yellow, cyan, blue);
+        vec3 delta_2_2[4] = vec3[](cyan, blue, red, yellow);
 
-       weights = (w == 1) ? delta_1_1[z] : delta_1_2[z];
-       return weights;
+        z = int(floor(mod(coord.x, 4.0)));
 
-    } else if(phosphor_layout == 12){
-       // delta_2_4x1_rgb
-       vec3 delta_2_1[4] = vec3[](red, yellow, cyan, blue);
-       vec3 delta_2_2[4] = vec3[](cyan, blue, red, yellow);
+        weights = (w == 1) ? delta_2_1[z] : delta_2_2[z];
+        return weights;
+	}
+*/
+/*
+    else if (phosphor_layout == 13) {
+        // delta_2_4x2_rgb
+        vec3 delta_1[4] = vec3[](red, yellow, cyan, blue);
+        vec3 delta_2[4] = vec3[](red, yellow, cyan, blue);
+        vec3 delta_3[4] = vec3[](cyan, blue, red, yellow);
+        vec3 delta_4[4] = vec3[](cyan, blue, red, yellow);
 
-       z = int(floor(mod(coord.x, 4.0)));
+        w = int(floor(mod(coord.y, 4.0)));
+        z = int(floor(mod(coord.x, 4.0)));
 
-       weights = (w == 1) ? delta_2_1[z] : delta_2_2[z];
-       return weights;
+        weights = (w == 1) ? delta_1[z] : (w == 2) ? delta_2[z] : (w == 3) ? delta_3[z] : delta_4[z];
+        return weights;
+    }
+*/
+    else if (phosphor_layout == 14) {
+        // slot mask for RGB panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
+        // {magenta, green, black, black,   black, black},
+        // {magenta, green, black, magenta, green, black},
+        // {black,   black, black, magenta, green, black}
+        vec3 slot2_1[6] = vec3[](magenta, green, black, black,   black, black);
+        vec3 slot2_2[6] = vec3[](magenta, green, black, magenta, green, black);
+        vec3 slot2_3[6] = vec3[](black,   black, black, magenta, green, black);
 
-    } else if(phosphor_layout == 13){
-       // delta_2_4x2_rgb
-       vec3 delta_1[4] = vec3[](red, yellow, cyan, blue);
-       vec3 delta_2[4] = vec3[](red, yellow, cyan, blue);
-       vec3 delta_3[4] = vec3[](cyan, blue, red, yellow);
-       vec3 delta_4[4] = vec3[](cyan, blue, red, yellow);
+        w = int(floor(mod(coord.y, 3.0)));
+        z = int(floor(mod(coord.x, 6.0)));
 
-       w = int(floor(mod(coord.y, 4.0)));
-       z = int(floor(mod(coord.x, 4.0)));
+        weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
+        return weights;
+    }
+/*
+    else if(phosphor_layout == 15) {
+        // slot_2_4x4_rgb
+        // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
+        // {red,   yellow, cyan,  blue,  black, black,  black, black},
+        // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
+        // {black, black,  black, black, red,   yellow, cyan,  blue }
+        vec3 slotmask_RBG_x1[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
+        vec3 slotmask_RBG_x2[8] = vec3[](red,   yellow, cyan,  blue,  black, black,  black, black);
+        vec3 slotmask_RBG_x3[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
+        vec3 slotmask_RBG_x4[8] = vec3[](black, black,  black, black, red,   yellow, cyan,  blue );
 
-       weights = (w == 1) ? delta_1[z] : (w == 2) ? delta_2[z] : (w == 3) ? delta_3[z] : delta_4[z];
-       return weights;
+        // find the vertical index
+        w = int(floor(mod(coord.y, 4.0)));
 
-    } else if(phosphor_layout == 14){
-       // slot mask for RGB panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
-       // {magenta, green, black, black,   black, black},
-       // {magenta, green, black, magenta, green, black},
-       // {black,   black, black, magenta, green, black}
-       vec3 slot2_1[6] = vec3[](magenta, green, black, black,   black, black);
-       vec3 slot2_2[6] = vec3[](magenta, green, black, magenta, green, black);
-       vec3 slot2_3[6] = vec3[](black,   black, black, magenta, green, black);
+        // find the horizontal index
+        z = int(floor(mod(coord.x, 8.0)));
 
-       w = int(floor(mod(coord.y, 3.0)));
-       z = int(floor(mod(coord.x, 6.0)));
+        weights = (w == 1) ? slotmask_RBG_x1[z] : (w == 2) ? slotmask_RBG_x2[z] : (w == 3) ? slotmask_RBG_x3[z] : slotmask_RBG_x4[z];
+        return weights;
+	}
+*/
+/*
+	else if(phosphor_layout == 16) {
+        // slot mask for RBG panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
+        // {yellow, blue,  black,  black},
+        // {yellow, blue,  yellow, blue},
+        // {black,  black, yellow, blue}
+        vec3 slot2_1[4] = vec3[](yellow, blue,  black,  black);
+        vec3 slot2_2[4] = vec3[](yellow, blue,  yellow, blue);
+        vec3 slot2_3[4] = vec3[](black,  black, yellow, blue);
 
-       weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
-       return weights;
+        w = int(floor(mod(coord.y, 3.0)));
+        z = int(floor(mod(coord.x, 4.0)));
 
-    } else if(phosphor_layout == 15){
-       // slot_2_4x4_rgb
-       // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
-       // {red,   yellow, cyan,  blue,  black, black,  black, black},
-       // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
-       // {black, black,  black, black, red,   yellow, cyan,  blue }
-       vec3 slotmask_RBG_x1[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
-       vec3 slotmask_RBG_x2[8] = vec3[](red,   yellow, cyan,  blue,  black, black,  black, black);
-       vec3 slotmask_RBG_x3[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
-       vec3 slotmask_RBG_x4[8] = vec3[](black, black,  black, black, red,   yellow, cyan,  blue );
+        weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
+        return weights;
+    }
+*/
+	else if (phosphor_layout == 17) {
+        // slot_2_5x4_bgr
+        // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
+        // {black, blue,    blue,  green, green, red,   red,     black, black, black},
+        // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
+        // {red,   red,     black, black, black, black, blue,    blue,  green, green}
+        vec3 slot_1[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
+        vec3 slot_2[10] = vec3[](black, blue,    blue,  green, green, red,   red,     black, black, black);
+        vec3 slot_3[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
+        vec3 slot_4[10] = vec3[](red,   red,     black, black, black, black, blue,    blue,  green, green);
 
-       // find the vertical index
-       w = int(floor(mod(coord.y, 4.0)));
+        w = int(floor(mod(coord.y, 4.0)));
+        z = int(floor(mod(coord.x, 10.0)));
 
-       // find the horizontal index
-       z = int(floor(mod(coord.x, 8.0)));
+        weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
+        return weights;
+    }
+/*
+    else if (phosphor_layout == 18) {
+        // same as above but for RBG panels
+        // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
+        // {black, green,  green, blue,  blue,  red,   red,    black, black, black},
+        // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
+        // {red,   red,    black, black, black, black, green,  green, blue,  blue }
+        vec3 slot_1[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
+        vec3 slot_2[10] = vec3[](black, green,  green, blue,  blue,  red,   red,    black, black, black);
+        vec3 slot_3[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
+        vec3 slot_4[10] = vec3[](red,   red,    black, black, black, black, green,  green, blue,  blue );
 
-       weights = (w == 1) ? slotmask_RBG_x1[z] : (w == 2) ? slotmask_RBG_x2[z] : (w == 3) ? slotmask_RBG_x3[z] : slotmask_RBG_x4[z];
-       return weights;
+        w = int(floor(mod(coord.y, 4.0)));
+        z = int(floor(mod(coord.x, 10.0)));
 
-     } else if(phosphor_layout == 16){
-       // slot mask for RBG panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
-       // {yellow, blue,  black,  black},
-       // {yellow, blue,  yellow, blue},
-       // {black,  black, yellow, blue}
-       vec3 slot2_1[4] = vec3[](yellow, blue,  black,  black);
-       vec3 slot2_2[4] = vec3[](yellow, blue,  yellow, blue);
-       vec3 slot2_3[4] = vec3[](black,  black, yellow, blue);
+        weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
+        return weights;
+    }
+*/
+/*
+    else if(phosphor_layout == 19) {
+        // slot_3_7x6_rgb
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue}
 
-       w = int(floor(mod(coord.y, 3.0)));
-       z = int(floor(mod(coord.x, 4.0)));
+        vec3 slot_1[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_2[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_3[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black);
+        vec3 slot_4[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_5[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_6[14] = vec3[](black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue);
 
-       weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
-       return weights;
+        w = int(floor(mod(coord.y, 6.0)));
+        z = int(floor(mod(coord.x, 14.0)));
 
-    } else if (phosphor_layout == 17) {
-       // slot_2_5x4_bgr
-       // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
-       // {black, blue,    blue,  green, green, red,   red,     black, black, black},
-       // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
-       // {red,   red,     black, black, black, black, blue,    blue,  green, green}
-       vec3 slot_1[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
-       vec3 slot_2[10] = vec3[](black, blue,    blue,  green, green, red,   red,     black, black, black);
-       vec3 slot_3[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
-       vec3 slot_4[10] = vec3[](red,   red,     black, black, black, black, blue,    blue,  green, green);
-
-       w = int(floor(mod(coord.y, 4.0)));
-       z = int(floor(mod(coord.x, 10.0)));
-
-       weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
-       return weights;
-
-    } else if (phosphor_layout == 18) {
-       // same as above but for RBG panels
-       // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
-       // {black, green,  green, blue,  blue,  red,   red,    black, black, black},
-       // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
-       // {red,   red,    black, black, black, black, green,  green, blue,  blue }
-       vec3 slot_1[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
-       vec3 slot_2[10] = vec3[](black, green,  green, blue,  blue,  red,   red,    black, black, black);
-       vec3 slot_3[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
-       vec3 slot_4[10] = vec3[](red,   red,    black, black, black, black, green,  green, blue,  blue );
-
-       w = int(floor(mod(coord.y, 4.0)));
-       z = int(floor(mod(coord.x, 10.0)));
-
-       weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
-       return weights;
-
-    } else if(phosphor_layout == 19) {
-       // slot_3_7x6_rgb
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue}
-
-       vec3 slot_1[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_2[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_3[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black);
-       vec3 slot_4[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_5[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_6[14] = vec3[](black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue);
-
-       w = int(floor(mod(coord.y, 6.0)));
-       z = int(floor(mod(coord.x, 14.0)));
-
-       weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : (w == 4) ? slot_4[z] : (w == 5) ? slot_5[z] : slot_6[z];
-       return weights;
-
-    } else {
+        weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : (w == 4) ? slot_4[z] : (w == 5) ? slot_5[z] : slot_6[z];
+        return weights;
+     }
+*/
+	else {
         return weights;
     }
 }

--- a/contrib/resources/glshaders/crt/cga-720p.glsl
+++ b/contrib/resources/glshaders/crt/cga-720p.glsl
@@ -169,10 +169,10 @@ uniform PRECISION float BLUE_SHIFT;
 
 #define WP_ADJUST           0.00
 #define TEMPERATURE      9300.00
-#define LUMA_PRESERVE 		1.00
-#define RED_SHIFT 			0.00
-#define GREEN_SHIFT 		0.00
-#define BLUE_SHIFT 			0.00
+#define LUMA_PRESERVE       1.00
+#define RED_SHIFT           0.00
+#define GREEN_SHIFT         0.00
+#define BLUE_SHIFT          0.00
 #endif
 // END PARAMETERS //
 
@@ -275,10 +275,10 @@ vec3 YxytoXYZ(vec3 Yxy) {
     Many of these mask arrays are adapted from cgwg's crt-geom-deluxe LUTs, and
     those have their filenames included for easy identification
 
-	NOTE: Having too many branches result in a black screen (but no
-	compilation errors) on some older GPUs such as the Intel HD 4000 iGPU. So
-	we're commenting out the branches that are not used by the adaptive CRT
-	shaders.
+    NOTE: Having too many branches result in a black screen (but no
+    compilation errors) on some older GPUs such as the Intel HD 4000 iGPU. So
+    we're commenting out the branches that are not used by the adaptive CRT
+    shaders.
 */
 vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
     vec3 weights = vec3(1.,1.,1.);
@@ -302,14 +302,14 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
     if (phosphor_layout == 0) {
         return weights;
-	}
+    }
 
     else if (phosphor_layout == 1) {
-    	// classic aperture for RGB panels; good for 1080p, too small for 4K+
+        // classic aperture for RGB panels; good for 1080p, too small for 4K+
         // aka aperture_1_2_bgr
         weights  = aperture_weights;
         return weights;
-	}
+    }
 
     else if (phosphor_layout == 2) {
         // 2x2 shadow mask for RGB panels; good for 1080p, too small for 4K+
@@ -317,7 +317,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
         vec3 inverse_aperture = mix(green, magenta, floor(mod(coord.x, 2.0)));
         weights               = mix(aperture_weights, inverse_aperture, floor(mod(coord.y, 2.0)));
         return weights;
-	}
+    }
 
 /*
     else if (phosphor_layout == 3) {
@@ -340,14 +340,14 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         // do a big, dumb comparison in place of a 2D array
         weights = (w == 1) ? slotmask_x1[z] : (w == 2) ? slotmask_x2[z] :  slotmask_x3[z];
-		return weights;
+        return weights;
     }
 */
     else if (phosphor_layout == 4) {
         // classic aperture for RBG panels; good for 1080p, too small for 4K+
         weights  = mix(yellow, blue, floor(mod(coord.x, 2.0)));
         return weights;
-	}
+    }
 /*
     else if (phosphor_layout == 5) {
         // 2x2 shadow mask for RBG panels; good for 1080p, too small for 4K+
@@ -359,7 +359,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
             floor(mod(coord.y, 2.0))
         );
         return weights;
-	}
+    }
 */
 /*
     else if (phosphor_layout == 6) {
@@ -370,7 +370,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = ap4[z];
         return weights;
-	}
+    }
 */
 /*
     else if (phosphor_layout == 7) {
@@ -391,7 +391,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap[w];
         return weights;
-	}
+    }
 */
     else if (phosphor_layout == 9) {
         // reduced TVL aperture for RGB panels
@@ -402,7 +402,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rgb[w];
         return weights;
-	}
+    }
 /*
     else if (phosphor_layout == 10) {
         // reduced TVL aperture for RBG panels
@@ -412,7 +412,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rbg[w];
         return weights;
-	}
+    }
 */
     else if(phosphor_layout == 11) {
         // delta_1_4x1_rgb; dunno why this is called 4x1 when it's obviously 4x2 /shrug
@@ -435,7 +435,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = (w == 1) ? delta_2_1[z] : delta_2_2[z];
         return weights;
-	}
+    }
 */
 /*
     else if (phosphor_layout == 13) {
@@ -487,10 +487,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = (w == 1) ? slotmask_RBG_x1[z] : (w == 2) ? slotmask_RBG_x2[z] : (w == 3) ? slotmask_RBG_x3[z] : slotmask_RBG_x4[z];
         return weights;
-	}
+    }
 */
 /*
-	else if(phosphor_layout == 16) {
+    else if(phosphor_layout == 16) {
         // slot mask for RBG panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
         // {yellow, blue,  black,  black},
         // {yellow, blue,  yellow, blue},
@@ -506,7 +506,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
         return weights;
     }
 */
-	else if (phosphor_layout == 17) {
+    else if (phosphor_layout == 17) {
         // slot_2_5x4_bgr
         // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
         // {black, blue,    blue,  green, green, red,   red,     black, black, black},
@@ -566,7 +566,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
         return weights;
      }
 */
-	else {
+    else {
         return weights;
     }
 }
@@ -586,10 +586,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 // For more info, see: http://www.imagemagick.org/Usage/img_diagrams/cubic_survey.gif
 mat4x4 get_hfilter_profile()
 {
-	float bf = 0.0;
-	float cf = 0.0;
+    float bf = 0.0;
+    float cf = 0.0;
 
-	if (HFILTER_PROFILE == 1) {
+    if (HFILTER_PROFILE == 1) {
         bf = 0.0;
         cf = 0.5;
     }
@@ -691,14 +691,14 @@ void main()
     mask_coords = mix(mask_coords.xy, mask_coords.yx, VSCANLINES);
     color.rgb *= mask_weights(mask_coords, MASK_INTENSITY, int(PHOSPHOR_LAYOUT));
 
-	// Colour temperature
-	if (WP_ADJUST == 1.0) {
-		vec3 wp_adjusted = wp_adjust(color.rgb);
-		vec3 base_luma = XYZtoYxy(sRGB_to_XYZ(color.rgb));
-		vec3 adjusted_luma = XYZtoYxy(sRGB_to_XYZ(wp_adjusted));
-		wp_adjusted = (LUMA_PRESERVE == 1.0) ? adjusted_luma + (vec3(base_luma.r,0.,0.) - vec3(adjusted_luma.r,0.,0.)) : adjusted_luma;
-		color = vec4(XYZ_to_sRGB(YxytoXYZ(wp_adjusted)), 1.0);
-	}
+    // Colour temperature
+    if (WP_ADJUST == 1.0) {
+        vec3 wp_adjusted = wp_adjust(color.rgb);
+        vec3 base_luma = XYZtoYxy(sRGB_to_XYZ(color.rgb));
+        vec3 adjusted_luma = XYZtoYxy(sRGB_to_XYZ(wp_adjusted));
+        wp_adjusted = (LUMA_PRESERVE == 1.0) ? adjusted_luma + (vec3(base_luma.r,0.,0.) - vec3(adjusted_luma.r,0.,0.)) : adjusted_luma;
+        color = vec4(XYZ_to_sRGB(YxytoXYZ(wp_adjusted)), 1.0);
+    }
 
     // Output gamma
     color = clamp(GAMMA_OUT(color), 0.0, 1.0);

--- a/contrib/resources/glshaders/crt/cga-720p.glsl
+++ b/contrib/resources/glshaders/crt/cga-720p.glsl
@@ -248,7 +248,6 @@ vec3 YxytoXYZ(vec3 Yxy) {
     return XYZ;
 }
 
-
 /*
     A collection of CRT mask effects that work with LCD subpixel structures for
     small details
@@ -275,11 +274,18 @@ vec3 YxytoXYZ(vec3 Yxy) {
 
     Many of these mask arrays are adapted from cgwg's crt-geom-deluxe LUTs, and
     those have their filenames included for easy identification
+
+	NOTE: Having too many branches result in a black screen (but no
+	compilation errors) on some older GPUs such as the Intel HD 4000 iGPU. So
+	we're commenting out the branches that are not used by the adaptive CRT
+	shaders.
 */
 vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
     vec3 weights = vec3(1.,1.,1.);
+
     float on = 1.;
     float off = 1.-mask_intensity;
+
     vec3 red     = vec3(on,  off, off);
     vec3 green   = vec3(off, on,  off);
     vec3 blue    = vec3(off, off, on );
@@ -288,6 +294,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
     vec3 cyan    = vec3(off, on,  on );
     vec3 black   = vec3(off, off, off);
     vec3 white   = vec3(on,  on,  on );
+
     int w, z = 0;
 
     // This pattern is used by a few layouts, so we'll define it here
@@ -295,21 +302,25 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
     if (phosphor_layout == 0) {
         return weights;
+	}
 
-    } else if (phosphor_layout == 1) {
-        // classic aperture for RGB panels; good for 1080p, too small for 4K+
+    else if (phosphor_layout == 1) {
+    	// classic aperture for RGB panels; good for 1080p, too small for 4K+
         // aka aperture_1_2_bgr
         weights  = aperture_weights;
         return weights;
+	}
 
-    } else if (phosphor_layout == 2) {
+    else if (phosphor_layout == 2) {
         // 2x2 shadow mask for RGB panels; good for 1080p, too small for 4K+
         // aka delta_1_2x1_bgr
         vec3 inverse_aperture = mix(green, magenta, floor(mod(coord.x, 2.0)));
         weights               = mix(aperture_weights, inverse_aperture, floor(mod(coord.y, 2.0)));
         return weights;
+	}
 
-    } else if (phosphor_layout == 3) {
+/*
+    else if (phosphor_layout == 3) {
         // slot mask for RGB panels; looks okay at 1080p, looks better at 4K
         // {magenta, green, black,   black},
         // {magenta, green, magenta, green},
@@ -329,14 +340,16 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         // do a big, dumb comparison in place of a 2D array
         weights = (w == 1) ? slotmask_x1[z] : (w == 2) ? slotmask_x2[z] :  slotmask_x3[z];
+		return weights;
     }
-
-    if (phosphor_layout == 4) {
+*/
+    else if (phosphor_layout == 4) {
         // classic aperture for RBG panels; good for 1080p, too small for 4K+
         weights  = mix(yellow, blue, floor(mod(coord.x, 2.0)));
         return weights;
-
-    } else if (phosphor_layout == 5) {
+	}
+/*
+    else if (phosphor_layout == 5) {
         // 2x2 shadow mask for RBG panels; good for 1080p, too small for 4K+
         vec3 inverse_aperture = mix(blue, yellow, floor(mod(coord.x, 2.0)));
 
@@ -346,8 +359,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
             floor(mod(coord.y, 2.0))
         );
         return weights;
-
-    } else if (phosphor_layout == 6) {
+	}
+*/
+/*
+    else if (phosphor_layout == 6) {
         // aperture_1_4_rgb; good for simulating lower
         vec3 ap4[4] = vec3[](red, green, blue, black);
 
@@ -355,8 +370,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = ap4[z];
         return weights;
-
-    } else if (phosphor_layout == 7) {
+	}
+*/
+/*
+    else if (phosphor_layout == 7) {
         // aperture_2_5_bgr
         vec3 ap3[5] = vec3[](red, magenta, blue, green, green);
 
@@ -364,8 +381,9 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = ap3[z];
         return weights;
-
-    } else if (phosphor_layout == 8){
+*/
+/*
+    else if (phosphor_layout == 8) {
         // aperture_3_6_rgb
         vec3 big_ap[7] = vec3[](red, red, yellow, green, cyan, blue, blue);
 
@@ -373,8 +391,9 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap[w];
         return weights;
-
-    } else if (phosphor_layout == 9) {
+	}
+*/
+    else if (phosphor_layout == 9) {
         // reduced TVL aperture for RGB panels
         // aperture_2_4_rgb
         vec3 big_ap_rgb[4] = vec3[](red, yellow, cyan, blue);
@@ -383,8 +402,9 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rgb[w];
         return weights;
-
-    } else if (phosphor_layout == 10) {
+	}
+/*
+    else if (phosphor_layout == 10) {
         // reduced TVL aperture for RBG panels
         vec3 big_ap_rbg[4] = vec3[](red, magenta, cyan, green);
 
@@ -392,148 +412,161 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rbg[w];
         return weights;
+	}
+*/
+    else if(phosphor_layout == 11) {
+        // delta_1_4x1_rgb; dunno why this is called 4x1 when it's obviously 4x2 /shrug
+        vec3 delta_1_1[4] = vec3[](red, green, blue, black);
+        vec3 delta_1_2[4] = vec3[](blue, black, red, green);
 
-    } else if(phosphor_layout == 11){
-       // delta_1_4x1_rgb; dunno why this is called 4x1 when it's obviously 4x2 /shrug
-       vec3 delta_1_1[4] = vec3[](red, green, blue, black);
-       vec3 delta_1_2[4] = vec3[](blue, black, red, green);
+        w = int(floor(mod(coord.y, 2.0)));
+        z = int(floor(mod(coord.x, 4.0)));
 
-       w = int(floor(mod(coord.y, 2.0)));
-       z = int(floor(mod(coord.x, 4.0)));
+        weights = (w == 1) ? delta_1_1[z] : delta_1_2[z];
+        return weights;
+    }
+/*
+    else if (phosphor_layout == 12) {
+        // delta_2_4x1_rgb
+        vec3 delta_2_1[4] = vec3[](red, yellow, cyan, blue);
+        vec3 delta_2_2[4] = vec3[](cyan, blue, red, yellow);
 
-       weights = (w == 1) ? delta_1_1[z] : delta_1_2[z];
-       return weights;
+        z = int(floor(mod(coord.x, 4.0)));
 
-    } else if(phosphor_layout == 12){
-       // delta_2_4x1_rgb
-       vec3 delta_2_1[4] = vec3[](red, yellow, cyan, blue);
-       vec3 delta_2_2[4] = vec3[](cyan, blue, red, yellow);
+        weights = (w == 1) ? delta_2_1[z] : delta_2_2[z];
+        return weights;
+	}
+*/
+/*
+    else if (phosphor_layout == 13) {
+        // delta_2_4x2_rgb
+        vec3 delta_1[4] = vec3[](red, yellow, cyan, blue);
+        vec3 delta_2[4] = vec3[](red, yellow, cyan, blue);
+        vec3 delta_3[4] = vec3[](cyan, blue, red, yellow);
+        vec3 delta_4[4] = vec3[](cyan, blue, red, yellow);
 
-       z = int(floor(mod(coord.x, 4.0)));
+        w = int(floor(mod(coord.y, 4.0)));
+        z = int(floor(mod(coord.x, 4.0)));
 
-       weights = (w == 1) ? delta_2_1[z] : delta_2_2[z];
-       return weights;
+        weights = (w == 1) ? delta_1[z] : (w == 2) ? delta_2[z] : (w == 3) ? delta_3[z] : delta_4[z];
+        return weights;
+    }
+*/
+    else if (phosphor_layout == 14) {
+        // slot mask for RGB panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
+        // {magenta, green, black, black,   black, black},
+        // {magenta, green, black, magenta, green, black},
+        // {black,   black, black, magenta, green, black}
+        vec3 slot2_1[6] = vec3[](magenta, green, black, black,   black, black);
+        vec3 slot2_2[6] = vec3[](magenta, green, black, magenta, green, black);
+        vec3 slot2_3[6] = vec3[](black,   black, black, magenta, green, black);
 
-    } else if(phosphor_layout == 13){
-       // delta_2_4x2_rgb
-       vec3 delta_1[4] = vec3[](red, yellow, cyan, blue);
-       vec3 delta_2[4] = vec3[](red, yellow, cyan, blue);
-       vec3 delta_3[4] = vec3[](cyan, blue, red, yellow);
-       vec3 delta_4[4] = vec3[](cyan, blue, red, yellow);
+        w = int(floor(mod(coord.y, 3.0)));
+        z = int(floor(mod(coord.x, 6.0)));
 
-       w = int(floor(mod(coord.y, 4.0)));
-       z = int(floor(mod(coord.x, 4.0)));
+        weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
+        return weights;
+    }
+/*
+    else if(phosphor_layout == 15) {
+        // slot_2_4x4_rgb
+        // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
+        // {red,   yellow, cyan,  blue,  black, black,  black, black},
+        // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
+        // {black, black,  black, black, red,   yellow, cyan,  blue }
+        vec3 slotmask_RBG_x1[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
+        vec3 slotmask_RBG_x2[8] = vec3[](red,   yellow, cyan,  blue,  black, black,  black, black);
+        vec3 slotmask_RBG_x3[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
+        vec3 slotmask_RBG_x4[8] = vec3[](black, black,  black, black, red,   yellow, cyan,  blue );
 
-       weights = (w == 1) ? delta_1[z] : (w == 2) ? delta_2[z] : (w == 3) ? delta_3[z] : delta_4[z];
-       return weights;
+        // find the vertical index
+        w = int(floor(mod(coord.y, 4.0)));
 
-    } else if(phosphor_layout == 14){
-       // slot mask for RGB panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
-       // {magenta, green, black, black,   black, black},
-       // {magenta, green, black, magenta, green, black},
-       // {black,   black, black, magenta, green, black}
-       vec3 slot2_1[6] = vec3[](magenta, green, black, black,   black, black);
-       vec3 slot2_2[6] = vec3[](magenta, green, black, magenta, green, black);
-       vec3 slot2_3[6] = vec3[](black,   black, black, magenta, green, black);
+        // find the horizontal index
+        z = int(floor(mod(coord.x, 8.0)));
 
-       w = int(floor(mod(coord.y, 3.0)));
-       z = int(floor(mod(coord.x, 6.0)));
+        weights = (w == 1) ? slotmask_RBG_x1[z] : (w == 2) ? slotmask_RBG_x2[z] : (w == 3) ? slotmask_RBG_x3[z] : slotmask_RBG_x4[z];
+        return weights;
+	}
+*/
+/*
+	else if(phosphor_layout == 16) {
+        // slot mask for RBG panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
+        // {yellow, blue,  black,  black},
+        // {yellow, blue,  yellow, blue},
+        // {black,  black, yellow, blue}
+        vec3 slot2_1[4] = vec3[](yellow, blue,  black,  black);
+        vec3 slot2_2[4] = vec3[](yellow, blue,  yellow, blue);
+        vec3 slot2_3[4] = vec3[](black,  black, yellow, blue);
 
-       weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
-       return weights;
+        w = int(floor(mod(coord.y, 3.0)));
+        z = int(floor(mod(coord.x, 4.0)));
 
-    } else if(phosphor_layout == 15){
-       // slot_2_4x4_rgb
-       // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
-       // {red,   yellow, cyan,  blue,  black, black,  black, black},
-       // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
-       // {black, black,  black, black, red,   yellow, cyan,  blue }
-       vec3 slotmask_RBG_x1[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
-       vec3 slotmask_RBG_x2[8] = vec3[](red,   yellow, cyan,  blue,  black, black,  black, black);
-       vec3 slotmask_RBG_x3[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
-       vec3 slotmask_RBG_x4[8] = vec3[](black, black,  black, black, red,   yellow, cyan,  blue );
+        weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
+        return weights;
+    }
+*/
+	else if (phosphor_layout == 17) {
+        // slot_2_5x4_bgr
+        // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
+        // {black, blue,    blue,  green, green, red,   red,     black, black, black},
+        // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
+        // {red,   red,     black, black, black, black, blue,    blue,  green, green}
+        vec3 slot_1[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
+        vec3 slot_2[10] = vec3[](black, blue,    blue,  green, green, red,   red,     black, black, black);
+        vec3 slot_3[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
+        vec3 slot_4[10] = vec3[](red,   red,     black, black, black, black, blue,    blue,  green, green);
 
-       // find the vertical index
-       w = int(floor(mod(coord.y, 4.0)));
+        w = int(floor(mod(coord.y, 4.0)));
+        z = int(floor(mod(coord.x, 10.0)));
 
-       // find the horizontal index
-       z = int(floor(mod(coord.x, 8.0)));
+        weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
+        return weights;
+    }
+/*
+    else if (phosphor_layout == 18) {
+        // same as above but for RBG panels
+        // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
+        // {black, green,  green, blue,  blue,  red,   red,    black, black, black},
+        // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
+        // {red,   red,    black, black, black, black, green,  green, blue,  blue }
+        vec3 slot_1[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
+        vec3 slot_2[10] = vec3[](black, green,  green, blue,  blue,  red,   red,    black, black, black);
+        vec3 slot_3[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
+        vec3 slot_4[10] = vec3[](red,   red,    black, black, black, black, green,  green, blue,  blue );
 
-       weights = (w == 1) ? slotmask_RBG_x1[z] : (w == 2) ? slotmask_RBG_x2[z] : (w == 3) ? slotmask_RBG_x3[z] : slotmask_RBG_x4[z];
-       return weights;
+        w = int(floor(mod(coord.y, 4.0)));
+        z = int(floor(mod(coord.x, 10.0)));
 
-     } else if(phosphor_layout == 16){
-       // slot mask for RBG panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
-       // {yellow, blue,  black,  black},
-       // {yellow, blue,  yellow, blue},
-       // {black,  black, yellow, blue}
-       vec3 slot2_1[4] = vec3[](yellow, blue,  black,  black);
-       vec3 slot2_2[4] = vec3[](yellow, blue,  yellow, blue);
-       vec3 slot2_3[4] = vec3[](black,  black, yellow, blue);
+        weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
+        return weights;
+    }
+*/
+/*
+    else if(phosphor_layout == 19) {
+        // slot_3_7x6_rgb
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue}
 
-       w = int(floor(mod(coord.y, 3.0)));
-       z = int(floor(mod(coord.x, 4.0)));
+        vec3 slot_1[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_2[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_3[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black);
+        vec3 slot_4[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_5[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_6[14] = vec3[](black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue);
 
-       weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
-       return weights;
+        w = int(floor(mod(coord.y, 6.0)));
+        z = int(floor(mod(coord.x, 14.0)));
 
-    } else if (phosphor_layout == 17) {
-       // slot_2_5x4_bgr
-       // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
-       // {black, blue,    blue,  green, green, red,   red,     black, black, black},
-       // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
-       // {red,   red,     black, black, black, black, blue,    blue,  green, green}
-       vec3 slot_1[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
-       vec3 slot_2[10] = vec3[](black, blue,    blue,  green, green, red,   red,     black, black, black);
-       vec3 slot_3[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
-       vec3 slot_4[10] = vec3[](red,   red,     black, black, black, black, blue,    blue,  green, green);
-
-       w = int(floor(mod(coord.y, 4.0)));
-       z = int(floor(mod(coord.x, 10.0)));
-
-       weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
-       return weights;
-
-    } else if (phosphor_layout == 18) {
-       // same as above but for RBG panels
-       // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
-       // {black, green,  green, blue,  blue,  red,   red,    black, black, black},
-       // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
-       // {red,   red,    black, black, black, black, green,  green, blue,  blue }
-       vec3 slot_1[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
-       vec3 slot_2[10] = vec3[](black, green,  green, blue,  blue,  red,   red,    black, black, black);
-       vec3 slot_3[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
-       vec3 slot_4[10] = vec3[](red,   red,    black, black, black, black, green,  green, blue,  blue );
-
-       w = int(floor(mod(coord.y, 4.0)));
-       z = int(floor(mod(coord.x, 10.0)));
-
-       weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
-       return weights;
-
-    } else if(phosphor_layout == 19) {
-       // slot_3_7x6_rgb
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue}
-
-       vec3 slot_1[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_2[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_3[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black);
-       vec3 slot_4[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_5[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_6[14] = vec3[](black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue);
-
-       w = int(floor(mod(coord.y, 6.0)));
-       z = int(floor(mod(coord.x, 14.0)));
-
-       weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : (w == 4) ? slot_4[z] : (w == 5) ? slot_5[z] : slot_6[z];
-       return weights;
-
-    } else {
+        weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : (w == 4) ? slot_4[z] : (w == 5) ? slot_5[z] : slot_6[z];
+        return weights;
+     }
+*/
+	else {
         return weights;
     }
 }

--- a/contrib/resources/glshaders/crt/composite-1080p.glsl
+++ b/contrib/resources/glshaders/crt/composite-1080p.glsl
@@ -169,10 +169,10 @@ uniform PRECISION float BLUE_SHIFT;
 
 #define WP_ADJUST           0.00
 #define TEMPERATURE      9300.00
-#define LUMA_PRESERVE 		1.00
-#define RED_SHIFT 			0.00
-#define GREEN_SHIFT 		0.00
-#define BLUE_SHIFT 			0.00
+#define LUMA_PRESERVE       1.00
+#define RED_SHIFT           0.00
+#define GREEN_SHIFT         0.00
+#define BLUE_SHIFT          0.00
 #endif
 // END PARAMETERS //
 
@@ -275,10 +275,10 @@ vec3 YxytoXYZ(vec3 Yxy) {
     Many of these mask arrays are adapted from cgwg's crt-geom-deluxe LUTs, and
     those have their filenames included for easy identification
 
-	NOTE: Having too many branches result in a black screen (but no
-	compilation errors) on some older GPUs such as the Intel HD 4000 iGPU. So
-	we're commenting out the branches that are not used by the adaptive CRT
-	shaders.
+    NOTE: Having too many branches result in a black screen (but no
+    compilation errors) on some older GPUs such as the Intel HD 4000 iGPU. So
+    we're commenting out the branches that are not used by the adaptive CRT
+    shaders.
 */
 vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
     vec3 weights = vec3(1.,1.,1.);
@@ -302,14 +302,14 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
     if (phosphor_layout == 0) {
         return weights;
-	}
+    }
 
     else if (phosphor_layout == 1) {
-    	// classic aperture for RGB panels; good for 1080p, too small for 4K+
+        // classic aperture for RGB panels; good for 1080p, too small for 4K+
         // aka aperture_1_2_bgr
         weights  = aperture_weights;
         return weights;
-	}
+    }
 
     else if (phosphor_layout == 2) {
         // 2x2 shadow mask for RGB panels; good for 1080p, too small for 4K+
@@ -317,7 +317,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
         vec3 inverse_aperture = mix(green, magenta, floor(mod(coord.x, 2.0)));
         weights               = mix(aperture_weights, inverse_aperture, floor(mod(coord.y, 2.0)));
         return weights;
-	}
+    }
 
 /*
     else if (phosphor_layout == 3) {
@@ -340,14 +340,14 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         // do a big, dumb comparison in place of a 2D array
         weights = (w == 1) ? slotmask_x1[z] : (w == 2) ? slotmask_x2[z] :  slotmask_x3[z];
-		return weights;
+        return weights;
     }
 */
     else if (phosphor_layout == 4) {
         // classic aperture for RBG panels; good for 1080p, too small for 4K+
         weights  = mix(yellow, blue, floor(mod(coord.x, 2.0)));
         return weights;
-	}
+    }
 /*
     else if (phosphor_layout == 5) {
         // 2x2 shadow mask for RBG panels; good for 1080p, too small for 4K+
@@ -359,7 +359,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
             floor(mod(coord.y, 2.0))
         );
         return weights;
-	}
+    }
 */
 /*
     else if (phosphor_layout == 6) {
@@ -370,7 +370,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = ap4[z];
         return weights;
-	}
+    }
 */
 /*
     else if (phosphor_layout == 7) {
@@ -391,7 +391,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap[w];
         return weights;
-	}
+    }
 */
     else if (phosphor_layout == 9) {
         // reduced TVL aperture for RGB panels
@@ -402,7 +402,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rgb[w];
         return weights;
-	}
+    }
 /*
     else if (phosphor_layout == 10) {
         // reduced TVL aperture for RBG panels
@@ -412,7 +412,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rbg[w];
         return weights;
-	}
+    }
 */
     else if(phosphor_layout == 11) {
         // delta_1_4x1_rgb; dunno why this is called 4x1 when it's obviously 4x2 /shrug
@@ -435,7 +435,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = (w == 1) ? delta_2_1[z] : delta_2_2[z];
         return weights;
-	}
+    }
 */
 /*
     else if (phosphor_layout == 13) {
@@ -487,10 +487,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = (w == 1) ? slotmask_RBG_x1[z] : (w == 2) ? slotmask_RBG_x2[z] : (w == 3) ? slotmask_RBG_x3[z] : slotmask_RBG_x4[z];
         return weights;
-	}
+    }
 */
 /*
-	else if(phosphor_layout == 16) {
+    else if(phosphor_layout == 16) {
         // slot mask for RBG panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
         // {yellow, blue,  black,  black},
         // {yellow, blue,  yellow, blue},
@@ -506,7 +506,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
         return weights;
     }
 */
-	else if (phosphor_layout == 17) {
+    else if (phosphor_layout == 17) {
         // slot_2_5x4_bgr
         // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
         // {black, blue,    blue,  green, green, red,   red,     black, black, black},
@@ -566,7 +566,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
         return weights;
      }
 */
-	else {
+    else {
         return weights;
     }
 }
@@ -586,10 +586,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 // For more info, see: http://www.imagemagick.org/Usage/img_diagrams/cubic_survey.gif
 mat4x4 get_hfilter_profile()
 {
-	float bf = 0.0;
-	float cf = 0.0;
+    float bf = 0.0;
+    float cf = 0.0;
 
-	if (HFILTER_PROFILE == 1) {
+    if (HFILTER_PROFILE == 1) {
         bf = 0.0;
         cf = 0.5;
     }
@@ -691,14 +691,14 @@ void main()
     mask_coords = mix(mask_coords.xy, mask_coords.yx, VSCANLINES);
     color.rgb *= mask_weights(mask_coords, MASK_INTENSITY, int(PHOSPHOR_LAYOUT));
 
-	// Colour temperature
-	if (WP_ADJUST == 1.0) {
-		vec3 wp_adjusted = wp_adjust(color.rgb);
-		vec3 base_luma = XYZtoYxy(sRGB_to_XYZ(color.rgb));
-		vec3 adjusted_luma = XYZtoYxy(sRGB_to_XYZ(wp_adjusted));
-		wp_adjusted = (LUMA_PRESERVE == 1.0) ? adjusted_luma + (vec3(base_luma.r,0.,0.) - vec3(adjusted_luma.r,0.,0.)) : adjusted_luma;
-		color = vec4(XYZ_to_sRGB(YxytoXYZ(wp_adjusted)), 1.0);
-	}
+    // Colour temperature
+    if (WP_ADJUST == 1.0) {
+        vec3 wp_adjusted = wp_adjust(color.rgb);
+        vec3 base_luma = XYZtoYxy(sRGB_to_XYZ(color.rgb));
+        vec3 adjusted_luma = XYZtoYxy(sRGB_to_XYZ(wp_adjusted));
+        wp_adjusted = (LUMA_PRESERVE == 1.0) ? adjusted_luma + (vec3(base_luma.r,0.,0.) - vec3(adjusted_luma.r,0.,0.)) : adjusted_luma;
+        color = vec4(XYZ_to_sRGB(YxytoXYZ(wp_adjusted)), 1.0);
+    }
 
     // Output gamma
     color = clamp(GAMMA_OUT(color), 0.0, 1.0);

--- a/contrib/resources/glshaders/crt/composite-1080p.glsl
+++ b/contrib/resources/glshaders/crt/composite-1080p.glsl
@@ -248,7 +248,6 @@ vec3 YxytoXYZ(vec3 Yxy) {
     return XYZ;
 }
 
-
 /*
     A collection of CRT mask effects that work with LCD subpixel structures for
     small details
@@ -275,11 +274,18 @@ vec3 YxytoXYZ(vec3 Yxy) {
 
     Many of these mask arrays are adapted from cgwg's crt-geom-deluxe LUTs, and
     those have their filenames included for easy identification
+
+	NOTE: Having too many branches result in a black screen (but no
+	compilation errors) on some older GPUs such as the Intel HD 4000 iGPU. So
+	we're commenting out the branches that are not used by the adaptive CRT
+	shaders.
 */
 vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
     vec3 weights = vec3(1.,1.,1.);
+
     float on = 1.;
     float off = 1.-mask_intensity;
+
     vec3 red     = vec3(on,  off, off);
     vec3 green   = vec3(off, on,  off);
     vec3 blue    = vec3(off, off, on );
@@ -288,6 +294,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
     vec3 cyan    = vec3(off, on,  on );
     vec3 black   = vec3(off, off, off);
     vec3 white   = vec3(on,  on,  on );
+
     int w, z = 0;
 
     // This pattern is used by a few layouts, so we'll define it here
@@ -295,21 +302,25 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
     if (phosphor_layout == 0) {
         return weights;
+	}
 
-    } else if (phosphor_layout == 1) {
-        // classic aperture for RGB panels; good for 1080p, too small for 4K+
+    else if (phosphor_layout == 1) {
+    	// classic aperture for RGB panels; good for 1080p, too small for 4K+
         // aka aperture_1_2_bgr
         weights  = aperture_weights;
         return weights;
+	}
 
-    } else if (phosphor_layout == 2) {
+    else if (phosphor_layout == 2) {
         // 2x2 shadow mask for RGB panels; good for 1080p, too small for 4K+
         // aka delta_1_2x1_bgr
         vec3 inverse_aperture = mix(green, magenta, floor(mod(coord.x, 2.0)));
         weights               = mix(aperture_weights, inverse_aperture, floor(mod(coord.y, 2.0)));
         return weights;
+	}
 
-    } else if (phosphor_layout == 3) {
+/*
+    else if (phosphor_layout == 3) {
         // slot mask for RGB panels; looks okay at 1080p, looks better at 4K
         // {magenta, green, black,   black},
         // {magenta, green, magenta, green},
@@ -329,14 +340,16 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         // do a big, dumb comparison in place of a 2D array
         weights = (w == 1) ? slotmask_x1[z] : (w == 2) ? slotmask_x2[z] :  slotmask_x3[z];
+		return weights;
     }
-
-    if (phosphor_layout == 4) {
+*/
+    else if (phosphor_layout == 4) {
         // classic aperture for RBG panels; good for 1080p, too small for 4K+
         weights  = mix(yellow, blue, floor(mod(coord.x, 2.0)));
         return weights;
-
-    } else if (phosphor_layout == 5) {
+	}
+/*
+    else if (phosphor_layout == 5) {
         // 2x2 shadow mask for RBG panels; good for 1080p, too small for 4K+
         vec3 inverse_aperture = mix(blue, yellow, floor(mod(coord.x, 2.0)));
 
@@ -346,8 +359,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
             floor(mod(coord.y, 2.0))
         );
         return weights;
-
-    } else if (phosphor_layout == 6) {
+	}
+*/
+/*
+    else if (phosphor_layout == 6) {
         // aperture_1_4_rgb; good for simulating lower
         vec3 ap4[4] = vec3[](red, green, blue, black);
 
@@ -355,8 +370,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = ap4[z];
         return weights;
-
-    } else if (phosphor_layout == 7) {
+	}
+*/
+/*
+    else if (phosphor_layout == 7) {
         // aperture_2_5_bgr
         vec3 ap3[5] = vec3[](red, magenta, blue, green, green);
 
@@ -364,8 +381,9 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = ap3[z];
         return weights;
-
-    } else if (phosphor_layout == 8){
+*/
+/*
+    else if (phosphor_layout == 8) {
         // aperture_3_6_rgb
         vec3 big_ap[7] = vec3[](red, red, yellow, green, cyan, blue, blue);
 
@@ -373,8 +391,9 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap[w];
         return weights;
-
-    } else if (phosphor_layout == 9) {
+	}
+*/
+    else if (phosphor_layout == 9) {
         // reduced TVL aperture for RGB panels
         // aperture_2_4_rgb
         vec3 big_ap_rgb[4] = vec3[](red, yellow, cyan, blue);
@@ -383,8 +402,9 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rgb[w];
         return weights;
-
-    } else if (phosphor_layout == 10) {
+	}
+/*
+    else if (phosphor_layout == 10) {
         // reduced TVL aperture for RBG panels
         vec3 big_ap_rbg[4] = vec3[](red, magenta, cyan, green);
 
@@ -392,148 +412,161 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rbg[w];
         return weights;
+	}
+*/
+    else if(phosphor_layout == 11) {
+        // delta_1_4x1_rgb; dunno why this is called 4x1 when it's obviously 4x2 /shrug
+        vec3 delta_1_1[4] = vec3[](red, green, blue, black);
+        vec3 delta_1_2[4] = vec3[](blue, black, red, green);
 
-    } else if(phosphor_layout == 11){
-       // delta_1_4x1_rgb; dunno why this is called 4x1 when it's obviously 4x2 /shrug
-       vec3 delta_1_1[4] = vec3[](red, green, blue, black);
-       vec3 delta_1_2[4] = vec3[](blue, black, red, green);
+        w = int(floor(mod(coord.y, 2.0)));
+        z = int(floor(mod(coord.x, 4.0)));
 
-       w = int(floor(mod(coord.y, 2.0)));
-       z = int(floor(mod(coord.x, 4.0)));
+        weights = (w == 1) ? delta_1_1[z] : delta_1_2[z];
+        return weights;
+    }
+/*
+    else if (phosphor_layout == 12) {
+        // delta_2_4x1_rgb
+        vec3 delta_2_1[4] = vec3[](red, yellow, cyan, blue);
+        vec3 delta_2_2[4] = vec3[](cyan, blue, red, yellow);
 
-       weights = (w == 1) ? delta_1_1[z] : delta_1_2[z];
-       return weights;
+        z = int(floor(mod(coord.x, 4.0)));
 
-    } else if(phosphor_layout == 12){
-       // delta_2_4x1_rgb
-       vec3 delta_2_1[4] = vec3[](red, yellow, cyan, blue);
-       vec3 delta_2_2[4] = vec3[](cyan, blue, red, yellow);
+        weights = (w == 1) ? delta_2_1[z] : delta_2_2[z];
+        return weights;
+	}
+*/
+/*
+    else if (phosphor_layout == 13) {
+        // delta_2_4x2_rgb
+        vec3 delta_1[4] = vec3[](red, yellow, cyan, blue);
+        vec3 delta_2[4] = vec3[](red, yellow, cyan, blue);
+        vec3 delta_3[4] = vec3[](cyan, blue, red, yellow);
+        vec3 delta_4[4] = vec3[](cyan, blue, red, yellow);
 
-       z = int(floor(mod(coord.x, 4.0)));
+        w = int(floor(mod(coord.y, 4.0)));
+        z = int(floor(mod(coord.x, 4.0)));
 
-       weights = (w == 1) ? delta_2_1[z] : delta_2_2[z];
-       return weights;
+        weights = (w == 1) ? delta_1[z] : (w == 2) ? delta_2[z] : (w == 3) ? delta_3[z] : delta_4[z];
+        return weights;
+    }
+*/
+    else if (phosphor_layout == 14) {
+        // slot mask for RGB panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
+        // {magenta, green, black, black,   black, black},
+        // {magenta, green, black, magenta, green, black},
+        // {black,   black, black, magenta, green, black}
+        vec3 slot2_1[6] = vec3[](magenta, green, black, black,   black, black);
+        vec3 slot2_2[6] = vec3[](magenta, green, black, magenta, green, black);
+        vec3 slot2_3[6] = vec3[](black,   black, black, magenta, green, black);
 
-    } else if(phosphor_layout == 13){
-       // delta_2_4x2_rgb
-       vec3 delta_1[4] = vec3[](red, yellow, cyan, blue);
-       vec3 delta_2[4] = vec3[](red, yellow, cyan, blue);
-       vec3 delta_3[4] = vec3[](cyan, blue, red, yellow);
-       vec3 delta_4[4] = vec3[](cyan, blue, red, yellow);
+        w = int(floor(mod(coord.y, 3.0)));
+        z = int(floor(mod(coord.x, 6.0)));
 
-       w = int(floor(mod(coord.y, 4.0)));
-       z = int(floor(mod(coord.x, 4.0)));
+        weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
+        return weights;
+    }
+/*
+    else if(phosphor_layout == 15) {
+        // slot_2_4x4_rgb
+        // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
+        // {red,   yellow, cyan,  blue,  black, black,  black, black},
+        // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
+        // {black, black,  black, black, red,   yellow, cyan,  blue }
+        vec3 slotmask_RBG_x1[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
+        vec3 slotmask_RBG_x2[8] = vec3[](red,   yellow, cyan,  blue,  black, black,  black, black);
+        vec3 slotmask_RBG_x3[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
+        vec3 slotmask_RBG_x4[8] = vec3[](black, black,  black, black, red,   yellow, cyan,  blue );
 
-       weights = (w == 1) ? delta_1[z] : (w == 2) ? delta_2[z] : (w == 3) ? delta_3[z] : delta_4[z];
-       return weights;
+        // find the vertical index
+        w = int(floor(mod(coord.y, 4.0)));
 
-    } else if(phosphor_layout == 14){
-       // slot mask for RGB panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
-       // {magenta, green, black, black,   black, black},
-       // {magenta, green, black, magenta, green, black},
-       // {black,   black, black, magenta, green, black}
-       vec3 slot2_1[6] = vec3[](magenta, green, black, black,   black, black);
-       vec3 slot2_2[6] = vec3[](magenta, green, black, magenta, green, black);
-       vec3 slot2_3[6] = vec3[](black,   black, black, magenta, green, black);
+        // find the horizontal index
+        z = int(floor(mod(coord.x, 8.0)));
 
-       w = int(floor(mod(coord.y, 3.0)));
-       z = int(floor(mod(coord.x, 6.0)));
+        weights = (w == 1) ? slotmask_RBG_x1[z] : (w == 2) ? slotmask_RBG_x2[z] : (w == 3) ? slotmask_RBG_x3[z] : slotmask_RBG_x4[z];
+        return weights;
+	}
+*/
+/*
+	else if(phosphor_layout == 16) {
+        // slot mask for RBG panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
+        // {yellow, blue,  black,  black},
+        // {yellow, blue,  yellow, blue},
+        // {black,  black, yellow, blue}
+        vec3 slot2_1[4] = vec3[](yellow, blue,  black,  black);
+        vec3 slot2_2[4] = vec3[](yellow, blue,  yellow, blue);
+        vec3 slot2_3[4] = vec3[](black,  black, yellow, blue);
 
-       weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
-       return weights;
+        w = int(floor(mod(coord.y, 3.0)));
+        z = int(floor(mod(coord.x, 4.0)));
 
-    } else if(phosphor_layout == 15){
-       // slot_2_4x4_rgb
-       // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
-       // {red,   yellow, cyan,  blue,  black, black,  black, black},
-       // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
-       // {black, black,  black, black, red,   yellow, cyan,  blue }
-       vec3 slotmask_RBG_x1[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
-       vec3 slotmask_RBG_x2[8] = vec3[](red,   yellow, cyan,  blue,  black, black,  black, black);
-       vec3 slotmask_RBG_x3[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
-       vec3 slotmask_RBG_x4[8] = vec3[](black, black,  black, black, red,   yellow, cyan,  blue );
+        weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
+        return weights;
+    }
+*/
+	else if (phosphor_layout == 17) {
+        // slot_2_5x4_bgr
+        // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
+        // {black, blue,    blue,  green, green, red,   red,     black, black, black},
+        // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
+        // {red,   red,     black, black, black, black, blue,    blue,  green, green}
+        vec3 slot_1[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
+        vec3 slot_2[10] = vec3[](black, blue,    blue,  green, green, red,   red,     black, black, black);
+        vec3 slot_3[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
+        vec3 slot_4[10] = vec3[](red,   red,     black, black, black, black, blue,    blue,  green, green);
 
-       // find the vertical index
-       w = int(floor(mod(coord.y, 4.0)));
+        w = int(floor(mod(coord.y, 4.0)));
+        z = int(floor(mod(coord.x, 10.0)));
 
-       // find the horizontal index
-       z = int(floor(mod(coord.x, 8.0)));
+        weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
+        return weights;
+    }
+/*
+    else if (phosphor_layout == 18) {
+        // same as above but for RBG panels
+        // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
+        // {black, green,  green, blue,  blue,  red,   red,    black, black, black},
+        // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
+        // {red,   red,    black, black, black, black, green,  green, blue,  blue }
+        vec3 slot_1[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
+        vec3 slot_2[10] = vec3[](black, green,  green, blue,  blue,  red,   red,    black, black, black);
+        vec3 slot_3[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
+        vec3 slot_4[10] = vec3[](red,   red,    black, black, black, black, green,  green, blue,  blue );
 
-       weights = (w == 1) ? slotmask_RBG_x1[z] : (w == 2) ? slotmask_RBG_x2[z] : (w == 3) ? slotmask_RBG_x3[z] : slotmask_RBG_x4[z];
-       return weights;
+        w = int(floor(mod(coord.y, 4.0)));
+        z = int(floor(mod(coord.x, 10.0)));
 
-     } else if(phosphor_layout == 16){
-       // slot mask for RBG panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
-       // {yellow, blue,  black,  black},
-       // {yellow, blue,  yellow, blue},
-       // {black,  black, yellow, blue}
-       vec3 slot2_1[4] = vec3[](yellow, blue,  black,  black);
-       vec3 slot2_2[4] = vec3[](yellow, blue,  yellow, blue);
-       vec3 slot2_3[4] = vec3[](black,  black, yellow, blue);
+        weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
+        return weights;
+    }
+*/
+/*
+    else if(phosphor_layout == 19) {
+        // slot_3_7x6_rgb
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue}
 
-       w = int(floor(mod(coord.y, 3.0)));
-       z = int(floor(mod(coord.x, 4.0)));
+        vec3 slot_1[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_2[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_3[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black);
+        vec3 slot_4[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_5[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_6[14] = vec3[](black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue);
 
-       weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
-       return weights;
+        w = int(floor(mod(coord.y, 6.0)));
+        z = int(floor(mod(coord.x, 14.0)));
 
-    } else if (phosphor_layout == 17) {
-       // slot_2_5x4_bgr
-       // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
-       // {black, blue,    blue,  green, green, red,   red,     black, black, black},
-       // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
-       // {red,   red,     black, black, black, black, blue,    blue,  green, green}
-       vec3 slot_1[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
-       vec3 slot_2[10] = vec3[](black, blue,    blue,  green, green, red,   red,     black, black, black);
-       vec3 slot_3[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
-       vec3 slot_4[10] = vec3[](red,   red,     black, black, black, black, blue,    blue,  green, green);
-
-       w = int(floor(mod(coord.y, 4.0)));
-       z = int(floor(mod(coord.x, 10.0)));
-
-       weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
-       return weights;
-
-    } else if (phosphor_layout == 18) {
-       // same as above but for RBG panels
-       // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
-       // {black, green,  green, blue,  blue,  red,   red,    black, black, black},
-       // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
-       // {red,   red,    black, black, black, black, green,  green, blue,  blue }
-       vec3 slot_1[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
-       vec3 slot_2[10] = vec3[](black, green,  green, blue,  blue,  red,   red,    black, black, black);
-       vec3 slot_3[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
-       vec3 slot_4[10] = vec3[](red,   red,    black, black, black, black, green,  green, blue,  blue );
-
-       w = int(floor(mod(coord.y, 4.0)));
-       z = int(floor(mod(coord.x, 10.0)));
-
-       weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
-       return weights;
-
-    } else if(phosphor_layout == 19) {
-       // slot_3_7x6_rgb
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue}
-
-       vec3 slot_1[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_2[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_3[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black);
-       vec3 slot_4[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_5[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_6[14] = vec3[](black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue);
-
-       w = int(floor(mod(coord.y, 6.0)));
-       z = int(floor(mod(coord.x, 14.0)));
-
-       weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : (w == 4) ? slot_4[z] : (w == 5) ? slot_5[z] : slot_6[z];
-       return weights;
-
-    } else {
+        weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : (w == 4) ? slot_4[z] : (w == 5) ? slot_5[z] : slot_6[z];
+        return weights;
+     }
+*/
+	else {
         return weights;
     }
 }

--- a/contrib/resources/glshaders/crt/composite-1440p.glsl
+++ b/contrib/resources/glshaders/crt/composite-1440p.glsl
@@ -169,10 +169,10 @@ uniform PRECISION float BLUE_SHIFT;
 
 #define WP_ADJUST           0.00
 #define TEMPERATURE      9300.00
-#define LUMA_PRESERVE 		1.00
-#define RED_SHIFT 			0.00
-#define GREEN_SHIFT 		0.00
-#define BLUE_SHIFT 			0.00
+#define LUMA_PRESERVE       1.00
+#define RED_SHIFT           0.00
+#define GREEN_SHIFT         0.00
+#define BLUE_SHIFT          0.00
 #endif
 // END PARAMETERS //
 
@@ -275,10 +275,10 @@ vec3 YxytoXYZ(vec3 Yxy) {
     Many of these mask arrays are adapted from cgwg's crt-geom-deluxe LUTs, and
     those have their filenames included for easy identification
 
-	NOTE: Having too many branches result in a black screen (but no
-	compilation errors) on some older GPUs such as the Intel HD 4000 iGPU. So
-	we're commenting out the branches that are not used by the adaptive CRT
-	shaders.
+    NOTE: Having too many branches result in a black screen (but no
+    compilation errors) on some older GPUs such as the Intel HD 4000 iGPU. So
+    we're commenting out the branches that are not used by the adaptive CRT
+    shaders.
 */
 vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
     vec3 weights = vec3(1.,1.,1.);
@@ -302,14 +302,14 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
     if (phosphor_layout == 0) {
         return weights;
-	}
+    }
 
     else if (phosphor_layout == 1) {
-    	// classic aperture for RGB panels; good for 1080p, too small for 4K+
+        // classic aperture for RGB panels; good for 1080p, too small for 4K+
         // aka aperture_1_2_bgr
         weights  = aperture_weights;
         return weights;
-	}
+    }
 
     else if (phosphor_layout == 2) {
         // 2x2 shadow mask for RGB panels; good for 1080p, too small for 4K+
@@ -317,7 +317,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
         vec3 inverse_aperture = mix(green, magenta, floor(mod(coord.x, 2.0)));
         weights               = mix(aperture_weights, inverse_aperture, floor(mod(coord.y, 2.0)));
         return weights;
-	}
+    }
 
 /*
     else if (phosphor_layout == 3) {
@@ -340,14 +340,14 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         // do a big, dumb comparison in place of a 2D array
         weights = (w == 1) ? slotmask_x1[z] : (w == 2) ? slotmask_x2[z] :  slotmask_x3[z];
-		return weights;
+        return weights;
     }
 */
     else if (phosphor_layout == 4) {
         // classic aperture for RBG panels; good for 1080p, too small for 4K+
         weights  = mix(yellow, blue, floor(mod(coord.x, 2.0)));
         return weights;
-	}
+    }
 /*
     else if (phosphor_layout == 5) {
         // 2x2 shadow mask for RBG panels; good for 1080p, too small for 4K+
@@ -359,7 +359,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
             floor(mod(coord.y, 2.0))
         );
         return weights;
-	}
+    }
 */
 /*
     else if (phosphor_layout == 6) {
@@ -370,7 +370,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = ap4[z];
         return weights;
-	}
+    }
 */
 /*
     else if (phosphor_layout == 7) {
@@ -391,7 +391,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap[w];
         return weights;
-	}
+    }
 */
     else if (phosphor_layout == 9) {
         // reduced TVL aperture for RGB panels
@@ -402,7 +402,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rgb[w];
         return weights;
-	}
+    }
 /*
     else if (phosphor_layout == 10) {
         // reduced TVL aperture for RBG panels
@@ -412,7 +412,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rbg[w];
         return weights;
-	}
+    }
 */
     else if(phosphor_layout == 11) {
         // delta_1_4x1_rgb; dunno why this is called 4x1 when it's obviously 4x2 /shrug
@@ -435,7 +435,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = (w == 1) ? delta_2_1[z] : delta_2_2[z];
         return weights;
-	}
+    }
 */
 /*
     else if (phosphor_layout == 13) {
@@ -487,10 +487,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = (w == 1) ? slotmask_RBG_x1[z] : (w == 2) ? slotmask_RBG_x2[z] : (w == 3) ? slotmask_RBG_x3[z] : slotmask_RBG_x4[z];
         return weights;
-	}
+    }
 */
 /*
-	else if(phosphor_layout == 16) {
+    else if(phosphor_layout == 16) {
         // slot mask for RBG panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
         // {yellow, blue,  black,  black},
         // {yellow, blue,  yellow, blue},
@@ -506,7 +506,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
         return weights;
     }
 */
-	else if (phosphor_layout == 17) {
+    else if (phosphor_layout == 17) {
         // slot_2_5x4_bgr
         // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
         // {black, blue,    blue,  green, green, red,   red,     black, black, black},
@@ -566,7 +566,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
         return weights;
      }
 */
-	else {
+    else {
         return weights;
     }
 }
@@ -586,10 +586,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 // For more info, see: http://www.imagemagick.org/Usage/img_diagrams/cubic_survey.gif
 mat4x4 get_hfilter_profile()
 {
-	float bf = 0.0;
-	float cf = 0.0;
+    float bf = 0.0;
+    float cf = 0.0;
 
-	if (HFILTER_PROFILE == 1) {
+    if (HFILTER_PROFILE == 1) {
         bf = 0.0;
         cf = 0.5;
     }
@@ -691,14 +691,14 @@ void main()
     mask_coords = mix(mask_coords.xy, mask_coords.yx, VSCANLINES);
     color.rgb *= mask_weights(mask_coords, MASK_INTENSITY, int(PHOSPHOR_LAYOUT));
 
-	// Colour temperature
-	if (WP_ADJUST == 1.0) {
-		vec3 wp_adjusted = wp_adjust(color.rgb);
-		vec3 base_luma = XYZtoYxy(sRGB_to_XYZ(color.rgb));
-		vec3 adjusted_luma = XYZtoYxy(sRGB_to_XYZ(wp_adjusted));
-		wp_adjusted = (LUMA_PRESERVE == 1.0) ? adjusted_luma + (vec3(base_luma.r,0.,0.) - vec3(adjusted_luma.r,0.,0.)) : adjusted_luma;
-		color = vec4(XYZ_to_sRGB(YxytoXYZ(wp_adjusted)), 1.0);
-	}
+    // Colour temperature
+    if (WP_ADJUST == 1.0) {
+        vec3 wp_adjusted = wp_adjust(color.rgb);
+        vec3 base_luma = XYZtoYxy(sRGB_to_XYZ(color.rgb));
+        vec3 adjusted_luma = XYZtoYxy(sRGB_to_XYZ(wp_adjusted));
+        wp_adjusted = (LUMA_PRESERVE == 1.0) ? adjusted_luma + (vec3(base_luma.r,0.,0.) - vec3(adjusted_luma.r,0.,0.)) : adjusted_luma;
+        color = vec4(XYZ_to_sRGB(YxytoXYZ(wp_adjusted)), 1.0);
+    }
 
     // Output gamma
     color = clamp(GAMMA_OUT(color), 0.0, 1.0);

--- a/contrib/resources/glshaders/crt/composite-1440p.glsl
+++ b/contrib/resources/glshaders/crt/composite-1440p.glsl
@@ -248,7 +248,6 @@ vec3 YxytoXYZ(vec3 Yxy) {
     return XYZ;
 }
 
-
 /*
     A collection of CRT mask effects that work with LCD subpixel structures for
     small details
@@ -275,11 +274,18 @@ vec3 YxytoXYZ(vec3 Yxy) {
 
     Many of these mask arrays are adapted from cgwg's crt-geom-deluxe LUTs, and
     those have their filenames included for easy identification
+
+	NOTE: Having too many branches result in a black screen (but no
+	compilation errors) on some older GPUs such as the Intel HD 4000 iGPU. So
+	we're commenting out the branches that are not used by the adaptive CRT
+	shaders.
 */
 vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
     vec3 weights = vec3(1.,1.,1.);
+
     float on = 1.;
     float off = 1.-mask_intensity;
+
     vec3 red     = vec3(on,  off, off);
     vec3 green   = vec3(off, on,  off);
     vec3 blue    = vec3(off, off, on );
@@ -288,6 +294,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
     vec3 cyan    = vec3(off, on,  on );
     vec3 black   = vec3(off, off, off);
     vec3 white   = vec3(on,  on,  on );
+
     int w, z = 0;
 
     // This pattern is used by a few layouts, so we'll define it here
@@ -295,21 +302,25 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
     if (phosphor_layout == 0) {
         return weights;
+	}
 
-    } else if (phosphor_layout == 1) {
-        // classic aperture for RGB panels; good for 1080p, too small for 4K+
+    else if (phosphor_layout == 1) {
+    	// classic aperture for RGB panels; good for 1080p, too small for 4K+
         // aka aperture_1_2_bgr
         weights  = aperture_weights;
         return weights;
+	}
 
-    } else if (phosphor_layout == 2) {
+    else if (phosphor_layout == 2) {
         // 2x2 shadow mask for RGB panels; good for 1080p, too small for 4K+
         // aka delta_1_2x1_bgr
         vec3 inverse_aperture = mix(green, magenta, floor(mod(coord.x, 2.0)));
         weights               = mix(aperture_weights, inverse_aperture, floor(mod(coord.y, 2.0)));
         return weights;
+	}
 
-    } else if (phosphor_layout == 3) {
+/*
+    else if (phosphor_layout == 3) {
         // slot mask for RGB panels; looks okay at 1080p, looks better at 4K
         // {magenta, green, black,   black},
         // {magenta, green, magenta, green},
@@ -329,14 +340,16 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         // do a big, dumb comparison in place of a 2D array
         weights = (w == 1) ? slotmask_x1[z] : (w == 2) ? slotmask_x2[z] :  slotmask_x3[z];
+		return weights;
     }
-
-    if (phosphor_layout == 4) {
+*/
+    else if (phosphor_layout == 4) {
         // classic aperture for RBG panels; good for 1080p, too small for 4K+
         weights  = mix(yellow, blue, floor(mod(coord.x, 2.0)));
         return weights;
-
-    } else if (phosphor_layout == 5) {
+	}
+/*
+    else if (phosphor_layout == 5) {
         // 2x2 shadow mask for RBG panels; good for 1080p, too small for 4K+
         vec3 inverse_aperture = mix(blue, yellow, floor(mod(coord.x, 2.0)));
 
@@ -346,8 +359,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
             floor(mod(coord.y, 2.0))
         );
         return weights;
-
-    } else if (phosphor_layout == 6) {
+	}
+*/
+/*
+    else if (phosphor_layout == 6) {
         // aperture_1_4_rgb; good for simulating lower
         vec3 ap4[4] = vec3[](red, green, blue, black);
 
@@ -355,8 +370,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = ap4[z];
         return weights;
-
-    } else if (phosphor_layout == 7) {
+	}
+*/
+/*
+    else if (phosphor_layout == 7) {
         // aperture_2_5_bgr
         vec3 ap3[5] = vec3[](red, magenta, blue, green, green);
 
@@ -364,8 +381,9 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = ap3[z];
         return weights;
-
-    } else if (phosphor_layout == 8){
+*/
+/*
+    else if (phosphor_layout == 8) {
         // aperture_3_6_rgb
         vec3 big_ap[7] = vec3[](red, red, yellow, green, cyan, blue, blue);
 
@@ -373,8 +391,9 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap[w];
         return weights;
-
-    } else if (phosphor_layout == 9) {
+	}
+*/
+    else if (phosphor_layout == 9) {
         // reduced TVL aperture for RGB panels
         // aperture_2_4_rgb
         vec3 big_ap_rgb[4] = vec3[](red, yellow, cyan, blue);
@@ -383,8 +402,9 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rgb[w];
         return weights;
-
-    } else if (phosphor_layout == 10) {
+	}
+/*
+    else if (phosphor_layout == 10) {
         // reduced TVL aperture for RBG panels
         vec3 big_ap_rbg[4] = vec3[](red, magenta, cyan, green);
 
@@ -392,148 +412,161 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rbg[w];
         return weights;
+	}
+*/
+    else if(phosphor_layout == 11) {
+        // delta_1_4x1_rgb; dunno why this is called 4x1 when it's obviously 4x2 /shrug
+        vec3 delta_1_1[4] = vec3[](red, green, blue, black);
+        vec3 delta_1_2[4] = vec3[](blue, black, red, green);
 
-    } else if(phosphor_layout == 11){
-       // delta_1_4x1_rgb; dunno why this is called 4x1 when it's obviously 4x2 /shrug
-       vec3 delta_1_1[4] = vec3[](red, green, blue, black);
-       vec3 delta_1_2[4] = vec3[](blue, black, red, green);
+        w = int(floor(mod(coord.y, 2.0)));
+        z = int(floor(mod(coord.x, 4.0)));
 
-       w = int(floor(mod(coord.y, 2.0)));
-       z = int(floor(mod(coord.x, 4.0)));
+        weights = (w == 1) ? delta_1_1[z] : delta_1_2[z];
+        return weights;
+    }
+/*
+    else if (phosphor_layout == 12) {
+        // delta_2_4x1_rgb
+        vec3 delta_2_1[4] = vec3[](red, yellow, cyan, blue);
+        vec3 delta_2_2[4] = vec3[](cyan, blue, red, yellow);
 
-       weights = (w == 1) ? delta_1_1[z] : delta_1_2[z];
-       return weights;
+        z = int(floor(mod(coord.x, 4.0)));
 
-    } else if(phosphor_layout == 12){
-       // delta_2_4x1_rgb
-       vec3 delta_2_1[4] = vec3[](red, yellow, cyan, blue);
-       vec3 delta_2_2[4] = vec3[](cyan, blue, red, yellow);
+        weights = (w == 1) ? delta_2_1[z] : delta_2_2[z];
+        return weights;
+	}
+*/
+/*
+    else if (phosphor_layout == 13) {
+        // delta_2_4x2_rgb
+        vec3 delta_1[4] = vec3[](red, yellow, cyan, blue);
+        vec3 delta_2[4] = vec3[](red, yellow, cyan, blue);
+        vec3 delta_3[4] = vec3[](cyan, blue, red, yellow);
+        vec3 delta_4[4] = vec3[](cyan, blue, red, yellow);
 
-       z = int(floor(mod(coord.x, 4.0)));
+        w = int(floor(mod(coord.y, 4.0)));
+        z = int(floor(mod(coord.x, 4.0)));
 
-       weights = (w == 1) ? delta_2_1[z] : delta_2_2[z];
-       return weights;
+        weights = (w == 1) ? delta_1[z] : (w == 2) ? delta_2[z] : (w == 3) ? delta_3[z] : delta_4[z];
+        return weights;
+    }
+*/
+    else if (phosphor_layout == 14) {
+        // slot mask for RGB panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
+        // {magenta, green, black, black,   black, black},
+        // {magenta, green, black, magenta, green, black},
+        // {black,   black, black, magenta, green, black}
+        vec3 slot2_1[6] = vec3[](magenta, green, black, black,   black, black);
+        vec3 slot2_2[6] = vec3[](magenta, green, black, magenta, green, black);
+        vec3 slot2_3[6] = vec3[](black,   black, black, magenta, green, black);
 
-    } else if(phosphor_layout == 13){
-       // delta_2_4x2_rgb
-       vec3 delta_1[4] = vec3[](red, yellow, cyan, blue);
-       vec3 delta_2[4] = vec3[](red, yellow, cyan, blue);
-       vec3 delta_3[4] = vec3[](cyan, blue, red, yellow);
-       vec3 delta_4[4] = vec3[](cyan, blue, red, yellow);
+        w = int(floor(mod(coord.y, 3.0)));
+        z = int(floor(mod(coord.x, 6.0)));
 
-       w = int(floor(mod(coord.y, 4.0)));
-       z = int(floor(mod(coord.x, 4.0)));
+        weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
+        return weights;
+    }
+/*
+    else if(phosphor_layout == 15) {
+        // slot_2_4x4_rgb
+        // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
+        // {red,   yellow, cyan,  blue,  black, black,  black, black},
+        // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
+        // {black, black,  black, black, red,   yellow, cyan,  blue }
+        vec3 slotmask_RBG_x1[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
+        vec3 slotmask_RBG_x2[8] = vec3[](red,   yellow, cyan,  blue,  black, black,  black, black);
+        vec3 slotmask_RBG_x3[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
+        vec3 slotmask_RBG_x4[8] = vec3[](black, black,  black, black, red,   yellow, cyan,  blue );
 
-       weights = (w == 1) ? delta_1[z] : (w == 2) ? delta_2[z] : (w == 3) ? delta_3[z] : delta_4[z];
-       return weights;
+        // find the vertical index
+        w = int(floor(mod(coord.y, 4.0)));
 
-    } else if(phosphor_layout == 14){
-       // slot mask for RGB panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
-       // {magenta, green, black, black,   black, black},
-       // {magenta, green, black, magenta, green, black},
-       // {black,   black, black, magenta, green, black}
-       vec3 slot2_1[6] = vec3[](magenta, green, black, black,   black, black);
-       vec3 slot2_2[6] = vec3[](magenta, green, black, magenta, green, black);
-       vec3 slot2_3[6] = vec3[](black,   black, black, magenta, green, black);
+        // find the horizontal index
+        z = int(floor(mod(coord.x, 8.0)));
 
-       w = int(floor(mod(coord.y, 3.0)));
-       z = int(floor(mod(coord.x, 6.0)));
+        weights = (w == 1) ? slotmask_RBG_x1[z] : (w == 2) ? slotmask_RBG_x2[z] : (w == 3) ? slotmask_RBG_x3[z] : slotmask_RBG_x4[z];
+        return weights;
+	}
+*/
+/*
+	else if(phosphor_layout == 16) {
+        // slot mask for RBG panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
+        // {yellow, blue,  black,  black},
+        // {yellow, blue,  yellow, blue},
+        // {black,  black, yellow, blue}
+        vec3 slot2_1[4] = vec3[](yellow, blue,  black,  black);
+        vec3 slot2_2[4] = vec3[](yellow, blue,  yellow, blue);
+        vec3 slot2_3[4] = vec3[](black,  black, yellow, blue);
 
-       weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
-       return weights;
+        w = int(floor(mod(coord.y, 3.0)));
+        z = int(floor(mod(coord.x, 4.0)));
 
-    } else if(phosphor_layout == 15){
-       // slot_2_4x4_rgb
-       // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
-       // {red,   yellow, cyan,  blue,  black, black,  black, black},
-       // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
-       // {black, black,  black, black, red,   yellow, cyan,  blue }
-       vec3 slotmask_RBG_x1[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
-       vec3 slotmask_RBG_x2[8] = vec3[](red,   yellow, cyan,  blue,  black, black,  black, black);
-       vec3 slotmask_RBG_x3[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
-       vec3 slotmask_RBG_x4[8] = vec3[](black, black,  black, black, red,   yellow, cyan,  blue );
+        weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
+        return weights;
+    }
+*/
+	else if (phosphor_layout == 17) {
+        // slot_2_5x4_bgr
+        // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
+        // {black, blue,    blue,  green, green, red,   red,     black, black, black},
+        // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
+        // {red,   red,     black, black, black, black, blue,    blue,  green, green}
+        vec3 slot_1[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
+        vec3 slot_2[10] = vec3[](black, blue,    blue,  green, green, red,   red,     black, black, black);
+        vec3 slot_3[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
+        vec3 slot_4[10] = vec3[](red,   red,     black, black, black, black, blue,    blue,  green, green);
 
-       // find the vertical index
-       w = int(floor(mod(coord.y, 4.0)));
+        w = int(floor(mod(coord.y, 4.0)));
+        z = int(floor(mod(coord.x, 10.0)));
 
-       // find the horizontal index
-       z = int(floor(mod(coord.x, 8.0)));
+        weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
+        return weights;
+    }
+/*
+    else if (phosphor_layout == 18) {
+        // same as above but for RBG panels
+        // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
+        // {black, green,  green, blue,  blue,  red,   red,    black, black, black},
+        // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
+        // {red,   red,    black, black, black, black, green,  green, blue,  blue }
+        vec3 slot_1[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
+        vec3 slot_2[10] = vec3[](black, green,  green, blue,  blue,  red,   red,    black, black, black);
+        vec3 slot_3[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
+        vec3 slot_4[10] = vec3[](red,   red,    black, black, black, black, green,  green, blue,  blue );
 
-       weights = (w == 1) ? slotmask_RBG_x1[z] : (w == 2) ? slotmask_RBG_x2[z] : (w == 3) ? slotmask_RBG_x3[z] : slotmask_RBG_x4[z];
-       return weights;
+        w = int(floor(mod(coord.y, 4.0)));
+        z = int(floor(mod(coord.x, 10.0)));
 
-     } else if(phosphor_layout == 16){
-       // slot mask for RBG panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
-       // {yellow, blue,  black,  black},
-       // {yellow, blue,  yellow, blue},
-       // {black,  black, yellow, blue}
-       vec3 slot2_1[4] = vec3[](yellow, blue,  black,  black);
-       vec3 slot2_2[4] = vec3[](yellow, blue,  yellow, blue);
-       vec3 slot2_3[4] = vec3[](black,  black, yellow, blue);
+        weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
+        return weights;
+    }
+*/
+/*
+    else if(phosphor_layout == 19) {
+        // slot_3_7x6_rgb
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue}
 
-       w = int(floor(mod(coord.y, 3.0)));
-       z = int(floor(mod(coord.x, 4.0)));
+        vec3 slot_1[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_2[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_3[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black);
+        vec3 slot_4[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_5[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_6[14] = vec3[](black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue);
 
-       weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
-       return weights;
+        w = int(floor(mod(coord.y, 6.0)));
+        z = int(floor(mod(coord.x, 14.0)));
 
-    } else if (phosphor_layout == 17) {
-       // slot_2_5x4_bgr
-       // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
-       // {black, blue,    blue,  green, green, red,   red,     black, black, black},
-       // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
-       // {red,   red,     black, black, black, black, blue,    blue,  green, green}
-       vec3 slot_1[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
-       vec3 slot_2[10] = vec3[](black, blue,    blue,  green, green, red,   red,     black, black, black);
-       vec3 slot_3[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
-       vec3 slot_4[10] = vec3[](red,   red,     black, black, black, black, blue,    blue,  green, green);
-
-       w = int(floor(mod(coord.y, 4.0)));
-       z = int(floor(mod(coord.x, 10.0)));
-
-       weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
-       return weights;
-
-    } else if (phosphor_layout == 18) {
-       // same as above but for RBG panels
-       // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
-       // {black, green,  green, blue,  blue,  red,   red,    black, black, black},
-       // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
-       // {red,   red,    black, black, black, black, green,  green, blue,  blue }
-       vec3 slot_1[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
-       vec3 slot_2[10] = vec3[](black, green,  green, blue,  blue,  red,   red,    black, black, black);
-       vec3 slot_3[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
-       vec3 slot_4[10] = vec3[](red,   red,    black, black, black, black, green,  green, blue,  blue );
-
-       w = int(floor(mod(coord.y, 4.0)));
-       z = int(floor(mod(coord.x, 10.0)));
-
-       weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
-       return weights;
-
-    } else if(phosphor_layout == 19) {
-       // slot_3_7x6_rgb
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue}
-
-       vec3 slot_1[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_2[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_3[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black);
-       vec3 slot_4[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_5[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_6[14] = vec3[](black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue);
-
-       w = int(floor(mod(coord.y, 6.0)));
-       z = int(floor(mod(coord.x, 14.0)));
-
-       weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : (w == 4) ? slot_4[z] : (w == 5) ? slot_5[z] : slot_6[z];
-       return weights;
-
-    } else {
+        weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : (w == 4) ? slot_4[z] : (w == 5) ? slot_5[z] : slot_6[z];
+        return weights;
+     }
+*/
+	else {
         return weights;
     }
 }

--- a/contrib/resources/glshaders/crt/composite-4k.glsl
+++ b/contrib/resources/glshaders/crt/composite-4k.glsl
@@ -169,10 +169,10 @@ uniform PRECISION float BLUE_SHIFT;
 
 #define WP_ADJUST           0.00
 #define TEMPERATURE      9300.00
-#define LUMA_PRESERVE 		1.00
-#define RED_SHIFT 			0.00
-#define GREEN_SHIFT 		0.00
-#define BLUE_SHIFT 			0.00
+#define LUMA_PRESERVE       1.00
+#define RED_SHIFT           0.00
+#define GREEN_SHIFT         0.00
+#define BLUE_SHIFT          0.00
 #endif
 // END PARAMETERS //
 
@@ -275,10 +275,10 @@ vec3 YxytoXYZ(vec3 Yxy) {
     Many of these mask arrays are adapted from cgwg's crt-geom-deluxe LUTs, and
     those have their filenames included for easy identification
 
-	NOTE: Having too many branches result in a black screen (but no
-	compilation errors) on some older GPUs such as the Intel HD 4000 iGPU. So
-	we're commenting out the branches that are not used by the adaptive CRT
-	shaders.
+    NOTE: Having too many branches result in a black screen (but no
+    compilation errors) on some older GPUs such as the Intel HD 4000 iGPU. So
+    we're commenting out the branches that are not used by the adaptive CRT
+    shaders.
 */
 vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
     vec3 weights = vec3(1.,1.,1.);
@@ -302,14 +302,14 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
     if (phosphor_layout == 0) {
         return weights;
-	}
+    }
 
     else if (phosphor_layout == 1) {
-    	// classic aperture for RGB panels; good for 1080p, too small for 4K+
+        // classic aperture for RGB panels; good for 1080p, too small for 4K+
         // aka aperture_1_2_bgr
         weights  = aperture_weights;
         return weights;
-	}
+    }
 
     else if (phosphor_layout == 2) {
         // 2x2 shadow mask for RGB panels; good for 1080p, too small for 4K+
@@ -317,7 +317,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
         vec3 inverse_aperture = mix(green, magenta, floor(mod(coord.x, 2.0)));
         weights               = mix(aperture_weights, inverse_aperture, floor(mod(coord.y, 2.0)));
         return weights;
-	}
+    }
 
 /*
     else if (phosphor_layout == 3) {
@@ -340,14 +340,14 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         // do a big, dumb comparison in place of a 2D array
         weights = (w == 1) ? slotmask_x1[z] : (w == 2) ? slotmask_x2[z] :  slotmask_x3[z];
-		return weights;
+        return weights;
     }
 */
     else if (phosphor_layout == 4) {
         // classic aperture for RBG panels; good for 1080p, too small for 4K+
         weights  = mix(yellow, blue, floor(mod(coord.x, 2.0)));
         return weights;
-	}
+    }
 /*
     else if (phosphor_layout == 5) {
         // 2x2 shadow mask for RBG panels; good for 1080p, too small for 4K+
@@ -359,7 +359,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
             floor(mod(coord.y, 2.0))
         );
         return weights;
-	}
+    }
 */
 /*
     else if (phosphor_layout == 6) {
@@ -370,7 +370,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = ap4[z];
         return weights;
-	}
+    }
 */
 /*
     else if (phosphor_layout == 7) {
@@ -391,7 +391,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap[w];
         return weights;
-	}
+    }
 */
     else if (phosphor_layout == 9) {
         // reduced TVL aperture for RGB panels
@@ -402,7 +402,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rgb[w];
         return weights;
-	}
+    }
 /*
     else if (phosphor_layout == 10) {
         // reduced TVL aperture for RBG panels
@@ -412,7 +412,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rbg[w];
         return weights;
-	}
+    }
 */
     else if(phosphor_layout == 11) {
         // delta_1_4x1_rgb; dunno why this is called 4x1 when it's obviously 4x2 /shrug
@@ -435,7 +435,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = (w == 1) ? delta_2_1[z] : delta_2_2[z];
         return weights;
-	}
+    }
 */
 /*
     else if (phosphor_layout == 13) {
@@ -487,10 +487,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = (w == 1) ? slotmask_RBG_x1[z] : (w == 2) ? slotmask_RBG_x2[z] : (w == 3) ? slotmask_RBG_x3[z] : slotmask_RBG_x4[z];
         return weights;
-	}
+    }
 */
 /*
-	else if(phosphor_layout == 16) {
+    else if(phosphor_layout == 16) {
         // slot mask for RBG panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
         // {yellow, blue,  black,  black},
         // {yellow, blue,  yellow, blue},
@@ -506,7 +506,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
         return weights;
     }
 */
-	else if (phosphor_layout == 17) {
+    else if (phosphor_layout == 17) {
         // slot_2_5x4_bgr
         // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
         // {black, blue,    blue,  green, green, red,   red,     black, black, black},
@@ -566,7 +566,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
         return weights;
      }
 */
-	else {
+    else {
         return weights;
     }
 }
@@ -586,10 +586,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 // For more info, see: http://www.imagemagick.org/Usage/img_diagrams/cubic_survey.gif
 mat4x4 get_hfilter_profile()
 {
-	float bf = 0.0;
-	float cf = 0.0;
+    float bf = 0.0;
+    float cf = 0.0;
 
-	if (HFILTER_PROFILE == 1) {
+    if (HFILTER_PROFILE == 1) {
         bf = 0.0;
         cf = 0.5;
     }
@@ -691,14 +691,14 @@ void main()
     mask_coords = mix(mask_coords.xy, mask_coords.yx, VSCANLINES);
     color.rgb *= mask_weights(mask_coords, MASK_INTENSITY, int(PHOSPHOR_LAYOUT));
 
-	// Colour temperature
-	if (WP_ADJUST == 1.0) {
-		vec3 wp_adjusted = wp_adjust(color.rgb);
-		vec3 base_luma = XYZtoYxy(sRGB_to_XYZ(color.rgb));
-		vec3 adjusted_luma = XYZtoYxy(sRGB_to_XYZ(wp_adjusted));
-		wp_adjusted = (LUMA_PRESERVE == 1.0) ? adjusted_luma + (vec3(base_luma.r,0.,0.) - vec3(adjusted_luma.r,0.,0.)) : adjusted_luma;
-		color = vec4(XYZ_to_sRGB(YxytoXYZ(wp_adjusted)), 1.0);
-	}
+    // Colour temperature
+    if (WP_ADJUST == 1.0) {
+        vec3 wp_adjusted = wp_adjust(color.rgb);
+        vec3 base_luma = XYZtoYxy(sRGB_to_XYZ(color.rgb));
+        vec3 adjusted_luma = XYZtoYxy(sRGB_to_XYZ(wp_adjusted));
+        wp_adjusted = (LUMA_PRESERVE == 1.0) ? adjusted_luma + (vec3(base_luma.r,0.,0.) - vec3(adjusted_luma.r,0.,0.)) : adjusted_luma;
+        color = vec4(XYZ_to_sRGB(YxytoXYZ(wp_adjusted)), 1.0);
+    }
 
     // Output gamma
     color = clamp(GAMMA_OUT(color), 0.0, 1.0);

--- a/contrib/resources/glshaders/crt/composite-4k.glsl
+++ b/contrib/resources/glshaders/crt/composite-4k.glsl
@@ -248,7 +248,6 @@ vec3 YxytoXYZ(vec3 Yxy) {
     return XYZ;
 }
 
-
 /*
     A collection of CRT mask effects that work with LCD subpixel structures for
     small details
@@ -275,11 +274,18 @@ vec3 YxytoXYZ(vec3 Yxy) {
 
     Many of these mask arrays are adapted from cgwg's crt-geom-deluxe LUTs, and
     those have their filenames included for easy identification
+
+	NOTE: Having too many branches result in a black screen (but no
+	compilation errors) on some older GPUs such as the Intel HD 4000 iGPU. So
+	we're commenting out the branches that are not used by the adaptive CRT
+	shaders.
 */
 vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
     vec3 weights = vec3(1.,1.,1.);
+
     float on = 1.;
     float off = 1.-mask_intensity;
+
     vec3 red     = vec3(on,  off, off);
     vec3 green   = vec3(off, on,  off);
     vec3 blue    = vec3(off, off, on );
@@ -288,6 +294,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
     vec3 cyan    = vec3(off, on,  on );
     vec3 black   = vec3(off, off, off);
     vec3 white   = vec3(on,  on,  on );
+
     int w, z = 0;
 
     // This pattern is used by a few layouts, so we'll define it here
@@ -295,21 +302,25 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
     if (phosphor_layout == 0) {
         return weights;
+	}
 
-    } else if (phosphor_layout == 1) {
-        // classic aperture for RGB panels; good for 1080p, too small for 4K+
+    else if (phosphor_layout == 1) {
+    	// classic aperture for RGB panels; good for 1080p, too small for 4K+
         // aka aperture_1_2_bgr
         weights  = aperture_weights;
         return weights;
+	}
 
-    } else if (phosphor_layout == 2) {
+    else if (phosphor_layout == 2) {
         // 2x2 shadow mask for RGB panels; good for 1080p, too small for 4K+
         // aka delta_1_2x1_bgr
         vec3 inverse_aperture = mix(green, magenta, floor(mod(coord.x, 2.0)));
         weights               = mix(aperture_weights, inverse_aperture, floor(mod(coord.y, 2.0)));
         return weights;
+	}
 
-    } else if (phosphor_layout == 3) {
+/*
+    else if (phosphor_layout == 3) {
         // slot mask for RGB panels; looks okay at 1080p, looks better at 4K
         // {magenta, green, black,   black},
         // {magenta, green, magenta, green},
@@ -329,14 +340,16 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         // do a big, dumb comparison in place of a 2D array
         weights = (w == 1) ? slotmask_x1[z] : (w == 2) ? slotmask_x2[z] :  slotmask_x3[z];
+		return weights;
     }
-
-    if (phosphor_layout == 4) {
+*/
+    else if (phosphor_layout == 4) {
         // classic aperture for RBG panels; good for 1080p, too small for 4K+
         weights  = mix(yellow, blue, floor(mod(coord.x, 2.0)));
         return weights;
-
-    } else if (phosphor_layout == 5) {
+	}
+/*
+    else if (phosphor_layout == 5) {
         // 2x2 shadow mask for RBG panels; good for 1080p, too small for 4K+
         vec3 inverse_aperture = mix(blue, yellow, floor(mod(coord.x, 2.0)));
 
@@ -346,8 +359,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
             floor(mod(coord.y, 2.0))
         );
         return weights;
-
-    } else if (phosphor_layout == 6) {
+	}
+*/
+/*
+    else if (phosphor_layout == 6) {
         // aperture_1_4_rgb; good for simulating lower
         vec3 ap4[4] = vec3[](red, green, blue, black);
 
@@ -355,8 +370,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = ap4[z];
         return weights;
-
-    } else if (phosphor_layout == 7) {
+	}
+*/
+/*
+    else if (phosphor_layout == 7) {
         // aperture_2_5_bgr
         vec3 ap3[5] = vec3[](red, magenta, blue, green, green);
 
@@ -364,8 +381,9 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = ap3[z];
         return weights;
-
-    } else if (phosphor_layout == 8){
+*/
+/*
+    else if (phosphor_layout == 8) {
         // aperture_3_6_rgb
         vec3 big_ap[7] = vec3[](red, red, yellow, green, cyan, blue, blue);
 
@@ -373,8 +391,9 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap[w];
         return weights;
-
-    } else if (phosphor_layout == 9) {
+	}
+*/
+    else if (phosphor_layout == 9) {
         // reduced TVL aperture for RGB panels
         // aperture_2_4_rgb
         vec3 big_ap_rgb[4] = vec3[](red, yellow, cyan, blue);
@@ -383,8 +402,9 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rgb[w];
         return weights;
-
-    } else if (phosphor_layout == 10) {
+	}
+/*
+    else if (phosphor_layout == 10) {
         // reduced TVL aperture for RBG panels
         vec3 big_ap_rbg[4] = vec3[](red, magenta, cyan, green);
 
@@ -392,148 +412,161 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rbg[w];
         return weights;
+	}
+*/
+    else if(phosphor_layout == 11) {
+        // delta_1_4x1_rgb; dunno why this is called 4x1 when it's obviously 4x2 /shrug
+        vec3 delta_1_1[4] = vec3[](red, green, blue, black);
+        vec3 delta_1_2[4] = vec3[](blue, black, red, green);
 
-    } else if(phosphor_layout == 11){
-       // delta_1_4x1_rgb; dunno why this is called 4x1 when it's obviously 4x2 /shrug
-       vec3 delta_1_1[4] = vec3[](red, green, blue, black);
-       vec3 delta_1_2[4] = vec3[](blue, black, red, green);
+        w = int(floor(mod(coord.y, 2.0)));
+        z = int(floor(mod(coord.x, 4.0)));
 
-       w = int(floor(mod(coord.y, 2.0)));
-       z = int(floor(mod(coord.x, 4.0)));
+        weights = (w == 1) ? delta_1_1[z] : delta_1_2[z];
+        return weights;
+    }
+/*
+    else if (phosphor_layout == 12) {
+        // delta_2_4x1_rgb
+        vec3 delta_2_1[4] = vec3[](red, yellow, cyan, blue);
+        vec3 delta_2_2[4] = vec3[](cyan, blue, red, yellow);
 
-       weights = (w == 1) ? delta_1_1[z] : delta_1_2[z];
-       return weights;
+        z = int(floor(mod(coord.x, 4.0)));
 
-    } else if(phosphor_layout == 12){
-       // delta_2_4x1_rgb
-       vec3 delta_2_1[4] = vec3[](red, yellow, cyan, blue);
-       vec3 delta_2_2[4] = vec3[](cyan, blue, red, yellow);
+        weights = (w == 1) ? delta_2_1[z] : delta_2_2[z];
+        return weights;
+	}
+*/
+/*
+    else if (phosphor_layout == 13) {
+        // delta_2_4x2_rgb
+        vec3 delta_1[4] = vec3[](red, yellow, cyan, blue);
+        vec3 delta_2[4] = vec3[](red, yellow, cyan, blue);
+        vec3 delta_3[4] = vec3[](cyan, blue, red, yellow);
+        vec3 delta_4[4] = vec3[](cyan, blue, red, yellow);
 
-       z = int(floor(mod(coord.x, 4.0)));
+        w = int(floor(mod(coord.y, 4.0)));
+        z = int(floor(mod(coord.x, 4.0)));
 
-       weights = (w == 1) ? delta_2_1[z] : delta_2_2[z];
-       return weights;
+        weights = (w == 1) ? delta_1[z] : (w == 2) ? delta_2[z] : (w == 3) ? delta_3[z] : delta_4[z];
+        return weights;
+    }
+*/
+    else if (phosphor_layout == 14) {
+        // slot mask for RGB panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
+        // {magenta, green, black, black,   black, black},
+        // {magenta, green, black, magenta, green, black},
+        // {black,   black, black, magenta, green, black}
+        vec3 slot2_1[6] = vec3[](magenta, green, black, black,   black, black);
+        vec3 slot2_2[6] = vec3[](magenta, green, black, magenta, green, black);
+        vec3 slot2_3[6] = vec3[](black,   black, black, magenta, green, black);
 
-    } else if(phosphor_layout == 13){
-       // delta_2_4x2_rgb
-       vec3 delta_1[4] = vec3[](red, yellow, cyan, blue);
-       vec3 delta_2[4] = vec3[](red, yellow, cyan, blue);
-       vec3 delta_3[4] = vec3[](cyan, blue, red, yellow);
-       vec3 delta_4[4] = vec3[](cyan, blue, red, yellow);
+        w = int(floor(mod(coord.y, 3.0)));
+        z = int(floor(mod(coord.x, 6.0)));
 
-       w = int(floor(mod(coord.y, 4.0)));
-       z = int(floor(mod(coord.x, 4.0)));
+        weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
+        return weights;
+    }
+/*
+    else if(phosphor_layout == 15) {
+        // slot_2_4x4_rgb
+        // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
+        // {red,   yellow, cyan,  blue,  black, black,  black, black},
+        // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
+        // {black, black,  black, black, red,   yellow, cyan,  blue }
+        vec3 slotmask_RBG_x1[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
+        vec3 slotmask_RBG_x2[8] = vec3[](red,   yellow, cyan,  blue,  black, black,  black, black);
+        vec3 slotmask_RBG_x3[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
+        vec3 slotmask_RBG_x4[8] = vec3[](black, black,  black, black, red,   yellow, cyan,  blue );
 
-       weights = (w == 1) ? delta_1[z] : (w == 2) ? delta_2[z] : (w == 3) ? delta_3[z] : delta_4[z];
-       return weights;
+        // find the vertical index
+        w = int(floor(mod(coord.y, 4.0)));
 
-    } else if(phosphor_layout == 14){
-       // slot mask for RGB panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
-       // {magenta, green, black, black,   black, black},
-       // {magenta, green, black, magenta, green, black},
-       // {black,   black, black, magenta, green, black}
-       vec3 slot2_1[6] = vec3[](magenta, green, black, black,   black, black);
-       vec3 slot2_2[6] = vec3[](magenta, green, black, magenta, green, black);
-       vec3 slot2_3[6] = vec3[](black,   black, black, magenta, green, black);
+        // find the horizontal index
+        z = int(floor(mod(coord.x, 8.0)));
 
-       w = int(floor(mod(coord.y, 3.0)));
-       z = int(floor(mod(coord.x, 6.0)));
+        weights = (w == 1) ? slotmask_RBG_x1[z] : (w == 2) ? slotmask_RBG_x2[z] : (w == 3) ? slotmask_RBG_x3[z] : slotmask_RBG_x4[z];
+        return weights;
+	}
+*/
+/*
+	else if(phosphor_layout == 16) {
+        // slot mask for RBG panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
+        // {yellow, blue,  black,  black},
+        // {yellow, blue,  yellow, blue},
+        // {black,  black, yellow, blue}
+        vec3 slot2_1[4] = vec3[](yellow, blue,  black,  black);
+        vec3 slot2_2[4] = vec3[](yellow, blue,  yellow, blue);
+        vec3 slot2_3[4] = vec3[](black,  black, yellow, blue);
 
-       weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
-       return weights;
+        w = int(floor(mod(coord.y, 3.0)));
+        z = int(floor(mod(coord.x, 4.0)));
 
-    } else if(phosphor_layout == 15){
-       // slot_2_4x4_rgb
-       // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
-       // {red,   yellow, cyan,  blue,  black, black,  black, black},
-       // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
-       // {black, black,  black, black, red,   yellow, cyan,  blue }
-       vec3 slotmask_RBG_x1[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
-       vec3 slotmask_RBG_x2[8] = vec3[](red,   yellow, cyan,  blue,  black, black,  black, black);
-       vec3 slotmask_RBG_x3[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
-       vec3 slotmask_RBG_x4[8] = vec3[](black, black,  black, black, red,   yellow, cyan,  blue );
+        weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
+        return weights;
+    }
+*/
+	else if (phosphor_layout == 17) {
+        // slot_2_5x4_bgr
+        // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
+        // {black, blue,    blue,  green, green, red,   red,     black, black, black},
+        // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
+        // {red,   red,     black, black, black, black, blue,    blue,  green, green}
+        vec3 slot_1[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
+        vec3 slot_2[10] = vec3[](black, blue,    blue,  green, green, red,   red,     black, black, black);
+        vec3 slot_3[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
+        vec3 slot_4[10] = vec3[](red,   red,     black, black, black, black, blue,    blue,  green, green);
 
-       // find the vertical index
-       w = int(floor(mod(coord.y, 4.0)));
+        w = int(floor(mod(coord.y, 4.0)));
+        z = int(floor(mod(coord.x, 10.0)));
 
-       // find the horizontal index
-       z = int(floor(mod(coord.x, 8.0)));
+        weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
+        return weights;
+    }
+/*
+    else if (phosphor_layout == 18) {
+        // same as above but for RBG panels
+        // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
+        // {black, green,  green, blue,  blue,  red,   red,    black, black, black},
+        // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
+        // {red,   red,    black, black, black, black, green,  green, blue,  blue }
+        vec3 slot_1[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
+        vec3 slot_2[10] = vec3[](black, green,  green, blue,  blue,  red,   red,    black, black, black);
+        vec3 slot_3[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
+        vec3 slot_4[10] = vec3[](red,   red,    black, black, black, black, green,  green, blue,  blue );
 
-       weights = (w == 1) ? slotmask_RBG_x1[z] : (w == 2) ? slotmask_RBG_x2[z] : (w == 3) ? slotmask_RBG_x3[z] : slotmask_RBG_x4[z];
-       return weights;
+        w = int(floor(mod(coord.y, 4.0)));
+        z = int(floor(mod(coord.x, 10.0)));
 
-     } else if(phosphor_layout == 16){
-       // slot mask for RBG panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
-       // {yellow, blue,  black,  black},
-       // {yellow, blue,  yellow, blue},
-       // {black,  black, yellow, blue}
-       vec3 slot2_1[4] = vec3[](yellow, blue,  black,  black);
-       vec3 slot2_2[4] = vec3[](yellow, blue,  yellow, blue);
-       vec3 slot2_3[4] = vec3[](black,  black, yellow, blue);
+        weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
+        return weights;
+    }
+*/
+/*
+    else if(phosphor_layout == 19) {
+        // slot_3_7x6_rgb
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue}
 
-       w = int(floor(mod(coord.y, 3.0)));
-       z = int(floor(mod(coord.x, 4.0)));
+        vec3 slot_1[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_2[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_3[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black);
+        vec3 slot_4[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_5[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_6[14] = vec3[](black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue);
 
-       weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
-       return weights;
+        w = int(floor(mod(coord.y, 6.0)));
+        z = int(floor(mod(coord.x, 14.0)));
 
-    } else if (phosphor_layout == 17) {
-       // slot_2_5x4_bgr
-       // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
-       // {black, blue,    blue,  green, green, red,   red,     black, black, black},
-       // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
-       // {red,   red,     black, black, black, black, blue,    blue,  green, green}
-       vec3 slot_1[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
-       vec3 slot_2[10] = vec3[](black, blue,    blue,  green, green, red,   red,     black, black, black);
-       vec3 slot_3[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
-       vec3 slot_4[10] = vec3[](red,   red,     black, black, black, black, blue,    blue,  green, green);
-
-       w = int(floor(mod(coord.y, 4.0)));
-       z = int(floor(mod(coord.x, 10.0)));
-
-       weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
-       return weights;
-
-    } else if (phosphor_layout == 18) {
-       // same as above but for RBG panels
-       // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
-       // {black, green,  green, blue,  blue,  red,   red,    black, black, black},
-       // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
-       // {red,   red,    black, black, black, black, green,  green, blue,  blue }
-       vec3 slot_1[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
-       vec3 slot_2[10] = vec3[](black, green,  green, blue,  blue,  red,   red,    black, black, black);
-       vec3 slot_3[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
-       vec3 slot_4[10] = vec3[](red,   red,    black, black, black, black, green,  green, blue,  blue );
-
-       w = int(floor(mod(coord.y, 4.0)));
-       z = int(floor(mod(coord.x, 10.0)));
-
-       weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
-       return weights;
-
-    } else if(phosphor_layout == 19) {
-       // slot_3_7x6_rgb
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue}
-
-       vec3 slot_1[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_2[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_3[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black);
-       vec3 slot_4[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_5[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_6[14] = vec3[](black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue);
-
-       w = int(floor(mod(coord.y, 6.0)));
-       z = int(floor(mod(coord.x, 14.0)));
-
-       weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : (w == 4) ? slot_4[z] : (w == 5) ? slot_5[z] : slot_6[z];
-       return weights;
-
-    } else {
+        weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : (w == 4) ? slot_4[z] : (w == 5) ? slot_5[z] : slot_6[z];
+        return weights;
+     }
+*/
+	else {
         return weights;
     }
 }

--- a/contrib/resources/glshaders/crt/ega-1080p.glsl
+++ b/contrib/resources/glshaders/crt/ega-1080p.glsl
@@ -168,10 +168,10 @@ uniform PRECISION float BLUE_SHIFT;
 
 #define WP_ADJUST           0.00
 #define TEMPERATURE      9300.00
-#define LUMA_PRESERVE 		1.00
-#define RED_SHIFT 			0.00
-#define GREEN_SHIFT 		0.00
-#define BLUE_SHIFT 			0.00
+#define LUMA_PRESERVE       1.00
+#define RED_SHIFT           0.00
+#define GREEN_SHIFT         0.00
+#define BLUE_SHIFT          0.00
 #endif
 // END PARAMETERS //
 
@@ -274,10 +274,10 @@ vec3 YxytoXYZ(vec3 Yxy) {
     Many of these mask arrays are adapted from cgwg's crt-geom-deluxe LUTs, and
     those have their filenames included for easy identification
 
-	NOTE: Having too many branches result in a black screen (but no
-	compilation errors) on some older GPUs such as the Intel HD 4000 iGPU. So
-	we're commenting out the branches that are not used by the adaptive CRT
-	shaders.
+    NOTE: Having too many branches result in a black screen (but no
+    compilation errors) on some older GPUs such as the Intel HD 4000 iGPU. So
+    we're commenting out the branches that are not used by the adaptive CRT
+    shaders.
 */
 vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
     vec3 weights = vec3(1.,1.,1.);
@@ -301,14 +301,14 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
     if (phosphor_layout == 0) {
         return weights;
-	}
+    }
 
     else if (phosphor_layout == 1) {
-    	// classic aperture for RGB panels; good for 1080p, too small for 4K+
+        // classic aperture for RGB panels; good for 1080p, too small for 4K+
         // aka aperture_1_2_bgr
         weights  = aperture_weights;
         return weights;
-	}
+    }
 
     else if (phosphor_layout == 2) {
         // 2x2 shadow mask for RGB panels; good for 1080p, too small for 4K+
@@ -316,7 +316,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
         vec3 inverse_aperture = mix(green, magenta, floor(mod(coord.x, 2.0)));
         weights               = mix(aperture_weights, inverse_aperture, floor(mod(coord.y, 2.0)));
         return weights;
-	}
+    }
 
 /*
     else if (phosphor_layout == 3) {
@@ -339,14 +339,14 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         // do a big, dumb comparison in place of a 2D array
         weights = (w == 1) ? slotmask_x1[z] : (w == 2) ? slotmask_x2[z] :  slotmask_x3[z];
-		return weights;
+        return weights;
     }
 */
     else if (phosphor_layout == 4) {
         // classic aperture for RBG panels; good for 1080p, too small for 4K+
         weights  = mix(yellow, blue, floor(mod(coord.x, 2.0)));
         return weights;
-	}
+    }
 /*
     else if (phosphor_layout == 5) {
         // 2x2 shadow mask for RBG panels; good for 1080p, too small for 4K+
@@ -358,7 +358,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
             floor(mod(coord.y, 2.0))
         );
         return weights;
-	}
+    }
 */
 /*
     else if (phosphor_layout == 6) {
@@ -369,7 +369,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = ap4[z];
         return weights;
-	}
+    }
 */
 /*
     else if (phosphor_layout == 7) {
@@ -390,7 +390,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap[w];
         return weights;
-	}
+    }
 */
     else if (phosphor_layout == 9) {
         // reduced TVL aperture for RGB panels
@@ -401,7 +401,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rgb[w];
         return weights;
-	}
+    }
 /*
     else if (phosphor_layout == 10) {
         // reduced TVL aperture for RBG panels
@@ -411,7 +411,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rbg[w];
         return weights;
-	}
+    }
 */
     else if(phosphor_layout == 11) {
         // delta_1_4x1_rgb; dunno why this is called 4x1 when it's obviously 4x2 /shrug
@@ -434,7 +434,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = (w == 1) ? delta_2_1[z] : delta_2_2[z];
         return weights;
-	}
+    }
 */
 /*
     else if (phosphor_layout == 13) {
@@ -486,10 +486,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = (w == 1) ? slotmask_RBG_x1[z] : (w == 2) ? slotmask_RBG_x2[z] : (w == 3) ? slotmask_RBG_x3[z] : slotmask_RBG_x4[z];
         return weights;
-	}
+    }
 */
 /*
-	else if(phosphor_layout == 16) {
+    else if(phosphor_layout == 16) {
         // slot mask for RBG panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
         // {yellow, blue,  black,  black},
         // {yellow, blue,  yellow, blue},
@@ -505,7 +505,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
         return weights;
     }
 */
-	else if (phosphor_layout == 17) {
+    else if (phosphor_layout == 17) {
         // slot_2_5x4_bgr
         // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
         // {black, blue,    blue,  green, green, red,   red,     black, black, black},
@@ -565,7 +565,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
         return weights;
      }
 */
-	else {
+    else {
         return weights;
     }
 }
@@ -585,10 +585,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 // For more info, see: http://www.imagemagick.org/Usage/img_diagrams/cubic_survey.gif
 mat4x4 get_hfilter_profile()
 {
-	float bf = 0.0;
-	float cf = 0.0;
+    float bf = 0.0;
+    float cf = 0.0;
 
-	if (HFILTER_PROFILE == 1) {
+    if (HFILTER_PROFILE == 1) {
         bf = 0.0;
         cf = 0.5;
     }
@@ -690,14 +690,14 @@ void main()
     mask_coords = mix(mask_coords.xy, mask_coords.yx, VSCANLINES);
     color.rgb *= mask_weights(mask_coords, MASK_INTENSITY, int(PHOSPHOR_LAYOUT));
 
-	// Colour temperature
-	if (WP_ADJUST == 1.0) {
-		vec3 wp_adjusted = wp_adjust(color.rgb);
-		vec3 base_luma = XYZtoYxy(sRGB_to_XYZ(color.rgb));
-		vec3 adjusted_luma = XYZtoYxy(sRGB_to_XYZ(wp_adjusted));
-		wp_adjusted = (LUMA_PRESERVE == 1.0) ? adjusted_luma + (vec3(base_luma.r,0.,0.) - vec3(adjusted_luma.r,0.,0.)) : adjusted_luma;
-		color = vec4(XYZ_to_sRGB(YxytoXYZ(wp_adjusted)), 1.0);
-	}
+    // Colour temperature
+    if (WP_ADJUST == 1.0) {
+        vec3 wp_adjusted = wp_adjust(color.rgb);
+        vec3 base_luma = XYZtoYxy(sRGB_to_XYZ(color.rgb));
+        vec3 adjusted_luma = XYZtoYxy(sRGB_to_XYZ(wp_adjusted));
+        wp_adjusted = (LUMA_PRESERVE == 1.0) ? adjusted_luma + (vec3(base_luma.r,0.,0.) - vec3(adjusted_luma.r,0.,0.)) : adjusted_luma;
+        color = vec4(XYZ_to_sRGB(YxytoXYZ(wp_adjusted)), 1.0);
+    }
 
     // Output gamma
     color = clamp(GAMMA_OUT(color), 0.0, 1.0);

--- a/contrib/resources/glshaders/crt/ega-1080p.glsl
+++ b/contrib/resources/glshaders/crt/ega-1080p.glsl
@@ -247,7 +247,6 @@ vec3 YxytoXYZ(vec3 Yxy) {
     return XYZ;
 }
 
-
 /*
     A collection of CRT mask effects that work with LCD subpixel structures for
     small details
@@ -274,11 +273,18 @@ vec3 YxytoXYZ(vec3 Yxy) {
 
     Many of these mask arrays are adapted from cgwg's crt-geom-deluxe LUTs, and
     those have their filenames included for easy identification
+
+	NOTE: Having too many branches result in a black screen (but no
+	compilation errors) on some older GPUs such as the Intel HD 4000 iGPU. So
+	we're commenting out the branches that are not used by the adaptive CRT
+	shaders.
 */
 vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
     vec3 weights = vec3(1.,1.,1.);
+
     float on = 1.;
     float off = 1.-mask_intensity;
+
     vec3 red     = vec3(on,  off, off);
     vec3 green   = vec3(off, on,  off);
     vec3 blue    = vec3(off, off, on );
@@ -287,6 +293,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
     vec3 cyan    = vec3(off, on,  on );
     vec3 black   = vec3(off, off, off);
     vec3 white   = vec3(on,  on,  on );
+
     int w, z = 0;
 
     // This pattern is used by a few layouts, so we'll define it here
@@ -294,21 +301,25 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
     if (phosphor_layout == 0) {
         return weights;
+	}
 
-    } else if (phosphor_layout == 1) {
-        // classic aperture for RGB panels; good for 1080p, too small for 4K+
+    else if (phosphor_layout == 1) {
+    	// classic aperture for RGB panels; good for 1080p, too small for 4K+
         // aka aperture_1_2_bgr
         weights  = aperture_weights;
         return weights;
+	}
 
-    } else if (phosphor_layout == 2) {
+    else if (phosphor_layout == 2) {
         // 2x2 shadow mask for RGB panels; good for 1080p, too small for 4K+
         // aka delta_1_2x1_bgr
         vec3 inverse_aperture = mix(green, magenta, floor(mod(coord.x, 2.0)));
         weights               = mix(aperture_weights, inverse_aperture, floor(mod(coord.y, 2.0)));
         return weights;
+	}
 
-    } else if (phosphor_layout == 3) {
+/*
+    else if (phosphor_layout == 3) {
         // slot mask for RGB panels; looks okay at 1080p, looks better at 4K
         // {magenta, green, black,   black},
         // {magenta, green, magenta, green},
@@ -328,14 +339,16 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         // do a big, dumb comparison in place of a 2D array
         weights = (w == 1) ? slotmask_x1[z] : (w == 2) ? slotmask_x2[z] :  slotmask_x3[z];
+		return weights;
     }
-
-    if (phosphor_layout == 4) {
+*/
+    else if (phosphor_layout == 4) {
         // classic aperture for RBG panels; good for 1080p, too small for 4K+
         weights  = mix(yellow, blue, floor(mod(coord.x, 2.0)));
         return weights;
-
-    } else if (phosphor_layout == 5) {
+	}
+/*
+    else if (phosphor_layout == 5) {
         // 2x2 shadow mask for RBG panels; good for 1080p, too small for 4K+
         vec3 inverse_aperture = mix(blue, yellow, floor(mod(coord.x, 2.0)));
 
@@ -345,8 +358,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
             floor(mod(coord.y, 2.0))
         );
         return weights;
-
-    } else if (phosphor_layout == 6) {
+	}
+*/
+/*
+    else if (phosphor_layout == 6) {
         // aperture_1_4_rgb; good for simulating lower
         vec3 ap4[4] = vec3[](red, green, blue, black);
 
@@ -354,8 +369,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = ap4[z];
         return weights;
-
-    } else if (phosphor_layout == 7) {
+	}
+*/
+/*
+    else if (phosphor_layout == 7) {
         // aperture_2_5_bgr
         vec3 ap3[5] = vec3[](red, magenta, blue, green, green);
 
@@ -363,8 +380,9 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = ap3[z];
         return weights;
-
-    } else if (phosphor_layout == 8){
+*/
+/*
+    else if (phosphor_layout == 8) {
         // aperture_3_6_rgb
         vec3 big_ap[7] = vec3[](red, red, yellow, green, cyan, blue, blue);
 
@@ -372,8 +390,9 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap[w];
         return weights;
-
-    } else if (phosphor_layout == 9) {
+	}
+*/
+    else if (phosphor_layout == 9) {
         // reduced TVL aperture for RGB panels
         // aperture_2_4_rgb
         vec3 big_ap_rgb[4] = vec3[](red, yellow, cyan, blue);
@@ -382,8 +401,9 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rgb[w];
         return weights;
-
-    } else if (phosphor_layout == 10) {
+	}
+/*
+    else if (phosphor_layout == 10) {
         // reduced TVL aperture for RBG panels
         vec3 big_ap_rbg[4] = vec3[](red, magenta, cyan, green);
 
@@ -391,148 +411,161 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rbg[w];
         return weights;
+	}
+*/
+    else if(phosphor_layout == 11) {
+        // delta_1_4x1_rgb; dunno why this is called 4x1 when it's obviously 4x2 /shrug
+        vec3 delta_1_1[4] = vec3[](red, green, blue, black);
+        vec3 delta_1_2[4] = vec3[](blue, black, red, green);
 
-    } else if(phosphor_layout == 11){
-       // delta_1_4x1_rgb; dunno why this is called 4x1 when it's obviously 4x2 /shrug
-       vec3 delta_1_1[4] = vec3[](red, green, blue, black);
-       vec3 delta_1_2[4] = vec3[](blue, black, red, green);
+        w = int(floor(mod(coord.y, 2.0)));
+        z = int(floor(mod(coord.x, 4.0)));
 
-       w = int(floor(mod(coord.y, 2.0)));
-       z = int(floor(mod(coord.x, 4.0)));
+        weights = (w == 1) ? delta_1_1[z] : delta_1_2[z];
+        return weights;
+    }
+/*
+    else if (phosphor_layout == 12) {
+        // delta_2_4x1_rgb
+        vec3 delta_2_1[4] = vec3[](red, yellow, cyan, blue);
+        vec3 delta_2_2[4] = vec3[](cyan, blue, red, yellow);
 
-       weights = (w == 1) ? delta_1_1[z] : delta_1_2[z];
-       return weights;
+        z = int(floor(mod(coord.x, 4.0)));
 
-    } else if(phosphor_layout == 12){
-       // delta_2_4x1_rgb
-       vec3 delta_2_1[4] = vec3[](red, yellow, cyan, blue);
-       vec3 delta_2_2[4] = vec3[](cyan, blue, red, yellow);
+        weights = (w == 1) ? delta_2_1[z] : delta_2_2[z];
+        return weights;
+	}
+*/
+/*
+    else if (phosphor_layout == 13) {
+        // delta_2_4x2_rgb
+        vec3 delta_1[4] = vec3[](red, yellow, cyan, blue);
+        vec3 delta_2[4] = vec3[](red, yellow, cyan, blue);
+        vec3 delta_3[4] = vec3[](cyan, blue, red, yellow);
+        vec3 delta_4[4] = vec3[](cyan, blue, red, yellow);
 
-       z = int(floor(mod(coord.x, 4.0)));
+        w = int(floor(mod(coord.y, 4.0)));
+        z = int(floor(mod(coord.x, 4.0)));
 
-       weights = (w == 1) ? delta_2_1[z] : delta_2_2[z];
-       return weights;
+        weights = (w == 1) ? delta_1[z] : (w == 2) ? delta_2[z] : (w == 3) ? delta_3[z] : delta_4[z];
+        return weights;
+    }
+*/
+    else if (phosphor_layout == 14) {
+        // slot mask for RGB panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
+        // {magenta, green, black, black,   black, black},
+        // {magenta, green, black, magenta, green, black},
+        // {black,   black, black, magenta, green, black}
+        vec3 slot2_1[6] = vec3[](magenta, green, black, black,   black, black);
+        vec3 slot2_2[6] = vec3[](magenta, green, black, magenta, green, black);
+        vec3 slot2_3[6] = vec3[](black,   black, black, magenta, green, black);
 
-    } else if(phosphor_layout == 13){
-       // delta_2_4x2_rgb
-       vec3 delta_1[4] = vec3[](red, yellow, cyan, blue);
-       vec3 delta_2[4] = vec3[](red, yellow, cyan, blue);
-       vec3 delta_3[4] = vec3[](cyan, blue, red, yellow);
-       vec3 delta_4[4] = vec3[](cyan, blue, red, yellow);
+        w = int(floor(mod(coord.y, 3.0)));
+        z = int(floor(mod(coord.x, 6.0)));
 
-       w = int(floor(mod(coord.y, 4.0)));
-       z = int(floor(mod(coord.x, 4.0)));
+        weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
+        return weights;
+    }
+/*
+    else if(phosphor_layout == 15) {
+        // slot_2_4x4_rgb
+        // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
+        // {red,   yellow, cyan,  blue,  black, black,  black, black},
+        // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
+        // {black, black,  black, black, red,   yellow, cyan,  blue }
+        vec3 slotmask_RBG_x1[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
+        vec3 slotmask_RBG_x2[8] = vec3[](red,   yellow, cyan,  blue,  black, black,  black, black);
+        vec3 slotmask_RBG_x3[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
+        vec3 slotmask_RBG_x4[8] = vec3[](black, black,  black, black, red,   yellow, cyan,  blue );
 
-       weights = (w == 1) ? delta_1[z] : (w == 2) ? delta_2[z] : (w == 3) ? delta_3[z] : delta_4[z];
-       return weights;
+        // find the vertical index
+        w = int(floor(mod(coord.y, 4.0)));
 
-    } else if(phosphor_layout == 14){
-       // slot mask for RGB panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
-       // {magenta, green, black, black,   black, black},
-       // {magenta, green, black, magenta, green, black},
-       // {black,   black, black, magenta, green, black}
-       vec3 slot2_1[6] = vec3[](magenta, green, black, black,   black, black);
-       vec3 slot2_2[6] = vec3[](magenta, green, black, magenta, green, black);
-       vec3 slot2_3[6] = vec3[](black,   black, black, magenta, green, black);
+        // find the horizontal index
+        z = int(floor(mod(coord.x, 8.0)));
 
-       w = int(floor(mod(coord.y, 3.0)));
-       z = int(floor(mod(coord.x, 6.0)));
+        weights = (w == 1) ? slotmask_RBG_x1[z] : (w == 2) ? slotmask_RBG_x2[z] : (w == 3) ? slotmask_RBG_x3[z] : slotmask_RBG_x4[z];
+        return weights;
+	}
+*/
+/*
+	else if(phosphor_layout == 16) {
+        // slot mask for RBG panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
+        // {yellow, blue,  black,  black},
+        // {yellow, blue,  yellow, blue},
+        // {black,  black, yellow, blue}
+        vec3 slot2_1[4] = vec3[](yellow, blue,  black,  black);
+        vec3 slot2_2[4] = vec3[](yellow, blue,  yellow, blue);
+        vec3 slot2_3[4] = vec3[](black,  black, yellow, blue);
 
-       weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
-       return weights;
+        w = int(floor(mod(coord.y, 3.0)));
+        z = int(floor(mod(coord.x, 4.0)));
 
-    } else if(phosphor_layout == 15){
-       // slot_2_4x4_rgb
-       // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
-       // {red,   yellow, cyan,  blue,  black, black,  black, black},
-       // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
-       // {black, black,  black, black, red,   yellow, cyan,  blue }
-       vec3 slotmask_RBG_x1[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
-       vec3 slotmask_RBG_x2[8] = vec3[](red,   yellow, cyan,  blue,  black, black,  black, black);
-       vec3 slotmask_RBG_x3[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
-       vec3 slotmask_RBG_x4[8] = vec3[](black, black,  black, black, red,   yellow, cyan,  blue );
+        weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
+        return weights;
+    }
+*/
+	else if (phosphor_layout == 17) {
+        // slot_2_5x4_bgr
+        // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
+        // {black, blue,    blue,  green, green, red,   red,     black, black, black},
+        // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
+        // {red,   red,     black, black, black, black, blue,    blue,  green, green}
+        vec3 slot_1[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
+        vec3 slot_2[10] = vec3[](black, blue,    blue,  green, green, red,   red,     black, black, black);
+        vec3 slot_3[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
+        vec3 slot_4[10] = vec3[](red,   red,     black, black, black, black, blue,    blue,  green, green);
 
-       // find the vertical index
-       w = int(floor(mod(coord.y, 4.0)));
+        w = int(floor(mod(coord.y, 4.0)));
+        z = int(floor(mod(coord.x, 10.0)));
 
-       // find the horizontal index
-       z = int(floor(mod(coord.x, 8.0)));
+        weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
+        return weights;
+    }
+/*
+    else if (phosphor_layout == 18) {
+        // same as above but for RBG panels
+        // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
+        // {black, green,  green, blue,  blue,  red,   red,    black, black, black},
+        // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
+        // {red,   red,    black, black, black, black, green,  green, blue,  blue }
+        vec3 slot_1[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
+        vec3 slot_2[10] = vec3[](black, green,  green, blue,  blue,  red,   red,    black, black, black);
+        vec3 slot_3[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
+        vec3 slot_4[10] = vec3[](red,   red,    black, black, black, black, green,  green, blue,  blue );
 
-       weights = (w == 1) ? slotmask_RBG_x1[z] : (w == 2) ? slotmask_RBG_x2[z] : (w == 3) ? slotmask_RBG_x3[z] : slotmask_RBG_x4[z];
-       return weights;
+        w = int(floor(mod(coord.y, 4.0)));
+        z = int(floor(mod(coord.x, 10.0)));
 
-     } else if(phosphor_layout == 16){
-       // slot mask for RBG panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
-       // {yellow, blue,  black,  black},
-       // {yellow, blue,  yellow, blue},
-       // {black,  black, yellow, blue}
-       vec3 slot2_1[4] = vec3[](yellow, blue,  black,  black);
-       vec3 slot2_2[4] = vec3[](yellow, blue,  yellow, blue);
-       vec3 slot2_3[4] = vec3[](black,  black, yellow, blue);
+        weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
+        return weights;
+    }
+*/
+/*
+    else if(phosphor_layout == 19) {
+        // slot_3_7x6_rgb
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue}
 
-       w = int(floor(mod(coord.y, 3.0)));
-       z = int(floor(mod(coord.x, 4.0)));
+        vec3 slot_1[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_2[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_3[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black);
+        vec3 slot_4[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_5[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_6[14] = vec3[](black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue);
 
-       weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
-       return weights;
+        w = int(floor(mod(coord.y, 6.0)));
+        z = int(floor(mod(coord.x, 14.0)));
 
-    } else if (phosphor_layout == 17) {
-       // slot_2_5x4_bgr
-       // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
-       // {black, blue,    blue,  green, green, red,   red,     black, black, black},
-       // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
-       // {red,   red,     black, black, black, black, blue,    blue,  green, green}
-       vec3 slot_1[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
-       vec3 slot_2[10] = vec3[](black, blue,    blue,  green, green, red,   red,     black, black, black);
-       vec3 slot_3[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
-       vec3 slot_4[10] = vec3[](red,   red,     black, black, black, black, blue,    blue,  green, green);
-
-       w = int(floor(mod(coord.y, 4.0)));
-       z = int(floor(mod(coord.x, 10.0)));
-
-       weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
-       return weights;
-
-    } else if (phosphor_layout == 18) {
-       // same as above but for RBG panels
-       // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
-       // {black, green,  green, blue,  blue,  red,   red,    black, black, black},
-       // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
-       // {red,   red,    black, black, black, black, green,  green, blue,  blue }
-       vec3 slot_1[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
-       vec3 slot_2[10] = vec3[](black, green,  green, blue,  blue,  red,   red,    black, black, black);
-       vec3 slot_3[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
-       vec3 slot_4[10] = vec3[](red,   red,    black, black, black, black, green,  green, blue,  blue );
-
-       w = int(floor(mod(coord.y, 4.0)));
-       z = int(floor(mod(coord.x, 10.0)));
-
-       weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
-       return weights;
-
-    } else if(phosphor_layout == 19) {
-       // slot_3_7x6_rgb
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue}
-
-       vec3 slot_1[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_2[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_3[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black);
-       vec3 slot_4[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_5[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_6[14] = vec3[](black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue);
-
-       w = int(floor(mod(coord.y, 6.0)));
-       z = int(floor(mod(coord.x, 14.0)));
-
-       weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : (w == 4) ? slot_4[z] : (w == 5) ? slot_5[z] : slot_6[z];
-       return weights;
-
-    } else {
+        weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : (w == 4) ? slot_4[z] : (w == 5) ? slot_5[z] : slot_6[z];
+        return weights;
+     }
+*/
+	else {
         return weights;
     }
 }

--- a/contrib/resources/glshaders/crt/ega-1440p.glsl
+++ b/contrib/resources/glshaders/crt/ega-1440p.glsl
@@ -168,10 +168,10 @@ uniform PRECISION float BLUE_SHIFT;
 
 #define WP_ADJUST           0.00
 #define TEMPERATURE      9300.00
-#define LUMA_PRESERVE 		1.00
-#define RED_SHIFT 			0.00
-#define GREEN_SHIFT 		0.00
-#define BLUE_SHIFT 			0.00
+#define LUMA_PRESERVE       1.00
+#define RED_SHIFT           0.00
+#define GREEN_SHIFT         0.00
+#define BLUE_SHIFT          0.00
 #endif
 // END PARAMETERS //
 
@@ -274,10 +274,10 @@ vec3 YxytoXYZ(vec3 Yxy) {
     Many of these mask arrays are adapted from cgwg's crt-geom-deluxe LUTs, and
     those have their filenames included for easy identification
 
-	NOTE: Having too many branches result in a black screen (but no
-	compilation errors) on some older GPUs such as the Intel HD 4000 iGPU. So
-	we're commenting out the branches that are not used by the adaptive CRT
-	shaders.
+    NOTE: Having too many branches result in a black screen (but no
+    compilation errors) on some older GPUs such as the Intel HD 4000 iGPU. So
+    we're commenting out the branches that are not used by the adaptive CRT
+    shaders.
 */
 vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
     vec3 weights = vec3(1.,1.,1.);
@@ -301,14 +301,14 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
     if (phosphor_layout == 0) {
         return weights;
-	}
+    }
 
     else if (phosphor_layout == 1) {
-    	// classic aperture for RGB panels; good for 1080p, too small for 4K+
+        // classic aperture for RGB panels; good for 1080p, too small for 4K+
         // aka aperture_1_2_bgr
         weights  = aperture_weights;
         return weights;
-	}
+    }
 
     else if (phosphor_layout == 2) {
         // 2x2 shadow mask for RGB panels; good for 1080p, too small for 4K+
@@ -316,7 +316,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
         vec3 inverse_aperture = mix(green, magenta, floor(mod(coord.x, 2.0)));
         weights               = mix(aperture_weights, inverse_aperture, floor(mod(coord.y, 2.0)));
         return weights;
-	}
+    }
 
 /*
     else if (phosphor_layout == 3) {
@@ -339,14 +339,14 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         // do a big, dumb comparison in place of a 2D array
         weights = (w == 1) ? slotmask_x1[z] : (w == 2) ? slotmask_x2[z] :  slotmask_x3[z];
-		return weights;
+        return weights;
     }
 */
     else if (phosphor_layout == 4) {
         // classic aperture for RBG panels; good for 1080p, too small for 4K+
         weights  = mix(yellow, blue, floor(mod(coord.x, 2.0)));
         return weights;
-	}
+    }
 /*
     else if (phosphor_layout == 5) {
         // 2x2 shadow mask for RBG panels; good for 1080p, too small for 4K+
@@ -358,7 +358,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
             floor(mod(coord.y, 2.0))
         );
         return weights;
-	}
+    }
 */
 /*
     else if (phosphor_layout == 6) {
@@ -369,7 +369,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = ap4[z];
         return weights;
-	}
+    }
 */
 /*
     else if (phosphor_layout == 7) {
@@ -390,7 +390,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap[w];
         return weights;
-	}
+    }
 */
     else if (phosphor_layout == 9) {
         // reduced TVL aperture for RGB panels
@@ -401,7 +401,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rgb[w];
         return weights;
-	}
+    }
 /*
     else if (phosphor_layout == 10) {
         // reduced TVL aperture for RBG panels
@@ -411,7 +411,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rbg[w];
         return weights;
-	}
+    }
 */
     else if(phosphor_layout == 11) {
         // delta_1_4x1_rgb; dunno why this is called 4x1 when it's obviously 4x2 /shrug
@@ -434,7 +434,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = (w == 1) ? delta_2_1[z] : delta_2_2[z];
         return weights;
-	}
+    }
 */
 /*
     else if (phosphor_layout == 13) {
@@ -486,10 +486,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = (w == 1) ? slotmask_RBG_x1[z] : (w == 2) ? slotmask_RBG_x2[z] : (w == 3) ? slotmask_RBG_x3[z] : slotmask_RBG_x4[z];
         return weights;
-	}
+    }
 */
 /*
-	else if(phosphor_layout == 16) {
+    else if(phosphor_layout == 16) {
         // slot mask for RBG panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
         // {yellow, blue,  black,  black},
         // {yellow, blue,  yellow, blue},
@@ -505,7 +505,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
         return weights;
     }
 */
-	else if (phosphor_layout == 17) {
+    else if (phosphor_layout == 17) {
         // slot_2_5x4_bgr
         // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
         // {black, blue,    blue,  green, green, red,   red,     black, black, black},
@@ -565,7 +565,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
         return weights;
      }
 */
-	else {
+    else {
         return weights;
     }
 }
@@ -585,10 +585,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 // For more info, see: http://www.imagemagick.org/Usage/img_diagrams/cubic_survey.gif
 mat4x4 get_hfilter_profile()
 {
-	float bf = 0.0;
-	float cf = 0.0;
+    float bf = 0.0;
+    float cf = 0.0;
 
-	if (HFILTER_PROFILE == 1) {
+    if (HFILTER_PROFILE == 1) {
         bf = 0.0;
         cf = 0.5;
     }
@@ -690,14 +690,14 @@ void main()
     mask_coords = mix(mask_coords.xy, mask_coords.yx, VSCANLINES);
     color.rgb *= mask_weights(mask_coords, MASK_INTENSITY, int(PHOSPHOR_LAYOUT));
 
-	// Colour temperature
-	if (WP_ADJUST == 1.0) {
-		vec3 wp_adjusted = wp_adjust(color.rgb);
-		vec3 base_luma = XYZtoYxy(sRGB_to_XYZ(color.rgb));
-		vec3 adjusted_luma = XYZtoYxy(sRGB_to_XYZ(wp_adjusted));
-		wp_adjusted = (LUMA_PRESERVE == 1.0) ? adjusted_luma + (vec3(base_luma.r,0.,0.) - vec3(adjusted_luma.r,0.,0.)) : adjusted_luma;
-		color = vec4(XYZ_to_sRGB(YxytoXYZ(wp_adjusted)), 1.0);
-	}
+    // Colour temperature
+    if (WP_ADJUST == 1.0) {
+        vec3 wp_adjusted = wp_adjust(color.rgb);
+        vec3 base_luma = XYZtoYxy(sRGB_to_XYZ(color.rgb));
+        vec3 adjusted_luma = XYZtoYxy(sRGB_to_XYZ(wp_adjusted));
+        wp_adjusted = (LUMA_PRESERVE == 1.0) ? adjusted_luma + (vec3(base_luma.r,0.,0.) - vec3(adjusted_luma.r,0.,0.)) : adjusted_luma;
+        color = vec4(XYZ_to_sRGB(YxytoXYZ(wp_adjusted)), 1.0);
+    }
 
     // Output gamma
     color = clamp(GAMMA_OUT(color), 0.0, 1.0);

--- a/contrib/resources/glshaders/crt/ega-1440p.glsl
+++ b/contrib/resources/glshaders/crt/ega-1440p.glsl
@@ -247,7 +247,6 @@ vec3 YxytoXYZ(vec3 Yxy) {
     return XYZ;
 }
 
-
 /*
     A collection of CRT mask effects that work with LCD subpixel structures for
     small details
@@ -274,11 +273,18 @@ vec3 YxytoXYZ(vec3 Yxy) {
 
     Many of these mask arrays are adapted from cgwg's crt-geom-deluxe LUTs, and
     those have their filenames included for easy identification
+
+	NOTE: Having too many branches result in a black screen (but no
+	compilation errors) on some older GPUs such as the Intel HD 4000 iGPU. So
+	we're commenting out the branches that are not used by the adaptive CRT
+	shaders.
 */
 vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
     vec3 weights = vec3(1.,1.,1.);
+
     float on = 1.;
     float off = 1.-mask_intensity;
+
     vec3 red     = vec3(on,  off, off);
     vec3 green   = vec3(off, on,  off);
     vec3 blue    = vec3(off, off, on );
@@ -287,6 +293,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
     vec3 cyan    = vec3(off, on,  on );
     vec3 black   = vec3(off, off, off);
     vec3 white   = vec3(on,  on,  on );
+
     int w, z = 0;
 
     // This pattern is used by a few layouts, so we'll define it here
@@ -294,21 +301,25 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
     if (phosphor_layout == 0) {
         return weights;
+	}
 
-    } else if (phosphor_layout == 1) {
-        // classic aperture for RGB panels; good for 1080p, too small for 4K+
+    else if (phosphor_layout == 1) {
+    	// classic aperture for RGB panels; good for 1080p, too small for 4K+
         // aka aperture_1_2_bgr
         weights  = aperture_weights;
         return weights;
+	}
 
-    } else if (phosphor_layout == 2) {
+    else if (phosphor_layout == 2) {
         // 2x2 shadow mask for RGB panels; good for 1080p, too small for 4K+
         // aka delta_1_2x1_bgr
         vec3 inverse_aperture = mix(green, magenta, floor(mod(coord.x, 2.0)));
         weights               = mix(aperture_weights, inverse_aperture, floor(mod(coord.y, 2.0)));
         return weights;
+	}
 
-    } else if (phosphor_layout == 3) {
+/*
+    else if (phosphor_layout == 3) {
         // slot mask for RGB panels; looks okay at 1080p, looks better at 4K
         // {magenta, green, black,   black},
         // {magenta, green, magenta, green},
@@ -328,14 +339,16 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         // do a big, dumb comparison in place of a 2D array
         weights = (w == 1) ? slotmask_x1[z] : (w == 2) ? slotmask_x2[z] :  slotmask_x3[z];
+		return weights;
     }
-
-    if (phosphor_layout == 4) {
+*/
+    else if (phosphor_layout == 4) {
         // classic aperture for RBG panels; good for 1080p, too small for 4K+
         weights  = mix(yellow, blue, floor(mod(coord.x, 2.0)));
         return weights;
-
-    } else if (phosphor_layout == 5) {
+	}
+/*
+    else if (phosphor_layout == 5) {
         // 2x2 shadow mask for RBG panels; good for 1080p, too small for 4K+
         vec3 inverse_aperture = mix(blue, yellow, floor(mod(coord.x, 2.0)));
 
@@ -345,8 +358,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
             floor(mod(coord.y, 2.0))
         );
         return weights;
-
-    } else if (phosphor_layout == 6) {
+	}
+*/
+/*
+    else if (phosphor_layout == 6) {
         // aperture_1_4_rgb; good for simulating lower
         vec3 ap4[4] = vec3[](red, green, blue, black);
 
@@ -354,8 +369,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = ap4[z];
         return weights;
-
-    } else if (phosphor_layout == 7) {
+	}
+*/
+/*
+    else if (phosphor_layout == 7) {
         // aperture_2_5_bgr
         vec3 ap3[5] = vec3[](red, magenta, blue, green, green);
 
@@ -363,8 +380,9 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = ap3[z];
         return weights;
-
-    } else if (phosphor_layout == 8){
+*/
+/*
+    else if (phosphor_layout == 8) {
         // aperture_3_6_rgb
         vec3 big_ap[7] = vec3[](red, red, yellow, green, cyan, blue, blue);
 
@@ -372,8 +390,9 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap[w];
         return weights;
-
-    } else if (phosphor_layout == 9) {
+	}
+*/
+    else if (phosphor_layout == 9) {
         // reduced TVL aperture for RGB panels
         // aperture_2_4_rgb
         vec3 big_ap_rgb[4] = vec3[](red, yellow, cyan, blue);
@@ -382,8 +401,9 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rgb[w];
         return weights;
-
-    } else if (phosphor_layout == 10) {
+	}
+/*
+    else if (phosphor_layout == 10) {
         // reduced TVL aperture for RBG panels
         vec3 big_ap_rbg[4] = vec3[](red, magenta, cyan, green);
 
@@ -391,148 +411,161 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rbg[w];
         return weights;
+	}
+*/
+    else if(phosphor_layout == 11) {
+        // delta_1_4x1_rgb; dunno why this is called 4x1 when it's obviously 4x2 /shrug
+        vec3 delta_1_1[4] = vec3[](red, green, blue, black);
+        vec3 delta_1_2[4] = vec3[](blue, black, red, green);
 
-    } else if(phosphor_layout == 11){
-       // delta_1_4x1_rgb; dunno why this is called 4x1 when it's obviously 4x2 /shrug
-       vec3 delta_1_1[4] = vec3[](red, green, blue, black);
-       vec3 delta_1_2[4] = vec3[](blue, black, red, green);
+        w = int(floor(mod(coord.y, 2.0)));
+        z = int(floor(mod(coord.x, 4.0)));
 
-       w = int(floor(mod(coord.y, 2.0)));
-       z = int(floor(mod(coord.x, 4.0)));
+        weights = (w == 1) ? delta_1_1[z] : delta_1_2[z];
+        return weights;
+    }
+/*
+    else if (phosphor_layout == 12) {
+        // delta_2_4x1_rgb
+        vec3 delta_2_1[4] = vec3[](red, yellow, cyan, blue);
+        vec3 delta_2_2[4] = vec3[](cyan, blue, red, yellow);
 
-       weights = (w == 1) ? delta_1_1[z] : delta_1_2[z];
-       return weights;
+        z = int(floor(mod(coord.x, 4.0)));
 
-    } else if(phosphor_layout == 12){
-       // delta_2_4x1_rgb
-       vec3 delta_2_1[4] = vec3[](red, yellow, cyan, blue);
-       vec3 delta_2_2[4] = vec3[](cyan, blue, red, yellow);
+        weights = (w == 1) ? delta_2_1[z] : delta_2_2[z];
+        return weights;
+	}
+*/
+/*
+    else if (phosphor_layout == 13) {
+        // delta_2_4x2_rgb
+        vec3 delta_1[4] = vec3[](red, yellow, cyan, blue);
+        vec3 delta_2[4] = vec3[](red, yellow, cyan, blue);
+        vec3 delta_3[4] = vec3[](cyan, blue, red, yellow);
+        vec3 delta_4[4] = vec3[](cyan, blue, red, yellow);
 
-       z = int(floor(mod(coord.x, 4.0)));
+        w = int(floor(mod(coord.y, 4.0)));
+        z = int(floor(mod(coord.x, 4.0)));
 
-       weights = (w == 1) ? delta_2_1[z] : delta_2_2[z];
-       return weights;
+        weights = (w == 1) ? delta_1[z] : (w == 2) ? delta_2[z] : (w == 3) ? delta_3[z] : delta_4[z];
+        return weights;
+    }
+*/
+    else if (phosphor_layout == 14) {
+        // slot mask for RGB panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
+        // {magenta, green, black, black,   black, black},
+        // {magenta, green, black, magenta, green, black},
+        // {black,   black, black, magenta, green, black}
+        vec3 slot2_1[6] = vec3[](magenta, green, black, black,   black, black);
+        vec3 slot2_2[6] = vec3[](magenta, green, black, magenta, green, black);
+        vec3 slot2_3[6] = vec3[](black,   black, black, magenta, green, black);
 
-    } else if(phosphor_layout == 13){
-       // delta_2_4x2_rgb
-       vec3 delta_1[4] = vec3[](red, yellow, cyan, blue);
-       vec3 delta_2[4] = vec3[](red, yellow, cyan, blue);
-       vec3 delta_3[4] = vec3[](cyan, blue, red, yellow);
-       vec3 delta_4[4] = vec3[](cyan, blue, red, yellow);
+        w = int(floor(mod(coord.y, 3.0)));
+        z = int(floor(mod(coord.x, 6.0)));
 
-       w = int(floor(mod(coord.y, 4.0)));
-       z = int(floor(mod(coord.x, 4.0)));
+        weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
+        return weights;
+    }
+/*
+    else if(phosphor_layout == 15) {
+        // slot_2_4x4_rgb
+        // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
+        // {red,   yellow, cyan,  blue,  black, black,  black, black},
+        // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
+        // {black, black,  black, black, red,   yellow, cyan,  blue }
+        vec3 slotmask_RBG_x1[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
+        vec3 slotmask_RBG_x2[8] = vec3[](red,   yellow, cyan,  blue,  black, black,  black, black);
+        vec3 slotmask_RBG_x3[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
+        vec3 slotmask_RBG_x4[8] = vec3[](black, black,  black, black, red,   yellow, cyan,  blue );
 
-       weights = (w == 1) ? delta_1[z] : (w == 2) ? delta_2[z] : (w == 3) ? delta_3[z] : delta_4[z];
-       return weights;
+        // find the vertical index
+        w = int(floor(mod(coord.y, 4.0)));
 
-    } else if(phosphor_layout == 14){
-       // slot mask for RGB panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
-       // {magenta, green, black, black,   black, black},
-       // {magenta, green, black, magenta, green, black},
-       // {black,   black, black, magenta, green, black}
-       vec3 slot2_1[6] = vec3[](magenta, green, black, black,   black, black);
-       vec3 slot2_2[6] = vec3[](magenta, green, black, magenta, green, black);
-       vec3 slot2_3[6] = vec3[](black,   black, black, magenta, green, black);
+        // find the horizontal index
+        z = int(floor(mod(coord.x, 8.0)));
 
-       w = int(floor(mod(coord.y, 3.0)));
-       z = int(floor(mod(coord.x, 6.0)));
+        weights = (w == 1) ? slotmask_RBG_x1[z] : (w == 2) ? slotmask_RBG_x2[z] : (w == 3) ? slotmask_RBG_x3[z] : slotmask_RBG_x4[z];
+        return weights;
+	}
+*/
+/*
+	else if(phosphor_layout == 16) {
+        // slot mask for RBG panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
+        // {yellow, blue,  black,  black},
+        // {yellow, blue,  yellow, blue},
+        // {black,  black, yellow, blue}
+        vec3 slot2_1[4] = vec3[](yellow, blue,  black,  black);
+        vec3 slot2_2[4] = vec3[](yellow, blue,  yellow, blue);
+        vec3 slot2_3[4] = vec3[](black,  black, yellow, blue);
 
-       weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
-       return weights;
+        w = int(floor(mod(coord.y, 3.0)));
+        z = int(floor(mod(coord.x, 4.0)));
 
-    } else if(phosphor_layout == 15){
-       // slot_2_4x4_rgb
-       // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
-       // {red,   yellow, cyan,  blue,  black, black,  black, black},
-       // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
-       // {black, black,  black, black, red,   yellow, cyan,  blue }
-       vec3 slotmask_RBG_x1[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
-       vec3 slotmask_RBG_x2[8] = vec3[](red,   yellow, cyan,  blue,  black, black,  black, black);
-       vec3 slotmask_RBG_x3[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
-       vec3 slotmask_RBG_x4[8] = vec3[](black, black,  black, black, red,   yellow, cyan,  blue );
+        weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
+        return weights;
+    }
+*/
+	else if (phosphor_layout == 17) {
+        // slot_2_5x4_bgr
+        // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
+        // {black, blue,    blue,  green, green, red,   red,     black, black, black},
+        // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
+        // {red,   red,     black, black, black, black, blue,    blue,  green, green}
+        vec3 slot_1[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
+        vec3 slot_2[10] = vec3[](black, blue,    blue,  green, green, red,   red,     black, black, black);
+        vec3 slot_3[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
+        vec3 slot_4[10] = vec3[](red,   red,     black, black, black, black, blue,    blue,  green, green);
 
-       // find the vertical index
-       w = int(floor(mod(coord.y, 4.0)));
+        w = int(floor(mod(coord.y, 4.0)));
+        z = int(floor(mod(coord.x, 10.0)));
 
-       // find the horizontal index
-       z = int(floor(mod(coord.x, 8.0)));
+        weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
+        return weights;
+    }
+/*
+    else if (phosphor_layout == 18) {
+        // same as above but for RBG panels
+        // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
+        // {black, green,  green, blue,  blue,  red,   red,    black, black, black},
+        // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
+        // {red,   red,    black, black, black, black, green,  green, blue,  blue }
+        vec3 slot_1[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
+        vec3 slot_2[10] = vec3[](black, green,  green, blue,  blue,  red,   red,    black, black, black);
+        vec3 slot_3[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
+        vec3 slot_4[10] = vec3[](red,   red,    black, black, black, black, green,  green, blue,  blue );
 
-       weights = (w == 1) ? slotmask_RBG_x1[z] : (w == 2) ? slotmask_RBG_x2[z] : (w == 3) ? slotmask_RBG_x3[z] : slotmask_RBG_x4[z];
-       return weights;
+        w = int(floor(mod(coord.y, 4.0)));
+        z = int(floor(mod(coord.x, 10.0)));
 
-     } else if(phosphor_layout == 16){
-       // slot mask for RBG panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
-       // {yellow, blue,  black,  black},
-       // {yellow, blue,  yellow, blue},
-       // {black,  black, yellow, blue}
-       vec3 slot2_1[4] = vec3[](yellow, blue,  black,  black);
-       vec3 slot2_2[4] = vec3[](yellow, blue,  yellow, blue);
-       vec3 slot2_3[4] = vec3[](black,  black, yellow, blue);
+        weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
+        return weights;
+    }
+*/
+/*
+    else if(phosphor_layout == 19) {
+        // slot_3_7x6_rgb
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue}
 
-       w = int(floor(mod(coord.y, 3.0)));
-       z = int(floor(mod(coord.x, 4.0)));
+        vec3 slot_1[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_2[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_3[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black);
+        vec3 slot_4[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_5[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_6[14] = vec3[](black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue);
 
-       weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
-       return weights;
+        w = int(floor(mod(coord.y, 6.0)));
+        z = int(floor(mod(coord.x, 14.0)));
 
-    } else if (phosphor_layout == 17) {
-       // slot_2_5x4_bgr
-       // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
-       // {black, blue,    blue,  green, green, red,   red,     black, black, black},
-       // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
-       // {red,   red,     black, black, black, black, blue,    blue,  green, green}
-       vec3 slot_1[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
-       vec3 slot_2[10] = vec3[](black, blue,    blue,  green, green, red,   red,     black, black, black);
-       vec3 slot_3[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
-       vec3 slot_4[10] = vec3[](red,   red,     black, black, black, black, blue,    blue,  green, green);
-
-       w = int(floor(mod(coord.y, 4.0)));
-       z = int(floor(mod(coord.x, 10.0)));
-
-       weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
-       return weights;
-
-    } else if (phosphor_layout == 18) {
-       // same as above but for RBG panels
-       // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
-       // {black, green,  green, blue,  blue,  red,   red,    black, black, black},
-       // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
-       // {red,   red,    black, black, black, black, green,  green, blue,  blue }
-       vec3 slot_1[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
-       vec3 slot_2[10] = vec3[](black, green,  green, blue,  blue,  red,   red,    black, black, black);
-       vec3 slot_3[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
-       vec3 slot_4[10] = vec3[](red,   red,    black, black, black, black, green,  green, blue,  blue );
-
-       w = int(floor(mod(coord.y, 4.0)));
-       z = int(floor(mod(coord.x, 10.0)));
-
-       weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
-       return weights;
-
-    } else if(phosphor_layout == 19) {
-       // slot_3_7x6_rgb
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue}
-
-       vec3 slot_1[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_2[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_3[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black);
-       vec3 slot_4[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_5[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_6[14] = vec3[](black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue);
-
-       w = int(floor(mod(coord.y, 6.0)));
-       z = int(floor(mod(coord.x, 14.0)));
-
-       weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : (w == 4) ? slot_4[z] : (w == 5) ? slot_5[z] : slot_6[z];
-       return weights;
-
-    } else {
+        weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : (w == 4) ? slot_4[z] : (w == 5) ? slot_5[z] : slot_6[z];
+        return weights;
+     }
+*/
+	else {
         return weights;
     }
 }

--- a/contrib/resources/glshaders/crt/ega-4k.glsl
+++ b/contrib/resources/glshaders/crt/ega-4k.glsl
@@ -168,10 +168,10 @@ uniform PRECISION float BLUE_SHIFT;
 
 #define WP_ADJUST           0.00
 #define TEMPERATURE      9300.00
-#define LUMA_PRESERVE 		1.00
-#define RED_SHIFT 			0.00
-#define GREEN_SHIFT 		0.00
-#define BLUE_SHIFT 			0.00
+#define LUMA_PRESERVE       1.00
+#define RED_SHIFT           0.00
+#define GREEN_SHIFT         0.00
+#define BLUE_SHIFT          0.00
 #endif
 // END PARAMETERS //
 
@@ -274,10 +274,10 @@ vec3 YxytoXYZ(vec3 Yxy) {
     Many of these mask arrays are adapted from cgwg's crt-geom-deluxe LUTs, and
     those have their filenames included for easy identification
 
-	NOTE: Having too many branches result in a black screen (but no
-	compilation errors) on some older GPUs such as the Intel HD 4000 iGPU. So
-	we're commenting out the branches that are not used by the adaptive CRT
-	shaders.
+    NOTE: Having too many branches result in a black screen (but no
+    compilation errors) on some older GPUs such as the Intel HD 4000 iGPU. So
+    we're commenting out the branches that are not used by the adaptive CRT
+    shaders.
 */
 vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
     vec3 weights = vec3(1.,1.,1.);
@@ -301,14 +301,14 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
     if (phosphor_layout == 0) {
         return weights;
-	}
+    }
 
     else if (phosphor_layout == 1) {
-    	// classic aperture for RGB panels; good for 1080p, too small for 4K+
+        // classic aperture for RGB panels; good for 1080p, too small for 4K+
         // aka aperture_1_2_bgr
         weights  = aperture_weights;
         return weights;
-	}
+    }
 
     else if (phosphor_layout == 2) {
         // 2x2 shadow mask for RGB panels; good for 1080p, too small for 4K+
@@ -316,7 +316,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
         vec3 inverse_aperture = mix(green, magenta, floor(mod(coord.x, 2.0)));
         weights               = mix(aperture_weights, inverse_aperture, floor(mod(coord.y, 2.0)));
         return weights;
-	}
+    }
 
 /*
     else if (phosphor_layout == 3) {
@@ -339,14 +339,14 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         // do a big, dumb comparison in place of a 2D array
         weights = (w == 1) ? slotmask_x1[z] : (w == 2) ? slotmask_x2[z] :  slotmask_x3[z];
-		return weights;
+        return weights;
     }
 */
     else if (phosphor_layout == 4) {
         // classic aperture for RBG panels; good for 1080p, too small for 4K+
         weights  = mix(yellow, blue, floor(mod(coord.x, 2.0)));
         return weights;
-	}
+    }
 /*
     else if (phosphor_layout == 5) {
         // 2x2 shadow mask for RBG panels; good for 1080p, too small for 4K+
@@ -358,7 +358,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
             floor(mod(coord.y, 2.0))
         );
         return weights;
-	}
+    }
 */
 /*
     else if (phosphor_layout == 6) {
@@ -369,7 +369,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = ap4[z];
         return weights;
-	}
+    }
 */
 /*
     else if (phosphor_layout == 7) {
@@ -390,7 +390,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap[w];
         return weights;
-	}
+    }
 */
     else if (phosphor_layout == 9) {
         // reduced TVL aperture for RGB panels
@@ -401,7 +401,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rgb[w];
         return weights;
-	}
+    }
 /*
     else if (phosphor_layout == 10) {
         // reduced TVL aperture for RBG panels
@@ -411,7 +411,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rbg[w];
         return weights;
-	}
+    }
 */
     else if(phosphor_layout == 11) {
         // delta_1_4x1_rgb; dunno why this is called 4x1 when it's obviously 4x2 /shrug
@@ -434,7 +434,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = (w == 1) ? delta_2_1[z] : delta_2_2[z];
         return weights;
-	}
+    }
 */
 /*
     else if (phosphor_layout == 13) {
@@ -486,10 +486,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = (w == 1) ? slotmask_RBG_x1[z] : (w == 2) ? slotmask_RBG_x2[z] : (w == 3) ? slotmask_RBG_x3[z] : slotmask_RBG_x4[z];
         return weights;
-	}
+    }
 */
 /*
-	else if(phosphor_layout == 16) {
+    else if(phosphor_layout == 16) {
         // slot mask for RBG panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
         // {yellow, blue,  black,  black},
         // {yellow, blue,  yellow, blue},
@@ -505,7 +505,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
         return weights;
     }
 */
-	else if (phosphor_layout == 17) {
+    else if (phosphor_layout == 17) {
         // slot_2_5x4_bgr
         // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
         // {black, blue,    blue,  green, green, red,   red,     black, black, black},
@@ -565,7 +565,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
         return weights;
      }
 */
-	else {
+    else {
         return weights;
     }
 }
@@ -584,10 +584,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 // For more info, see: http://www.imagemagick.org/Usage/img_diagrams/cubic_survey.gif
 mat4x4 get_hfilter_profile()
 {
-	float bf = 0.0;
-	float cf = 0.0;
+    float bf = 0.0;
+    float cf = 0.0;
 
-	if (HFILTER_PROFILE == 1) {
+    if (HFILTER_PROFILE == 1) {
         bf = 0.0;
         cf = 0.5;
     }
@@ -689,14 +689,14 @@ void main()
     mask_coords = mix(mask_coords.xy, mask_coords.yx, VSCANLINES);
     color.rgb *= mask_weights(mask_coords, MASK_INTENSITY, int(PHOSPHOR_LAYOUT));
 
-	// Colour temperature
-	if (WP_ADJUST == 1.0) {
-		vec3 wp_adjusted = wp_adjust(color.rgb);
-		vec3 base_luma = XYZtoYxy(sRGB_to_XYZ(color.rgb));
-		vec3 adjusted_luma = XYZtoYxy(sRGB_to_XYZ(wp_adjusted));
-		wp_adjusted = (LUMA_PRESERVE == 1.0) ? adjusted_luma + (vec3(base_luma.r,0.,0.) - vec3(adjusted_luma.r,0.,0.)) : adjusted_luma;
-		color = vec4(XYZ_to_sRGB(YxytoXYZ(wp_adjusted)), 1.0);
-	}
+    // Colour temperature
+    if (WP_ADJUST == 1.0) {
+        vec3 wp_adjusted = wp_adjust(color.rgb);
+        vec3 base_luma = XYZtoYxy(sRGB_to_XYZ(color.rgb));
+        vec3 adjusted_luma = XYZtoYxy(sRGB_to_XYZ(wp_adjusted));
+        wp_adjusted = (LUMA_PRESERVE == 1.0) ? adjusted_luma + (vec3(base_luma.r,0.,0.) - vec3(adjusted_luma.r,0.,0.)) : adjusted_luma;
+        color = vec4(XYZ_to_sRGB(YxytoXYZ(wp_adjusted)), 1.0);
+    }
 
     // Output gamma
     color = clamp(GAMMA_OUT(color), 0.0, 1.0);

--- a/contrib/resources/glshaders/crt/ega-4k.glsl
+++ b/contrib/resources/glshaders/crt/ega-4k.glsl
@@ -247,7 +247,6 @@ vec3 YxytoXYZ(vec3 Yxy) {
     return XYZ;
 }
 
-
 /*
     A collection of CRT mask effects that work with LCD subpixel structures for
     small details
@@ -274,11 +273,18 @@ vec3 YxytoXYZ(vec3 Yxy) {
 
     Many of these mask arrays are adapted from cgwg's crt-geom-deluxe LUTs, and
     those have their filenames included for easy identification
+
+	NOTE: Having too many branches result in a black screen (but no
+	compilation errors) on some older GPUs such as the Intel HD 4000 iGPU. So
+	we're commenting out the branches that are not used by the adaptive CRT
+	shaders.
 */
 vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
     vec3 weights = vec3(1.,1.,1.);
+
     float on = 1.;
     float off = 1.-mask_intensity;
+
     vec3 red     = vec3(on,  off, off);
     vec3 green   = vec3(off, on,  off);
     vec3 blue    = vec3(off, off, on );
@@ -287,6 +293,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
     vec3 cyan    = vec3(off, on,  on );
     vec3 black   = vec3(off, off, off);
     vec3 white   = vec3(on,  on,  on );
+
     int w, z = 0;
 
     // This pattern is used by a few layouts, so we'll define it here
@@ -294,21 +301,25 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
     if (phosphor_layout == 0) {
         return weights;
+	}
 
-    } else if (phosphor_layout == 1) {
-        // classic aperture for RGB panels; good for 1080p, too small for 4K+
+    else if (phosphor_layout == 1) {
+    	// classic aperture for RGB panels; good for 1080p, too small for 4K+
         // aka aperture_1_2_bgr
         weights  = aperture_weights;
         return weights;
+	}
 
-    } else if (phosphor_layout == 2) {
+    else if (phosphor_layout == 2) {
         // 2x2 shadow mask for RGB panels; good for 1080p, too small for 4K+
         // aka delta_1_2x1_bgr
         vec3 inverse_aperture = mix(green, magenta, floor(mod(coord.x, 2.0)));
         weights               = mix(aperture_weights, inverse_aperture, floor(mod(coord.y, 2.0)));
         return weights;
+	}
 
-    } else if (phosphor_layout == 3) {
+/*
+    else if (phosphor_layout == 3) {
         // slot mask for RGB panels; looks okay at 1080p, looks better at 4K
         // {magenta, green, black,   black},
         // {magenta, green, magenta, green},
@@ -328,14 +339,16 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         // do a big, dumb comparison in place of a 2D array
         weights = (w == 1) ? slotmask_x1[z] : (w == 2) ? slotmask_x2[z] :  slotmask_x3[z];
+		return weights;
     }
-
-    if (phosphor_layout == 4) {
+*/
+    else if (phosphor_layout == 4) {
         // classic aperture for RBG panels; good for 1080p, too small for 4K+
         weights  = mix(yellow, blue, floor(mod(coord.x, 2.0)));
         return weights;
-
-    } else if (phosphor_layout == 5) {
+	}
+/*
+    else if (phosphor_layout == 5) {
         // 2x2 shadow mask for RBG panels; good for 1080p, too small for 4K+
         vec3 inverse_aperture = mix(blue, yellow, floor(mod(coord.x, 2.0)));
 
@@ -345,8 +358,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
             floor(mod(coord.y, 2.0))
         );
         return weights;
-
-    } else if (phosphor_layout == 6) {
+	}
+*/
+/*
+    else if (phosphor_layout == 6) {
         // aperture_1_4_rgb; good for simulating lower
         vec3 ap4[4] = vec3[](red, green, blue, black);
 
@@ -354,8 +369,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = ap4[z];
         return weights;
-
-    } else if (phosphor_layout == 7) {
+	}
+*/
+/*
+    else if (phosphor_layout == 7) {
         // aperture_2_5_bgr
         vec3 ap3[5] = vec3[](red, magenta, blue, green, green);
 
@@ -363,8 +380,9 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = ap3[z];
         return weights;
-
-    } else if (phosphor_layout == 8){
+*/
+/*
+    else if (phosphor_layout == 8) {
         // aperture_3_6_rgb
         vec3 big_ap[7] = vec3[](red, red, yellow, green, cyan, blue, blue);
 
@@ -372,8 +390,9 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap[w];
         return weights;
-
-    } else if (phosphor_layout == 9) {
+	}
+*/
+    else if (phosphor_layout == 9) {
         // reduced TVL aperture for RGB panels
         // aperture_2_4_rgb
         vec3 big_ap_rgb[4] = vec3[](red, yellow, cyan, blue);
@@ -382,8 +401,9 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rgb[w];
         return weights;
-
-    } else if (phosphor_layout == 10) {
+	}
+/*
+    else if (phosphor_layout == 10) {
         // reduced TVL aperture for RBG panels
         vec3 big_ap_rbg[4] = vec3[](red, magenta, cyan, green);
 
@@ -391,152 +411,164 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rbg[w];
         return weights;
+	}
+*/
+    else if(phosphor_layout == 11) {
+        // delta_1_4x1_rgb; dunno why this is called 4x1 when it's obviously 4x2 /shrug
+        vec3 delta_1_1[4] = vec3[](red, green, blue, black);
+        vec3 delta_1_2[4] = vec3[](blue, black, red, green);
 
-    } else if(phosphor_layout == 11){
-       // delta_1_4x1_rgb; dunno why this is called 4x1 when it's obviously 4x2 /shrug
-       vec3 delta_1_1[4] = vec3[](red, green, blue, black);
-       vec3 delta_1_2[4] = vec3[](blue, black, red, green);
+        w = int(floor(mod(coord.y, 2.0)));
+        z = int(floor(mod(coord.x, 4.0)));
 
-       w = int(floor(mod(coord.y, 2.0)));
-       z = int(floor(mod(coord.x, 4.0)));
+        weights = (w == 1) ? delta_1_1[z] : delta_1_2[z];
+        return weights;
+    }
+/*
+    else if (phosphor_layout == 12) {
+        // delta_2_4x1_rgb
+        vec3 delta_2_1[4] = vec3[](red, yellow, cyan, blue);
+        vec3 delta_2_2[4] = vec3[](cyan, blue, red, yellow);
 
-       weights = (w == 1) ? delta_1_1[z] : delta_1_2[z];
-       return weights;
+        z = int(floor(mod(coord.x, 4.0)));
 
-    } else if(phosphor_layout == 12){
-       // delta_2_4x1_rgb
-       vec3 delta_2_1[4] = vec3[](red, yellow, cyan, blue);
-       vec3 delta_2_2[4] = vec3[](cyan, blue, red, yellow);
+        weights = (w == 1) ? delta_2_1[z] : delta_2_2[z];
+        return weights;
+	}
+*/
+/*
+    else if (phosphor_layout == 13) {
+        // delta_2_4x2_rgb
+        vec3 delta_1[4] = vec3[](red, yellow, cyan, blue);
+        vec3 delta_2[4] = vec3[](red, yellow, cyan, blue);
+        vec3 delta_3[4] = vec3[](cyan, blue, red, yellow);
+        vec3 delta_4[4] = vec3[](cyan, blue, red, yellow);
 
-       z = int(floor(mod(coord.x, 4.0)));
+        w = int(floor(mod(coord.y, 4.0)));
+        z = int(floor(mod(coord.x, 4.0)));
 
-       weights = (w == 1) ? delta_2_1[z] : delta_2_2[z];
-       return weights;
+        weights = (w == 1) ? delta_1[z] : (w == 2) ? delta_2[z] : (w == 3) ? delta_3[z] : delta_4[z];
+        return weights;
+    }
+*/
+    else if (phosphor_layout == 14) {
+        // slot mask for RGB panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
+        // {magenta, green, black, black,   black, black},
+        // {magenta, green, black, magenta, green, black},
+        // {black,   black, black, magenta, green, black}
+        vec3 slot2_1[6] = vec3[](magenta, green, black, black,   black, black);
+        vec3 slot2_2[6] = vec3[](magenta, green, black, magenta, green, black);
+        vec3 slot2_3[6] = vec3[](black,   black, black, magenta, green, black);
 
-    } else if(phosphor_layout == 13){
-       // delta_2_4x2_rgb
-       vec3 delta_1[4] = vec3[](red, yellow, cyan, blue);
-       vec3 delta_2[4] = vec3[](red, yellow, cyan, blue);
-       vec3 delta_3[4] = vec3[](cyan, blue, red, yellow);
-       vec3 delta_4[4] = vec3[](cyan, blue, red, yellow);
+        w = int(floor(mod(coord.y, 3.0)));
+        z = int(floor(mod(coord.x, 6.0)));
 
-       w = int(floor(mod(coord.y, 4.0)));
-       z = int(floor(mod(coord.x, 4.0)));
+        weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
+        return weights;
+    }
+/*
+    else if(phosphor_layout == 15) {
+        // slot_2_4x4_rgb
+        // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
+        // {red,   yellow, cyan,  blue,  black, black,  black, black},
+        // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
+        // {black, black,  black, black, red,   yellow, cyan,  blue }
+        vec3 slotmask_RBG_x1[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
+        vec3 slotmask_RBG_x2[8] = vec3[](red,   yellow, cyan,  blue,  black, black,  black, black);
+        vec3 slotmask_RBG_x3[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
+        vec3 slotmask_RBG_x4[8] = vec3[](black, black,  black, black, red,   yellow, cyan,  blue );
 
-       weights = (w == 1) ? delta_1[z] : (w == 2) ? delta_2[z] : (w == 3) ? delta_3[z] : delta_4[z];
-       return weights;
+        // find the vertical index
+        w = int(floor(mod(coord.y, 4.0)));
 
-    } else if(phosphor_layout == 14){
-       // slot mask for RGB panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
-       // {magenta, green, black, black,   black, black},
-       // {magenta, green, black, magenta, green, black},
-       // {black,   black, black, magenta, green, black}
-       vec3 slot2_1[6] = vec3[](magenta, green, black, black,   black, black);
-       vec3 slot2_2[6] = vec3[](magenta, green, black, magenta, green, black);
-       vec3 slot2_3[6] = vec3[](black,   black, black, magenta, green, black);
+        // find the horizontal index
+        z = int(floor(mod(coord.x, 8.0)));
 
-       w = int(floor(mod(coord.y, 3.0)));
-       z = int(floor(mod(coord.x, 6.0)));
+        weights = (w == 1) ? slotmask_RBG_x1[z] : (w == 2) ? slotmask_RBG_x2[z] : (w == 3) ? slotmask_RBG_x3[z] : slotmask_RBG_x4[z];
+        return weights;
+	}
+*/
+/*
+	else if(phosphor_layout == 16) {
+        // slot mask for RBG panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
+        // {yellow, blue,  black,  black},
+        // {yellow, blue,  yellow, blue},
+        // {black,  black, yellow, blue}
+        vec3 slot2_1[4] = vec3[](yellow, blue,  black,  black);
+        vec3 slot2_2[4] = vec3[](yellow, blue,  yellow, blue);
+        vec3 slot2_3[4] = vec3[](black,  black, yellow, blue);
 
-       weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
-       return weights;
+        w = int(floor(mod(coord.y, 3.0)));
+        z = int(floor(mod(coord.x, 4.0)));
 
-    } else if(phosphor_layout == 15){
-       // slot_2_4x4_rgb
-       // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
-       // {red,   yellow, cyan,  blue,  black, black,  black, black},
-       // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
-       // {black, black,  black, black, red,   yellow, cyan,  blue }
-       vec3 slotmask_RBG_x1[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
-       vec3 slotmask_RBG_x2[8] = vec3[](red,   yellow, cyan,  blue,  black, black,  black, black);
-       vec3 slotmask_RBG_x3[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
-       vec3 slotmask_RBG_x4[8] = vec3[](black, black,  black, black, red,   yellow, cyan,  blue );
+        weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
+        return weights;
+    }
+*/
+	else if (phosphor_layout == 17) {
+        // slot_2_5x4_bgr
+        // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
+        // {black, blue,    blue,  green, green, red,   red,     black, black, black},
+        // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
+        // {red,   red,     black, black, black, black, blue,    blue,  green, green}
+        vec3 slot_1[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
+        vec3 slot_2[10] = vec3[](black, blue,    blue,  green, green, red,   red,     black, black, black);
+        vec3 slot_3[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
+        vec3 slot_4[10] = vec3[](red,   red,     black, black, black, black, blue,    blue,  green, green);
 
-       // find the vertical index
-       w = int(floor(mod(coord.y, 4.0)));
+        w = int(floor(mod(coord.y, 4.0)));
+        z = int(floor(mod(coord.x, 10.0)));
 
-       // find the horizontal index
-       z = int(floor(mod(coord.x, 8.0)));
+        weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
+        return weights;
+    }
+/*
+    else if (phosphor_layout == 18) {
+        // same as above but for RBG panels
+        // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
+        // {black, green,  green, blue,  blue,  red,   red,    black, black, black},
+        // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
+        // {red,   red,    black, black, black, black, green,  green, blue,  blue }
+        vec3 slot_1[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
+        vec3 slot_2[10] = vec3[](black, green,  green, blue,  blue,  red,   red,    black, black, black);
+        vec3 slot_3[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
+        vec3 slot_4[10] = vec3[](red,   red,    black, black, black, black, green,  green, blue,  blue );
 
-       weights = (w == 1) ? slotmask_RBG_x1[z] : (w == 2) ? slotmask_RBG_x2[z] : (w == 3) ? slotmask_RBG_x3[z] : slotmask_RBG_x4[z];
-       return weights;
+        w = int(floor(mod(coord.y, 4.0)));
+        z = int(floor(mod(coord.x, 10.0)));
 
-     } else if(phosphor_layout == 16){
-       // slot mask for RBG panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
-       // {yellow, blue,  black,  black},
-       // {yellow, blue,  yellow, blue},
-       // {black,  black, yellow, blue}
-       vec3 slot2_1[4] = vec3[](yellow, blue,  black,  black);
-       vec3 slot2_2[4] = vec3[](yellow, blue,  yellow, blue);
-       vec3 slot2_3[4] = vec3[](black,  black, yellow, blue);
+        weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
+        return weights;
+    }
+*/
+/*
+    else if(phosphor_layout == 19) {
+        // slot_3_7x6_rgb
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue}
 
-       w = int(floor(mod(coord.y, 3.0)));
-       z = int(floor(mod(coord.x, 4.0)));
+        vec3 slot_1[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_2[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_3[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black);
+        vec3 slot_4[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_5[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_6[14] = vec3[](black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue);
 
-       weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
-       return weights;
+        w = int(floor(mod(coord.y, 6.0)));
+        z = int(floor(mod(coord.x, 14.0)));
 
-    } else if (phosphor_layout == 17) {
-       // slot_2_5x4_bgr
-       // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
-       // {black, blue,    blue,  green, green, red,   red,     black, black, black},
-       // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
-       // {red,   red,     black, black, black, black, blue,    blue,  green, green}
-       vec3 slot_1[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
-       vec3 slot_2[10] = vec3[](black, blue,    blue,  green, green, red,   red,     black, black, black);
-       vec3 slot_3[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
-       vec3 slot_4[10] = vec3[](red,   red,     black, black, black, black, blue,    blue,  green, green);
-
-       w = int(floor(mod(coord.y, 4.0)));
-       z = int(floor(mod(coord.x, 10.0)));
-
-       weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
-       return weights;
-
-    } else if (phosphor_layout == 18) {
-       // same as above but for RBG panels
-       // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
-       // {black, green,  green, blue,  blue,  red,   red,    black, black, black},
-       // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
-       // {red,   red,    black, black, black, black, green,  green, blue,  blue }
-       vec3 slot_1[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
-       vec3 slot_2[10] = vec3[](black, green,  green, blue,  blue,  red,   red,    black, black, black);
-       vec3 slot_3[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
-       vec3 slot_4[10] = vec3[](red,   red,    black, black, black, black, green,  green, blue,  blue );
-
-       w = int(floor(mod(coord.y, 4.0)));
-       z = int(floor(mod(coord.x, 10.0)));
-
-       weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
-       return weights;
-
-    } else if(phosphor_layout == 19) {
-       // slot_3_7x6_rgb
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue}
-
-       vec3 slot_1[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_2[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_3[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black);
-       vec3 slot_4[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_5[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_6[14] = vec3[](black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue);
-
-       w = int(floor(mod(coord.y, 6.0)));
-       z = int(floor(mod(coord.x, 14.0)));
-
-       weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : (w == 4) ? slot_4[z] : (w == 5) ? slot_5[z] : slot_6[z];
-       return weights;
-
-    } else {
+        weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : (w == 4) ? slot_4[z] : (w == 5) ? slot_5[z] : slot_6[z];
+        return weights;
+     }
+*/
+	else {
         return weights;
     }
 }
-
 // Horizontal cubic filter.
 //
 // Some known filters use these values:

--- a/contrib/resources/glshaders/crt/ega-720p.glsl
+++ b/contrib/resources/glshaders/crt/ega-720p.glsl
@@ -272,10 +272,10 @@ vec3 YxytoXYZ(vec3 Yxy) {
     Many of these mask arrays are adapted from cgwg's crt-geom-deluxe LUTs, and
     those have their filenames included for easy identification
 
-	NOTE: Having too many branches result in a black screen (but no
-	compilation errors) on some older GPUs such as the Intel HD 4000 iGPU. So
-	we're commenting out the branches that are not used by the adaptive CRT
-	shaders.
+    NOTE: Having too many branches result in a black screen (but no
+    compilation errors) on some older GPUs such as the Intel HD 4000 iGPU. So
+    we're commenting out the branches that are not used by the adaptive CRT
+    shaders.
 */
 vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
     vec3 weights = vec3(1.,1.,1.);
@@ -299,14 +299,14 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
     if (phosphor_layout == 0) {
         return weights;
-	}
+    }
 
     else if (phosphor_layout == 1) {
-    	// classic aperture for RGB panels; good for 1080p, too small for 4K+
+        // classic aperture for RGB panels; good for 1080p, too small for 4K+
         // aka aperture_1_2_bgr
         weights  = aperture_weights;
         return weights;
-	}
+    }
 
     else if (phosphor_layout == 2) {
         // 2x2 shadow mask for RGB panels; good for 1080p, too small for 4K+
@@ -314,7 +314,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
         vec3 inverse_aperture = mix(green, magenta, floor(mod(coord.x, 2.0)));
         weights               = mix(aperture_weights, inverse_aperture, floor(mod(coord.y, 2.0)));
         return weights;
-	}
+    }
 
 /*
     else if (phosphor_layout == 3) {
@@ -337,14 +337,14 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         // do a big, dumb comparison in place of a 2D array
         weights = (w == 1) ? slotmask_x1[z] : (w == 2) ? slotmask_x2[z] :  slotmask_x3[z];
-		return weights;
+        return weights;
     }
 */
     else if (phosphor_layout == 4) {
         // classic aperture for RBG panels; good for 1080p, too small for 4K+
         weights  = mix(yellow, blue, floor(mod(coord.x, 2.0)));
         return weights;
-	}
+    }
 /*
     else if (phosphor_layout == 5) {
         // 2x2 shadow mask for RBG panels; good for 1080p, too small for 4K+
@@ -356,7 +356,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
             floor(mod(coord.y, 2.0))
         );
         return weights;
-	}
+    }
 */
 /*
     else if (phosphor_layout == 6) {
@@ -367,7 +367,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = ap4[z];
         return weights;
-	}
+    }
 */
 /*
     else if (phosphor_layout == 7) {
@@ -388,7 +388,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap[w];
         return weights;
-	}
+    }
 */
     else if (phosphor_layout == 9) {
         // reduced TVL aperture for RGB panels
@@ -399,7 +399,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rgb[w];
         return weights;
-	}
+    }
 /*
     else if (phosphor_layout == 10) {
         // reduced TVL aperture for RBG panels
@@ -409,7 +409,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rbg[w];
         return weights;
-	}
+    }
 */
     else if(phosphor_layout == 11) {
         // delta_1_4x1_rgb; dunno why this is called 4x1 when it's obviously 4x2 /shrug
@@ -432,7 +432,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = (w == 1) ? delta_2_1[z] : delta_2_2[z];
         return weights;
-	}
+    }
 */
 /*
     else if (phosphor_layout == 13) {
@@ -484,10 +484,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = (w == 1) ? slotmask_RBG_x1[z] : (w == 2) ? slotmask_RBG_x2[z] : (w == 3) ? slotmask_RBG_x3[z] : slotmask_RBG_x4[z];
         return weights;
-	}
+    }
 */
 /*
-	else if(phosphor_layout == 16) {
+    else if(phosphor_layout == 16) {
         // slot mask for RBG panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
         // {yellow, blue,  black,  black},
         // {yellow, blue,  yellow, blue},
@@ -503,7 +503,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
         return weights;
     }
 */
-	else if (phosphor_layout == 17) {
+    else if (phosphor_layout == 17) {
         // slot_2_5x4_bgr
         // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
         // {black, blue,    blue,  green, green, red,   red,     black, black, black},
@@ -563,7 +563,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
         return weights;
      }
 */
-	else {
+    else {
         return weights;
     }
 }

--- a/contrib/resources/glshaders/crt/ega-720p.glsl
+++ b/contrib/resources/glshaders/crt/ega-720p.glsl
@@ -245,7 +245,6 @@ vec3 YxytoXYZ(vec3 Yxy) {
     return XYZ;
 }
 
-
 /*
     A collection of CRT mask effects that work with LCD subpixel structures for
     small details
@@ -272,11 +271,18 @@ vec3 YxytoXYZ(vec3 Yxy) {
 
     Many of these mask arrays are adapted from cgwg's crt-geom-deluxe LUTs, and
     those have their filenames included for easy identification
+
+	NOTE: Having too many branches result in a black screen (but no
+	compilation errors) on some older GPUs such as the Intel HD 4000 iGPU. So
+	we're commenting out the branches that are not used by the adaptive CRT
+	shaders.
 */
 vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
     vec3 weights = vec3(1.,1.,1.);
+
     float on = 1.;
     float off = 1.-mask_intensity;
+
     vec3 red     = vec3(on,  off, off);
     vec3 green   = vec3(off, on,  off);
     vec3 blue    = vec3(off, off, on );
@@ -285,6 +291,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
     vec3 cyan    = vec3(off, on,  on );
     vec3 black   = vec3(off, off, off);
     vec3 white   = vec3(on,  on,  on );
+
     int w, z = 0;
 
     // This pattern is used by a few layouts, so we'll define it here
@@ -292,21 +299,25 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
     if (phosphor_layout == 0) {
         return weights;
+	}
 
-    } else if (phosphor_layout == 1) {
-        // classic aperture for RGB panels; good for 1080p, too small for 4K+
+    else if (phosphor_layout == 1) {
+    	// classic aperture for RGB panels; good for 1080p, too small for 4K+
         // aka aperture_1_2_bgr
         weights  = aperture_weights;
         return weights;
+	}
 
-    } else if (phosphor_layout == 2) {
+    else if (phosphor_layout == 2) {
         // 2x2 shadow mask for RGB panels; good for 1080p, too small for 4K+
         // aka delta_1_2x1_bgr
         vec3 inverse_aperture = mix(green, magenta, floor(mod(coord.x, 2.0)));
         weights               = mix(aperture_weights, inverse_aperture, floor(mod(coord.y, 2.0)));
         return weights;
+	}
 
-    } else if (phosphor_layout == 3) {
+/*
+    else if (phosphor_layout == 3) {
         // slot mask for RGB panels; looks okay at 1080p, looks better at 4K
         // {magenta, green, black,   black},
         // {magenta, green, magenta, green},
@@ -326,14 +337,16 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         // do a big, dumb comparison in place of a 2D array
         weights = (w == 1) ? slotmask_x1[z] : (w == 2) ? slotmask_x2[z] :  slotmask_x3[z];
+		return weights;
     }
-
-    if (phosphor_layout == 4) {
+*/
+    else if (phosphor_layout == 4) {
         // classic aperture for RBG panels; good for 1080p, too small for 4K+
         weights  = mix(yellow, blue, floor(mod(coord.x, 2.0)));
         return weights;
-
-    } else if (phosphor_layout == 5) {
+	}
+/*
+    else if (phosphor_layout == 5) {
         // 2x2 shadow mask for RBG panels; good for 1080p, too small for 4K+
         vec3 inverse_aperture = mix(blue, yellow, floor(mod(coord.x, 2.0)));
 
@@ -343,8 +356,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
             floor(mod(coord.y, 2.0))
         );
         return weights;
-
-    } else if (phosphor_layout == 6) {
+	}
+*/
+/*
+    else if (phosphor_layout == 6) {
         // aperture_1_4_rgb; good for simulating lower
         vec3 ap4[4] = vec3[](red, green, blue, black);
 
@@ -352,8 +367,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = ap4[z];
         return weights;
-
-    } else if (phosphor_layout == 7) {
+	}
+*/
+/*
+    else if (phosphor_layout == 7) {
         // aperture_2_5_bgr
         vec3 ap3[5] = vec3[](red, magenta, blue, green, green);
 
@@ -361,8 +378,9 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = ap3[z];
         return weights;
-
-    } else if (phosphor_layout == 8){
+*/
+/*
+    else if (phosphor_layout == 8) {
         // aperture_3_6_rgb
         vec3 big_ap[7] = vec3[](red, red, yellow, green, cyan, blue, blue);
 
@@ -370,8 +388,9 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap[w];
         return weights;
-
-    } else if (phosphor_layout == 9) {
+	}
+*/
+    else if (phosphor_layout == 9) {
         // reduced TVL aperture for RGB panels
         // aperture_2_4_rgb
         vec3 big_ap_rgb[4] = vec3[](red, yellow, cyan, blue);
@@ -380,8 +399,9 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rgb[w];
         return weights;
-
-    } else if (phosphor_layout == 10) {
+	}
+/*
+    else if (phosphor_layout == 10) {
         // reduced TVL aperture for RBG panels
         vec3 big_ap_rbg[4] = vec3[](red, magenta, cyan, green);
 
@@ -389,148 +409,161 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rbg[w];
         return weights;
+	}
+*/
+    else if(phosphor_layout == 11) {
+        // delta_1_4x1_rgb; dunno why this is called 4x1 when it's obviously 4x2 /shrug
+        vec3 delta_1_1[4] = vec3[](red, green, blue, black);
+        vec3 delta_1_2[4] = vec3[](blue, black, red, green);
 
-    } else if (phosphor_layout == 11) {
-       // delta_1_4x1_rgb; dunno why this is called 4x1 when it's obviously 4x2 /shrug
-       vec3 delta_1_1[4] = vec3[](red, green, blue, black);
-       vec3 delta_1_2[4] = vec3[](blue, black, red, green);
+        w = int(floor(mod(coord.y, 2.0)));
+        z = int(floor(mod(coord.x, 4.0)));
 
-       w = int(floor(mod(coord.y, 2.0)));
-       z = int(floor(mod(coord.x, 4.0)));
+        weights = (w == 1) ? delta_1_1[z] : delta_1_2[z];
+        return weights;
+    }
+/*
+    else if (phosphor_layout == 12) {
+        // delta_2_4x1_rgb
+        vec3 delta_2_1[4] = vec3[](red, yellow, cyan, blue);
+        vec3 delta_2_2[4] = vec3[](cyan, blue, red, yellow);
 
-       weights = (w == 1) ? delta_1_1[z] : delta_1_2[z];
-       return weights;
+        z = int(floor(mod(coord.x, 4.0)));
 
-    } else if (phosphor_layout == 12) {
-       // delta_2_4x1_rgb
-       vec3 delta_2_1[4] = vec3[](red, yellow, cyan, blue);
-       vec3 delta_2_2[4] = vec3[](cyan, blue, red, yellow);
+        weights = (w == 1) ? delta_2_1[z] : delta_2_2[z];
+        return weights;
+	}
+*/
+/*
+    else if (phosphor_layout == 13) {
+        // delta_2_4x2_rgb
+        vec3 delta_1[4] = vec3[](red, yellow, cyan, blue);
+        vec3 delta_2[4] = vec3[](red, yellow, cyan, blue);
+        vec3 delta_3[4] = vec3[](cyan, blue, red, yellow);
+        vec3 delta_4[4] = vec3[](cyan, blue, red, yellow);
 
-       z = int(floor(mod(coord.x, 4.0)));
+        w = int(floor(mod(coord.y, 4.0)));
+        z = int(floor(mod(coord.x, 4.0)));
 
-       weights = (w == 1) ? delta_2_1[z] : delta_2_2[z];
-       return weights;
+        weights = (w == 1) ? delta_1[z] : (w == 2) ? delta_2[z] : (w == 3) ? delta_3[z] : delta_4[z];
+        return weights;
+    }
+*/
+    else if (phosphor_layout == 14) {
+        // slot mask for RGB panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
+        // {magenta, green, black, black,   black, black},
+        // {magenta, green, black, magenta, green, black},
+        // {black,   black, black, magenta, green, black}
+        vec3 slot2_1[6] = vec3[](magenta, green, black, black,   black, black);
+        vec3 slot2_2[6] = vec3[](magenta, green, black, magenta, green, black);
+        vec3 slot2_3[6] = vec3[](black,   black, black, magenta, green, black);
 
-    } else if (phosphor_layout == 13) {
-       // delta_2_4x2_rgb
-       vec3 delta_1[4] = vec3[](red, yellow, cyan, blue);
-       vec3 delta_2[4] = vec3[](red, yellow, cyan, blue);
-       vec3 delta_3[4] = vec3[](cyan, blue, red, yellow);
-       vec3 delta_4[4] = vec3[](cyan, blue, red, yellow);
+        w = int(floor(mod(coord.y, 3.0)));
+        z = int(floor(mod(coord.x, 6.0)));
 
-       w = int(floor(mod(coord.y, 4.0)));
-       z = int(floor(mod(coord.x, 4.0)));
+        weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
+        return weights;
+    }
+/*
+    else if(phosphor_layout == 15) {
+        // slot_2_4x4_rgb
+        // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
+        // {red,   yellow, cyan,  blue,  black, black,  black, black},
+        // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
+        // {black, black,  black, black, red,   yellow, cyan,  blue }
+        vec3 slotmask_RBG_x1[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
+        vec3 slotmask_RBG_x2[8] = vec3[](red,   yellow, cyan,  blue,  black, black,  black, black);
+        vec3 slotmask_RBG_x3[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
+        vec3 slotmask_RBG_x4[8] = vec3[](black, black,  black, black, red,   yellow, cyan,  blue );
 
-       weights = (w == 1) ? delta_1[z] : (w == 2) ? delta_2[z] : (w == 3) ? delta_3[z] : delta_4[z];
-       return weights;
+        // find the vertical index
+        w = int(floor(mod(coord.y, 4.0)));
 
-    } else if (phosphor_layout == 14) {
-       // slot mask for RGB panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
-       // {magenta, green, black, black,   black, black},
-       // {magenta, green, black, magenta, green, black},
-       // {black,   black, black, magenta, green, black}
-       vec3 slot2_1[6] = vec3[](magenta, green, black, black,   black, black);
-       vec3 slot2_2[6] = vec3[](magenta, green, black, magenta, green, black);
-       vec3 slot2_3[6] = vec3[](black,   black, black, magenta, green, black);
+        // find the horizontal index
+        z = int(floor(mod(coord.x, 8.0)));
 
-       w = int(floor(mod(coord.y, 3.0)));
-       z = int(floor(mod(coord.x, 6.0)));
+        weights = (w == 1) ? slotmask_RBG_x1[z] : (w == 2) ? slotmask_RBG_x2[z] : (w == 3) ? slotmask_RBG_x3[z] : slotmask_RBG_x4[z];
+        return weights;
+	}
+*/
+/*
+	else if(phosphor_layout == 16) {
+        // slot mask for RBG panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
+        // {yellow, blue,  black,  black},
+        // {yellow, blue,  yellow, blue},
+        // {black,  black, yellow, blue}
+        vec3 slot2_1[4] = vec3[](yellow, blue,  black,  black);
+        vec3 slot2_2[4] = vec3[](yellow, blue,  yellow, blue);
+        vec3 slot2_3[4] = vec3[](black,  black, yellow, blue);
 
-       weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
-       return weights;
+        w = int(floor(mod(coord.y, 3.0)));
+        z = int(floor(mod(coord.x, 4.0)));
 
-    } else if (phosphor_layout == 15) {
-       // slot_2_4x4_rgb
-       // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
-       // {red,   yellow, cyan,  blue,  black, black,  black, black},
-       // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
-       // {black, black,  black, black, red,   yellow, cyan,  blue }
-       vec3 slotmask_RBG_x1[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
-       vec3 slotmask_RBG_x2[8] = vec3[](red,   yellow, cyan,  blue,  black, black,  black, black);
-       vec3 slotmask_RBG_x3[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
-       vec3 slotmask_RBG_x4[8] = vec3[](black, black,  black, black, red,   yellow, cyan,  blue );
+        weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
+        return weights;
+    }
+*/
+	else if (phosphor_layout == 17) {
+        // slot_2_5x4_bgr
+        // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
+        // {black, blue,    blue,  green, green, red,   red,     black, black, black},
+        // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
+        // {red,   red,     black, black, black, black, blue,    blue,  green, green}
+        vec3 slot_1[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
+        vec3 slot_2[10] = vec3[](black, blue,    blue,  green, green, red,   red,     black, black, black);
+        vec3 slot_3[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
+        vec3 slot_4[10] = vec3[](red,   red,     black, black, black, black, blue,    blue,  green, green);
 
-       // find the vertical index
-       w = int(floor(mod(coord.y, 4.0)));
+        w = int(floor(mod(coord.y, 4.0)));
+        z = int(floor(mod(coord.x, 10.0)));
 
-       // find the horizontal index
-       z = int(floor(mod(coord.x, 8.0)));
+        weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
+        return weights;
+    }
+/*
+    else if (phosphor_layout == 18) {
+        // same as above but for RBG panels
+        // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
+        // {black, green,  green, blue,  blue,  red,   red,    black, black, black},
+        // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
+        // {red,   red,    black, black, black, black, green,  green, blue,  blue }
+        vec3 slot_1[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
+        vec3 slot_2[10] = vec3[](black, green,  green, blue,  blue,  red,   red,    black, black, black);
+        vec3 slot_3[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
+        vec3 slot_4[10] = vec3[](red,   red,    black, black, black, black, green,  green, blue,  blue );
 
-       weights = (w == 1) ? slotmask_RBG_x1[z] : (w == 2) ? slotmask_RBG_x2[z] : (w == 3) ? slotmask_RBG_x3[z] : slotmask_RBG_x4[z];
-       return weights;
+        w = int(floor(mod(coord.y, 4.0)));
+        z = int(floor(mod(coord.x, 10.0)));
 
-     } else if (phosphor_layout == 16) {
-       // slot mask for RBG panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
-       // {yellow, blue,  black,  black},
-       // {yellow, blue,  yellow, blue},
-       // {black,  black, yellow, blue}
-       vec3 slot2_1[4] = vec3[](yellow, blue,  black,  black);
-       vec3 slot2_2[4] = vec3[](yellow, blue,  yellow, blue);
-       vec3 slot2_3[4] = vec3[](black,  black, yellow, blue);
+        weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
+        return weights;
+    }
+*/
+/*
+    else if(phosphor_layout == 19) {
+        // slot_3_7x6_rgb
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue}
 
-       w = int(floor(mod(coord.y, 3.0)));
-       z = int(floor(mod(coord.x, 4.0)));
+        vec3 slot_1[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_2[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_3[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black);
+        vec3 slot_4[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_5[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_6[14] = vec3[](black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue);
 
-       weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
-       return weights;
+        w = int(floor(mod(coord.y, 6.0)));
+        z = int(floor(mod(coord.x, 14.0)));
 
-    } else if (phosphor_layout == 17) {
-       // slot_2_5x4_bgr
-       // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
-       // {black, blue,    blue,  green, green, red,   red,     black, black, black},
-       // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
-       // {red,   red,     black, black, black, black, blue,    blue,  green, green}
-       vec3 slot_1[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
-       vec3 slot_2[10] = vec3[](black, blue,    blue,  green, green, red,   red,     black, black, black);
-       vec3 slot_3[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
-       vec3 slot_4[10] = vec3[](red,   red,     black, black, black, black, blue,    blue,  green, green);
-
-       w = int(floor(mod(coord.y, 4.0)));
-       z = int(floor(mod(coord.x, 10.0)));
-
-       weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
-       return weights;
-
-    } else if (phosphor_layout == 18) {
-       // same as above but for RBG panels
-       // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
-       // {black, green,  green, blue,  blue,  red,   red,    black, black, black},
-       // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
-       // {red,   red,    black, black, black, black, green,  green, blue,  blue }
-       vec3 slot_1[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
-       vec3 slot_2[10] = vec3[](black, green,  green, blue,  blue,  red,   red,    black, black, black);
-       vec3 slot_3[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
-       vec3 slot_4[10] = vec3[](red,   red,    black, black, black, black, green,  green, blue,  blue );
-
-       w = int(floor(mod(coord.y, 4.0)));
-       z = int(floor(mod(coord.x, 10.0)));
-
-       weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
-       return weights;
-
-    } else if (phosphor_layout == 19) {
-       // slot_3_7x6_rgb
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue}
-
-       vec3 slot_1[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_2[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_3[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black);
-       vec3 slot_4[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_5[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_6[14] = vec3[](black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue);
-
-       w = int(floor(mod(coord.y, 6.0)));
-       z = int(floor(mod(coord.x, 14.0)));
-
-       weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : (w == 4) ? slot_4[z] : (w == 5) ? slot_5[z] : slot_6[z];
-       return weights;
-
-    } else {
+        weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : (w == 4) ? slot_4[z] : (w == 5) ? slot_5[z] : slot_6[z];
+        return weights;
+     }
+*/
+	else {
         return weights;
     }
 }

--- a/contrib/resources/glshaders/crt/hercules.glsl
+++ b/contrib/resources/glshaders/crt/hercules.glsl
@@ -246,7 +246,6 @@ vec3 YxytoXYZ(vec3 Yxy) {
     return XYZ;
 }
 
-
 /*
     A collection of CRT mask effects that work with LCD subpixel structures for
     small details
@@ -273,11 +272,18 @@ vec3 YxytoXYZ(vec3 Yxy) {
 
     Many of these mask arrays are adapted from cgwg's crt-geom-deluxe LUTs, and
     those have their filenames included for easy identification
+
+	NOTE: Having too many branches result in a black screen (but no
+	compilation errors) on some older GPUs such as the Intel HD 4000 iGPU. So
+	we're commenting out the branches that are not used by the adaptive CRT
+	shaders.
 */
 vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
     vec3 weights = vec3(1.,1.,1.);
+
     float on = 1.;
     float off = 1.-mask_intensity;
+
     vec3 red     = vec3(on,  off, off);
     vec3 green   = vec3(off, on,  off);
     vec3 blue    = vec3(off, off, on );
@@ -286,6 +292,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
     vec3 cyan    = vec3(off, on,  on );
     vec3 black   = vec3(off, off, off);
     vec3 white   = vec3(on,  on,  on );
+
     int w, z = 0;
 
     // This pattern is used by a few layouts, so we'll define it here
@@ -293,21 +300,25 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
     if (phosphor_layout == 0) {
         return weights;
+	}
 
-    } else if (phosphor_layout == 1) {
-        // classic aperture for RGB panels; good for 1080p, too small for 4K+
+    else if (phosphor_layout == 1) {
+    	// classic aperture for RGB panels; good for 1080p, too small for 4K+
         // aka aperture_1_2_bgr
         weights  = aperture_weights;
         return weights;
+	}
 
-    } else if (phosphor_layout == 2) {
+    else if (phosphor_layout == 2) {
         // 2x2 shadow mask for RGB panels; good for 1080p, too small for 4K+
         // aka delta_1_2x1_bgr
         vec3 inverse_aperture = mix(green, magenta, floor(mod(coord.x, 2.0)));
         weights               = mix(aperture_weights, inverse_aperture, floor(mod(coord.y, 2.0)));
         return weights;
+	}
 
-    } else if (phosphor_layout == 3) {
+/*
+    else if (phosphor_layout == 3) {
         // slot mask for RGB panels; looks okay at 1080p, looks better at 4K
         // {magenta, green, black,   black},
         // {magenta, green, magenta, green},
@@ -327,14 +338,16 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         // do a big, dumb comparison in place of a 2D array
         weights = (w == 1) ? slotmask_x1[z] : (w == 2) ? slotmask_x2[z] :  slotmask_x3[z];
+		return weights;
     }
-
-    if (phosphor_layout == 4) {
+*/
+    else if (phosphor_layout == 4) {
         // classic aperture for RBG panels; good for 1080p, too small for 4K+
         weights  = mix(yellow, blue, floor(mod(coord.x, 2.0)));
         return weights;
-
-    } else if (phosphor_layout == 5) {
+	}
+/*
+    else if (phosphor_layout == 5) {
         // 2x2 shadow mask for RBG panels; good for 1080p, too small for 4K+
         vec3 inverse_aperture = mix(blue, yellow, floor(mod(coord.x, 2.0)));
 
@@ -344,8 +357,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
             floor(mod(coord.y, 2.0))
         );
         return weights;
-
-    } else if (phosphor_layout == 6) {
+	}
+*/
+/*
+    else if (phosphor_layout == 6) {
         // aperture_1_4_rgb; good for simulating lower
         vec3 ap4[4] = vec3[](red, green, blue, black);
 
@@ -353,8 +368,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = ap4[z];
         return weights;
-
-    } else if (phosphor_layout == 7) {
+	}
+*/
+/*
+    else if (phosphor_layout == 7) {
         // aperture_2_5_bgr
         vec3 ap3[5] = vec3[](red, magenta, blue, green, green);
 
@@ -362,8 +379,9 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = ap3[z];
         return weights;
-
-    } else if (phosphor_layout == 8){
+*/
+/*
+    else if (phosphor_layout == 8) {
         // aperture_3_6_rgb
         vec3 big_ap[7] = vec3[](red, red, yellow, green, cyan, blue, blue);
 
@@ -371,8 +389,9 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap[w];
         return weights;
-
-    } else if (phosphor_layout == 9) {
+	}
+*/
+    else if (phosphor_layout == 9) {
         // reduced TVL aperture for RGB panels
         // aperture_2_4_rgb
         vec3 big_ap_rgb[4] = vec3[](red, yellow, cyan, blue);
@@ -381,8 +400,9 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rgb[w];
         return weights;
-
-    } else if (phosphor_layout == 10) {
+	}
+/*
+    else if (phosphor_layout == 10) {
         // reduced TVL aperture for RBG panels
         vec3 big_ap_rbg[4] = vec3[](red, magenta, cyan, green);
 
@@ -390,148 +410,161 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rbg[w];
         return weights;
+	}
+*/
+    else if(phosphor_layout == 11) {
+        // delta_1_4x1_rgb; dunno why this is called 4x1 when it's obviously 4x2 /shrug
+        vec3 delta_1_1[4] = vec3[](red, green, blue, black);
+        vec3 delta_1_2[4] = vec3[](blue, black, red, green);
 
-    } else if(phosphor_layout == 11){
-       // delta_1_4x1_rgb; dunno why this is called 4x1 when it's obviously 4x2 /shrug
-       vec3 delta_1_1[4] = vec3[](red, green, blue, black);
-       vec3 delta_1_2[4] = vec3[](blue, black, red, green);
+        w = int(floor(mod(coord.y, 2.0)));
+        z = int(floor(mod(coord.x, 4.0)));
 
-       w = int(floor(mod(coord.y, 2.0)));
-       z = int(floor(mod(coord.x, 4.0)));
+        weights = (w == 1) ? delta_1_1[z] : delta_1_2[z];
+        return weights;
+    }
+/*
+    else if (phosphor_layout == 12) {
+        // delta_2_4x1_rgb
+        vec3 delta_2_1[4] = vec3[](red, yellow, cyan, blue);
+        vec3 delta_2_2[4] = vec3[](cyan, blue, red, yellow);
 
-       weights = (w == 1) ? delta_1_1[z] : delta_1_2[z];
-       return weights;
+        z = int(floor(mod(coord.x, 4.0)));
 
-    } else if(phosphor_layout == 12){
-       // delta_2_4x1_rgb
-       vec3 delta_2_1[4] = vec3[](red, yellow, cyan, blue);
-       vec3 delta_2_2[4] = vec3[](cyan, blue, red, yellow);
+        weights = (w == 1) ? delta_2_1[z] : delta_2_2[z];
+        return weights;
+	}
+*/
+/*
+    else if (phosphor_layout == 13) {
+        // delta_2_4x2_rgb
+        vec3 delta_1[4] = vec3[](red, yellow, cyan, blue);
+        vec3 delta_2[4] = vec3[](red, yellow, cyan, blue);
+        vec3 delta_3[4] = vec3[](cyan, blue, red, yellow);
+        vec3 delta_4[4] = vec3[](cyan, blue, red, yellow);
 
-       z = int(floor(mod(coord.x, 4.0)));
+        w = int(floor(mod(coord.y, 4.0)));
+        z = int(floor(mod(coord.x, 4.0)));
 
-       weights = (w == 1) ? delta_2_1[z] : delta_2_2[z];
-       return weights;
+        weights = (w == 1) ? delta_1[z] : (w == 2) ? delta_2[z] : (w == 3) ? delta_3[z] : delta_4[z];
+        return weights;
+    }
+*/
+    else if (phosphor_layout == 14) {
+        // slot mask for RGB panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
+        // {magenta, green, black, black,   black, black},
+        // {magenta, green, black, magenta, green, black},
+        // {black,   black, black, magenta, green, black}
+        vec3 slot2_1[6] = vec3[](magenta, green, black, black,   black, black);
+        vec3 slot2_2[6] = vec3[](magenta, green, black, magenta, green, black);
+        vec3 slot2_3[6] = vec3[](black,   black, black, magenta, green, black);
 
-    } else if(phosphor_layout == 13){
-       // delta_2_4x2_rgb
-       vec3 delta_1[4] = vec3[](red, yellow, cyan, blue);
-       vec3 delta_2[4] = vec3[](red, yellow, cyan, blue);
-       vec3 delta_3[4] = vec3[](cyan, blue, red, yellow);
-       vec3 delta_4[4] = vec3[](cyan, blue, red, yellow);
+        w = int(floor(mod(coord.y, 3.0)));
+        z = int(floor(mod(coord.x, 6.0)));
 
-       w = int(floor(mod(coord.y, 4.0)));
-       z = int(floor(mod(coord.x, 4.0)));
+        weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
+        return weights;
+    }
+/*
+    else if(phosphor_layout == 15) {
+        // slot_2_4x4_rgb
+        // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
+        // {red,   yellow, cyan,  blue,  black, black,  black, black},
+        // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
+        // {black, black,  black, black, red,   yellow, cyan,  blue }
+        vec3 slotmask_RBG_x1[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
+        vec3 slotmask_RBG_x2[8] = vec3[](red,   yellow, cyan,  blue,  black, black,  black, black);
+        vec3 slotmask_RBG_x3[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
+        vec3 slotmask_RBG_x4[8] = vec3[](black, black,  black, black, red,   yellow, cyan,  blue );
 
-       weights = (w == 1) ? delta_1[z] : (w == 2) ? delta_2[z] : (w == 3) ? delta_3[z] : delta_4[z];
-       return weights;
+        // find the vertical index
+        w = int(floor(mod(coord.y, 4.0)));
 
-    } else if(phosphor_layout == 14){
-       // slot mask for RGB panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
-       // {magenta, green, black, black,   black, black},
-       // {magenta, green, black, magenta, green, black},
-       // {black,   black, black, magenta, green, black}
-       vec3 slot2_1[6] = vec3[](magenta, green, black, black,   black, black);
-       vec3 slot2_2[6] = vec3[](magenta, green, black, magenta, green, black);
-       vec3 slot2_3[6] = vec3[](black,   black, black, magenta, green, black);
+        // find the horizontal index
+        z = int(floor(mod(coord.x, 8.0)));
 
-       w = int(floor(mod(coord.y, 3.0)));
-       z = int(floor(mod(coord.x, 6.0)));
+        weights = (w == 1) ? slotmask_RBG_x1[z] : (w == 2) ? slotmask_RBG_x2[z] : (w == 3) ? slotmask_RBG_x3[z] : slotmask_RBG_x4[z];
+        return weights;
+	}
+*/
+/*
+	else if(phosphor_layout == 16) {
+        // slot mask for RBG panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
+        // {yellow, blue,  black,  black},
+        // {yellow, blue,  yellow, blue},
+        // {black,  black, yellow, blue}
+        vec3 slot2_1[4] = vec3[](yellow, blue,  black,  black);
+        vec3 slot2_2[4] = vec3[](yellow, blue,  yellow, blue);
+        vec3 slot2_3[4] = vec3[](black,  black, yellow, blue);
 
-       weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
-       return weights;
+        w = int(floor(mod(coord.y, 3.0)));
+        z = int(floor(mod(coord.x, 4.0)));
 
-    } else if(phosphor_layout == 15){
-       // slot_2_4x4_rgb
-       // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
-       // {red,   yellow, cyan,  blue,  black, black,  black, black},
-       // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
-       // {black, black,  black, black, red,   yellow, cyan,  blue }
-       vec3 slotmask_RBG_x1[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
-       vec3 slotmask_RBG_x2[8] = vec3[](red,   yellow, cyan,  blue,  black, black,  black, black);
-       vec3 slotmask_RBG_x3[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
-       vec3 slotmask_RBG_x4[8] = vec3[](black, black,  black, black, red,   yellow, cyan,  blue );
+        weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
+        return weights;
+    }
+*/
+	else if (phosphor_layout == 17) {
+        // slot_2_5x4_bgr
+        // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
+        // {black, blue,    blue,  green, green, red,   red,     black, black, black},
+        // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
+        // {red,   red,     black, black, black, black, blue,    blue,  green, green}
+        vec3 slot_1[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
+        vec3 slot_2[10] = vec3[](black, blue,    blue,  green, green, red,   red,     black, black, black);
+        vec3 slot_3[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
+        vec3 slot_4[10] = vec3[](red,   red,     black, black, black, black, blue,    blue,  green, green);
 
-       // find the vertical index
-       w = int(floor(mod(coord.y, 4.0)));
+        w = int(floor(mod(coord.y, 4.0)));
+        z = int(floor(mod(coord.x, 10.0)));
 
-       // find the horizontal index
-       z = int(floor(mod(coord.x, 8.0)));
+        weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
+        return weights;
+    }
+/*
+    else if (phosphor_layout == 18) {
+        // same as above but for RBG panels
+        // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
+        // {black, green,  green, blue,  blue,  red,   red,    black, black, black},
+        // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
+        // {red,   red,    black, black, black, black, green,  green, blue,  blue }
+        vec3 slot_1[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
+        vec3 slot_2[10] = vec3[](black, green,  green, blue,  blue,  red,   red,    black, black, black);
+        vec3 slot_3[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
+        vec3 slot_4[10] = vec3[](red,   red,    black, black, black, black, green,  green, blue,  blue );
 
-       weights = (w == 1) ? slotmask_RBG_x1[z] : (w == 2) ? slotmask_RBG_x2[z] : (w == 3) ? slotmask_RBG_x3[z] : slotmask_RBG_x4[z];
-       return weights;
+        w = int(floor(mod(coord.y, 4.0)));
+        z = int(floor(mod(coord.x, 10.0)));
 
-     } else if(phosphor_layout == 16){
-       // slot mask for RBG panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
-       // {yellow, blue,  black,  black},
-       // {yellow, blue,  yellow, blue},
-       // {black,  black, yellow, blue}
-       vec3 slot2_1[4] = vec3[](yellow, blue,  black,  black);
-       vec3 slot2_2[4] = vec3[](yellow, blue,  yellow, blue);
-       vec3 slot2_3[4] = vec3[](black,  black, yellow, blue);
+        weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
+        return weights;
+    }
+*/
+/*
+    else if(phosphor_layout == 19) {
+        // slot_3_7x6_rgb
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue}
 
-       w = int(floor(mod(coord.y, 3.0)));
-       z = int(floor(mod(coord.x, 4.0)));
+        vec3 slot_1[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_2[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_3[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black);
+        vec3 slot_4[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_5[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_6[14] = vec3[](black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue);
 
-       weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
-       return weights;
+        w = int(floor(mod(coord.y, 6.0)));
+        z = int(floor(mod(coord.x, 14.0)));
 
-    } else if (phosphor_layout == 17) {
-       // slot_2_5x4_bgr
-       // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
-       // {black, blue,    blue,  green, green, red,   red,     black, black, black},
-       // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
-       // {red,   red,     black, black, black, black, blue,    blue,  green, green}
-       vec3 slot_1[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
-       vec3 slot_2[10] = vec3[](black, blue,    blue,  green, green, red,   red,     black, black, black);
-       vec3 slot_3[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
-       vec3 slot_4[10] = vec3[](red,   red,     black, black, black, black, blue,    blue,  green, green);
-
-       w = int(floor(mod(coord.y, 4.0)));
-       z = int(floor(mod(coord.x, 10.0)));
-
-       weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
-       return weights;
-
-    } else if (phosphor_layout == 18) {
-       // same as above but for RBG panels
-       // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
-       // {black, green,  green, blue,  blue,  red,   red,    black, black, black},
-       // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
-       // {red,   red,    black, black, black, black, green,  green, blue,  blue }
-       vec3 slot_1[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
-       vec3 slot_2[10] = vec3[](black, green,  green, blue,  blue,  red,   red,    black, black, black);
-       vec3 slot_3[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
-       vec3 slot_4[10] = vec3[](red,   red,    black, black, black, black, green,  green, blue,  blue );
-
-       w = int(floor(mod(coord.y, 4.0)));
-       z = int(floor(mod(coord.x, 10.0)));
-
-       weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
-       return weights;
-
-    } else if(phosphor_layout == 19) {
-       // slot_3_7x6_rgb
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue}
-
-       vec3 slot_1[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_2[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_3[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black);
-       vec3 slot_4[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_5[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_6[14] = vec3[](black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue);
-
-       w = int(floor(mod(coord.y, 6.0)));
-       z = int(floor(mod(coord.x, 14.0)));
-
-       weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : (w == 4) ? slot_4[z] : (w == 5) ? slot_5[z] : slot_6[z];
-       return weights;
-
-    } else {
+        weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : (w == 4) ? slot_4[z] : (w == 5) ? slot_5[z] : slot_6[z];
+        return weights;
+     }
+*/
+	else {
         return weights;
     }
 }

--- a/contrib/resources/glshaders/crt/hercules.glsl
+++ b/contrib/resources/glshaders/crt/hercules.glsl
@@ -167,10 +167,10 @@ uniform PRECISION float BLUE_SHIFT;
 
 #define WP_ADJUST           0.00
 #define TEMPERATURE      9300.00
-#define LUMA_PRESERVE 		1.00
-#define RED_SHIFT 			0.00
-#define GREEN_SHIFT 		0.00
-#define BLUE_SHIFT 			0.00
+#define LUMA_PRESERVE       1.00
+#define RED_SHIFT           0.00
+#define GREEN_SHIFT         0.00
+#define BLUE_SHIFT          0.00
 #endif
 // END PARAMETERS //
 
@@ -273,10 +273,10 @@ vec3 YxytoXYZ(vec3 Yxy) {
     Many of these mask arrays are adapted from cgwg's crt-geom-deluxe LUTs, and
     those have their filenames included for easy identification
 
-	NOTE: Having too many branches result in a black screen (but no
-	compilation errors) on some older GPUs such as the Intel HD 4000 iGPU. So
-	we're commenting out the branches that are not used by the adaptive CRT
-	shaders.
+    NOTE: Having too many branches result in a black screen (but no
+    compilation errors) on some older GPUs such as the Intel HD 4000 iGPU. So
+    we're commenting out the branches that are not used by the adaptive CRT
+    shaders.
 */
 vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
     vec3 weights = vec3(1.,1.,1.);
@@ -300,14 +300,14 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
     if (phosphor_layout == 0) {
         return weights;
-	}
+    }
 
     else if (phosphor_layout == 1) {
-    	// classic aperture for RGB panels; good for 1080p, too small for 4K+
+        // classic aperture for RGB panels; good for 1080p, too small for 4K+
         // aka aperture_1_2_bgr
         weights  = aperture_weights;
         return weights;
-	}
+    }
 
     else if (phosphor_layout == 2) {
         // 2x2 shadow mask for RGB panels; good for 1080p, too small for 4K+
@@ -315,7 +315,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
         vec3 inverse_aperture = mix(green, magenta, floor(mod(coord.x, 2.0)));
         weights               = mix(aperture_weights, inverse_aperture, floor(mod(coord.y, 2.0)));
         return weights;
-	}
+    }
 
 /*
     else if (phosphor_layout == 3) {
@@ -338,14 +338,14 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         // do a big, dumb comparison in place of a 2D array
         weights = (w == 1) ? slotmask_x1[z] : (w == 2) ? slotmask_x2[z] :  slotmask_x3[z];
-		return weights;
+        return weights;
     }
 */
     else if (phosphor_layout == 4) {
         // classic aperture for RBG panels; good for 1080p, too small for 4K+
         weights  = mix(yellow, blue, floor(mod(coord.x, 2.0)));
         return weights;
-	}
+    }
 /*
     else if (phosphor_layout == 5) {
         // 2x2 shadow mask for RBG panels; good for 1080p, too small for 4K+
@@ -357,7 +357,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
             floor(mod(coord.y, 2.0))
         );
         return weights;
-	}
+    }
 */
 /*
     else if (phosphor_layout == 6) {
@@ -368,7 +368,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = ap4[z];
         return weights;
-	}
+    }
 */
 /*
     else if (phosphor_layout == 7) {
@@ -389,7 +389,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap[w];
         return weights;
-	}
+    }
 */
     else if (phosphor_layout == 9) {
         // reduced TVL aperture for RGB panels
@@ -400,7 +400,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rgb[w];
         return weights;
-	}
+    }
 /*
     else if (phosphor_layout == 10) {
         // reduced TVL aperture for RBG panels
@@ -410,7 +410,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rbg[w];
         return weights;
-	}
+    }
 */
     else if(phosphor_layout == 11) {
         // delta_1_4x1_rgb; dunno why this is called 4x1 when it's obviously 4x2 /shrug
@@ -433,7 +433,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = (w == 1) ? delta_2_1[z] : delta_2_2[z];
         return weights;
-	}
+    }
 */
 /*
     else if (phosphor_layout == 13) {
@@ -485,10 +485,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = (w == 1) ? slotmask_RBG_x1[z] : (w == 2) ? slotmask_RBG_x2[z] : (w == 3) ? slotmask_RBG_x3[z] : slotmask_RBG_x4[z];
         return weights;
-	}
+    }
 */
 /*
-	else if(phosphor_layout == 16) {
+    else if(phosphor_layout == 16) {
         // slot mask for RBG panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
         // {yellow, blue,  black,  black},
         // {yellow, blue,  yellow, blue},
@@ -504,7 +504,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
         return weights;
     }
 */
-	else if (phosphor_layout == 17) {
+    else if (phosphor_layout == 17) {
         // slot_2_5x4_bgr
         // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
         // {black, blue,    blue,  green, green, red,   red,     black, black, black},
@@ -564,7 +564,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
         return weights;
      }
 */
-	else {
+    else {
         return weights;
     }
 }
@@ -584,10 +584,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 // For more info, see: http://www.imagemagick.org/Usage/img_diagrams/cubic_survey.gif
 mat4x4 get_hfilter_profile()
 {
-	float bf = 0.0;
-	float cf = 0.0;
+    float bf = 0.0;
+    float cf = 0.0;
 
-	if (HFILTER_PROFILE == 1) {
+    if (HFILTER_PROFILE == 1) {
         bf = 0.0;
         cf = 0.5;
     }
@@ -689,14 +689,14 @@ void main()
     mask_coords = mix(mask_coords.xy, mask_coords.yx, VSCANLINES);
     color.rgb *= mask_weights(mask_coords, MASK_INTENSITY, int(PHOSPHOR_LAYOUT));
 
-	// Colour temperature
-	if (WP_ADJUST == 1.0) {
-		vec3 wp_adjusted = wp_adjust(color.rgb);
-		vec3 base_luma = XYZtoYxy(sRGB_to_XYZ(color.rgb));
-		vec3 adjusted_luma = XYZtoYxy(sRGB_to_XYZ(wp_adjusted));
-		wp_adjusted = (LUMA_PRESERVE == 1.0) ? adjusted_luma + (vec3(base_luma.r,0.,0.) - vec3(adjusted_luma.r,0.,0.)) : adjusted_luma;
-		color = vec4(XYZ_to_sRGB(YxytoXYZ(wp_adjusted)), 1.0);
-	}
+    // Colour temperature
+    if (WP_ADJUST == 1.0) {
+        vec3 wp_adjusted = wp_adjust(color.rgb);
+        vec3 base_luma = XYZtoYxy(sRGB_to_XYZ(color.rgb));
+        vec3 adjusted_luma = XYZtoYxy(sRGB_to_XYZ(wp_adjusted));
+        wp_adjusted = (LUMA_PRESERVE == 1.0) ? adjusted_luma + (vec3(base_luma.r,0.,0.) - vec3(adjusted_luma.r,0.,0.)) : adjusted_luma;
+        color = vec4(XYZ_to_sRGB(YxytoXYZ(wp_adjusted)), 1.0);
+    }
 
     // Output gamma
     color = clamp(GAMMA_OUT(color), 0.0, 1.0);

--- a/contrib/resources/glshaders/crt/monochrome-hires.glsl
+++ b/contrib/resources/glshaders/crt/monochrome-hires.glsl
@@ -246,7 +246,6 @@ vec3 YxytoXYZ(vec3 Yxy) {
     return XYZ;
 }
 
-
 /*
     A collection of CRT mask effects that work with LCD subpixel structures for
     small details
@@ -273,11 +272,18 @@ vec3 YxytoXYZ(vec3 Yxy) {
 
     Many of these mask arrays are adapted from cgwg's crt-geom-deluxe LUTs, and
     those have their filenames included for easy identification
+
+	NOTE: Having too many branches result in a black screen (but no
+	compilation errors) on some older GPUs such as the Intel HD 4000 iGPU. So
+	we're commenting out the branches that are not used by the adaptive CRT
+	shaders.
 */
 vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
     vec3 weights = vec3(1.,1.,1.);
+
     float on = 1.;
     float off = 1.-mask_intensity;
+
     vec3 red     = vec3(on,  off, off);
     vec3 green   = vec3(off, on,  off);
     vec3 blue    = vec3(off, off, on );
@@ -286,6 +292,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
     vec3 cyan    = vec3(off, on,  on );
     vec3 black   = vec3(off, off, off);
     vec3 white   = vec3(on,  on,  on );
+
     int w, z = 0;
 
     // This pattern is used by a few layouts, so we'll define it here
@@ -293,21 +300,25 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
     if (phosphor_layout == 0) {
         return weights;
+	}
 
-    } else if (phosphor_layout == 1) {
-        // classic aperture for RGB panels; good for 1080p, too small for 4K+
+    else if (phosphor_layout == 1) {
+    	// classic aperture for RGB panels; good for 1080p, too small for 4K+
         // aka aperture_1_2_bgr
         weights  = aperture_weights;
         return weights;
+	}
 
-    } else if (phosphor_layout == 2) {
+    else if (phosphor_layout == 2) {
         // 2x2 shadow mask for RGB panels; good for 1080p, too small for 4K+
         // aka delta_1_2x1_bgr
         vec3 inverse_aperture = mix(green, magenta, floor(mod(coord.x, 2.0)));
         weights               = mix(aperture_weights, inverse_aperture, floor(mod(coord.y, 2.0)));
         return weights;
+	}
 
-    } else if (phosphor_layout == 3) {
+/*
+    else if (phosphor_layout == 3) {
         // slot mask for RGB panels; looks okay at 1080p, looks better at 4K
         // {magenta, green, black,   black},
         // {magenta, green, magenta, green},
@@ -327,14 +338,16 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         // do a big, dumb comparison in place of a 2D array
         weights = (w == 1) ? slotmask_x1[z] : (w == 2) ? slotmask_x2[z] :  slotmask_x3[z];
+		return weights;
     }
-
-    if (phosphor_layout == 4) {
+*/
+    else if (phosphor_layout == 4) {
         // classic aperture for RBG panels; good for 1080p, too small for 4K+
         weights  = mix(yellow, blue, floor(mod(coord.x, 2.0)));
         return weights;
-
-    } else if (phosphor_layout == 5) {
+	}
+/*
+    else if (phosphor_layout == 5) {
         // 2x2 shadow mask for RBG panels; good for 1080p, too small for 4K+
         vec3 inverse_aperture = mix(blue, yellow, floor(mod(coord.x, 2.0)));
 
@@ -344,8 +357,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
             floor(mod(coord.y, 2.0))
         );
         return weights;
-
-    } else if (phosphor_layout == 6) {
+	}
+*/
+/*
+    else if (phosphor_layout == 6) {
         // aperture_1_4_rgb; good for simulating lower
         vec3 ap4[4] = vec3[](red, green, blue, black);
 
@@ -353,8 +368,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = ap4[z];
         return weights;
-
-    } else if (phosphor_layout == 7) {
+	}
+*/
+/*
+    else if (phosphor_layout == 7) {
         // aperture_2_5_bgr
         vec3 ap3[5] = vec3[](red, magenta, blue, green, green);
 
@@ -362,8 +379,9 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = ap3[z];
         return weights;
-
-    } else if (phosphor_layout == 8){
+*/
+/*
+    else if (phosphor_layout == 8) {
         // aperture_3_6_rgb
         vec3 big_ap[7] = vec3[](red, red, yellow, green, cyan, blue, blue);
 
@@ -371,8 +389,9 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap[w];
         return weights;
-
-    } else if (phosphor_layout == 9) {
+	}
+*/
+    else if (phosphor_layout == 9) {
         // reduced TVL aperture for RGB panels
         // aperture_2_4_rgb
         vec3 big_ap_rgb[4] = vec3[](red, yellow, cyan, blue);
@@ -381,8 +400,9 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rgb[w];
         return weights;
-
-    } else if (phosphor_layout == 10) {
+	}
+/*
+    else if (phosphor_layout == 10) {
         // reduced TVL aperture for RBG panels
         vec3 big_ap_rbg[4] = vec3[](red, magenta, cyan, green);
 
@@ -390,148 +410,161 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rbg[w];
         return weights;
+	}
+*/
+    else if(phosphor_layout == 11) {
+        // delta_1_4x1_rgb; dunno why this is called 4x1 when it's obviously 4x2 /shrug
+        vec3 delta_1_1[4] = vec3[](red, green, blue, black);
+        vec3 delta_1_2[4] = vec3[](blue, black, red, green);
 
-    } else if(phosphor_layout == 11){
-       // delta_1_4x1_rgb; dunno why this is called 4x1 when it's obviously 4x2 /shrug
-       vec3 delta_1_1[4] = vec3[](red, green, blue, black);
-       vec3 delta_1_2[4] = vec3[](blue, black, red, green);
+        w = int(floor(mod(coord.y, 2.0)));
+        z = int(floor(mod(coord.x, 4.0)));
 
-       w = int(floor(mod(coord.y, 2.0)));
-       z = int(floor(mod(coord.x, 4.0)));
+        weights = (w == 1) ? delta_1_1[z] : delta_1_2[z];
+        return weights;
+    }
+/*
+    else if (phosphor_layout == 12) {
+        // delta_2_4x1_rgb
+        vec3 delta_2_1[4] = vec3[](red, yellow, cyan, blue);
+        vec3 delta_2_2[4] = vec3[](cyan, blue, red, yellow);
 
-       weights = (w == 1) ? delta_1_1[z] : delta_1_2[z];
-       return weights;
+        z = int(floor(mod(coord.x, 4.0)));
 
-    } else if(phosphor_layout == 12){
-       // delta_2_4x1_rgb
-       vec3 delta_2_1[4] = vec3[](red, yellow, cyan, blue);
-       vec3 delta_2_2[4] = vec3[](cyan, blue, red, yellow);
+        weights = (w == 1) ? delta_2_1[z] : delta_2_2[z];
+        return weights;
+	}
+*/
+/*
+    else if (phosphor_layout == 13) {
+        // delta_2_4x2_rgb
+        vec3 delta_1[4] = vec3[](red, yellow, cyan, blue);
+        vec3 delta_2[4] = vec3[](red, yellow, cyan, blue);
+        vec3 delta_3[4] = vec3[](cyan, blue, red, yellow);
+        vec3 delta_4[4] = vec3[](cyan, blue, red, yellow);
 
-       z = int(floor(mod(coord.x, 4.0)));
+        w = int(floor(mod(coord.y, 4.0)));
+        z = int(floor(mod(coord.x, 4.0)));
 
-       weights = (w == 1) ? delta_2_1[z] : delta_2_2[z];
-       return weights;
+        weights = (w == 1) ? delta_1[z] : (w == 2) ? delta_2[z] : (w == 3) ? delta_3[z] : delta_4[z];
+        return weights;
+    }
+*/
+    else if (phosphor_layout == 14) {
+        // slot mask for RGB panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
+        // {magenta, green, black, black,   black, black},
+        // {magenta, green, black, magenta, green, black},
+        // {black,   black, black, magenta, green, black}
+        vec3 slot2_1[6] = vec3[](magenta, green, black, black,   black, black);
+        vec3 slot2_2[6] = vec3[](magenta, green, black, magenta, green, black);
+        vec3 slot2_3[6] = vec3[](black,   black, black, magenta, green, black);
 
-    } else if(phosphor_layout == 13){
-       // delta_2_4x2_rgb
-       vec3 delta_1[4] = vec3[](red, yellow, cyan, blue);
-       vec3 delta_2[4] = vec3[](red, yellow, cyan, blue);
-       vec3 delta_3[4] = vec3[](cyan, blue, red, yellow);
-       vec3 delta_4[4] = vec3[](cyan, blue, red, yellow);
+        w = int(floor(mod(coord.y, 3.0)));
+        z = int(floor(mod(coord.x, 6.0)));
 
-       w = int(floor(mod(coord.y, 4.0)));
-       z = int(floor(mod(coord.x, 4.0)));
+        weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
+        return weights;
+    }
+/*
+    else if(phosphor_layout == 15) {
+        // slot_2_4x4_rgb
+        // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
+        // {red,   yellow, cyan,  blue,  black, black,  black, black},
+        // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
+        // {black, black,  black, black, red,   yellow, cyan,  blue }
+        vec3 slotmask_RBG_x1[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
+        vec3 slotmask_RBG_x2[8] = vec3[](red,   yellow, cyan,  blue,  black, black,  black, black);
+        vec3 slotmask_RBG_x3[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
+        vec3 slotmask_RBG_x4[8] = vec3[](black, black,  black, black, red,   yellow, cyan,  blue );
 
-       weights = (w == 1) ? delta_1[z] : (w == 2) ? delta_2[z] : (w == 3) ? delta_3[z] : delta_4[z];
-       return weights;
+        // find the vertical index
+        w = int(floor(mod(coord.y, 4.0)));
 
-    } else if(phosphor_layout == 14){
-       // slot mask for RGB panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
-       // {magenta, green, black, black,   black, black},
-       // {magenta, green, black, magenta, green, black},
-       // {black,   black, black, magenta, green, black}
-       vec3 slot2_1[6] = vec3[](magenta, green, black, black,   black, black);
-       vec3 slot2_2[6] = vec3[](magenta, green, black, magenta, green, black);
-       vec3 slot2_3[6] = vec3[](black,   black, black, magenta, green, black);
+        // find the horizontal index
+        z = int(floor(mod(coord.x, 8.0)));
 
-       w = int(floor(mod(coord.y, 3.0)));
-       z = int(floor(mod(coord.x, 6.0)));
+        weights = (w == 1) ? slotmask_RBG_x1[z] : (w == 2) ? slotmask_RBG_x2[z] : (w == 3) ? slotmask_RBG_x3[z] : slotmask_RBG_x4[z];
+        return weights;
+	}
+*/
+/*
+	else if(phosphor_layout == 16) {
+        // slot mask for RBG panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
+        // {yellow, blue,  black,  black},
+        // {yellow, blue,  yellow, blue},
+        // {black,  black, yellow, blue}
+        vec3 slot2_1[4] = vec3[](yellow, blue,  black,  black);
+        vec3 slot2_2[4] = vec3[](yellow, blue,  yellow, blue);
+        vec3 slot2_3[4] = vec3[](black,  black, yellow, blue);
 
-       weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
-       return weights;
+        w = int(floor(mod(coord.y, 3.0)));
+        z = int(floor(mod(coord.x, 4.0)));
 
-    } else if(phosphor_layout == 15){
-       // slot_2_4x4_rgb
-       // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
-       // {red,   yellow, cyan,  blue,  black, black,  black, black},
-       // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
-       // {black, black,  black, black, red,   yellow, cyan,  blue }
-       vec3 slotmask_RBG_x1[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
-       vec3 slotmask_RBG_x2[8] = vec3[](red,   yellow, cyan,  blue,  black, black,  black, black);
-       vec3 slotmask_RBG_x3[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
-       vec3 slotmask_RBG_x4[8] = vec3[](black, black,  black, black, red,   yellow, cyan,  blue );
+        weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
+        return weights;
+    }
+*/
+	else if (phosphor_layout == 17) {
+        // slot_2_5x4_bgr
+        // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
+        // {black, blue,    blue,  green, green, red,   red,     black, black, black},
+        // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
+        // {red,   red,     black, black, black, black, blue,    blue,  green, green}
+        vec3 slot_1[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
+        vec3 slot_2[10] = vec3[](black, blue,    blue,  green, green, red,   red,     black, black, black);
+        vec3 slot_3[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
+        vec3 slot_4[10] = vec3[](red,   red,     black, black, black, black, blue,    blue,  green, green);
 
-       // find the vertical index
-       w = int(floor(mod(coord.y, 4.0)));
+        w = int(floor(mod(coord.y, 4.0)));
+        z = int(floor(mod(coord.x, 10.0)));
 
-       // find the horizontal index
-       z = int(floor(mod(coord.x, 8.0)));
+        weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
+        return weights;
+    }
+/*
+    else if (phosphor_layout == 18) {
+        // same as above but for RBG panels
+        // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
+        // {black, green,  green, blue,  blue,  red,   red,    black, black, black},
+        // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
+        // {red,   red,    black, black, black, black, green,  green, blue,  blue }
+        vec3 slot_1[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
+        vec3 slot_2[10] = vec3[](black, green,  green, blue,  blue,  red,   red,    black, black, black);
+        vec3 slot_3[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
+        vec3 slot_4[10] = vec3[](red,   red,    black, black, black, black, green,  green, blue,  blue );
 
-       weights = (w == 1) ? slotmask_RBG_x1[z] : (w == 2) ? slotmask_RBG_x2[z] : (w == 3) ? slotmask_RBG_x3[z] : slotmask_RBG_x4[z];
-       return weights;
+        w = int(floor(mod(coord.y, 4.0)));
+        z = int(floor(mod(coord.x, 10.0)));
 
-     } else if(phosphor_layout == 16){
-       // slot mask for RBG panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
-       // {yellow, blue,  black,  black},
-       // {yellow, blue,  yellow, blue},
-       // {black,  black, yellow, blue}
-       vec3 slot2_1[4] = vec3[](yellow, blue,  black,  black);
-       vec3 slot2_2[4] = vec3[](yellow, blue,  yellow, blue);
-       vec3 slot2_3[4] = vec3[](black,  black, yellow, blue);
+        weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
+        return weights;
+    }
+*/
+/*
+    else if(phosphor_layout == 19) {
+        // slot_3_7x6_rgb
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue}
 
-       w = int(floor(mod(coord.y, 3.0)));
-       z = int(floor(mod(coord.x, 4.0)));
+        vec3 slot_1[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_2[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_3[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black);
+        vec3 slot_4[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_5[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_6[14] = vec3[](black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue);
 
-       weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
-       return weights;
+        w = int(floor(mod(coord.y, 6.0)));
+        z = int(floor(mod(coord.x, 14.0)));
 
-    } else if (phosphor_layout == 17) {
-       // slot_2_5x4_bgr
-       // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
-       // {black, blue,    blue,  green, green, red,   red,     black, black, black},
-       // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
-       // {red,   red,     black, black, black, black, blue,    blue,  green, green}
-       vec3 slot_1[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
-       vec3 slot_2[10] = vec3[](black, blue,    blue,  green, green, red,   red,     black, black, black);
-       vec3 slot_3[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
-       vec3 slot_4[10] = vec3[](red,   red,     black, black, black, black, blue,    blue,  green, green);
-
-       w = int(floor(mod(coord.y, 4.0)));
-       z = int(floor(mod(coord.x, 10.0)));
-
-       weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
-       return weights;
-
-    } else if (phosphor_layout == 18) {
-       // same as above but for RBG panels
-       // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
-       // {black, green,  green, blue,  blue,  red,   red,    black, black, black},
-       // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
-       // {red,   red,    black, black, black, black, green,  green, blue,  blue }
-       vec3 slot_1[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
-       vec3 slot_2[10] = vec3[](black, green,  green, blue,  blue,  red,   red,    black, black, black);
-       vec3 slot_3[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
-       vec3 slot_4[10] = vec3[](red,   red,    black, black, black, black, green,  green, blue,  blue );
-
-       w = int(floor(mod(coord.y, 4.0)));
-       z = int(floor(mod(coord.x, 10.0)));
-
-       weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
-       return weights;
-
-    } else if(phosphor_layout == 19) {
-       // slot_3_7x6_rgb
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue}
-
-       vec3 slot_1[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_2[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_3[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black);
-       vec3 slot_4[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_5[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_6[14] = vec3[](black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue);
-
-       w = int(floor(mod(coord.y, 6.0)));
-       z = int(floor(mod(coord.x, 14.0)));
-
-       weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : (w == 4) ? slot_4[z] : (w == 5) ? slot_5[z] : slot_6[z];
-       return weights;
-
-    } else {
+        weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : (w == 4) ? slot_4[z] : (w == 5) ? slot_5[z] : slot_6[z];
+        return weights;
+     }
+*/
+	else {
         return weights;
     }
 }

--- a/contrib/resources/glshaders/crt/monochrome-hires.glsl
+++ b/contrib/resources/glshaders/crt/monochrome-hires.glsl
@@ -167,10 +167,10 @@ uniform PRECISION float BLUE_SHIFT;
 
 #define WP_ADJUST           0.00
 #define TEMPERATURE      9300.00
-#define LUMA_PRESERVE 		1.00
-#define RED_SHIFT 			0.00
-#define GREEN_SHIFT 		0.00
-#define BLUE_SHIFT 			0.00
+#define LUMA_PRESERVE       1.00
+#define RED_SHIFT           0.00
+#define GREEN_SHIFT         0.00
+#define BLUE_SHIFT          0.00
 #endif
 // END PARAMETERS //
 
@@ -273,10 +273,10 @@ vec3 YxytoXYZ(vec3 Yxy) {
     Many of these mask arrays are adapted from cgwg's crt-geom-deluxe LUTs, and
     those have their filenames included for easy identification
 
-	NOTE: Having too many branches result in a black screen (but no
-	compilation errors) on some older GPUs such as the Intel HD 4000 iGPU. So
-	we're commenting out the branches that are not used by the adaptive CRT
-	shaders.
+    NOTE: Having too many branches result in a black screen (but no
+    compilation errors) on some older GPUs such as the Intel HD 4000 iGPU. So
+    we're commenting out the branches that are not used by the adaptive CRT
+    shaders.
 */
 vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
     vec3 weights = vec3(1.,1.,1.);
@@ -300,14 +300,14 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
     if (phosphor_layout == 0) {
         return weights;
-	}
+    }
 
     else if (phosphor_layout == 1) {
-    	// classic aperture for RGB panels; good for 1080p, too small for 4K+
+        // classic aperture for RGB panels; good for 1080p, too small for 4K+
         // aka aperture_1_2_bgr
         weights  = aperture_weights;
         return weights;
-	}
+    }
 
     else if (phosphor_layout == 2) {
         // 2x2 shadow mask for RGB panels; good for 1080p, too small for 4K+
@@ -315,7 +315,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
         vec3 inverse_aperture = mix(green, magenta, floor(mod(coord.x, 2.0)));
         weights               = mix(aperture_weights, inverse_aperture, floor(mod(coord.y, 2.0)));
         return weights;
-	}
+    }
 
 /*
     else if (phosphor_layout == 3) {
@@ -338,14 +338,14 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         // do a big, dumb comparison in place of a 2D array
         weights = (w == 1) ? slotmask_x1[z] : (w == 2) ? slotmask_x2[z] :  slotmask_x3[z];
-		return weights;
+        return weights;
     }
 */
     else if (phosphor_layout == 4) {
         // classic aperture for RBG panels; good for 1080p, too small for 4K+
         weights  = mix(yellow, blue, floor(mod(coord.x, 2.0)));
         return weights;
-	}
+    }
 /*
     else if (phosphor_layout == 5) {
         // 2x2 shadow mask for RBG panels; good for 1080p, too small for 4K+
@@ -357,7 +357,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
             floor(mod(coord.y, 2.0))
         );
         return weights;
-	}
+    }
 */
 /*
     else if (phosphor_layout == 6) {
@@ -368,7 +368,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = ap4[z];
         return weights;
-	}
+    }
 */
 /*
     else if (phosphor_layout == 7) {
@@ -389,7 +389,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap[w];
         return weights;
-	}
+    }
 */
     else if (phosphor_layout == 9) {
         // reduced TVL aperture for RGB panels
@@ -400,7 +400,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rgb[w];
         return weights;
-	}
+    }
 /*
     else if (phosphor_layout == 10) {
         // reduced TVL aperture for RBG panels
@@ -410,7 +410,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rbg[w];
         return weights;
-	}
+    }
 */
     else if(phosphor_layout == 11) {
         // delta_1_4x1_rgb; dunno why this is called 4x1 when it's obviously 4x2 /shrug
@@ -433,7 +433,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = (w == 1) ? delta_2_1[z] : delta_2_2[z];
         return weights;
-	}
+    }
 */
 /*
     else if (phosphor_layout == 13) {
@@ -485,10 +485,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = (w == 1) ? slotmask_RBG_x1[z] : (w == 2) ? slotmask_RBG_x2[z] : (w == 3) ? slotmask_RBG_x3[z] : slotmask_RBG_x4[z];
         return weights;
-	}
+    }
 */
 /*
-	else if(phosphor_layout == 16) {
+    else if(phosphor_layout == 16) {
         // slot mask for RBG panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
         // {yellow, blue,  black,  black},
         // {yellow, blue,  yellow, blue},
@@ -504,7 +504,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
         return weights;
     }
 */
-	else if (phosphor_layout == 17) {
+    else if (phosphor_layout == 17) {
         // slot_2_5x4_bgr
         // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
         // {black, blue,    blue,  green, green, red,   red,     black, black, black},
@@ -564,7 +564,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
         return weights;
      }
 */
-	else {
+    else {
         return weights;
     }
 }
@@ -584,10 +584,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 // For more info, see: http://www.imagemagick.org/Usage/img_diagrams/cubic_survey.gif
 mat4x4 get_hfilter_profile()
 {
-	float bf = 0.0;
-	float cf = 0.0;
+    float bf = 0.0;
+    float cf = 0.0;
 
-	if (HFILTER_PROFILE == 1) {
+    if (HFILTER_PROFILE == 1) {
         bf = 0.0;
         cf = 0.5;
     }
@@ -689,14 +689,14 @@ void main()
     mask_coords = mix(mask_coords.xy, mask_coords.yx, VSCANLINES);
     color.rgb *= mask_weights(mask_coords, MASK_INTENSITY, int(PHOSPHOR_LAYOUT));
 
-	// Colour temperature
-	if (WP_ADJUST == 1.0) {
-		vec3 wp_adjusted = wp_adjust(color.rgb);
-		vec3 base_luma = XYZtoYxy(sRGB_to_XYZ(color.rgb));
-		vec3 adjusted_luma = XYZtoYxy(sRGB_to_XYZ(wp_adjusted));
-		wp_adjusted = (LUMA_PRESERVE == 1.0) ? adjusted_luma + (vec3(base_luma.r,0.,0.) - vec3(adjusted_luma.r,0.,0.)) : adjusted_luma;
-		color = vec4(XYZ_to_sRGB(YxytoXYZ(wp_adjusted)), 1.0);
-	}
+    // Colour temperature
+    if (WP_ADJUST == 1.0) {
+        vec3 wp_adjusted = wp_adjust(color.rgb);
+        vec3 base_luma = XYZtoYxy(sRGB_to_XYZ(color.rgb));
+        vec3 adjusted_luma = XYZtoYxy(sRGB_to_XYZ(wp_adjusted));
+        wp_adjusted = (LUMA_PRESERVE == 1.0) ? adjusted_luma + (vec3(base_luma.r,0.,0.) - vec3(adjusted_luma.r,0.,0.)) : adjusted_luma;
+        color = vec4(XYZ_to_sRGB(YxytoXYZ(wp_adjusted)), 1.0);
+    }
 
     // Output gamma
     color = clamp(GAMMA_OUT(color), 0.0, 1.0);

--- a/contrib/resources/glshaders/crt/monochrome-lowres.glsl
+++ b/contrib/resources/glshaders/crt/monochrome-lowres.glsl
@@ -169,10 +169,10 @@ uniform PRECISION float BLUE_SHIFT;
 
 #define WP_ADJUST           0.00
 #define TEMPERATURE      9300.00
-#define LUMA_PRESERVE 		1.00
-#define RED_SHIFT 			0.00
-#define GREEN_SHIFT 		0.00
-#define BLUE_SHIFT 			0.00
+#define LUMA_PRESERVE       1.00
+#define RED_SHIFT           0.00
+#define GREEN_SHIFT         0.00
+#define BLUE_SHIFT          0.00
 #endif
 // END PARAMETERS //
 
@@ -275,10 +275,10 @@ vec3 YxytoXYZ(vec3 Yxy) {
     Many of these mask arrays are adapted from cgwg's crt-geom-deluxe LUTs, and
     those have their filenames included for easy identification
 
-	NOTE: Having too many branches result in a black screen (but no
-	compilation errors) on some older GPUs such as the Intel HD 4000 iGPU. So
-	we're commenting out the branches that are not used by the adaptive CRT
-	shaders.
+    NOTE: Having too many branches result in a black screen (but no
+    compilation errors) on some older GPUs such as the Intel HD 4000 iGPU. So
+    we're commenting out the branches that are not used by the adaptive CRT
+    shaders.
 */
 vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
     vec3 weights = vec3(1.,1.,1.);
@@ -302,14 +302,14 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
     if (phosphor_layout == 0) {
         return weights;
-	}
+    }
 
     else if (phosphor_layout == 1) {
-    	// classic aperture for RGB panels; good for 1080p, too small for 4K+
+        // classic aperture for RGB panels; good for 1080p, too small for 4K+
         // aka aperture_1_2_bgr
         weights  = aperture_weights;
         return weights;
-	}
+    }
 
     else if (phosphor_layout == 2) {
         // 2x2 shadow mask for RGB panels; good for 1080p, too small for 4K+
@@ -317,7 +317,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
         vec3 inverse_aperture = mix(green, magenta, floor(mod(coord.x, 2.0)));
         weights               = mix(aperture_weights, inverse_aperture, floor(mod(coord.y, 2.0)));
         return weights;
-	}
+    }
 
 /*
     else if (phosphor_layout == 3) {
@@ -340,14 +340,14 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         // do a big, dumb comparison in place of a 2D array
         weights = (w == 1) ? slotmask_x1[z] : (w == 2) ? slotmask_x2[z] :  slotmask_x3[z];
-		return weights;
+        return weights;
     }
 */
     else if (phosphor_layout == 4) {
         // classic aperture for RBG panels; good for 1080p, too small for 4K+
         weights  = mix(yellow, blue, floor(mod(coord.x, 2.0)));
         return weights;
-	}
+    }
 /*
     else if (phosphor_layout == 5) {
         // 2x2 shadow mask for RBG panels; good for 1080p, too small for 4K+
@@ -359,7 +359,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
             floor(mod(coord.y, 2.0))
         );
         return weights;
-	}
+    }
 */
 /*
     else if (phosphor_layout == 6) {
@@ -370,7 +370,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = ap4[z];
         return weights;
-	}
+    }
 */
 /*
     else if (phosphor_layout == 7) {
@@ -391,7 +391,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap[w];
         return weights;
-	}
+    }
 */
     else if (phosphor_layout == 9) {
         // reduced TVL aperture for RGB panels
@@ -402,7 +402,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rgb[w];
         return weights;
-	}
+    }
 /*
     else if (phosphor_layout == 10) {
         // reduced TVL aperture for RBG panels
@@ -412,7 +412,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rbg[w];
         return weights;
-	}
+    }
 */
     else if(phosphor_layout == 11) {
         // delta_1_4x1_rgb; dunno why this is called 4x1 when it's obviously 4x2 /shrug
@@ -435,7 +435,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = (w == 1) ? delta_2_1[z] : delta_2_2[z];
         return weights;
-	}
+    }
 */
 /*
     else if (phosphor_layout == 13) {
@@ -487,10 +487,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = (w == 1) ? slotmask_RBG_x1[z] : (w == 2) ? slotmask_RBG_x2[z] : (w == 3) ? slotmask_RBG_x3[z] : slotmask_RBG_x4[z];
         return weights;
-	}
+    }
 */
 /*
-	else if(phosphor_layout == 16) {
+    else if(phosphor_layout == 16) {
         // slot mask for RBG panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
         // {yellow, blue,  black,  black},
         // {yellow, blue,  yellow, blue},
@@ -506,7 +506,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
         return weights;
     }
 */
-	else if (phosphor_layout == 17) {
+    else if (phosphor_layout == 17) {
         // slot_2_5x4_bgr
         // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
         // {black, blue,    blue,  green, green, red,   red,     black, black, black},
@@ -566,7 +566,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
         return weights;
      }
 */
-	else {
+    else {
         return weights;
     }
 }
@@ -586,10 +586,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 // For more info, see: http://www.imagemagick.org/Usage/img_diagrams/cubic_survey.gif
 mat4x4 get_hfilter_profile()
 {
-	float bf = 0.0;
-	float cf = 0.0;
+    float bf = 0.0;
+    float cf = 0.0;
 
-	if (HFILTER_PROFILE == 1) {
+    if (HFILTER_PROFILE == 1) {
         bf = 0.0;
         cf = 0.5;
     }
@@ -691,14 +691,14 @@ void main()
     mask_coords = mix(mask_coords.xy, mask_coords.yx, VSCANLINES);
     color.rgb *= mask_weights(mask_coords, MASK_INTENSITY, int(PHOSPHOR_LAYOUT));
 
-	// Colour temperature
-	if (WP_ADJUST == 1.0) {
-		vec3 wp_adjusted = wp_adjust(color.rgb);
-		vec3 base_luma = XYZtoYxy(sRGB_to_XYZ(color.rgb));
-		vec3 adjusted_luma = XYZtoYxy(sRGB_to_XYZ(wp_adjusted));
-		wp_adjusted = (LUMA_PRESERVE == 1.0) ? adjusted_luma + (vec3(base_luma.r,0.,0.) - vec3(adjusted_luma.r,0.,0.)) : adjusted_luma;
-		color = vec4(XYZ_to_sRGB(YxytoXYZ(wp_adjusted)), 1.0);
-	}
+    // Colour temperature
+    if (WP_ADJUST == 1.0) {
+        vec3 wp_adjusted = wp_adjust(color.rgb);
+        vec3 base_luma = XYZtoYxy(sRGB_to_XYZ(color.rgb));
+        vec3 adjusted_luma = XYZtoYxy(sRGB_to_XYZ(wp_adjusted));
+        wp_adjusted = (LUMA_PRESERVE == 1.0) ? adjusted_luma + (vec3(base_luma.r,0.,0.) - vec3(adjusted_luma.r,0.,0.)) : adjusted_luma;
+        color = vec4(XYZ_to_sRGB(YxytoXYZ(wp_adjusted)), 1.0);
+    }
 
     // Output gamma
     color = clamp(GAMMA_OUT(color), 0.0, 1.0);

--- a/contrib/resources/glshaders/crt/monochrome-lowres.glsl
+++ b/contrib/resources/glshaders/crt/monochrome-lowres.glsl
@@ -248,7 +248,6 @@ vec3 YxytoXYZ(vec3 Yxy) {
     return XYZ;
 }
 
-
 /*
     A collection of CRT mask effects that work with LCD subpixel structures for
     small details
@@ -275,11 +274,18 @@ vec3 YxytoXYZ(vec3 Yxy) {
 
     Many of these mask arrays are adapted from cgwg's crt-geom-deluxe LUTs, and
     those have their filenames included for easy identification
+
+	NOTE: Having too many branches result in a black screen (but no
+	compilation errors) on some older GPUs such as the Intel HD 4000 iGPU. So
+	we're commenting out the branches that are not used by the adaptive CRT
+	shaders.
 */
 vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
     vec3 weights = vec3(1.,1.,1.);
+
     float on = 1.;
     float off = 1.-mask_intensity;
+
     vec3 red     = vec3(on,  off, off);
     vec3 green   = vec3(off, on,  off);
     vec3 blue    = vec3(off, off, on );
@@ -288,6 +294,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
     vec3 cyan    = vec3(off, on,  on );
     vec3 black   = vec3(off, off, off);
     vec3 white   = vec3(on,  on,  on );
+
     int w, z = 0;
 
     // This pattern is used by a few layouts, so we'll define it here
@@ -295,21 +302,25 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
     if (phosphor_layout == 0) {
         return weights;
+	}
 
-    } else if (phosphor_layout == 1) {
-        // classic aperture for RGB panels; good for 1080p, too small for 4K+
+    else if (phosphor_layout == 1) {
+    	// classic aperture for RGB panels; good for 1080p, too small for 4K+
         // aka aperture_1_2_bgr
         weights  = aperture_weights;
         return weights;
+	}
 
-    } else if (phosphor_layout == 2) {
+    else if (phosphor_layout == 2) {
         // 2x2 shadow mask for RGB panels; good for 1080p, too small for 4K+
         // aka delta_1_2x1_bgr
         vec3 inverse_aperture = mix(green, magenta, floor(mod(coord.x, 2.0)));
         weights               = mix(aperture_weights, inverse_aperture, floor(mod(coord.y, 2.0)));
         return weights;
+	}
 
-    } else if (phosphor_layout == 3) {
+/*
+    else if (phosphor_layout == 3) {
         // slot mask for RGB panels; looks okay at 1080p, looks better at 4K
         // {magenta, green, black,   black},
         // {magenta, green, magenta, green},
@@ -329,14 +340,16 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         // do a big, dumb comparison in place of a 2D array
         weights = (w == 1) ? slotmask_x1[z] : (w == 2) ? slotmask_x2[z] :  slotmask_x3[z];
+		return weights;
     }
-
-    if (phosphor_layout == 4) {
+*/
+    else if (phosphor_layout == 4) {
         // classic aperture for RBG panels; good for 1080p, too small for 4K+
         weights  = mix(yellow, blue, floor(mod(coord.x, 2.0)));
         return weights;
-
-    } else if (phosphor_layout == 5) {
+	}
+/*
+    else if (phosphor_layout == 5) {
         // 2x2 shadow mask for RBG panels; good for 1080p, too small for 4K+
         vec3 inverse_aperture = mix(blue, yellow, floor(mod(coord.x, 2.0)));
 
@@ -346,8 +359,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
             floor(mod(coord.y, 2.0))
         );
         return weights;
-
-    } else if (phosphor_layout == 6) {
+	}
+*/
+/*
+    else if (phosphor_layout == 6) {
         // aperture_1_4_rgb; good for simulating lower
         vec3 ap4[4] = vec3[](red, green, blue, black);
 
@@ -355,8 +370,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = ap4[z];
         return weights;
-
-    } else if (phosphor_layout == 7) {
+	}
+*/
+/*
+    else if (phosphor_layout == 7) {
         // aperture_2_5_bgr
         vec3 ap3[5] = vec3[](red, magenta, blue, green, green);
 
@@ -364,8 +381,9 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = ap3[z];
         return weights;
-
-    } else if (phosphor_layout == 8){
+*/
+/*
+    else if (phosphor_layout == 8) {
         // aperture_3_6_rgb
         vec3 big_ap[7] = vec3[](red, red, yellow, green, cyan, blue, blue);
 
@@ -373,8 +391,9 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap[w];
         return weights;
-
-    } else if (phosphor_layout == 9) {
+	}
+*/
+    else if (phosphor_layout == 9) {
         // reduced TVL aperture for RGB panels
         // aperture_2_4_rgb
         vec3 big_ap_rgb[4] = vec3[](red, yellow, cyan, blue);
@@ -383,8 +402,9 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rgb[w];
         return weights;
-
-    } else if (phosphor_layout == 10) {
+	}
+/*
+    else if (phosphor_layout == 10) {
         // reduced TVL aperture for RBG panels
         vec3 big_ap_rbg[4] = vec3[](red, magenta, cyan, green);
 
@@ -392,148 +412,161 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rbg[w];
         return weights;
+	}
+*/
+    else if(phosphor_layout == 11) {
+        // delta_1_4x1_rgb; dunno why this is called 4x1 when it's obviously 4x2 /shrug
+        vec3 delta_1_1[4] = vec3[](red, green, blue, black);
+        vec3 delta_1_2[4] = vec3[](blue, black, red, green);
 
-    } else if(phosphor_layout == 11){
-       // delta_1_4x1_rgb; dunno why this is called 4x1 when it's obviously 4x2 /shrug
-       vec3 delta_1_1[4] = vec3[](red, green, blue, black);
-       vec3 delta_1_2[4] = vec3[](blue, black, red, green);
+        w = int(floor(mod(coord.y, 2.0)));
+        z = int(floor(mod(coord.x, 4.0)));
 
-       w = int(floor(mod(coord.y, 2.0)));
-       z = int(floor(mod(coord.x, 4.0)));
+        weights = (w == 1) ? delta_1_1[z] : delta_1_2[z];
+        return weights;
+    }
+/*
+    else if (phosphor_layout == 12) {
+        // delta_2_4x1_rgb
+        vec3 delta_2_1[4] = vec3[](red, yellow, cyan, blue);
+        vec3 delta_2_2[4] = vec3[](cyan, blue, red, yellow);
 
-       weights = (w == 1) ? delta_1_1[z] : delta_1_2[z];
-       return weights;
+        z = int(floor(mod(coord.x, 4.0)));
 
-    } else if(phosphor_layout == 12){
-       // delta_2_4x1_rgb
-       vec3 delta_2_1[4] = vec3[](red, yellow, cyan, blue);
-       vec3 delta_2_2[4] = vec3[](cyan, blue, red, yellow);
+        weights = (w == 1) ? delta_2_1[z] : delta_2_2[z];
+        return weights;
+	}
+*/
+/*
+    else if (phosphor_layout == 13) {
+        // delta_2_4x2_rgb
+        vec3 delta_1[4] = vec3[](red, yellow, cyan, blue);
+        vec3 delta_2[4] = vec3[](red, yellow, cyan, blue);
+        vec3 delta_3[4] = vec3[](cyan, blue, red, yellow);
+        vec3 delta_4[4] = vec3[](cyan, blue, red, yellow);
 
-       z = int(floor(mod(coord.x, 4.0)));
+        w = int(floor(mod(coord.y, 4.0)));
+        z = int(floor(mod(coord.x, 4.0)));
 
-       weights = (w == 1) ? delta_2_1[z] : delta_2_2[z];
-       return weights;
+        weights = (w == 1) ? delta_1[z] : (w == 2) ? delta_2[z] : (w == 3) ? delta_3[z] : delta_4[z];
+        return weights;
+    }
+*/
+    else if (phosphor_layout == 14) {
+        // slot mask for RGB panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
+        // {magenta, green, black, black,   black, black},
+        // {magenta, green, black, magenta, green, black},
+        // {black,   black, black, magenta, green, black}
+        vec3 slot2_1[6] = vec3[](magenta, green, black, black,   black, black);
+        vec3 slot2_2[6] = vec3[](magenta, green, black, magenta, green, black);
+        vec3 slot2_3[6] = vec3[](black,   black, black, magenta, green, black);
 
-    } else if(phosphor_layout == 13){
-       // delta_2_4x2_rgb
-       vec3 delta_1[4] = vec3[](red, yellow, cyan, blue);
-       vec3 delta_2[4] = vec3[](red, yellow, cyan, blue);
-       vec3 delta_3[4] = vec3[](cyan, blue, red, yellow);
-       vec3 delta_4[4] = vec3[](cyan, blue, red, yellow);
+        w = int(floor(mod(coord.y, 3.0)));
+        z = int(floor(mod(coord.x, 6.0)));
 
-       w = int(floor(mod(coord.y, 4.0)));
-       z = int(floor(mod(coord.x, 4.0)));
+        weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
+        return weights;
+    }
+/*
+    else if(phosphor_layout == 15) {
+        // slot_2_4x4_rgb
+        // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
+        // {red,   yellow, cyan,  blue,  black, black,  black, black},
+        // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
+        // {black, black,  black, black, red,   yellow, cyan,  blue }
+        vec3 slotmask_RBG_x1[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
+        vec3 slotmask_RBG_x2[8] = vec3[](red,   yellow, cyan,  blue,  black, black,  black, black);
+        vec3 slotmask_RBG_x3[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
+        vec3 slotmask_RBG_x4[8] = vec3[](black, black,  black, black, red,   yellow, cyan,  blue );
 
-       weights = (w == 1) ? delta_1[z] : (w == 2) ? delta_2[z] : (w == 3) ? delta_3[z] : delta_4[z];
-       return weights;
+        // find the vertical index
+        w = int(floor(mod(coord.y, 4.0)));
 
-    } else if(phosphor_layout == 14){
-       // slot mask for RGB panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
-       // {magenta, green, black, black,   black, black},
-       // {magenta, green, black, magenta, green, black},
-       // {black,   black, black, magenta, green, black}
-       vec3 slot2_1[6] = vec3[](magenta, green, black, black,   black, black);
-       vec3 slot2_2[6] = vec3[](magenta, green, black, magenta, green, black);
-       vec3 slot2_3[6] = vec3[](black,   black, black, magenta, green, black);
+        // find the horizontal index
+        z = int(floor(mod(coord.x, 8.0)));
 
-       w = int(floor(mod(coord.y, 3.0)));
-       z = int(floor(mod(coord.x, 6.0)));
+        weights = (w == 1) ? slotmask_RBG_x1[z] : (w == 2) ? slotmask_RBG_x2[z] : (w == 3) ? slotmask_RBG_x3[z] : slotmask_RBG_x4[z];
+        return weights;
+	}
+*/
+/*
+	else if(phosphor_layout == 16) {
+        // slot mask for RBG panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
+        // {yellow, blue,  black,  black},
+        // {yellow, blue,  yellow, blue},
+        // {black,  black, yellow, blue}
+        vec3 slot2_1[4] = vec3[](yellow, blue,  black,  black);
+        vec3 slot2_2[4] = vec3[](yellow, blue,  yellow, blue);
+        vec3 slot2_3[4] = vec3[](black,  black, yellow, blue);
 
-       weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
-       return weights;
+        w = int(floor(mod(coord.y, 3.0)));
+        z = int(floor(mod(coord.x, 4.0)));
 
-    } else if(phosphor_layout == 15){
-       // slot_2_4x4_rgb
-       // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
-       // {red,   yellow, cyan,  blue,  black, black,  black, black},
-       // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
-       // {black, black,  black, black, red,   yellow, cyan,  blue }
-       vec3 slotmask_RBG_x1[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
-       vec3 slotmask_RBG_x2[8] = vec3[](red,   yellow, cyan,  blue,  black, black,  black, black);
-       vec3 slotmask_RBG_x3[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
-       vec3 slotmask_RBG_x4[8] = vec3[](black, black,  black, black, red,   yellow, cyan,  blue );
+        weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
+        return weights;
+    }
+*/
+	else if (phosphor_layout == 17) {
+        // slot_2_5x4_bgr
+        // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
+        // {black, blue,    blue,  green, green, red,   red,     black, black, black},
+        // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
+        // {red,   red,     black, black, black, black, blue,    blue,  green, green}
+        vec3 slot_1[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
+        vec3 slot_2[10] = vec3[](black, blue,    blue,  green, green, red,   red,     black, black, black);
+        vec3 slot_3[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
+        vec3 slot_4[10] = vec3[](red,   red,     black, black, black, black, blue,    blue,  green, green);
 
-       // find the vertical index
-       w = int(floor(mod(coord.y, 4.0)));
+        w = int(floor(mod(coord.y, 4.0)));
+        z = int(floor(mod(coord.x, 10.0)));
 
-       // find the horizontal index
-       z = int(floor(mod(coord.x, 8.0)));
+        weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
+        return weights;
+    }
+/*
+    else if (phosphor_layout == 18) {
+        // same as above but for RBG panels
+        // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
+        // {black, green,  green, blue,  blue,  red,   red,    black, black, black},
+        // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
+        // {red,   red,    black, black, black, black, green,  green, blue,  blue }
+        vec3 slot_1[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
+        vec3 slot_2[10] = vec3[](black, green,  green, blue,  blue,  red,   red,    black, black, black);
+        vec3 slot_3[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
+        vec3 slot_4[10] = vec3[](red,   red,    black, black, black, black, green,  green, blue,  blue );
 
-       weights = (w == 1) ? slotmask_RBG_x1[z] : (w == 2) ? slotmask_RBG_x2[z] : (w == 3) ? slotmask_RBG_x3[z] : slotmask_RBG_x4[z];
-       return weights;
+        w = int(floor(mod(coord.y, 4.0)));
+        z = int(floor(mod(coord.x, 10.0)));
 
-     } else if(phosphor_layout == 16){
-       // slot mask for RBG panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
-       // {yellow, blue,  black,  black},
-       // {yellow, blue,  yellow, blue},
-       // {black,  black, yellow, blue}
-       vec3 slot2_1[4] = vec3[](yellow, blue,  black,  black);
-       vec3 slot2_2[4] = vec3[](yellow, blue,  yellow, blue);
-       vec3 slot2_3[4] = vec3[](black,  black, yellow, blue);
+        weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
+        return weights;
+    }
+*/
+/*
+    else if(phosphor_layout == 19) {
+        // slot_3_7x6_rgb
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue}
 
-       w = int(floor(mod(coord.y, 3.0)));
-       z = int(floor(mod(coord.x, 4.0)));
+        vec3 slot_1[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_2[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_3[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black);
+        vec3 slot_4[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_5[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_6[14] = vec3[](black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue);
 
-       weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
-       return weights;
+        w = int(floor(mod(coord.y, 6.0)));
+        z = int(floor(mod(coord.x, 14.0)));
 
-    } else if (phosphor_layout == 17) {
-       // slot_2_5x4_bgr
-       // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
-       // {black, blue,    blue,  green, green, red,   red,     black, black, black},
-       // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
-       // {red,   red,     black, black, black, black, blue,    blue,  green, green}
-       vec3 slot_1[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
-       vec3 slot_2[10] = vec3[](black, blue,    blue,  green, green, red,   red,     black, black, black);
-       vec3 slot_3[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
-       vec3 slot_4[10] = vec3[](red,   red,     black, black, black, black, blue,    blue,  green, green);
-
-       w = int(floor(mod(coord.y, 4.0)));
-       z = int(floor(mod(coord.x, 10.0)));
-
-       weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
-       return weights;
-
-    } else if (phosphor_layout == 18) {
-       // same as above but for RBG panels
-       // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
-       // {black, green,  green, blue,  blue,  red,   red,    black, black, black},
-       // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
-       // {red,   red,    black, black, black, black, green,  green, blue,  blue }
-       vec3 slot_1[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
-       vec3 slot_2[10] = vec3[](black, green,  green, blue,  blue,  red,   red,    black, black, black);
-       vec3 slot_3[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
-       vec3 slot_4[10] = vec3[](red,   red,    black, black, black, black, green,  green, blue,  blue );
-
-       w = int(floor(mod(coord.y, 4.0)));
-       z = int(floor(mod(coord.x, 10.0)));
-
-       weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
-       return weights;
-
-    } else if(phosphor_layout == 19) {
-       // slot_3_7x6_rgb
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue}
-
-       vec3 slot_1[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_2[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_3[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black);
-       vec3 slot_4[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_5[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_6[14] = vec3[](black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue);
-
-       w = int(floor(mod(coord.y, 6.0)));
-       z = int(floor(mod(coord.x, 14.0)));
-
-       weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : (w == 4) ? slot_4[z] : (w == 5) ? slot_5[z] : slot_6[z];
-       return weights;
-
-    } else {
+        weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : (w == 4) ? slot_4[z] : (w == 5) ? slot_5[z] : slot_6[z];
+        return weights;
+     }
+*/
+	else {
         return weights;
     }
 }

--- a/contrib/resources/glshaders/crt/vga-1080p-fake-double-scan.glsl
+++ b/contrib/resources/glshaders/crt/vga-1080p-fake-double-scan.glsl
@@ -29,7 +29,7 @@ varying vec2 prescale;
 attribute vec4 a_position;
 
 void main() {
-	gl_Position = a_position;
+    gl_Position = a_position;
 
     v_texCoord_lores = vec2(a_position.x + 1.0, 1.0 - a_position.y) / 2.0 * rubyInputSize;
 
@@ -45,7 +45,7 @@ uniform sampler2D rubyTexture;
 
 // Macro for weights computing
 #define WEIGHT(w) \
-	if (w > 1.0) w = 1.0; \
+    if (w > 1.0) w = 1.0; \
   w = 1.0 - w * w; \
   w = w * w;
 
@@ -61,7 +61,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout){
    vec3 aperture_weights = mix(magenta, green, floor(mod(coord.x, 2.0)));
 
    if (phosphor_layout == 0) {
-	   return weights;
+       return weights;
 
    } else if (phosphor_layout == 1) {
       // classic aperture for RGB panels; good for 1080p, too small for 4K+
@@ -77,7 +77,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout){
       return weights;
 
    } else {
-	   return weights;
+       return weights;
    }
 }
 
@@ -111,25 +111,25 @@ vec4 add_vga_overlay(vec4 color, float scanlineStrengthMin, float scanlineStreng
 
 vec4 tex2D_linear(in sampler2D sampler, in vec2 uv) {
 
-	// subtract 0.5 here and add it again after the floor to centre the texel
-	vec2 texCoord = uv * rubyTextureSize - vec2(0.5);
-	vec2 s0t0 = floor(texCoord) + vec2(0.5);
-	vec2 s0t1 = s0t0 + vec2(0.0, 1.0);
-	vec2 s1t0 = s0t0 + vec2(1.0, 0.0);
-	vec2 s1t1 = s0t0 + vec2(1.0);
+    // subtract 0.5 here and add it again after the floor to centre the texel
+    vec2 texCoord = uv * rubyTextureSize - vec2(0.5);
+    vec2 s0t0 = floor(texCoord) + vec2(0.5);
+    vec2 s0t1 = s0t0 + vec2(0.0, 1.0);
+    vec2 s1t0 = s0t0 + vec2(1.0, 0.0);
+    vec2 s1t1 = s0t0 + vec2(1.0);
 
-	vec2 invTexSize = 1.0 / rubyTextureSize;
-	vec4 c_s0t0 = GAMMA_IN(texture2D(sampler, s0t0 * invTexSize));
-	vec4 c_s0t1 = GAMMA_IN(texture2D(sampler, s0t1 * invTexSize));
-	vec4 c_s1t0 = GAMMA_IN(texture2D(sampler, s1t0 * invTexSize));
-	vec4 c_s1t1 = GAMMA_IN(texture2D(sampler, s1t1 * invTexSize));
+    vec2 invTexSize = 1.0 / rubyTextureSize;
+    vec4 c_s0t0 = GAMMA_IN(texture2D(sampler, s0t0 * invTexSize));
+    vec4 c_s0t1 = GAMMA_IN(texture2D(sampler, s0t1 * invTexSize));
+    vec4 c_s1t0 = GAMMA_IN(texture2D(sampler, s1t0 * invTexSize));
+    vec4 c_s1t1 = GAMMA_IN(texture2D(sampler, s1t1 * invTexSize));
 
-	vec2 weight = fract(texCoord);
+    vec2 weight = fract(texCoord);
 
-	vec4 c0 = c_s0t0 + (c_s1t0 - c_s0t0) * weight.x;
-	vec4 c1 = c_s0t1 + (c_s1t1 - c_s0t1) * weight.x;
+    vec4 c0 = c_s0t0 + (c_s1t0 - c_s0t0) * weight.x;
+    vec4 c1 = c_s0t1 + (c_s1t1 - c_s0t1) * weight.x;
 
-	return (c0 + (c1 - c0) * weight.y);
+    return (c0 + (c1 - c0) * weight.y);
 }
 
 void main()

--- a/contrib/resources/glshaders/crt/vga-1080p-fake-double-scan.glsl
+++ b/contrib/resources/glshaders/crt/vga-1080p-fake-double-scan.glsl
@@ -19,8 +19,6 @@ uniform vec2 rubyOutputSize;
 uniform vec2 rubyTextureSize;
 
 varying vec2 v_texCoord_lores;
-varying vec2 onex;
-varying vec2 oney;
 varying vec2 prescale;
 
 #define SourceSize vec4(rubyTextureSize, 1.0 / rubyTextureSize)
@@ -36,9 +34,6 @@ void main() {
     v_texCoord_lores = vec2(a_position.x + 1.0, 1.0 - a_position.y) / 2.0 * rubyInputSize;
 
     prescale = ceil(rubyOutputSize / rubyInputSize);
-
-	onex = vec2(SourceSize.z, 0.0);
-	oney = vec2(0.0, SourceSize.w);
 }
 
 
@@ -59,275 +54,31 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout){
    vec3 weights = vec3(1.,1.,1.);
    float on = 1.;
    float off = 1.-mask_intensity;
-   vec3 red     = vec3(on,  off, off);
    vec3 green   = vec3(off, on,  off);
-   vec3 blue    = vec3(off, off, on );
    vec3 magenta = vec3(on,  off, on );
-   vec3 yellow  = vec3(on,  on,  off);
-   vec3 cyan    = vec3(off, on,  on );
-   vec3 black   = vec3(off, off, off);
-   vec3 white   = vec3(on,  on,  on );
-   int w, z = 0;
 
    // This pattern is used by a few layouts, so we'll define it here
    vec3 aperture_weights = mix(magenta, green, floor(mod(coord.x, 2.0)));
 
-   if(phosphor_layout == 0) return weights;
+   if (phosphor_layout == 0) {
+	   return weights;
 
-   else if(phosphor_layout == 1){
+   } else if (phosphor_layout == 1) {
       // classic aperture for RGB panels; good for 1080p, too small for 4K+
       // aka aperture_1_2_bgr
       weights  = aperture_weights;
       return weights;
-   }
 
-   else if(phosphor_layout == 2){
+   } else if (phosphor_layout == 2) {
       // 2x2 shadow mask for RGB panels; good for 1080p, too small for 4K+
       // aka delta_1_2x1_bgr
       vec3 inverse_aperture = mix(green, magenta, floor(mod(coord.x, 2.0)));
       weights               = mix(aperture_weights, inverse_aperture, floor(mod(coord.y, 2.0)));
       return weights;
+
+   } else {
+	   return weights;
    }
-
-   else if(phosphor_layout == 3){
-      // slot mask for RGB panels; looks okay at 1080p, looks better at 4K
-      // {magenta, green, black,   black},
-      // {magenta, green, magenta, green},
-      // {black,   black, magenta, green}
-
-      // GLSL can't do 2D arrays until version 430, so do this stupid thing instead for compatibility's sake:
-      // First lay out the horizontal pixels in arrays
-      vec3 slotmask_x1[4] = vec3[](magenta, green, black,   black);
-      vec3 slotmask_x2[4] = vec3[](magenta, green, magenta, green);
-      vec3 slotmask_x3[4] = vec3[](black,   black, magenta, green);
-
-      // find the vertical index
-      w = int(floor(mod(coord.y, 3.0)));
-
-      // find the horizontal index
-      z = int(floor(mod(coord.x, 4.0)));
-
-      // do a big, dumb comparison in place of a 2D array
-      weights = (w == 1) ? slotmask_x1[z] : (w == 2) ? slotmask_x2[z] :  slotmask_x3[z];
-    }
-
-   if(phosphor_layout == 4){
-      // classic aperture for RBG panels; good for 1080p, too small for 4K+
-      weights  = mix(yellow, blue, floor(mod(coord.x, 2.0)));
-      return weights;
-   }
-
-   else if(phosphor_layout == 5){
-      // 2x2 shadow mask for RBG panels; good for 1080p, too small for 4K+
-      vec3 inverse_aperture = mix(blue, yellow, floor(mod(coord.x, 2.0)));
-      weights               = mix(mix(yellow, blue, floor(mod(coord.x, 2.0))), inverse_aperture, floor(mod(coord.y, 2.0)));
-      return weights;
-   }
-
-   else if(phosphor_layout == 6){
-      // aperture_1_4_rgb; good for simulating lower
-      vec3 ap4[4] = vec3[](red, green, blue, black);
-
-      z = int(floor(mod(coord.x, 4.0)));
-
-      weights = ap4[z];
-      return weights;
-   }
-
-   else if(phosphor_layout == 7){
-      // aperture_2_5_bgr
-      vec3 ap3[5] = vec3[](red, magenta, blue, green, green);
-
-      z = int(floor(mod(coord.x, 5.0)));
-
-      weights = ap3[z];
-      return weights;
-   }
-
-   else if(phosphor_layout == 8){
-      // aperture_3_6_rgb
-
-      vec3 big_ap[7] = vec3[](red, red, yellow, green, cyan, blue, blue);
-
-      w = int(floor(mod(coord.x, 7.)));
-
-      weights = big_ap[w];
-      return weights;
-   }
-
-   else if(phosphor_layout == 9){
-      // reduced TVL aperture for RGB panels
-      // aperture_2_4_rgb
-
-      vec3 big_ap_rgb[4] = vec3[](red, yellow, cyan, blue);
-
-      w = int(floor(mod(coord.x, 4.)));
-
-      weights = big_ap_rgb[w];
-      return weights;
-   }
-
-   else if(phosphor_layout == 10){
-      // reduced TVL aperture for RBG panels
-
-      vec3 big_ap_rbg[4] = vec3[](red, magenta, cyan, green);
-
-      w = int(floor(mod(coord.x, 4.)));
-
-      weights = big_ap_rbg[w];
-      return weights;
-   }
-
-   else if(phosphor_layout == 11){
-      // delta_1_4x1_rgb; dunno why this is called 4x1 when it's obviously 4x2 /shrug
-      vec3 delta_1_1[4] = vec3[](red, green, blue, black);
-      vec3 delta_1_2[4] = vec3[](blue, black, red, green);
-
-      w = int(floor(mod(coord.y, 2.0)));
-      z = int(floor(mod(coord.x, 4.0)));
-
-      weights = (w == 1) ? delta_1_1[z] : delta_1_2[z];
-      return weights;
-   }
-
-   else if(phosphor_layout == 12){
-      // delta_2_4x1_rgb
-      vec3 delta_2_1[4] = vec3[](red, yellow, cyan, blue);
-      vec3 delta_2_2[4] = vec3[](cyan, blue, red, yellow);
-
-      z = int(floor(mod(coord.x, 4.0)));
-
-      weights = (w == 1) ? delta_2_1[z] : delta_2_2[z];
-      return weights;
-   }
-
-   else if(phosphor_layout == 13){
-      // delta_2_4x2_rgb
-      vec3 delta_1[4] = vec3[](red, yellow, cyan, blue);
-      vec3 delta_2[4] = vec3[](red, yellow, cyan, blue);
-      vec3 delta_3[4] = vec3[](cyan, blue, red, yellow);
-      vec3 delta_4[4] = vec3[](cyan, blue, red, yellow);
-
-      w = int(floor(mod(coord.y, 4.0)));
-      z = int(floor(mod(coord.x, 4.0)));
-
-      weights = (w == 1) ? delta_1[z] : (w == 2) ? delta_2[z] : (w == 3) ? delta_3[z] : delta_4[z];
-      return weights;
-   }
-
-   else if(phosphor_layout == 14){
-      // slot mask for RGB panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
-      // {magenta, green, black, black,   black, black},
-      // {magenta, green, black, magenta, green, black},
-      // {black,   black, black, magenta, green, black}
-      vec3 slot2_1[6] = vec3[](magenta, green, black, black,   black, black);
-      vec3 slot2_2[6] = vec3[](magenta, green, black, magenta, green, black);
-      vec3 slot2_3[6] = vec3[](black,   black, black, magenta, green, black);
-
-      w = int(floor(mod(coord.y, 3.0)));
-      z = int(floor(mod(coord.x, 6.0)));
-
-      weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
-      return weights;
-   }
-
-   else if(phosphor_layout == 15){
-      // slot_2_4x4_rgb
-      // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
-      // {red,   yellow, cyan,  blue,  black, black,  black, black},
-      // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
-      // {black, black,  black, black, red,   yellow, cyan,  blue }
-      vec3 slotmask_RBG_x1[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
-      vec3 slotmask_RBG_x2[8] = vec3[](red,   yellow, cyan,  blue,  black, black,  black, black);
-      vec3 slotmask_RBG_x3[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
-      vec3 slotmask_RBG_x4[8] = vec3[](black, black,  black, black, red,   yellow, cyan,  blue );
-
-      // find the vertical index
-      w = int(floor(mod(coord.y, 4.0)));
-
-      // find the horizontal index
-      z = int(floor(mod(coord.x, 8.0)));
-
-      weights = (w == 1) ? slotmask_RBG_x1[z] : (w == 2) ? slotmask_RBG_x2[z] : (w == 3) ? slotmask_RBG_x3[z] : slotmask_RBG_x4[z];
-      return weights;
-    }
-
-   else if(phosphor_layout == 16){
-      // slot mask for RBG panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
-      // {yellow, blue,  black,  black},
-      // {yellow, blue,  yellow, blue},
-      // {black,  black, yellow, blue}
-      vec3 slot2_1[4] = vec3[](yellow, blue,  black,  black);
-      vec3 slot2_2[4] = vec3[](yellow, blue,  yellow, blue);
-      vec3 slot2_3[4] = vec3[](black,  black, yellow, blue);
-
-      w = int(floor(mod(coord.y, 3.0)));
-      z = int(floor(mod(coord.x, 4.0)));
-
-      weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
-      return weights;
-   }
-
-   else if(phosphor_layout == 17){
-      // slot_2_5x4_bgr
-      // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
-      // {black, blue,    blue,  green, green, red,   red,     black, black, black},
-      // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
-      // {red,   red,     black, black, black, black, blue,    blue,  green, green}
-      vec3 slot_1[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
-      vec3 slot_2[10] = vec3[](black, blue,    blue,  green, green, red,   red,     black, black, black);
-      vec3 slot_3[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
-      vec3 slot_4[10] = vec3[](red,   red,     black, black, black, black, blue,    blue,  green, green);
-
-      w = int(floor(mod(coord.y, 4.0)));
-      z = int(floor(mod(coord.x, 10.0)));
-
-      weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
-      return weights;
-   }
-
-   else if(phosphor_layout == 18){
-      // same as above but for RBG panels
-      // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
-      // {black, green,  green, blue,  blue,  red,   red,    black, black, black},
-      // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
-      // {red,   red,    black, black, black, black, green,  green, blue,  blue }
-      vec3 slot_1[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
-      vec3 slot_2[10] = vec3[](black, green,  green, blue,  blue,  red,   red,    black, black, black);
-      vec3 slot_3[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
-      vec3 slot_4[10] = vec3[](red,   red,    black, black, black, black, green,  green, blue,  blue );
-
-      w = int(floor(mod(coord.y, 4.0)));
-      z = int(floor(mod(coord.x, 10.0)));
-
-      weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
-      return weights;
-   }
-
-   else if(phosphor_layout == 19){
-      // slot_3_7x6_rgb
-      // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-      // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-      // {red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black},
-      // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-      // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-      // {black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue}
-
-      vec3 slot_1[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-      vec3 slot_2[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-      vec3 slot_3[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black);
-      vec3 slot_4[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-      vec3 slot_5[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-      vec3 slot_6[14] = vec3[](black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue);
-
-      w = int(floor(mod(coord.y, 6.0)));
-      z = int(floor(mod(coord.x, 14.0)));
-
-      weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : (w == 4) ? slot_4[z] : (w == 5) ? slot_5[z] : slot_6[z];
-      return weights;
-   }
-
-   else return weights;
 }
 
 vec4 add_vga_overlay(vec4 color, float scanlineStrengthMin, float scanlineStrengthMax, float color_boost_even, float color_boost_odd, float mask_strength) {

--- a/contrib/resources/glshaders/crt/vga-1080p.glsl
+++ b/contrib/resources/glshaders/crt/vga-1080p.glsl
@@ -59,275 +59,31 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout){
    vec3 weights = vec3(1.,1.,1.);
    float on = 1.;
    float off = 1.-mask_intensity;
-   vec3 red     = vec3(on,  off, off);
    vec3 green   = vec3(off, on,  off);
-   vec3 blue    = vec3(off, off, on );
    vec3 magenta = vec3(on,  off, on );
-   vec3 yellow  = vec3(on,  on,  off);
-   vec3 cyan    = vec3(off, on,  on );
-   vec3 black   = vec3(off, off, off);
-   vec3 white   = vec3(on,  on,  on );
-   int w, z = 0;
 
    // This pattern is used by a few layouts, so we'll define it here
    vec3 aperture_weights = mix(magenta, green, floor(mod(coord.x, 2.0)));
 
-   if(phosphor_layout == 0) return weights;
+   if (phosphor_layout == 0) {
+	   return weights;
 
-   else if(phosphor_layout == 1){
+   } else if (phosphor_layout == 1) {
       // classic aperture for RGB panels; good for 1080p, too small for 4K+
       // aka aperture_1_2_bgr
       weights  = aperture_weights;
       return weights;
-   }
 
-   else if(phosphor_layout == 2){
+   } else if (phosphor_layout == 2) {
       // 2x2 shadow mask for RGB panels; good for 1080p, too small for 4K+
       // aka delta_1_2x1_bgr
       vec3 inverse_aperture = mix(green, magenta, floor(mod(coord.x, 2.0)));
       weights               = mix(aperture_weights, inverse_aperture, floor(mod(coord.y, 2.0)));
       return weights;
+
+   } else {
+	   return weights;
    }
-
-   else if(phosphor_layout == 3){
-      // slot mask for RGB panels; looks okay at 1080p, looks better at 4K
-      // {magenta, green, black,   black},
-      // {magenta, green, magenta, green},
-      // {black,   black, magenta, green}
-
-      // GLSL can't do 2D arrays until version 430, so do this stupid thing instead for compatibility's sake:
-      // First lay out the horizontal pixels in arrays
-      vec3 slotmask_x1[4] = vec3[](magenta, green, black,   black);
-      vec3 slotmask_x2[4] = vec3[](magenta, green, magenta, green);
-      vec3 slotmask_x3[4] = vec3[](black,   black, magenta, green);
-
-      // find the vertical index
-      w = int(floor(mod(coord.y, 3.0)));
-
-      // find the horizontal index
-      z = int(floor(mod(coord.x, 4.0)));
-
-      // do a big, dumb comparison in place of a 2D array
-      weights = (w == 1) ? slotmask_x1[z] : (w == 2) ? slotmask_x2[z] :  slotmask_x3[z];
-    }
-
-   if(phosphor_layout == 4){
-      // classic aperture for RBG panels; good for 1080p, too small for 4K+
-      weights  = mix(yellow, blue, floor(mod(coord.x, 2.0)));
-      return weights;
-   }
-
-   else if(phosphor_layout == 5){
-      // 2x2 shadow mask for RBG panels; good for 1080p, too small for 4K+
-      vec3 inverse_aperture = mix(blue, yellow, floor(mod(coord.x, 2.0)));
-      weights               = mix(mix(yellow, blue, floor(mod(coord.x, 2.0))), inverse_aperture, floor(mod(coord.y, 2.0)));
-      return weights;
-   }
-
-   else if(phosphor_layout == 6){
-      // aperture_1_4_rgb; good for simulating lower
-      vec3 ap4[4] = vec3[](red, green, blue, black);
-
-      z = int(floor(mod(coord.x, 4.0)));
-
-      weights = ap4[z];
-      return weights;
-   }
-
-   else if(phosphor_layout == 7){
-      // aperture_2_5_bgr
-      vec3 ap3[5] = vec3[](red, magenta, blue, green, green);
-
-      z = int(floor(mod(coord.x, 5.0)));
-
-      weights = ap3[z];
-      return weights;
-   }
-
-   else if(phosphor_layout == 8){
-      // aperture_3_6_rgb
-
-      vec3 big_ap[7] = vec3[](red, red, yellow, green, cyan, blue, blue);
-
-      w = int(floor(mod(coord.x, 7.)));
-
-      weights = big_ap[w];
-      return weights;
-   }
-
-   else if(phosphor_layout == 9){
-      // reduced TVL aperture for RGB panels
-      // aperture_2_4_rgb
-
-      vec3 big_ap_rgb[4] = vec3[](red, yellow, cyan, blue);
-
-      w = int(floor(mod(coord.x, 4.)));
-
-      weights = big_ap_rgb[w];
-      return weights;
-   }
-
-   else if(phosphor_layout == 10){
-      // reduced TVL aperture for RBG panels
-
-      vec3 big_ap_rbg[4] = vec3[](red, magenta, cyan, green);
-
-      w = int(floor(mod(coord.x, 4.)));
-
-      weights = big_ap_rbg[w];
-      return weights;
-   }
-
-   else if(phosphor_layout == 11){
-      // delta_1_4x1_rgb; dunno why this is called 4x1 when it's obviously 4x2 /shrug
-      vec3 delta_1_1[4] = vec3[](red, green, blue, black);
-      vec3 delta_1_2[4] = vec3[](blue, black, red, green);
-
-      w = int(floor(mod(coord.y, 2.0)));
-      z = int(floor(mod(coord.x, 4.0)));
-
-      weights = (w == 1) ? delta_1_1[z] : delta_1_2[z];
-      return weights;
-   }
-
-   else if(phosphor_layout == 12){
-      // delta_2_4x1_rgb
-      vec3 delta_2_1[4] = vec3[](red, yellow, cyan, blue);
-      vec3 delta_2_2[4] = vec3[](cyan, blue, red, yellow);
-
-      z = int(floor(mod(coord.x, 4.0)));
-
-      weights = (w == 1) ? delta_2_1[z] : delta_2_2[z];
-      return weights;
-   }
-
-   else if(phosphor_layout == 13){
-      // delta_2_4x2_rgb
-      vec3 delta_1[4] = vec3[](red, yellow, cyan, blue);
-      vec3 delta_2[4] = vec3[](red, yellow, cyan, blue);
-      vec3 delta_3[4] = vec3[](cyan, blue, red, yellow);
-      vec3 delta_4[4] = vec3[](cyan, blue, red, yellow);
-
-      w = int(floor(mod(coord.y, 4.0)));
-      z = int(floor(mod(coord.x, 4.0)));
-
-      weights = (w == 1) ? delta_1[z] : (w == 2) ? delta_2[z] : (w == 3) ? delta_3[z] : delta_4[z];
-      return weights;
-   }
-
-   else if(phosphor_layout == 14){
-      // slot mask for RGB panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
-      // {magenta, green, black, black,   black, black},
-      // {magenta, green, black, magenta, green, black},
-      // {black,   black, black, magenta, green, black}
-      vec3 slot2_1[6] = vec3[](magenta, green, black, black,   black, black);
-      vec3 slot2_2[6] = vec3[](magenta, green, black, magenta, green, black);
-      vec3 slot2_3[6] = vec3[](black,   black, black, magenta, green, black);
-
-      w = int(floor(mod(coord.y, 3.0)));
-      z = int(floor(mod(coord.x, 6.0)));
-
-      weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
-      return weights;
-   }
-
-   else if(phosphor_layout == 15){
-      // slot_2_4x4_rgb
-      // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
-      // {red,   yellow, cyan,  blue,  black, black,  black, black},
-      // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
-      // {black, black,  black, black, red,   yellow, cyan,  blue }
-      vec3 slotmask_RBG_x1[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
-      vec3 slotmask_RBG_x2[8] = vec3[](red,   yellow, cyan,  blue,  black, black,  black, black);
-      vec3 slotmask_RBG_x3[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
-      vec3 slotmask_RBG_x4[8] = vec3[](black, black,  black, black, red,   yellow, cyan,  blue );
-
-      // find the vertical index
-      w = int(floor(mod(coord.y, 4.0)));
-
-      // find the horizontal index
-      z = int(floor(mod(coord.x, 8.0)));
-
-      weights = (w == 1) ? slotmask_RBG_x1[z] : (w == 2) ? slotmask_RBG_x2[z] : (w == 3) ? slotmask_RBG_x3[z] : slotmask_RBG_x4[z];
-      return weights;
-    }
-
-   else if(phosphor_layout == 16){
-      // slot mask for RBG panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
-      // {yellow, blue,  black,  black},
-      // {yellow, blue,  yellow, blue},
-      // {black,  black, yellow, blue}
-      vec3 slot2_1[4] = vec3[](yellow, blue,  black,  black);
-      vec3 slot2_2[4] = vec3[](yellow, blue,  yellow, blue);
-      vec3 slot2_3[4] = vec3[](black,  black, yellow, blue);
-
-      w = int(floor(mod(coord.y, 3.0)));
-      z = int(floor(mod(coord.x, 4.0)));
-
-      weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
-      return weights;
-   }
-
-   else if(phosphor_layout == 17){
-      // slot_2_5x4_bgr
-      // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
-      // {black, blue,    blue,  green, green, red,   red,     black, black, black},
-      // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
-      // {red,   red,     black, black, black, black, blue,    blue,  green, green}
-      vec3 slot_1[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
-      vec3 slot_2[10] = vec3[](black, blue,    blue,  green, green, red,   red,     black, black, black);
-      vec3 slot_3[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
-      vec3 slot_4[10] = vec3[](red,   red,     black, black, black, black, blue,    blue,  green, green);
-
-      w = int(floor(mod(coord.y, 4.0)));
-      z = int(floor(mod(coord.x, 10.0)));
-
-      weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
-      return weights;
-   }
-
-   else if(phosphor_layout == 18){
-      // same as above but for RBG panels
-      // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
-      // {black, green,  green, blue,  blue,  red,   red,    black, black, black},
-      // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
-      // {red,   red,    black, black, black, black, green,  green, blue,  blue }
-      vec3 slot_1[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
-      vec3 slot_2[10] = vec3[](black, green,  green, blue,  blue,  red,   red,    black, black, black);
-      vec3 slot_3[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
-      vec3 slot_4[10] = vec3[](red,   red,    black, black, black, black, green,  green, blue,  blue );
-
-      w = int(floor(mod(coord.y, 4.0)));
-      z = int(floor(mod(coord.x, 10.0)));
-
-      weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
-      return weights;
-   }
-
-   else if(phosphor_layout == 19){
-      // slot_3_7x6_rgb
-      // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-      // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-      // {red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black},
-      // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-      // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-      // {black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue}
-
-      vec3 slot_1[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-      vec3 slot_2[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-      vec3 slot_3[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black);
-      vec3 slot_4[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-      vec3 slot_5[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-      vec3 slot_6[14] = vec3[](black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue);
-
-      w = int(floor(mod(coord.y, 6.0)));
-      z = int(floor(mod(coord.x, 14.0)));
-
-      weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : (w == 4) ? slot_4[z] : (w == 5) ? slot_5[z] : slot_6[z];
-      return weights;
-   }
-
-   else return weights;
 }
 
 vec4 add_vga_overlay(vec4 color, float scanlineStrengthMin, float scanlineStrengthMax, float color_boost_even, float color_boost_odd, float mask_strength) {

--- a/contrib/resources/glshaders/crt/vga-1080p.glsl
+++ b/contrib/resources/glshaders/crt/vga-1080p.glsl
@@ -66,7 +66,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout){
    vec3 aperture_weights = mix(magenta, green, floor(mod(coord.x, 2.0)));
 
    if (phosphor_layout == 0) {
-	   return weights;
+       return weights;
 
    } else if (phosphor_layout == 1) {
       // classic aperture for RGB panels; good for 1080p, too small for 4K+
@@ -82,7 +82,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout){
       return weights;
 
    } else {
-	   return weights;
+       return weights;
    }
 }
 

--- a/contrib/resources/glshaders/crt/vga-1440p.glsl
+++ b/contrib/resources/glshaders/crt/vga-1440p.glsl
@@ -273,11 +273,18 @@ vec3 YxytoXYZ(vec3 Yxy) {
 
     Many of these mask arrays are adapted from cgwg's crt-geom-deluxe LUTs, and
     those have their filenames included for easy identification
+
+	NOTE: Having too many branches result in a black screen (but no
+	compilation errors) on some older GPUs such as the Intel HD 4000 iGPU. So
+	we're commenting out the branches that are not used by the adaptive CRT
+	shaders.
 */
 vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
     vec3 weights = vec3(1.,1.,1.);
+
     float on = 1.;
     float off = 1.-mask_intensity;
+
     vec3 red     = vec3(on,  off, off);
     vec3 green   = vec3(off, on,  off);
     vec3 blue    = vec3(off, off, on );
@@ -286,6 +293,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
     vec3 cyan    = vec3(off, on,  on );
     vec3 black   = vec3(off, off, off);
     vec3 white   = vec3(on,  on,  on );
+
     int w, z = 0;
 
     // This pattern is used by a few layouts, so we'll define it here
@@ -293,21 +301,25 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
     if (phosphor_layout == 0) {
         return weights;
+	}
 
-    } else if (phosphor_layout == 1) {
-        // classic aperture for RGB panels; good for 1080p, too small for 4K+
+    else if (phosphor_layout == 1) {
+    	// classic aperture for RGB panels; good for 1080p, too small for 4K+
         // aka aperture_1_2_bgr
         weights  = aperture_weights;
         return weights;
+	}
 
-    } else if (phosphor_layout == 2) {
+    else if (phosphor_layout == 2) {
         // 2x2 shadow mask for RGB panels; good for 1080p, too small for 4K+
         // aka delta_1_2x1_bgr
         vec3 inverse_aperture = mix(green, magenta, floor(mod(coord.x, 2.0)));
         weights               = mix(aperture_weights, inverse_aperture, floor(mod(coord.y, 2.0)));
         return weights;
+	}
 
-    } else if (phosphor_layout == 3) {
+/*
+    else if (phosphor_layout == 3) {
         // slot mask for RGB panels; looks okay at 1080p, looks better at 4K
         // {magenta, green, black,   black},
         // {magenta, green, magenta, green},
@@ -327,14 +339,16 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         // do a big, dumb comparison in place of a 2D array
         weights = (w == 1) ? slotmask_x1[z] : (w == 2) ? slotmask_x2[z] :  slotmask_x3[z];
+		return weights;
     }
-
-    if (phosphor_layout == 4) {
+*/
+    else if (phosphor_layout == 4) {
         // classic aperture for RBG panels; good for 1080p, too small for 4K+
         weights  = mix(yellow, blue, floor(mod(coord.x, 2.0)));
         return weights;
-
-    } else if (phosphor_layout == 5) {
+	}
+/*
+    else if (phosphor_layout == 5) {
         // 2x2 shadow mask for RBG panels; good for 1080p, too small for 4K+
         vec3 inverse_aperture = mix(blue, yellow, floor(mod(coord.x, 2.0)));
 
@@ -344,8 +358,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
             floor(mod(coord.y, 2.0))
         );
         return weights;
-
-    } else if (phosphor_layout == 6) {
+	}
+*/
+/*
+    else if (phosphor_layout == 6) {
         // aperture_1_4_rgb; good for simulating lower
         vec3 ap4[4] = vec3[](red, green, blue, black);
 
@@ -353,8 +369,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = ap4[z];
         return weights;
-
-    } else if (phosphor_layout == 7) {
+	}
+*/
+/*
+    else if (phosphor_layout == 7) {
         // aperture_2_5_bgr
         vec3 ap3[5] = vec3[](red, magenta, blue, green, green);
 
@@ -362,8 +380,9 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = ap3[z];
         return weights;
-
-    } else if (phosphor_layout == 8){
+*/
+/*
+    else if (phosphor_layout == 8) {
         // aperture_3_6_rgb
         vec3 big_ap[7] = vec3[](red, red, yellow, green, cyan, blue, blue);
 
@@ -371,8 +390,9 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap[w];
         return weights;
-
-    } else if (phosphor_layout == 9) {
+	}
+*/
+    else if (phosphor_layout == 9) {
         // reduced TVL aperture for RGB panels
         // aperture_2_4_rgb
         vec3 big_ap_rgb[4] = vec3[](red, yellow, cyan, blue);
@@ -381,8 +401,9 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rgb[w];
         return weights;
-
-    } else if (phosphor_layout == 10) {
+	}
+/*
+    else if (phosphor_layout == 10) {
         // reduced TVL aperture for RBG panels
         vec3 big_ap_rbg[4] = vec3[](red, magenta, cyan, green);
 
@@ -390,148 +411,161 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rbg[w];
         return weights;
+	}
+*/
+    else if(phosphor_layout == 11) {
+        // delta_1_4x1_rgb; dunno why this is called 4x1 when it's obviously 4x2 /shrug
+        vec3 delta_1_1[4] = vec3[](red, green, blue, black);
+        vec3 delta_1_2[4] = vec3[](blue, black, red, green);
 
-    } else if(phosphor_layout == 11){
-       // delta_1_4x1_rgb; dunno why this is called 4x1 when it's obviously 4x2 /shrug
-       vec3 delta_1_1[4] = vec3[](red, green, blue, black);
-       vec3 delta_1_2[4] = vec3[](blue, black, red, green);
+        w = int(floor(mod(coord.y, 2.0)));
+        z = int(floor(mod(coord.x, 4.0)));
 
-       w = int(floor(mod(coord.y, 2.0)));
-       z = int(floor(mod(coord.x, 4.0)));
+        weights = (w == 1) ? delta_1_1[z] : delta_1_2[z];
+        return weights;
+    }
+/*
+    else if (phosphor_layout == 12) {
+        // delta_2_4x1_rgb
+        vec3 delta_2_1[4] = vec3[](red, yellow, cyan, blue);
+        vec3 delta_2_2[4] = vec3[](cyan, blue, red, yellow);
 
-       weights = (w == 1) ? delta_1_1[z] : delta_1_2[z];
-       return weights;
+        z = int(floor(mod(coord.x, 4.0)));
 
-    } else if(phosphor_layout == 12){
-       // delta_2_4x1_rgb
-       vec3 delta_2_1[4] = vec3[](red, yellow, cyan, blue);
-       vec3 delta_2_2[4] = vec3[](cyan, blue, red, yellow);
+        weights = (w == 1) ? delta_2_1[z] : delta_2_2[z];
+        return weights;
+	}
+*/
+/*
+    else if (phosphor_layout == 13) {
+        // delta_2_4x2_rgb
+        vec3 delta_1[4] = vec3[](red, yellow, cyan, blue);
+        vec3 delta_2[4] = vec3[](red, yellow, cyan, blue);
+        vec3 delta_3[4] = vec3[](cyan, blue, red, yellow);
+        vec3 delta_4[4] = vec3[](cyan, blue, red, yellow);
 
-       z = int(floor(mod(coord.x, 4.0)));
+        w = int(floor(mod(coord.y, 4.0)));
+        z = int(floor(mod(coord.x, 4.0)));
 
-       weights = (w == 1) ? delta_2_1[z] : delta_2_2[z];
-       return weights;
+        weights = (w == 1) ? delta_1[z] : (w == 2) ? delta_2[z] : (w == 3) ? delta_3[z] : delta_4[z];
+        return weights;
+    }
+*/
+    else if (phosphor_layout == 14) {
+        // slot mask for RGB panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
+        // {magenta, green, black, black,   black, black},
+        // {magenta, green, black, magenta, green, black},
+        // {black,   black, black, magenta, green, black}
+        vec3 slot2_1[6] = vec3[](magenta, green, black, black,   black, black);
+        vec3 slot2_2[6] = vec3[](magenta, green, black, magenta, green, black);
+        vec3 slot2_3[6] = vec3[](black,   black, black, magenta, green, black);
 
-    } else if(phosphor_layout == 13){
-       // delta_2_4x2_rgb
-       vec3 delta_1[4] = vec3[](red, yellow, cyan, blue);
-       vec3 delta_2[4] = vec3[](red, yellow, cyan, blue);
-       vec3 delta_3[4] = vec3[](cyan, blue, red, yellow);
-       vec3 delta_4[4] = vec3[](cyan, blue, red, yellow);
+        w = int(floor(mod(coord.y, 3.0)));
+        z = int(floor(mod(coord.x, 6.0)));
 
-       w = int(floor(mod(coord.y, 4.0)));
-       z = int(floor(mod(coord.x, 4.0)));
+        weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
+        return weights;
+    }
+/*
+    else if(phosphor_layout == 15) {
+        // slot_2_4x4_rgb
+        // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
+        // {red,   yellow, cyan,  blue,  black, black,  black, black},
+        // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
+        // {black, black,  black, black, red,   yellow, cyan,  blue }
+        vec3 slotmask_RBG_x1[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
+        vec3 slotmask_RBG_x2[8] = vec3[](red,   yellow, cyan,  blue,  black, black,  black, black);
+        vec3 slotmask_RBG_x3[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
+        vec3 slotmask_RBG_x4[8] = vec3[](black, black,  black, black, red,   yellow, cyan,  blue );
 
-       weights = (w == 1) ? delta_1[z] : (w == 2) ? delta_2[z] : (w == 3) ? delta_3[z] : delta_4[z];
-       return weights;
+        // find the vertical index
+        w = int(floor(mod(coord.y, 4.0)));
 
-    } else if(phosphor_layout == 14){
-       // slot mask for RGB panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
-       // {magenta, green, black, black,   black, black},
-       // {magenta, green, black, magenta, green, black},
-       // {black,   black, black, magenta, green, black}
-       vec3 slot2_1[6] = vec3[](magenta, green, black, black,   black, black);
-       vec3 slot2_2[6] = vec3[](magenta, green, black, magenta, green, black);
-       vec3 slot2_3[6] = vec3[](black,   black, black, magenta, green, black);
+        // find the horizontal index
+        z = int(floor(mod(coord.x, 8.0)));
 
-       w = int(floor(mod(coord.y, 3.0)));
-       z = int(floor(mod(coord.x, 6.0)));
+        weights = (w == 1) ? slotmask_RBG_x1[z] : (w == 2) ? slotmask_RBG_x2[z] : (w == 3) ? slotmask_RBG_x3[z] : slotmask_RBG_x4[z];
+        return weights;
+	}
+*/
+/*
+	else if(phosphor_layout == 16) {
+        // slot mask for RBG panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
+        // {yellow, blue,  black,  black},
+        // {yellow, blue,  yellow, blue},
+        // {black,  black, yellow, blue}
+        vec3 slot2_1[4] = vec3[](yellow, blue,  black,  black);
+        vec3 slot2_2[4] = vec3[](yellow, blue,  yellow, blue);
+        vec3 slot2_3[4] = vec3[](black,  black, yellow, blue);
 
-       weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
-       return weights;
+        w = int(floor(mod(coord.y, 3.0)));
+        z = int(floor(mod(coord.x, 4.0)));
 
-    } else if(phosphor_layout == 15){
-       // slot_2_4x4_rgb
-       // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
-       // {red,   yellow, cyan,  blue,  black, black,  black, black},
-       // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
-       // {black, black,  black, black, red,   yellow, cyan,  blue }
-       vec3 slotmask_RBG_x1[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
-       vec3 slotmask_RBG_x2[8] = vec3[](red,   yellow, cyan,  blue,  black, black,  black, black);
-       vec3 slotmask_RBG_x3[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
-       vec3 slotmask_RBG_x4[8] = vec3[](black, black,  black, black, red,   yellow, cyan,  blue );
+        weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
+        return weights;
+    }
+*/
+	else if (phosphor_layout == 17) {
+        // slot_2_5x4_bgr
+        // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
+        // {black, blue,    blue,  green, green, red,   red,     black, black, black},
+        // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
+        // {red,   red,     black, black, black, black, blue,    blue,  green, green}
+        vec3 slot_1[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
+        vec3 slot_2[10] = vec3[](black, blue,    blue,  green, green, red,   red,     black, black, black);
+        vec3 slot_3[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
+        vec3 slot_4[10] = vec3[](red,   red,     black, black, black, black, blue,    blue,  green, green);
 
-       // find the vertical index
-       w = int(floor(mod(coord.y, 4.0)));
+        w = int(floor(mod(coord.y, 4.0)));
+        z = int(floor(mod(coord.x, 10.0)));
 
-       // find the horizontal index
-       z = int(floor(mod(coord.x, 8.0)));
+        weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
+        return weights;
+    }
+/*
+    else if (phosphor_layout == 18) {
+        // same as above but for RBG panels
+        // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
+        // {black, green,  green, blue,  blue,  red,   red,    black, black, black},
+        // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
+        // {red,   red,    black, black, black, black, green,  green, blue,  blue }
+        vec3 slot_1[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
+        vec3 slot_2[10] = vec3[](black, green,  green, blue,  blue,  red,   red,    black, black, black);
+        vec3 slot_3[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
+        vec3 slot_4[10] = vec3[](red,   red,    black, black, black, black, green,  green, blue,  blue );
 
-       weights = (w == 1) ? slotmask_RBG_x1[z] : (w == 2) ? slotmask_RBG_x2[z] : (w == 3) ? slotmask_RBG_x3[z] : slotmask_RBG_x4[z];
-       return weights;
+        w = int(floor(mod(coord.y, 4.0)));
+        z = int(floor(mod(coord.x, 10.0)));
 
-     } else if(phosphor_layout == 16){
-       // slot mask for RBG panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
-       // {yellow, blue,  black,  black},
-       // {yellow, blue,  yellow, blue},
-       // {black,  black, yellow, blue}
-       vec3 slot2_1[4] = vec3[](yellow, blue,  black,  black);
-       vec3 slot2_2[4] = vec3[](yellow, blue,  yellow, blue);
-       vec3 slot2_3[4] = vec3[](black,  black, yellow, blue);
+        weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
+        return weights;
+    }
+*/
+/*
+    else if(phosphor_layout == 19) {
+        // slot_3_7x6_rgb
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue}
 
-       w = int(floor(mod(coord.y, 3.0)));
-       z = int(floor(mod(coord.x, 4.0)));
+        vec3 slot_1[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_2[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_3[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black);
+        vec3 slot_4[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_5[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_6[14] = vec3[](black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue);
 
-       weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
-       return weights;
+        w = int(floor(mod(coord.y, 6.0)));
+        z = int(floor(mod(coord.x, 14.0)));
 
-    } else if (phosphor_layout == 17) {
-       // slot_2_5x4_bgr
-       // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
-       // {black, blue,    blue,  green, green, red,   red,     black, black, black},
-       // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
-       // {red,   red,     black, black, black, black, blue,    blue,  green, green}
-       vec3 slot_1[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
-       vec3 slot_2[10] = vec3[](black, blue,    blue,  green, green, red,   red,     black, black, black);
-       vec3 slot_3[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
-       vec3 slot_4[10] = vec3[](red,   red,     black, black, black, black, blue,    blue,  green, green);
-
-       w = int(floor(mod(coord.y, 4.0)));
-       z = int(floor(mod(coord.x, 10.0)));
-
-       weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
-       return weights;
-
-    } else if (phosphor_layout == 18) {
-       // same as above but for RBG panels
-       // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
-       // {black, green,  green, blue,  blue,  red,   red,    black, black, black},
-       // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
-       // {red,   red,    black, black, black, black, green,  green, blue,  blue }
-       vec3 slot_1[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
-       vec3 slot_2[10] = vec3[](black, green,  green, blue,  blue,  red,   red,    black, black, black);
-       vec3 slot_3[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
-       vec3 slot_4[10] = vec3[](red,   red,    black, black, black, black, green,  green, blue,  blue );
-
-       w = int(floor(mod(coord.y, 4.0)));
-       z = int(floor(mod(coord.x, 10.0)));
-
-       weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
-       return weights;
-
-    } else if(phosphor_layout == 19) {
-       // slot_3_7x6_rgb
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue}
-
-       vec3 slot_1[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_2[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_3[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black);
-       vec3 slot_4[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_5[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_6[14] = vec3[](black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue);
-
-       w = int(floor(mod(coord.y, 6.0)));
-       z = int(floor(mod(coord.x, 14.0)));
-
-       weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : (w == 4) ? slot_4[z] : (w == 5) ? slot_5[z] : slot_6[z];
-       return weights;
-
-    } else {
+        weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : (w == 4) ? slot_4[z] : (w == 5) ? slot_5[z] : slot_6[z];
+        return weights;
+     }
+*/
+	else {
         return weights;
     }
 }

--- a/contrib/resources/glshaders/crt/vga-1440p.glsl
+++ b/contrib/resources/glshaders/crt/vga-1440p.glsl
@@ -167,10 +167,10 @@ uniform PRECISION float BLUE_SHIFT;
 
 #define WP_ADJUST           0.00
 #define TEMPERATURE      9300.00
-#define LUMA_PRESERVE 		1.00
-#define RED_SHIFT 			0.00
-#define GREEN_SHIFT 		0.00
-#define BLUE_SHIFT 			0.00
+#define LUMA_PRESERVE       1.00
+#define RED_SHIFT           0.00
+#define GREEN_SHIFT         0.00
+#define BLUE_SHIFT          0.00
 #endif
 // END PARAMETERS //
 
@@ -274,10 +274,10 @@ vec3 YxytoXYZ(vec3 Yxy) {
     Many of these mask arrays are adapted from cgwg's crt-geom-deluxe LUTs, and
     those have their filenames included for easy identification
 
-	NOTE: Having too many branches result in a black screen (but no
-	compilation errors) on some older GPUs such as the Intel HD 4000 iGPU. So
-	we're commenting out the branches that are not used by the adaptive CRT
-	shaders.
+    NOTE: Having too many branches result in a black screen (but no
+    compilation errors) on some older GPUs such as the Intel HD 4000 iGPU. So
+    we're commenting out the branches that are not used by the adaptive CRT
+    shaders.
 */
 vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
     vec3 weights = vec3(1.,1.,1.);
@@ -301,14 +301,14 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
     if (phosphor_layout == 0) {
         return weights;
-	}
+    }
 
     else if (phosphor_layout == 1) {
-    	// classic aperture for RGB panels; good for 1080p, too small for 4K+
+        // classic aperture for RGB panels; good for 1080p, too small for 4K+
         // aka aperture_1_2_bgr
         weights  = aperture_weights;
         return weights;
-	}
+    }
 
     else if (phosphor_layout == 2) {
         // 2x2 shadow mask for RGB panels; good for 1080p, too small for 4K+
@@ -316,7 +316,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
         vec3 inverse_aperture = mix(green, magenta, floor(mod(coord.x, 2.0)));
         weights               = mix(aperture_weights, inverse_aperture, floor(mod(coord.y, 2.0)));
         return weights;
-	}
+    }
 
 /*
     else if (phosphor_layout == 3) {
@@ -339,14 +339,14 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         // do a big, dumb comparison in place of a 2D array
         weights = (w == 1) ? slotmask_x1[z] : (w == 2) ? slotmask_x2[z] :  slotmask_x3[z];
-		return weights;
+        return weights;
     }
 */
     else if (phosphor_layout == 4) {
         // classic aperture for RBG panels; good for 1080p, too small for 4K+
         weights  = mix(yellow, blue, floor(mod(coord.x, 2.0)));
         return weights;
-	}
+    }
 /*
     else if (phosphor_layout == 5) {
         // 2x2 shadow mask for RBG panels; good for 1080p, too small for 4K+
@@ -358,7 +358,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
             floor(mod(coord.y, 2.0))
         );
         return weights;
-	}
+    }
 */
 /*
     else if (phosphor_layout == 6) {
@@ -369,7 +369,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = ap4[z];
         return weights;
-	}
+    }
 */
 /*
     else if (phosphor_layout == 7) {
@@ -390,7 +390,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap[w];
         return weights;
-	}
+    }
 */
     else if (phosphor_layout == 9) {
         // reduced TVL aperture for RGB panels
@@ -401,7 +401,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rgb[w];
         return weights;
-	}
+    }
 /*
     else if (phosphor_layout == 10) {
         // reduced TVL aperture for RBG panels
@@ -411,7 +411,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rbg[w];
         return weights;
-	}
+    }
 */
     else if(phosphor_layout == 11) {
         // delta_1_4x1_rgb; dunno why this is called 4x1 when it's obviously 4x2 /shrug
@@ -434,7 +434,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = (w == 1) ? delta_2_1[z] : delta_2_2[z];
         return weights;
-	}
+    }
 */
 /*
     else if (phosphor_layout == 13) {
@@ -486,10 +486,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = (w == 1) ? slotmask_RBG_x1[z] : (w == 2) ? slotmask_RBG_x2[z] : (w == 3) ? slotmask_RBG_x3[z] : slotmask_RBG_x4[z];
         return weights;
-	}
+    }
 */
 /*
-	else if(phosphor_layout == 16) {
+    else if(phosphor_layout == 16) {
         // slot mask for RBG panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
         // {yellow, blue,  black,  black},
         // {yellow, blue,  yellow, blue},
@@ -505,7 +505,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
         return weights;
     }
 */
-	else if (phosphor_layout == 17) {
+    else if (phosphor_layout == 17) {
         // slot_2_5x4_bgr
         // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
         // {black, blue,    blue,  green, green, red,   red,     black, black, black},
@@ -565,7 +565,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
         return weights;
      }
 */
-	else {
+    else {
         return weights;
     }
 }
@@ -585,10 +585,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 // For more info, see: http://www.imagemagick.org/Usage/img_diagrams/cubic_survey.gif
 mat4x4 get_hfilter_profile()
 {
-	float bf = 0.0;
-	float cf = 0.0;
+    float bf = 0.0;
+    float cf = 0.0;
 
-	if (HFILTER_PROFILE == 1) {
+    if (HFILTER_PROFILE == 1) {
         bf = 0.0;
         cf = 0.5;
     }
@@ -690,14 +690,14 @@ void main()
     mask_coords = mix(mask_coords.xy, mask_coords.yx, VSCANLINES);
     color.rgb *= mask_weights(mask_coords, MASK_INTENSITY, int(PHOSPHOR_LAYOUT));
 
-	// Colour temperature
-	if (WP_ADJUST == 1.0) {
-		vec3 wp_adjusted = wp_adjust(color.rgb);
-		vec3 base_luma = XYZtoYxy(sRGB_to_XYZ(color.rgb));
-		vec3 adjusted_luma = XYZtoYxy(sRGB_to_XYZ(wp_adjusted));
-		wp_adjusted = (LUMA_PRESERVE == 1.0) ? adjusted_luma + (vec3(base_luma.r,0.,0.) - vec3(adjusted_luma.r,0.,0.)) : adjusted_luma;
-		color = vec4(XYZ_to_sRGB(YxytoXYZ(wp_adjusted)), 1.0);
-	}
+    // Colour temperature
+    if (WP_ADJUST == 1.0) {
+        vec3 wp_adjusted = wp_adjust(color.rgb);
+        vec3 base_luma = XYZtoYxy(sRGB_to_XYZ(color.rgb));
+        vec3 adjusted_luma = XYZtoYxy(sRGB_to_XYZ(wp_adjusted));
+        wp_adjusted = (LUMA_PRESERVE == 1.0) ? adjusted_luma + (vec3(base_luma.r,0.,0.) - vec3(adjusted_luma.r,0.,0.)) : adjusted_luma;
+        color = vec4(XYZ_to_sRGB(YxytoXYZ(wp_adjusted)), 1.0);
+    }
 
     // Output gamma
     color = clamp(GAMMA_OUT(color), 0.0, 1.0);

--- a/contrib/resources/glshaders/crt/vga-4k.glsl
+++ b/contrib/resources/glshaders/crt/vga-4k.glsl
@@ -246,7 +246,6 @@ vec3 YxytoXYZ(vec3 Yxy) {
     return XYZ;
 }
 
-
 /*
     A collection of CRT mask effects that work with LCD subpixel structures for
     small details
@@ -273,11 +272,18 @@ vec3 YxytoXYZ(vec3 Yxy) {
 
     Many of these mask arrays are adapted from cgwg's crt-geom-deluxe LUTs, and
     those have their filenames included for easy identification
+
+	NOTE: Having too many branches result in a black screen (but no
+	compilation errors) on some older GPUs such as the Intel HD 4000 iGPU. So
+	we're commenting out the branches that are not used by the adaptive CRT
+	shaders.
 */
 vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
     vec3 weights = vec3(1.,1.,1.);
+
     float on = 1.;
     float off = 1.-mask_intensity;
+
     vec3 red     = vec3(on,  off, off);
     vec3 green   = vec3(off, on,  off);
     vec3 blue    = vec3(off, off, on );
@@ -286,6 +292,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
     vec3 cyan    = vec3(off, on,  on );
     vec3 black   = vec3(off, off, off);
     vec3 white   = vec3(on,  on,  on );
+
     int w, z = 0;
 
     // This pattern is used by a few layouts, so we'll define it here
@@ -293,21 +300,25 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
     if (phosphor_layout == 0) {
         return weights;
+	}
 
-    } else if (phosphor_layout == 1) {
-        // classic aperture for RGB panels; good for 1080p, too small for 4K+
+    else if (phosphor_layout == 1) {
+    	// classic aperture for RGB panels; good for 1080p, too small for 4K+
         // aka aperture_1_2_bgr
         weights  = aperture_weights;
         return weights;
+	}
 
-    } else if (phosphor_layout == 2) {
+    else if (phosphor_layout == 2) {
         // 2x2 shadow mask for RGB panels; good for 1080p, too small for 4K+
         // aka delta_1_2x1_bgr
         vec3 inverse_aperture = mix(green, magenta, floor(mod(coord.x, 2.0)));
         weights               = mix(aperture_weights, inverse_aperture, floor(mod(coord.y, 2.0)));
         return weights;
+	}
 
-    } else if (phosphor_layout == 3) {
+/*
+    else if (phosphor_layout == 3) {
         // slot mask for RGB panels; looks okay at 1080p, looks better at 4K
         // {magenta, green, black,   black},
         // {magenta, green, magenta, green},
@@ -327,14 +338,16 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         // do a big, dumb comparison in place of a 2D array
         weights = (w == 1) ? slotmask_x1[z] : (w == 2) ? slotmask_x2[z] :  slotmask_x3[z];
+		return weights;
     }
-
-    if (phosphor_layout == 4) {
+*/
+    else if (phosphor_layout == 4) {
         // classic aperture for RBG panels; good for 1080p, too small for 4K+
         weights  = mix(yellow, blue, floor(mod(coord.x, 2.0)));
         return weights;
-
-    } else if (phosphor_layout == 5) {
+	}
+/*
+    else if (phosphor_layout == 5) {
         // 2x2 shadow mask for RBG panels; good for 1080p, too small for 4K+
         vec3 inverse_aperture = mix(blue, yellow, floor(mod(coord.x, 2.0)));
 
@@ -344,8 +357,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
             floor(mod(coord.y, 2.0))
         );
         return weights;
-
-    } else if (phosphor_layout == 6) {
+	}
+*/
+/*
+    else if (phosphor_layout == 6) {
         // aperture_1_4_rgb; good for simulating lower
         vec3 ap4[4] = vec3[](red, green, blue, black);
 
@@ -353,8 +368,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = ap4[z];
         return weights;
-
-    } else if (phosphor_layout == 7) {
+	}
+*/
+/*
+    else if (phosphor_layout == 7) {
         // aperture_2_5_bgr
         vec3 ap3[5] = vec3[](red, magenta, blue, green, green);
 
@@ -362,8 +379,9 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = ap3[z];
         return weights;
-
-    } else if (phosphor_layout == 8){
+*/
+/*
+    else if (phosphor_layout == 8) {
         // aperture_3_6_rgb
         vec3 big_ap[7] = vec3[](red, red, yellow, green, cyan, blue, blue);
 
@@ -371,8 +389,9 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap[w];
         return weights;
-
-    } else if (phosphor_layout == 9) {
+	}
+*/
+    else if (phosphor_layout == 9) {
         // reduced TVL aperture for RGB panels
         // aperture_2_4_rgb
         vec3 big_ap_rgb[4] = vec3[](red, yellow, cyan, blue);
@@ -381,8 +400,9 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rgb[w];
         return weights;
-
-    } else if (phosphor_layout == 10) {
+	}
+/*
+    else if (phosphor_layout == 10) {
         // reduced TVL aperture for RBG panels
         vec3 big_ap_rbg[4] = vec3[](red, magenta, cyan, green);
 
@@ -390,148 +410,161 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rbg[w];
         return weights;
+	}
+*/
+    else if(phosphor_layout == 11) {
+        // delta_1_4x1_rgb; dunno why this is called 4x1 when it's obviously 4x2 /shrug
+        vec3 delta_1_1[4] = vec3[](red, green, blue, black);
+        vec3 delta_1_2[4] = vec3[](blue, black, red, green);
 
-    } else if(phosphor_layout == 11){
-       // delta_1_4x1_rgb; dunno why this is called 4x1 when it's obviously 4x2 /shrug
-       vec3 delta_1_1[4] = vec3[](red, green, blue, black);
-       vec3 delta_1_2[4] = vec3[](blue, black, red, green);
+        w = int(floor(mod(coord.y, 2.0)));
+        z = int(floor(mod(coord.x, 4.0)));
 
-       w = int(floor(mod(coord.y, 2.0)));
-       z = int(floor(mod(coord.x, 4.0)));
+        weights = (w == 1) ? delta_1_1[z] : delta_1_2[z];
+        return weights;
+    }
+/*
+    else if (phosphor_layout == 12) {
+        // delta_2_4x1_rgb
+        vec3 delta_2_1[4] = vec3[](red, yellow, cyan, blue);
+        vec3 delta_2_2[4] = vec3[](cyan, blue, red, yellow);
 
-       weights = (w == 1) ? delta_1_1[z] : delta_1_2[z];
-       return weights;
+        z = int(floor(mod(coord.x, 4.0)));
 
-    } else if(phosphor_layout == 12){
-       // delta_2_4x1_rgb
-       vec3 delta_2_1[4] = vec3[](red, yellow, cyan, blue);
-       vec3 delta_2_2[4] = vec3[](cyan, blue, red, yellow);
+        weights = (w == 1) ? delta_2_1[z] : delta_2_2[z];
+        return weights;
+	}
+*/
+/*
+    else if (phosphor_layout == 13) {
+        // delta_2_4x2_rgb
+        vec3 delta_1[4] = vec3[](red, yellow, cyan, blue);
+        vec3 delta_2[4] = vec3[](red, yellow, cyan, blue);
+        vec3 delta_3[4] = vec3[](cyan, blue, red, yellow);
+        vec3 delta_4[4] = vec3[](cyan, blue, red, yellow);
 
-       z = int(floor(mod(coord.x, 4.0)));
+        w = int(floor(mod(coord.y, 4.0)));
+        z = int(floor(mod(coord.x, 4.0)));
 
-       weights = (w == 1) ? delta_2_1[z] : delta_2_2[z];
-       return weights;
+        weights = (w == 1) ? delta_1[z] : (w == 2) ? delta_2[z] : (w == 3) ? delta_3[z] : delta_4[z];
+        return weights;
+    }
+*/
+    else if (phosphor_layout == 14) {
+        // slot mask for RGB panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
+        // {magenta, green, black, black,   black, black},
+        // {magenta, green, black, magenta, green, black},
+        // {black,   black, black, magenta, green, black}
+        vec3 slot2_1[6] = vec3[](magenta, green, black, black,   black, black);
+        vec3 slot2_2[6] = vec3[](magenta, green, black, magenta, green, black);
+        vec3 slot2_3[6] = vec3[](black,   black, black, magenta, green, black);
 
-    } else if(phosphor_layout == 13){
-       // delta_2_4x2_rgb
-       vec3 delta_1[4] = vec3[](red, yellow, cyan, blue);
-       vec3 delta_2[4] = vec3[](red, yellow, cyan, blue);
-       vec3 delta_3[4] = vec3[](cyan, blue, red, yellow);
-       vec3 delta_4[4] = vec3[](cyan, blue, red, yellow);
+        w = int(floor(mod(coord.y, 3.0)));
+        z = int(floor(mod(coord.x, 6.0)));
 
-       w = int(floor(mod(coord.y, 4.0)));
-       z = int(floor(mod(coord.x, 4.0)));
+        weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
+        return weights;
+    }
+/*
+    else if(phosphor_layout == 15) {
+        // slot_2_4x4_rgb
+        // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
+        // {red,   yellow, cyan,  blue,  black, black,  black, black},
+        // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
+        // {black, black,  black, black, red,   yellow, cyan,  blue }
+        vec3 slotmask_RBG_x1[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
+        vec3 slotmask_RBG_x2[8] = vec3[](red,   yellow, cyan,  blue,  black, black,  black, black);
+        vec3 slotmask_RBG_x3[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
+        vec3 slotmask_RBG_x4[8] = vec3[](black, black,  black, black, red,   yellow, cyan,  blue );
 
-       weights = (w == 1) ? delta_1[z] : (w == 2) ? delta_2[z] : (w == 3) ? delta_3[z] : delta_4[z];
-       return weights;
+        // find the vertical index
+        w = int(floor(mod(coord.y, 4.0)));
 
-    } else if(phosphor_layout == 14){
-       // slot mask for RGB panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
-       // {magenta, green, black, black,   black, black},
-       // {magenta, green, black, magenta, green, black},
-       // {black,   black, black, magenta, green, black}
-       vec3 slot2_1[6] = vec3[](magenta, green, black, black,   black, black);
-       vec3 slot2_2[6] = vec3[](magenta, green, black, magenta, green, black);
-       vec3 slot2_3[6] = vec3[](black,   black, black, magenta, green, black);
+        // find the horizontal index
+        z = int(floor(mod(coord.x, 8.0)));
 
-       w = int(floor(mod(coord.y, 3.0)));
-       z = int(floor(mod(coord.x, 6.0)));
+        weights = (w == 1) ? slotmask_RBG_x1[z] : (w == 2) ? slotmask_RBG_x2[z] : (w == 3) ? slotmask_RBG_x3[z] : slotmask_RBG_x4[z];
+        return weights;
+	}
+*/
+/*
+	else if(phosphor_layout == 16) {
+        // slot mask for RBG panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
+        // {yellow, blue,  black,  black},
+        // {yellow, blue,  yellow, blue},
+        // {black,  black, yellow, blue}
+        vec3 slot2_1[4] = vec3[](yellow, blue,  black,  black);
+        vec3 slot2_2[4] = vec3[](yellow, blue,  yellow, blue);
+        vec3 slot2_3[4] = vec3[](black,  black, yellow, blue);
 
-       weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
-       return weights;
+        w = int(floor(mod(coord.y, 3.0)));
+        z = int(floor(mod(coord.x, 4.0)));
 
-    } else if(phosphor_layout == 15){
-       // slot_2_4x4_rgb
-       // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
-       // {red,   yellow, cyan,  blue,  black, black,  black, black},
-       // {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
-       // {black, black,  black, black, red,   yellow, cyan,  blue }
-       vec3 slotmask_RBG_x1[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
-       vec3 slotmask_RBG_x2[8] = vec3[](red,   yellow, cyan,  blue,  black, black,  black, black);
-       vec3 slotmask_RBG_x3[8] = vec3[](red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue );
-       vec3 slotmask_RBG_x4[8] = vec3[](black, black,  black, black, red,   yellow, cyan,  blue );
+        weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
+        return weights;
+    }
+*/
+	else if (phosphor_layout == 17) {
+        // slot_2_5x4_bgr
+        // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
+        // {black, blue,    blue,  green, green, red,   red,     black, black, black},
+        // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
+        // {red,   red,     black, black, black, black, blue,    blue,  green, green}
+        vec3 slot_1[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
+        vec3 slot_2[10] = vec3[](black, blue,    blue,  green, green, red,   red,     black, black, black);
+        vec3 slot_3[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
+        vec3 slot_4[10] = vec3[](red,   red,     black, black, black, black, blue,    blue,  green, green);
 
-       // find the vertical index
-       w = int(floor(mod(coord.y, 4.0)));
+        w = int(floor(mod(coord.y, 4.0)));
+        z = int(floor(mod(coord.x, 10.0)));
 
-       // find the horizontal index
-       z = int(floor(mod(coord.x, 8.0)));
+        weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
+        return weights;
+    }
+/*
+    else if (phosphor_layout == 18) {
+        // same as above but for RBG panels
+        // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
+        // {black, green,  green, blue,  blue,  red,   red,    black, black, black},
+        // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
+        // {red,   red,    black, black, black, black, green,  green, blue,  blue }
+        vec3 slot_1[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
+        vec3 slot_2[10] = vec3[](black, green,  green, blue,  blue,  red,   red,    black, black, black);
+        vec3 slot_3[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
+        vec3 slot_4[10] = vec3[](red,   red,    black, black, black, black, green,  green, blue,  blue );
 
-       weights = (w == 1) ? slotmask_RBG_x1[z] : (w == 2) ? slotmask_RBG_x2[z] : (w == 3) ? slotmask_RBG_x3[z] : slotmask_RBG_x4[z];
-       return weights;
+        w = int(floor(mod(coord.y, 4.0)));
+        z = int(floor(mod(coord.x, 10.0)));
 
-     } else if(phosphor_layout == 16){
-       // slot mask for RBG panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
-       // {yellow, blue,  black,  black},
-       // {yellow, blue,  yellow, blue},
-       // {black,  black, yellow, blue}
-       vec3 slot2_1[4] = vec3[](yellow, blue,  black,  black);
-       vec3 slot2_2[4] = vec3[](yellow, blue,  yellow, blue);
-       vec3 slot2_3[4] = vec3[](black,  black, yellow, blue);
+        weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
+        return weights;
+    }
+*/
+/*
+    else if(phosphor_layout == 19) {
+        // slot_3_7x6_rgb
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+        // {black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue}
 
-       w = int(floor(mod(coord.y, 3.0)));
-       z = int(floor(mod(coord.x, 4.0)));
+        vec3 slot_1[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_2[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_3[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black);
+        vec3 slot_4[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_5[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
+        vec3 slot_6[14] = vec3[](black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue);
 
-       weights = (w == 1) ? slot2_1[z] : (w == 2) ? slot2_2[z] : slot2_3[z];
-       return weights;
+        w = int(floor(mod(coord.y, 6.0)));
+        z = int(floor(mod(coord.x, 14.0)));
 
-    } else if (phosphor_layout == 17) {
-       // slot_2_5x4_bgr
-       // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
-       // {black, blue,    blue,  green, green, red,   red,     black, black, black},
-       // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
-       // {red,   red,     black, black, black, black, blue,    blue,  green, green}
-       vec3 slot_1[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
-       vec3 slot_2[10] = vec3[](black, blue,    blue,  green, green, red,   red,     black, black, black);
-       vec3 slot_3[10] = vec3[](red,   magenta, blue,  green, green, red,   magenta, blue,  green, green);
-       vec3 slot_4[10] = vec3[](red,   red,     black, black, black, black, blue,    blue,  green, green);
-
-       w = int(floor(mod(coord.y, 4.0)));
-       z = int(floor(mod(coord.x, 10.0)));
-
-       weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
-       return weights;
-
-    } else if (phosphor_layout == 18) {
-       // same as above but for RBG panels
-       // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
-       // {black, green,  green, blue,  blue,  red,   red,    black, black, black},
-       // {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
-       // {red,   red,    black, black, black, black, green,  green, blue,  blue }
-       vec3 slot_1[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
-       vec3 slot_2[10] = vec3[](black, green,  green, blue,  blue,  red,   red,    black, black, black);
-       vec3 slot_3[10] = vec3[](red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue );
-       vec3 slot_4[10] = vec3[](red,   red,    black, black, black, black, green,  green, blue,  blue );
-
-       w = int(floor(mod(coord.y, 4.0)));
-       z = int(floor(mod(coord.x, 10.0)));
-
-       weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : slot_4[z];
-       return weights;
-
-    } else if(phosphor_layout == 19) {
-       // slot_3_7x6_rgb
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
-       // {black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue}
-
-       vec3 slot_1[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_2[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_3[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black);
-       vec3 slot_4[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_5[14] = vec3[](red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue);
-       vec3 slot_6[14] = vec3[](black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue);
-
-       w = int(floor(mod(coord.y, 6.0)));
-       z = int(floor(mod(coord.x, 14.0)));
-
-       weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : (w == 4) ? slot_4[z] : (w == 5) ? slot_5[z] : slot_6[z];
-       return weights;
-
-    } else {
+        weights = (w == 1) ? slot_1[z] : (w == 2) ? slot_2[z] : (w == 3) ? slot_3[z] : (w == 4) ? slot_4[z] : (w == 5) ? slot_5[z] : slot_6[z];
+        return weights;
+     }
+*/
+	else {
         return weights;
     }
 }

--- a/contrib/resources/glshaders/crt/vga-4k.glsl
+++ b/contrib/resources/glshaders/crt/vga-4k.glsl
@@ -167,10 +167,10 @@ uniform PRECISION float BLUE_SHIFT;
 
 #define WP_ADJUST           0.00
 #define TEMPERATURE      9300.00
-#define LUMA_PRESERVE 		1.00
-#define RED_SHIFT 			0.00
-#define GREEN_SHIFT 		0.00
-#define BLUE_SHIFT 			0.00
+#define LUMA_PRESERVE       1.00
+#define RED_SHIFT           0.00
+#define GREEN_SHIFT         0.00
+#define BLUE_SHIFT          0.00
 #endif
 // END PARAMETERS //
 
@@ -273,10 +273,10 @@ vec3 YxytoXYZ(vec3 Yxy) {
     Many of these mask arrays are adapted from cgwg's crt-geom-deluxe LUTs, and
     those have their filenames included for easy identification
 
-	NOTE: Having too many branches result in a black screen (but no
-	compilation errors) on some older GPUs such as the Intel HD 4000 iGPU. So
-	we're commenting out the branches that are not used by the adaptive CRT
-	shaders.
+    NOTE: Having too many branches result in a black screen (but no
+    compilation errors) on some older GPUs such as the Intel HD 4000 iGPU. So
+    we're commenting out the branches that are not used by the adaptive CRT
+    shaders.
 */
 vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
     vec3 weights = vec3(1.,1.,1.);
@@ -300,14 +300,14 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
     if (phosphor_layout == 0) {
         return weights;
-	}
+    }
 
     else if (phosphor_layout == 1) {
-    	// classic aperture for RGB panels; good for 1080p, too small for 4K+
+        // classic aperture for RGB panels; good for 1080p, too small for 4K+
         // aka aperture_1_2_bgr
         weights  = aperture_weights;
         return weights;
-	}
+    }
 
     else if (phosphor_layout == 2) {
         // 2x2 shadow mask for RGB panels; good for 1080p, too small for 4K+
@@ -315,7 +315,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
         vec3 inverse_aperture = mix(green, magenta, floor(mod(coord.x, 2.0)));
         weights               = mix(aperture_weights, inverse_aperture, floor(mod(coord.y, 2.0)));
         return weights;
-	}
+    }
 
 /*
     else if (phosphor_layout == 3) {
@@ -338,14 +338,14 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         // do a big, dumb comparison in place of a 2D array
         weights = (w == 1) ? slotmask_x1[z] : (w == 2) ? slotmask_x2[z] :  slotmask_x3[z];
-		return weights;
+        return weights;
     }
 */
     else if (phosphor_layout == 4) {
         // classic aperture for RBG panels; good for 1080p, too small for 4K+
         weights  = mix(yellow, blue, floor(mod(coord.x, 2.0)));
         return weights;
-	}
+    }
 /*
     else if (phosphor_layout == 5) {
         // 2x2 shadow mask for RBG panels; good for 1080p, too small for 4K+
@@ -357,7 +357,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
             floor(mod(coord.y, 2.0))
         );
         return weights;
-	}
+    }
 */
 /*
     else if (phosphor_layout == 6) {
@@ -368,7 +368,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = ap4[z];
         return weights;
-	}
+    }
 */
 /*
     else if (phosphor_layout == 7) {
@@ -389,7 +389,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap[w];
         return weights;
-	}
+    }
 */
     else if (phosphor_layout == 9) {
         // reduced TVL aperture for RGB panels
@@ -400,7 +400,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rgb[w];
         return weights;
-	}
+    }
 /*
     else if (phosphor_layout == 10) {
         // reduced TVL aperture for RBG panels
@@ -410,7 +410,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = big_ap_rbg[w];
         return weights;
-	}
+    }
 */
     else if(phosphor_layout == 11) {
         // delta_1_4x1_rgb; dunno why this is called 4x1 when it's obviously 4x2 /shrug
@@ -433,7 +433,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = (w == 1) ? delta_2_1[z] : delta_2_2[z];
         return weights;
-	}
+    }
 */
 /*
     else if (phosphor_layout == 13) {
@@ -485,10 +485,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 
         weights = (w == 1) ? slotmask_RBG_x1[z] : (w == 2) ? slotmask_RBG_x2[z] : (w == 3) ? slotmask_RBG_x3[z] : slotmask_RBG_x4[z];
         return weights;
-	}
+    }
 */
 /*
-	else if(phosphor_layout == 16) {
+    else if(phosphor_layout == 16) {
         // slot mask for RBG panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
         // {yellow, blue,  black,  black},
         // {yellow, blue,  yellow, blue},
@@ -504,7 +504,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
         return weights;
     }
 */
-	else if (phosphor_layout == 17) {
+    else if (phosphor_layout == 17) {
         // slot_2_5x4_bgr
         // {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
         // {black, blue,    blue,  green, green, red,   red,     black, black, black},
@@ -564,7 +564,7 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
         return weights;
      }
 */
-	else {
+    else {
         return weights;
     }
 }
@@ -584,10 +584,10 @@ vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout) {
 // For more info, see: http://www.imagemagick.org/Usage/img_diagrams/cubic_survey.gif
 mat4x4 get_hfilter_profile()
 {
-	float bf = 0.0;
-	float cf = 0.0;
+    float bf = 0.0;
+    float cf = 0.0;
 
-	if (HFILTER_PROFILE == 1) {
+    if (HFILTER_PROFILE == 1) {
         bf = 0.0;
         cf = 0.5;
     }
@@ -689,14 +689,14 @@ void main()
     mask_coords = mix(mask_coords.xy, mask_coords.yx, VSCANLINES);
     color.rgb *= mask_weights(mask_coords, MASK_INTENSITY, int(PHOSPHOR_LAYOUT));
 
-	// Colour temperature
-	if (WP_ADJUST == 1.0) {
-		vec3 wp_adjusted = wp_adjust(color.rgb);
-		vec3 base_luma = XYZtoYxy(sRGB_to_XYZ(color.rgb));
-		vec3 adjusted_luma = XYZtoYxy(sRGB_to_XYZ(wp_adjusted));
-		wp_adjusted = (LUMA_PRESERVE == 1.0) ? adjusted_luma + (vec3(base_luma.r,0.,0.) - vec3(adjusted_luma.r,0.,0.)) : adjusted_luma;
-		color = vec4(XYZ_to_sRGB(YxytoXYZ(wp_adjusted)), 1.0);
-	}
+    // Colour temperature
+    if (WP_ADJUST == 1.0) {
+        vec3 wp_adjusted = wp_adjust(color.rgb);
+        vec3 base_luma = XYZtoYxy(sRGB_to_XYZ(color.rgb));
+        vec3 adjusted_luma = XYZtoYxy(sRGB_to_XYZ(wp_adjusted));
+        wp_adjusted = (LUMA_PRESERVE == 1.0) ? adjusted_luma + (vec3(base_luma.r,0.,0.) - vec3(adjusted_luma.r,0.,0.)) : adjusted_luma;
+        color = vec4(XYZ_to_sRGB(YxytoXYZ(wp_adjusted)), 1.0);
+    }
 
     // Output gamma
     color = clamp(GAMMA_OUT(color), 0.0, 1.0);


### PR DESCRIPTION
# Description

Fixes https://github.com/dosbox-staging/dosbox-staging/issues/3114

@Burrito78 kindly gave me remote desktop access to his problematic old MacMini with an Intel HD 4000 iGPU that displays only a black screen when using any of the new adaptive CRT shaders. I was able to pinpoint the problem by the time-tested method of trial and error, also known as "just dicking around" in some circles 😎 

The problem seems to be that there's just too much branching going on in one of the functions. GLSL is still a fairly high-level language at the end of the day, and the shader compilers try to do their best to optimise per-pixel branching away. This branching code is not a problem at all on more recent GPUs (7-8 years old), but on this ancient 10+ year old iGPU, the shader compiles without errors, but somehow, who knows how and why, it just displays a black screen at runtime... Commenting out some of the branches fixes it, so the solution I adopted is to comment every branch of the function out that is not used by the adaptive shaders. This is an attempt to pre-empt similar problems on other weird old GPUs.

For the record, the problem could not be reproduced on my $200 bottom-of-the-barrel mini laptop I bought in 2015 which also has an Intel iGPU, but a more recent model. So I have reason to believe the issue could only manifest on ancient 10+ year old GPUs...

## Disclaimer

Yes, I know that it's **_absolutely_** **_horrible_** that I have 22 copies of the _exact same_ (!) shader code, just with different settings... 🥶 But we have no preset support, so this was the only practical way to release my set of shaders this year (and to do this before eXoDOS v6 is out, so our shader work can be included) using our current shader pipeline which is very barebones.

I have plans for how to make this a lot nicer in the future; most likely these 22 copies will be replaced by a single shader, and I'll just send it different settings at runtime when there's a "shader change" (which is really just a "preset change"). But that's for the future... 😄 

# Manual testing

Tested a few fixed shaders on Burrito's box to make sure I understood the problem.

Regression tested all fixed shaders on my M1 MacBook to make sure they still work.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

