### PR TITLE
Fix raw video capture so it always writes non-double-scanned raw output

### DIFF
--- a/include/reelmagic.h
+++ b/include/reelmagic.h
@@ -40,12 +40,11 @@ struct ReelMagic_VideoMixerMPEGProvider {
 void ReelMagic_RENDER_SetPalette(const uint8_t entry, const uint8_t red,
                                  const uint8_t green, const uint8_t blue);
 
-void ReelMagic_RENDER_SetSize(const uint16_t width, const uint16_t height,
-                              const bool double_width, const bool double_height,
-                              const Fraction& render_pixel_aspect_ratio,
-                              const PixelFormat pixel_format,
-                              const double frames_per_second,
-                              const VideoMode& video_mode);
+// forward declaration
+struct ImageInfo;
+
+void ReelMagic_RENDER_SetSize(const ImageInfo& image_info,
+                              const double frames_per_second);
 
 bool ReelMagic_RENDER_StartUpdate(void);
 

--- a/include/render.h
+++ b/include/render.h
@@ -201,11 +201,7 @@ void RENDER_SyncMonochromePaletteSetting(const enum MonochromePalette palette);
 std::deque<std::string> RENDER_GenerateShaderInventoryMessage();
 void RENDER_AddMessages();
 
-void RENDER_SetSize(const uint16_t width, const uint16_t height,
-                    const bool double_width, const bool double_height,
-                    const Fraction& render_pixel_aspect_ratio,
-                    const PixelFormat pixel_format,
-                    const double frames_per_second, const VideoMode& video_mode);
+void RENDER_SetSize(const ImageInfo& image_info, const double frames_per_second);
 
 bool RENDER_StartUpdate(void);
 void RENDER_EndUpdate(bool abort);

--- a/include/vga.h
+++ b/include/vga.h
@@ -234,7 +234,7 @@ enum class PixelFormat : uint8_t;
 struct VgaDraw {
 	bool resizing = false;
 
-	ImageInfo render = {};
+	ImageInfo image_info = {};
 
 	uint32_t blocks             = 0;
 	Bitu address                = 0;

--- a/include/video.h
+++ b/include/video.h
@@ -292,6 +292,13 @@ struct ImageInfo {
 
 	// If true, we're dealing with a double-scanned VGA mode that was
 	// force-rendered as single-scanned.
+	//
+	// We need to store this flag so we can include it in the video mode
+	// equality criteria. E.g., the render dimensions of the double-scanned
+	// 320x200 VGA mode (mode 13h) and 320x400 (non-VESA Mode X variant) are
+	// both 320x400, so they would be considered equal if this flag was not
+	// included. This would throw off the adaptive shader switching logic when
+	// such video mode transitions happen.
 	bool force_single_scan = false;
 
 	// Pixel aspect ratio to be applied to the final image, *after*

--- a/include/video.h
+++ b/include/video.h
@@ -301,6 +301,13 @@ struct ImageInfo {
 	// such video mode transitions happen.
 	bool force_single_scan = false;
 
+	// If true, we're dealing with "baked-in" double scanning, i.e., when
+	// 320x200 is rendered as 320x400. This can happen for non-VESA VGA modes
+	// and for EGA modes on VGA. Every other double-scanned mode on VGA (all
+	// CGA modes and all double-scanned VESA modes) are "fake-double scanned"
+	// (doubled post-render by setting `double_height` to true).
+	bool rendered_double_scan = false;
+
 	// Pixel aspect ratio to be applied to the final image, *after*
 	// optional width and height doubling, so it appears as intended.
 	// (`video_mode.pixel_aspect_ratio` holds the "nominal" pixel

--- a/include/video.h
+++ b/include/video.h
@@ -299,7 +299,7 @@ struct ImageInfo {
 	// both 320x400, so they would be considered equal if this flag was not
 	// included. This would throw off the adaptive shader switching logic when
 	// such video mode transitions happen.
-	bool force_single_scan = false;
+	bool forced_single_scan = false;
 
 	// If true, we're dealing with "baked-in" double scanning, i.e., when
 	// 320x200 is rendered as 320x400. This can happen for non-VESA VGA modes
@@ -333,7 +333,7 @@ struct ImageInfo {
 		return (width == that.width && height == that.height &&
 		        double_width == that.double_width &&
 		        double_height == that.double_height &&
-		        force_single_scan == that.force_single_scan &&
+		        forced_single_scan == that.forced_single_scan &&
 		        pixel_aspect_ratio == that.pixel_aspect_ratio &&
 		        pixel_format == that.pixel_format &&
 		        video_mode == that.video_mode);

--- a/src/capture/capture_video.cpp
+++ b/src/capture/capture_video.cpp
@@ -368,9 +368,9 @@ static void create_avi_file(const uint16_t width, const uint16_t height,
 //   post-processing step; it's never "baked-into" the rendered image.
 //   We just need to completely ignore the `double_width` flag.
 //
-// - Double-scanning can be either "baked-in" or performed in post-processing.
+// - Double scanning can be either "baked-in" or performed in post-processing.
 //   Ignoring the `double_height` flag takes care of the post-processing
-//   variety, but for "baked-in" double-scanning, we need to skip every second
+//   variety, but for "baked-in" double scanning, we need to skip every second
 //   row.
 //
 // So, for example, the 320x200 13h VGA mode is always written as 320x200 in

--- a/src/capture/image/image_capturer.cpp
+++ b/src/capture/image/image_capturer.cpp
@@ -249,8 +249,9 @@ uint8_t get_double_scan_row_skip_count(const RenderedImage& image)
 	// and scaling operations, so we must skip every second row if we're
 	// dealing with "baked in" double-scanning.
 	//
-	// This function returns `0` for case 1 images (faked double-scan), and
-	// `1` for case 2 images (baked-in double-scan).
+	// The function returns `0` for case 1 images (faked double-scan) and
+	// non-double-scanned images, and `1` for case 2 images (baked-in
+	// double-scan).
 	//
 	const auto& src = image.params;
 

--- a/src/capture/image/image_capturer.cpp
+++ b/src/capture/image/image_capturer.cpp
@@ -230,33 +230,3 @@ void ImageCapturer::RequestGroupedCapture()
 	}
 	state.grouped = CaptureState::Pending;
 }
-
-uint8_t get_double_scan_row_skip_count(const RenderedImage& image)
-{
-	// Double-scanning can be either:
-	//
-	// 1) "baked" into the image; `image.image_data` contains twice as many
-	// rows (e.g. `video_mode.height` is 200 and `image.height` 400),
-	//
-	// 2) or it can be "faked" with `image.double_height` set to true, in
-	// which case `video_mode.height` equals `image.height` (e.g. both are
-	// 200) and the height-doubling happens as a post-processing step on
-	// `image.image_data` just before the final output.
-	//
-	// For case 2, there's nothing to do; the image data itself is not
-	// double-scanned. For case 1, we need to reconstruct the raw,
-	// non-double-scanned image to serve as the basis for our further output
-	// and scaling operations, so we must skip every second row if we're
-	// dealing with "baked in" double-scanning.
-	//
-	// The function returns `0` for case 1 images (faked double-scan) and
-	// non-double-scanned images, and `1` for case 2 images (baked-in
-	// double-scan).
-	//
-	const auto& src = image.params;
-
-	assert(src.height >= src.video_mode.height);
-	assert(src.height % src.video_mode.height == 0);
-
-	return check_cast<uint8_t>(src.height / src.video_mode.height - 1);
-}

--- a/src/capture/image/image_capturer.h
+++ b/src/capture/image/image_capturer.h
@@ -105,6 +105,4 @@ private:
 	ImageSaver& GetNextImageSaver();
 };
 
-uint8_t get_double_scan_row_skip_count(const RenderedImage& image);
-
 #endif // DOSBOX_IMAGE_CAPTURER_H

--- a/src/capture/image/image_decoder.h
+++ b/src/capture/image/image_decoder.h
@@ -39,7 +39,7 @@ public:
 	~ImageDecoder() = default;
 
 	// Set `row_skip_count` to 1 to de-double-scan an image with "baked in"
-	// double-scanning.
+	// double scanning.
 	void Init(const RenderedImage& image, const uint8_t row_skip_count);
 
 	inline uint8_t GetNextIndexed8Pixel()

--- a/src/capture/image/image_decoder.h
+++ b/src/capture/image/image_decoder.h
@@ -83,7 +83,7 @@ private:
 		case PixelFormat::RGB565_Packed16: pos += 2; break;
 		case PixelFormat::BGR24_ByteArray: pos += 3; break;
 		case PixelFormat::BGRX32_ByteArray: pos += 4; break;
-		default: assertm(false, "Invalid pixel_format value");
+		default: assertm(false, "Invalid PixelFormat value");
 		}
 	}
 
@@ -124,7 +124,7 @@ private:
 			pixel = {r, g, b};
 		} break;
 
-		default: assertm(false, "Invalid pixel_format value");
+		default: assertm(false, "Invalid PixelFormat value");
 		}
 
 		IncrementPos();

--- a/src/capture/image/image_saver.cpp
+++ b/src/capture/image/image_saver.cpp
@@ -154,7 +154,7 @@ void ImageSaver::SaveRawImage(const RenderedImage& image)
 	PngWriter png_writer = {};
 
 	// To reconstruct the raw image, we must skip every second row if we're
-	// dealing with "baked in" double-scanning.
+	// dealing with "baked in" double scanning.
 	const uint8_t row_skip_count = (image.params.rendered_double_scan ? 1 : 0);
 	image_decoder.Init(image, row_skip_count);
 

--- a/src/capture/image/image_saver.cpp
+++ b/src/capture/image/image_saver.cpp
@@ -94,7 +94,7 @@ static CaptureType to_capture_type(const CapturedImageType type)
 	case CapturedImageType::Raw: return CaptureType::RawImage;
 	case CapturedImageType::Upscaled: return CaptureType::UpscaledImage;
 	case CapturedImageType::Rendered: return CaptureType::RenderedImage;
-	default: assertm(false, "Invalid CaptureImageType"); return {};
+	default: assertm(false, "Invalid CaptureImageType value"); return {};
 	}
 }
 

--- a/src/capture/image/image_saver.cpp
+++ b/src/capture/image/image_saver.cpp
@@ -149,14 +149,13 @@ static void write_upscaled_png(FILE* outfile, PngWriter& png_writer,
 	}
 }
 
-// to avoid circular dependency
-uint8_t get_double_scan_row_skip_count(const RenderedImage&);
-
 void ImageSaver::SaveRawImage(const RenderedImage& image)
 {
 	PngWriter png_writer = {};
 
-	auto row_skip_count = get_double_scan_row_skip_count(image);
+	// To reconstruct the raw image, we must skip every second row if we're
+	// dealing with "baked in" double-scanning.
+	const uint8_t row_skip_count = (image.params.rendered_double_scan ? 1 : 0);
 	image_decoder.Init(image, row_skip_count);
 
 	const auto& src = image.params;

--- a/src/capture/image/image_scaler.cpp
+++ b/src/capture/image/image_scaler.cpp
@@ -97,7 +97,10 @@ void ImageScaler::UpdateOutputParamsUpscale()
 		if (is_integer(output.horiz_scale)) {
 			// Ensure the upscaled image is at least 1000px high for
 			// 1:1 pixel aspect ratio images.
-			if (output.height < 1000) {
+
+			constexpr auto MinUpscaledHeight = 1000;
+
+			if (output.height < MinUpscaledHeight) {
 				++output.vert_scale;
 			} else {
 				break;
@@ -106,7 +109,10 @@ void ImageScaler::UpdateOutputParamsUpscale()
 			// Ensure fractional horizontal scale factors are
 			// above 2.0, otherwise we'd get bad looking horizontal
 			// blur.
-			if (output.horiz_scale < 2.0f) {
+
+			constexpr auto MinHorizScaleFactor = 2.0f;
+
+			if (output.horiz_scale < MinHorizScaleFactor) {
 				++output.vert_scale;
 			} else {
 				break;

--- a/src/capture/image/image_scaler.cpp
+++ b/src/capture/image/image_scaler.cpp
@@ -30,14 +30,13 @@
 
 CHECK_NARROWING();
 
-// to avoid circular dependency
-uint8_t get_double_scan_row_skip_count(const RenderedImage&);
-
 void ImageScaler::Init(const RenderedImage& image)
 {
 	input = image;
 
-	auto row_skip_count = get_double_scan_row_skip_count(image);
+	// To reconstruct the raw image, we must skip every second row if we're
+	// dealing with "baked in" double-scanning.
+	const uint8_t row_skip_count = (image.params.rendered_double_scan ? 1 : 0);
 	input_decoder.Init(image, row_skip_count);
 
 	UpdateOutputParamsUpscale();
@@ -61,7 +60,7 @@ void ImageScaler::UpdateOutputParamsUpscale()
 {
 	constexpr auto target_output_height = 1200;
 
-	auto video_mode = input.params.video_mode;
+	const auto& video_mode = input.params.video_mode;
 
 	// Calculate initial integer vertical scaling factor so the resulting
 	// output image height is roughly around 1200px.

--- a/src/capture/image/image_scaler.cpp
+++ b/src/capture/image/image_scaler.cpp
@@ -35,7 +35,7 @@ void ImageScaler::Init(const RenderedImage& image)
 	input = image;
 
 	// To reconstruct the raw image, we must skip every second row if we're
-	// dealing with "baked in" double-scanning.
+	// dealing with "baked in" double scanning.
 	const uint8_t row_skip_count = (image.params.rendered_double_scan ? 1 : 0);
 	input_decoder.Init(image, row_skip_count);
 

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -544,13 +544,13 @@ static bool force_no_pixel_doubling = false;
 
 // Double-scan VGA modes and pixel-double all video modes by default unless:
 //
-//  1) Single-scanning or no pixel-doubling is requested by the OpenGL shader.
+//  1) Single scanning or no pixel doubling is requested by the OpenGL shader.
 //  2) The interpolation mode is nearest-neighbour in texture output mode.
 //
-// The default `interpolation/sharp.glsl` shader requests both single-scanning
-// and no pixel-doubling because it scales pixels as flat adjacent rectangles.
-// This not only produces identical output versus double-scanning and
-// pixel-doubling, but also provides finer integer scaling steps (especially
+// The default `interpolation/sharp.glsl` shader requests both single scanning
+// and no pixel doubling because it scales pixels as flat adjacent rectangles.
+// This not only produces identical output versus double scanning and
+// pixel doubling, but also provides finer integer scaling steps (especially
 // important on sub-4K screens), plus improves performance on low-end systems
 // like the Raspberry Pi.
 //

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -523,26 +523,17 @@ static void render_callback(GFX_CallBackFunctions_t function)
 	}
 }
 
-void RENDER_SetSize(const uint16_t width, const uint16_t height,
-                    const bool double_width, const bool double_height,
-                    const Fraction& render_pixel_aspect_ratio,
-                    const PixelFormat pixel_format,
-                    const double frames_per_second, const VideoMode& video_mode)
+void RENDER_SetSize(const ImageInfo& image_info, const double frames_per_second)
 {
 	halt_render();
 
-	if (!width || !height || width > SCALER_MAXWIDTH || height > SCALER_MAXHEIGHT) {
+	if (image_info.width == 0 || image_info.height == 0 ||
+	    image_info.width > SCALER_MAXWIDTH ||
+	    image_info.height > SCALER_MAXHEIGHT) {
 		return;
 	}
 
-	render.src.width              = width;
-	render.src.height             = height;
-	render.src.double_width       = double_width;
-	render.src.double_height      = double_height;
-	render.src.pixel_aspect_ratio = render_pixel_aspect_ratio;
-	render.src.pixel_format       = pixel_format;
-	render.src.video_mode         = video_mode;
-
+	render.src = image_info;
 	render.fps = frames_per_second;
 
 	render_reset();

--- a/src/gui/shader_manager.cpp
+++ b/src/gui/shader_manager.cpp
@@ -89,14 +89,14 @@ void ShaderManager::NotifyRenderParametersChanged(const DosBox::Rect canvas_size
 	//
 	// We need to derive the potentially double-scanned dimensions from the
 	// video mode, *not* the current render dimensions! That's because we
-	// might be in forced single-scanning and/or no pixel-doubling mode
+	// might be in forced single scanning and/or no pixel doubling mode
 	// already in the renderer, but that's actually irrelevant for the
 	// shader auto-switching algorithm. All in all, it's easiest to start
 	// from a fixed, unchanging starting point, which is the "nominal"
 	// dimensions of the current video made.
 
 	// 1) Calculate vertical scale factor for the standard output resolution
-	// (i.e., always double-scanning on VGA).
+	// (i.e., always double scanning on VGA).
 	//
 	scale_y = [&] {
 		const auto double_scan = video_mode.is_double_scanned_mode ? 2 : 1;
@@ -110,7 +110,7 @@ void ShaderManager::NotifyRenderParametersChanged(const DosBox::Rect canvas_size
 		return static_cast<double>(draw_rect_px.h) / render_size_px.h;
 	}();
 
-	// 2) Calculate vertical scale factor for forced single-scanning on VGA
+	// 2) Calculate vertical scale factor for forced single scanning on VGA
 	// for double-scanned modes.
 	if (video_mode.is_double_scanned_mode) {
 		const DosBox::Rect render_size_px = {video_mode.width,
@@ -483,9 +483,9 @@ std::string ShaderManager::GetVgaShader() const
 	if (scale_y >= 2.0) {
 		// Up to 1080/5 = 216-line double-scanned VGA modes can be
 		// displayed with 5x vertical scaling on 1080p screens in
-		// fullscreen with forced single-scanning and a "fake
-		// double-scanning" shader that gives the *impression* of
-		// double-scanning (clearly, our options at 1080p are limited as
+		// fullscreen with forced single scanning and a "fake
+		// double scanning" shader that gives the *impression* of
+		// double scanning (clearly, our options at 1080p are limited as
 		// we'd need 3 pixels per emulated scanline at the very minimum
 		// for a somewhat convincing scanline emulation).
 		//

--- a/src/gui/shader_manager.cpp
+++ b/src/gui/shader_manager.cpp
@@ -105,9 +105,7 @@ void ShaderManager::NotifyRenderParametersChanged(const DosBox::Rect canvas_size
 		                                     video_mode.height * double_scan};
 
 		const auto draw_rect_px = GFX_CalcDrawRectInPixels(
-		        canvas_size_px,
-		        render_size_px,
-		        video_mode.pixel_aspect_ratio);
+		        canvas_size_px, render_size_px, video_mode.pixel_aspect_ratio);
 
 		return static_cast<double>(draw_rect_px.h) / render_size_px.h;
 	}();
@@ -119,9 +117,7 @@ void ShaderManager::NotifyRenderParametersChanged(const DosBox::Rect canvas_size
 		                                     video_mode.height};
 
 		const auto draw_rect_px = GFX_CalcDrawRectInPixels(
-		        canvas_size_px,
-		        render_size_px,
-		        video_mode.pixel_aspect_ratio);
+		        canvas_size_px, render_size_px, video_mode.pixel_aspect_ratio);
 
 		scale_y_force_single_scan = static_cast<double>(draw_rect_px.h) /
 		                            render_size_px.h;
@@ -497,10 +493,10 @@ std::string ShaderManager::GetVgaShader() const
 		// would be auto-scaled to 1067x800 in fullscreen, which is too
 		// small and would not please most users.
 		//
-		const auto max_fake_double_scan_video_mode_height = 1080 / 5;
+		constexpr auto MaxFakeDoubleScanVideoModeHeight = 1080 / 5;
 
 		if (video_mode.is_double_scanned_mode &&
-		    video_mode.height <= max_fake_double_scan_video_mode_height) {
+		    video_mode.height <= MaxFakeDoubleScanVideoModeHeight) {
 			return "crt/vga-1080p-fake-double-scan";
 		} else {
 			// This shader works correctly only with exact 2x

--- a/src/gui/shader_manager.h
+++ b/src/gui/shader_manager.h
@@ -80,8 +80,8 @@ enum class ShaderMode {
 	// 15 kHz arcade / home computer monitor adaptive CRT shader mode.
 	// Enabled via the 'crt-machine-arcade' magic 'glshader' setting.
 	//
-	// This basically forces single-scanning of all double-scanned VGA modes
-	// and no pixel-doubling in all modes to achieve a somewhat less sharp
+	// This basically forces single scanning of all double-scanned VGA modes
+	// and no pixel doubling in all modes to achieve a somewhat less sharp
 	// look with more blending and "rounder" pixels than what you'd get on a
 	// typical sharp EGA/VGA PC monitor.
 	//
@@ -92,7 +92,7 @@ enum class ShaderMode {
 	AutoArcade,
 
 	// A sharper variant of the arcade shader. It's the exact same shader but
-	// with pixel-doubling enabled.
+	// with pixel doubling enabled.
 	AutoArcadeSharp
 };
 

--- a/src/hardware/vga.cpp
+++ b/src/hardware/vga.cpp
@@ -371,10 +371,10 @@ void VGA_EnableVgaDoubleScanning(const bool enable)
 		return;
 	}
 	if (enable && !vga.draw.double_scanning_enabled) {
-		LOG_MSG("VGA: Double-scanning VGA video modes enabled");
+		LOG_MSG("VGA: Double scanning VGA video modes enabled");
 	}
 	if (!enable && vga.draw.double_scanning_enabled) {
-		LOG_MSG("VGA: Forcing single-scanning of double-scanned VGA video modes");
+		LOG_MSG("VGA: Forcing single scanning of double-scanned VGA video modes");
 	}
 	vga.draw.double_scanning_enabled = enable;
 }
@@ -382,10 +382,10 @@ void VGA_EnableVgaDoubleScanning(const bool enable)
 void VGA_EnablePixelDoubling(const bool enable)
 {
 	if (enable && !vga.draw.pixel_doubling_enabled) {
-		LOG_MSG("VGA: Pixel-doubling enabled");
+		LOG_MSG("VGA: Pixel doubling enabled");
 	}
 	if (!enable && vga.draw.pixel_doubling_enabled) {
-		LOG_MSG("VGA: Forcing no pixel-doubling");
+		LOG_MSG("VGA: Forcing no pixel doubling");
 	}
 	vga.draw.pixel_doubling_enabled = enable;
 }

--- a/src/hardware/vga.cpp
+++ b/src/hardware/vga.cpp
@@ -481,6 +481,6 @@ void SVGA_Setup_Driver(void) {
 }
 
 const VideoMode& VGA_GetCurrentVideoMode() {
-	return vga.draw.render.video_mode;
+	return vga.draw.image_info.video_mode;
 }
 

--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -1647,7 +1647,7 @@ static VgaTimings calculate_vga_timings()
 		               ? PixelsPerChar::Eight
 		               : PixelsPerChar::Nine;
 
-		// Adjust the horizontal frequency if in pixel-doubling mode
+		// Adjust the horizontal frequency if in pixel doubling mode
 		// (clock/2)
 		if (vga.seq.clocking_mode.is_pixel_doubling) {
 			horiz.total *= 2;
@@ -1821,7 +1821,7 @@ static UpdatedTimings update_vga_timings(const VgaTimings& timings)
 
 static bool is_vga_scan_doubling()
 {
-	// Scan-doubling on VGA is generally achieved in one of two ways,
+	// Scan doubling on VGA is generally achieved in one of two ways,
 	// depending on the video mode:
 	//
 	// 1) The 16-colour VGA mode, and all CGA, EGA and VESA modes set the
@@ -1904,10 +1904,10 @@ ImageInfo setup_drawing()
 	default: vga.draw.mode = PART; break;
 	}
 
-	// We need to set the address_line_total according to the scan-doubling
+	// We need to set the address_line_total according to the scan doubling
 	// state on VGA before calling calculate_vga_timings(). Then we can
 	// divide address_line_total later if we decide to do "fake"
-	// scan-doubling only.
+	// scan doubling only.
 	if (IS_EGAVGA_ARCH) {
 		vga.draw.address_line_total = vga.crtc.maximum_scan_line.maximum_scan_line +
 		                              1;
@@ -2156,7 +2156,7 @@ ImageInfo setup_drawing()
 		video_mode.width = horiz_end * 4;
 		render_width     = video_mode.width;
 
-		// We only render "baked-in" double-scanning (when we literally render
+		// We only render "baked-in" double scanning (when we literally render
 		// twice as many rows) for the M_VGA modes and M_EGA modes on emulated
 		// VGA adapters only; for everything else, we "fake double-scan" on
 		// VGA (render single-scanned, then double the image vertically with a
@@ -2178,11 +2178,11 @@ ImageInfo setup_drawing()
 			render_height     = video_mode.height;
 		}
 
-		// Mode 13h and practically all tweak-modes use pixel-doubling.
+		// Mode 13h and practically all tweak-modes use pixel doubling.
 		// Note this is not accomplished via dividing the memory address
 		// clock by 2 like in other SVGA/VESA modes, but by some complex
 		// interaction between various VGA registers that is specific to
-		// mode 13h. So we'll just assume that pixel-doubling is always
+		// mode 13h. So we'll just assume that pixel doubling is always
 		// on for M_VGA.
 		//
 		// More information here:
@@ -2250,7 +2250,7 @@ ImageInfo setup_drawing()
 			render_pixel_aspect_ratio = calc_pixel_aspect_from_timings(
 			        vga_timings);
 
-			// We only render "baked-in" double-scanning (when we literally
+			// We only render "baked-in" double scanning (when we literally
 			// render twice as many rows) for the M_VGA modes and M_EGA modes
 			// on emulated VGA adapters only; for everything else, we "fake
 			// double-scan" on VGA (render single-scanned, then double the
@@ -2350,7 +2350,7 @@ ImageInfo setup_drawing()
 		/*
 		        TODO This bit is not set for the 640x200
 		        Tandy mode; this cannot be correct. This would
-		        result in width-doubling the 640x200 mode. A
+		        result in width doubling the 640x200 mode. A
 		        simple 'width < 640' check will suffice instead
 		        until someone investigates this...
 
@@ -2722,7 +2722,7 @@ ImageInfo setup_drawing()
 		vblank_skip /= 2;
 	}
 
-	// 'render_pixel_aspect_ratio' has any post-render width/height-doubling
+	// 'render_pixel_aspect_ratio' has any post-render width/height doubling
 	// already factored in, so we need to multiply it by
 	// 'render_per_video_mode_scale' to derive the video mode's pixel aspect
 	// ratio. It's just less redundant and error prone to derive the video

--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -1983,7 +1983,7 @@ ImageInfo setup_drawing()
 	// If true, we're rendering a double-scanned VGA mode as single-scanned
 	// (so rendering half the lines only, e.g., only 200 lines for the
 	// double-scanned 320x200 13h VGA mode).
-	bool force_single_scan = false;
+	bool forced_single_scan = false;
 
 	// If true, we're dealing with "baked-in" double scanning, i.e., when
 	// 320x200 is rendered as 320x400.
@@ -2106,9 +2106,9 @@ ImageInfo setup_drawing()
 			video_mode.is_double_scanned_mode = true;
 
 			vga.draw.address_line_total /= 2;
-			video_mode.height = vert_end / 2;
-			double_height     = vga.draw.double_scanning_enabled;
-			force_single_scan = !vga.draw.double_scanning_enabled;
+			video_mode.height  = vert_end / 2;
+			double_height      = vga.draw.double_scanning_enabled;
+			forced_single_scan = !vga.draw.double_scanning_enabled;
 		} else {
 			video_mode.height = vert_end;
 		}
@@ -2162,8 +2162,8 @@ ImageInfo setup_drawing()
 		// VGA (render single-scanned, then double the image vertically with a
 		// scaler).
 		if (is_double_scanning) {
-			video_mode.height = vert_end / 2;
-			force_single_scan = !vga.draw.double_scanning_enabled;
+			video_mode.height  = vert_end / 2;
+			forced_single_scan = !vga.draw.double_scanning_enabled;
 
 			if (vga.draw.double_scanning_enabled) {
 				render_height = video_mode.height * 2;
@@ -2258,7 +2258,7 @@ ImageInfo setup_drawing()
 			if (is_vga_scan_doubling()) {
 				video_mode.is_double_scanned_mode = true;
 				video_mode.height = vert_end / 2;
-				force_single_scan = !vga.draw.double_scanning_enabled;
+				forced_single_scan = !vga.draw.double_scanning_enabled;
 
 				if (vga.draw.double_scanning_enabled) {
 					render_height = video_mode.height * 2;
@@ -2460,7 +2460,7 @@ ImageInfo setup_drawing()
 
 			// We never render true double-scanned CGA modes; we
 			// always fake it even if double scanning is requested
-			force_single_scan = true;
+			forced_single_scan = true;
 
 			render_pixel_aspect_ratio = calc_pixel_aspect_from_timings(
 			        vga_timings);
@@ -2800,8 +2800,8 @@ ImageInfo setup_drawing()
 	          render_pixel_aspect_ratio.Denom(),
 	          render_pixel_aspect_ratio.Inverse().ToDouble());
 
-	LOG_DEBUG("VGA: force_single_scan: %d, rendered_double_scan: %d",
-	          force_single_scan,
+	LOG_DEBUG("VGA: forced_single_scan: %d, rendered_double_scan: %d",
+	          forced_single_scan,
 	          rendered_double_scan);
 
 	LOG_DEBUG("VGA: VIDEO_MODE: width: %d, height: %d, PAR: %lld:%lld (1:%g)",
@@ -2834,7 +2834,7 @@ ImageInfo setup_drawing()
 	render.height               = render_height;
 	render.double_width         = double_width;
 	render.double_height        = double_height;
-	render.force_single_scan    = force_single_scan;
+	render.forced_single_scan   = forced_single_scan;
 	render.rendered_double_scan = rendered_double_scan;
 	render.pixel_aspect_ratio   = render_pixel_aspect_ratio;
 	render.pixel_format         = pixel_format;
@@ -2910,7 +2910,7 @@ void VGA_SetupDrawing(uint32_t /*val*/)
 			                                          SCALER_MAXHEIGHT));
 		}
 
-		vga.draw.lines_scaled = image_info.force_single_scan ? 2 : 1;
+		vga.draw.lines_scaled = image_info.forced_single_scan ? 2 : 1;
 
 		if (!vga.draw.vga_override) {
 			ReelMagic_RENDER_SetSize(image_info, fps);

--- a/src/hardware/voodoo.cpp
+++ b/src/hardware/voodoo.cpp
@@ -7353,7 +7353,7 @@ static void Voodoo_UpdateScreen()
 			image_info.height               = height;
 			image_info.double_width         = false;
 			image_info.double_height        = false;
-			image_info.force_single_scan    = false;
+			image_info.forced_single_scan   = false;
 			image_info.rendered_double_scan = false;
 			image_info.pixel_aspect_ratio   = {1};
 			image_info.pixel_format = PixelFormat::RGB565_Packed16;

--- a/src/hardware/voodoo.cpp
+++ b/src/hardware/voodoo.cpp
@@ -7344,34 +7344,39 @@ static void Voodoo_UpdateScreen()
 		} else
 #endif
 		{
-			const auto width  = v->fbi.width;
-			const auto height = v->fbi.height;
+			ImageInfo image_info = {};
 
-			constexpr auto double_width  = false;
-			constexpr auto double_height = false;
+			const auto width  = check_cast<uint16_t>(v->fbi.width);
+			const auto height = check_cast<uint16_t>(v->fbi.height);
 
-			constexpr Fraction render_pixel_aspect_ratio = {1};
+			image_info.width                = width;
+			image_info.height               = height;
+			image_info.double_width         = false;
+			image_info.double_height        = false;
+			image_info.force_single_scan    = false;
+			image_info.rendered_double_scan = false;
+			image_info.pixel_aspect_ratio   = {1};
+			image_info.pixel_format = PixelFormat::RGB565_Packed16;
 
-			VideoMode video_mode        = {};
-			video_mode.bios_mode_number = 0;
-			video_mode.width  = check_cast<uint16_t>(width);
-			video_mode.height = check_cast<uint16_t>(height);
-			video_mode.pixel_aspect_ratio = render_pixel_aspect_ratio;
-			video_mode.graphics_standard  = GraphicsStandard::Svga;
-			video_mode.color_depth        = ColorDepth::HighColor16Bit;
+			VideoMode video_mode = {};
+
+			video_mode.bios_mode_number   = 0;
 			video_mode.is_custom_mode     = false;
 			video_mode.is_graphics_mode   = true;
+			video_mode.width              = width;
+			video_mode.height             = height;
+			video_mode.pixel_aspect_ratio = {1};
+			video_mode.graphics_standard  = GraphicsStandard::Svga;
+			video_mode.color_depth = ColorDepth::HighColor16Bit;
+			video_mode.is_double_scanned_mode = false;
+			video_mode.has_vga_colors         = false;
 
-			const auto frames_per_second = 1000.0 / v->draw.frame_period_ms;
+			image_info.video_mode = video_mode;
 
-			RENDER_SetSize(width,
-			               height,
-			               double_width,
-			               double_height,
-			               render_pixel_aspect_ratio,
-			               PixelFormat::RGB565_Packed16,
-			               static_cast<float>(frames_per_second),
-			               video_mode);
+			const auto frames_per_second = static_cast<float>(
+			        1000.0 / v->draw.frame_period_ms);
+
+			RENDER_SetSize(image_info, frames_per_second);
 		}
 
 		Voodoo_VerticalTimer(0);


### PR DESCRIPTION
# Description

My last code change for the release 😅 

Fixes https://github.com/dosbox-staging/dosbox-staging/issues/2734, https://github.com/dosbox-staging/dosbox-staging/issues/2813 and https://github.com/dosbox-staging/dosbox-staging/issues/2812 .

With this change, we're always writing non-double-scanned and non-pixel-doubled frames in raw video capture mode. This makes raw video captures consistent with the raw image captures.

For example, the 320x200 13h VGA mode is always written as 320x200 in raw video capture mode, irrespective of whether the passed-down image is 320x200 (e.g., when forcing single-scanning with the `crt-auto-arcade` shader) or 320x400 with "baked-in" double-scanning (the normal use-case without forced single scanning). Pixel doubling and fake double scanning performed as a post-processing step via the `double_width` and `double_height` flags are now always ignored; again, this guarantees 100% consistency with the revised raw image capture feature which is already doing the same thing.

Composite modes are special because they're rendered at 2x the width of the video mode to allow enough horizontal resolution to represent composite artifacts (so 320x200 is rendered as 640x200, and 640x200 as 1280x200). These are written as-is, otherwise we'd be losing information.

This is for the _raw_ video capture mode, which is a slightly revised version of the legacy video capture feature. @weirddan455 is planning to add further video capture modes going forward to capture the video in the correct aspect ratio, similar to the new "upscaled" image capture mode. The specifics of that are still very much in flux and it requires more research and experimentation—that's @weirddan455's territory!

PS: Someone please do a quick Voodoo regression test. Just make sure that Voodoo still works, basically, because I touched `voodoo.cpp` too.

# Related issues

https://github.com/dosbox-staging/dosbox-staging/pull/2817

https://github.com/dosbox-staging/dosbox-staging/pull/2785

# Manual testing

## VGA 320x200 (double-scanned & pixel-doubled)

### Gods

- **double-scanned & pixel-doubled:**
  - using `crt-auto` 320x200 mode 13h is rendered as 640x400 internally (that's what's sent to the shader), but the video capture must be 320x200.

-  **single-scanned & pixel-doubled:**
   - using `crt-auto-arcade` 320x200 mode 13h is rendered as 640x200 internally, but the video capture must be 320x200.

- **single-scanned & not pixel-doubled:**
  - using `crt-auto-arcade-sharp` 320x200 mode 13h is rendered as 320x200 internally, but the video capture must be 320x200.

<img width="1215" alt="image" src="https://github.com/dosbox-staging/dosbox-staging/assets/698770/ff4a3e25-0334-4e28-8a62-5ee5ebe3b2b4">

<img width="633" alt="image" src="https://github.com/dosbox-staging/dosbox-staging/assets/698770/b1987429-9a16-4d96-9a51-7e34305a7639">

## EGA 320x200 

### Space Quest III

<img width="1215" alt="image" src="https://github.com/dosbox-staging/dosbox-staging/assets/698770/f5ae746e-ab7a-4912-aee1-1dc934b88931">

<img width="625" alt="image" src="https://github.com/dosbox-staging/dosbox-staging/assets/698770/b858c51c-1bbf-4d71-8da9-19aa852f4d70">

## EGA 640x200

### Sargon 5 - World Class Chess

<img width="1215" alt="image" src="https://github.com/dosbox-staging/dosbox-staging/assets/698770/342424b3-8000-44cb-9f5b-2303cf5343fb">

<img width="664" alt="image" src="https://github.com/dosbox-staging/dosbox-staging/assets/698770/31b8ac38-5f67-43c1-a87b-875b98ffbf51">


## CGA 320x200 composite

320x200 composite is rendered as 640x200, so that's what we write.

### Ancient Art of War

<img width="1215" alt="image" src="https://github.com/dosbox-staging/dosbox-staging/assets/698770/ac3569f7-56d6-4205-87f2-afc4cde5a4c7">

<img width="690" alt="image" src="https://github.com/dosbox-staging/dosbox-staging/assets/698770/269dbce0-66aa-4de6-8396-b6e53afeb150">

## Tandy 640x200 composite

640x200 composite is rendered as 1280x200, so that's what we write.

### Zak McKracken and the Alien Mindbenders (v2, enhanced version)

<img width="1215" alt="image" src="https://github.com/dosbox-staging/dosbox-staging/assets/698770/a42e9259-3914-4a1c-800e-551d168c67f7">

<img width="1304" alt="image" src="https://github.com/dosbox-staging/dosbox-staging/assets/698770/a8ca7759-bdd1-4ffe-b724-755315c35b83">

## ReelMagic regression test

### Return to Zork

Because I had to clean up & refactor the ReelMagic video mixer too.

<img width="1215" alt="image" src="https://github.com/dosbox-staging/dosbox-staging/assets/698770/19266de0-859a-43c0-8511-be8582220aa7">


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

