### PR TITLE
Make `--list-glshaders` output translatable

### DIFF
--- a/contrib/resources/translations/pl.lng
+++ b/contrib/resources/translations/pl.lng
@@ -67,7 +67,6 @@ Lista dostępnych opcji:
 .
 :DOSBOX_HELP_LIST_COUNTRIES_1
 Kody krajów, często takie same jak telefoniczny numer kierunkowy
-----------------------------------------------------------------
 .
 :DOSBOX_HELP_LIST_COUNTRIES_2
 Powyższych kodów numerycznych należy użyć w ustawieniu 'country'

--- a/include/render.h
+++ b/include/render.h
@@ -199,6 +199,7 @@ const std::string RENDER_GetCgaColorsSetting();
 void RENDER_SyncMonochromePaletteSetting(const enum MonochromePalette palette);
 
 std::deque<std::string> RENDER_GenerateShaderInventoryMessage();
+void RENDER_AddMessages();
 
 void RENDER_SetSize(const uint16_t width, const uint16_t height,
                     const bool double_width, const bool double_height,

--- a/src/dos/dos_locale.cpp
+++ b/src/dos/dos_locale.cpp
@@ -1902,8 +1902,11 @@ static std::string get_country_name(const Country country)
 
 std::string DOS_GenerateListCountriesMessage()
 {
+	const std::string heading = MSG_GetRaw("DOSBOX_HELP_LIST_COUNTRIES_1");
 	std::string message = "\n";
-	message += MSG_GetRaw("DOSBOX_HELP_LIST_COUNTRIES_1");
+	message += heading;
+	message += "\n";
+	message += std::string(heading.size(), '-');
 	message += "\n\n";
 
 	for (auto it = CountryData.begin(); it != CountryData.end(); ++it) {
@@ -2894,8 +2897,7 @@ void DOS_Locale_Init(Section* sec)
 void DOS_Locale_AddMessages()
 {
 	MSG_Add("DOSBOX_HELP_LIST_COUNTRIES_1",
-	        "List of country codes (mostly same as telephone call codes)\n"
-	        "-----------------------------------------------------------");
+	        "List of country codes (mostly same as telephone call codes)");
 	MSG_Add("DOSBOX_HELP_LIST_COUNTRIES_2",
 	        "The above numeric country codes can be used exactly as listed\n"
 	        "in the 'country' config setting.");

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -668,6 +668,11 @@ std::deque<std::string> RENDER_GenerateShaderInventoryMessage()
 	return get_shader_manager().GenerateShaderInventoryMessage();
 }
 
+void RENDER_AddMessages()
+{
+	ShaderManager::AddMessages();
+}
+
 static void reload_shader([[maybe_unused]] const bool pressed)
 {
 	if (GFX_GetRenderingBackend() != RenderingBackend::OpenGl) {

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -4673,6 +4673,7 @@ int sdl_main(int argc, char* argv[])
 		// DOS messages, needed by some command line switches
 		messages_add_command_line();
 		DOS_Locale_AddMessages();
+		RENDER_AddMessages();
 		messages_add_sdl();
 		config_add_sdl();
 

--- a/src/gui/shader_manager.cpp
+++ b/src/gui/shader_manager.cpp
@@ -196,10 +196,8 @@ std::deque<std::string> ShaderManager::GenerateShaderInventoryMessage() const
 {
 	std::deque<std::string> inventory;
 	inventory.emplace_back("");
-	inventory.emplace_back("List of available GLSL shaders");
-	inventory.emplace_back("------------------------------");
+	inventory.emplace_back(MSG_GetRaw("DOSBOX_HELP_LIST_GLSHADERS_1"));
 
-	const std::string dir_prefix  = "Path '";
 	const std::string file_prefix = "        ";
 
 	std::error_code ec = {};
@@ -207,29 +205,44 @@ std::deque<std::string> ShaderManager::GenerateShaderInventoryMessage() const
 		const auto dir_exists      = std_fs::is_directory(dir, ec);
 		auto shader                = shaders.begin();
 		const auto dir_has_shaders = shader != shaders.end();
-		const auto dir_postfix     = dir_exists
-		                                   ? (dir_has_shaders ? "' has:"
-		                                                      : "' has no shaders")
-		                                   : "' does not exist";
 
-		inventory.emplace_back(dir_prefix + dir.string() + dir_postfix);
+		const char *pattern = nullptr;
+		if (!dir_exists) {
+			pattern = MSG_GetRaw("DOSBOX_HELP_LIST_GLSHADERS_NOT_EXISTS");
+		} else if (!dir_has_shaders) {
+			pattern = MSG_GetRaw("DOSBOX_HELP_LIST_GLSHADERS_NO_SHADERS");
+		} else {
+			pattern = MSG_GetRaw("DOSBOX_HELP_LIST_GLSHADERS_LIST");
+		}
+		inventory.emplace_back(format_string(pattern, dir.u8string().c_str()));
 
 		while (shader != shaders.end()) {
 			shader->replace_extension("");
 			const auto is_last = (shader + 1 == shaders.end());
 			inventory.emplace_back(file_prefix +
 			                       (is_last ? "`- " : "|- ") +
-			                       shader->string());
+			                       shader->u8string());
 			++shader;
 		}
 		inventory.emplace_back("");
 	}
-	inventory.emplace_back(
-	        "The above shaders can be used exactly as listed in the 'glshader'");
-	inventory.emplace_back(
-	        "conf setting, without the need for the resource path or .glsl extension.");
+	inventory.emplace_back(MSG_GetRaw("DOSBOX_HELP_LIST_GLSHADERS_2"));
 
 	return inventory;
+}
+
+void ShaderManager::AddMessages()
+{
+	MSG_Add("DOSBOX_HELP_LIST_GLSHADERS_1",
+	        "List of available GLSL shaders\n"
+	        "------------------------------");
+	MSG_Add("DOSBOX_HELP_LIST_GLSHADERS_2",
+	        "The above shaders can be used exactly as listed in the 'glshader'\n"
+	        "config setting, without the need for the resource path or .glsl extension.");
+
+	MSG_Add("DOSBOX_HELP_LIST_GLSHADERS_NOT_EXISTS", "Path '%s' does not exist");
+	MSG_Add("DOSBOX_HELP_LIST_GLSHADERS_NO_SHADERS", "Path '%s' has no shaders");
+	MSG_Add("DOSBOX_HELP_LIST_GLSHADERS_LIST",       "Path '%s' has:");
 }
 
 std::string ShaderManager::MapShaderName(const std::string& name) const

--- a/src/gui/shader_manager.cpp
+++ b/src/gui/shader_manager.cpp
@@ -197,6 +197,7 @@ std::deque<std::string> ShaderManager::GenerateShaderInventoryMessage() const
 	std::deque<std::string> inventory;
 	inventory.emplace_back("");
 	inventory.emplace_back(MSG_GetRaw("DOSBOX_HELP_LIST_GLSHADERS_1"));
+	inventory.emplace_back(inventory.back().size(), '-');
 
 	const std::string file_prefix = "        ";
 
@@ -234,8 +235,7 @@ std::deque<std::string> ShaderManager::GenerateShaderInventoryMessage() const
 void ShaderManager::AddMessages()
 {
 	MSG_Add("DOSBOX_HELP_LIST_GLSHADERS_1",
-	        "List of available GLSL shaders\n"
-	        "------------------------------");
+	        "List of available GLSL shaders");
 	MSG_Add("DOSBOX_HELP_LIST_GLSHADERS_2",
 	        "The above shaders can be used exactly as listed in the 'glshader'\n"
 	        "config setting, without the need for the resource path or .glsl extension.");

--- a/src/gui/shader_manager.h
+++ b/src/gui/shader_manager.h
@@ -135,6 +135,7 @@ public:
 	// Generate a human-readable shader inventory message (one list element
 	// per line).
 	std::deque<std::string> GenerateShaderInventoryMessage() const;
+	static void AddMessages();
 
 	std::string MapShaderName(const std::string& name) const;
 


### PR DESCRIPTION
# Description

As the title says - make `--list-glshaders` output translatable. Nothing more, nothing less.

# Manual testing

- execute `dosbox --list-glshaders` and check that the output is correct
- inside DOSBox execute `config -wl en.lng` and check that new strings were written


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

