### PR TITLE
Update Coverity to version 2023.6.2

### DIFF
--- a/.github/workflows/coverity.md
+++ b/.github/workflows/coverity.md
@@ -1,7 +1,7 @@
 # Steps to Refresh the Coverity Software
 
 1. Every 6 months check <https://scan.coverity.com/download> for
-   a package newer than 2022.09
+   a package newer than 2023.06
 
 2. Download it, extract it, and remove unnecessary content:
 
@@ -17,7 +17,7 @@
 3. Compress and Checksum the archive:
 
    ``` shell
-   tar -cv cov-analysis-linux64-YYYY-MM | zstd -19 > coverity.tar.zst
+   tar -cv cov-analysis-linux64-YYYY-MM | zstd --long --ultra -22 > coverity.tar.zst
    sha256sum coverity.tar.zst
    ```
 

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -16,15 +16,15 @@ env:
   PACKAGE: "/dev/shm/coverity-package/coverity.tar.zst"
   PACKAGE_DIR: "/dev/shm/coverity-package"
   # Latest package: https://scan.coverity.com/download
-  PACKAGE_VERSION: "2022.6.0"
+  PACKAGE_VERSION: "2023.6.2"
   # One-time download, then lives in GitHub cache
-  TARBALL_URL: "https://kcgen.duckdns.org/coverity-2022.tar.zst"
-  TARBALL_SHA256: "8e95399eb7306c7cb8cc5e59807d6d479cf8ae65b683f3904e9537db6864288f"
+  TARBALL_URL: "https://kcgen.duckdns.org/coverity-2023.tar.zst"
+  TARBALL_SHA256: "eeda957cab17f8f1602b011b4d187ebd6cb8e78b79bc4f5b0eab59ba38441104"
 
 jobs:
   coverity_scan:
     name: Coverity static analyzer
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -40,7 +40,7 @@ jobs:
 
       - name: Install C++ compiler and dependencies
         run: |
-          sudo apt-get install curl zstd clang $(cat packages/ubuntu-20.04-apt.txt)
+          sudo apt-get install curl zstd clang $(cat packages/ubuntu-22.04-apt.txt)
           sudo pip3 install --upgrade meson ninja
 
       - name: Cache subprojects


### PR DESCRIPTION
# Description

Coverity has stopped working because they've updated their backend and only accept reports using their new 2023 package.

# Manual testing

Tested the new version, and it's found a bunch of new detections.

![2023-12-04_20-52](https://github.com/dosbox-staging/dosbox-staging/assets/1557255/bd0dc605-aad4-4577-acbb-48149a2aafba)

# Checklist

I have:

- [ ] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [ ] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [ ] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

