### PR TITLE
Cleanup a handful of unchecked return-code issues flagged by Coverity

### DIFF
--- a/include/fs_utils.h
+++ b/include/fs_utils.h
@@ -89,6 +89,39 @@ constexpr uint32_t OK_IF_EXISTS = 0x1;
 
 int create_dir(const std_fs::path& path, uint32_t mode, uint32_t flags = 0x0) noexcept;
 
+// Behaves like fseek, but logs an error stating the module, byte offset, file
+// description, filename, and strerror on failure. Returns true on success and
+// false on failure. On failure, it closes the file as it's no longer in a good
+// state.
+//
+bool check_fseek(const char* module_name, const char* file_description,
+                 const char* filename, FILE*& stream, const long long offset,
+                 const int whence);
+
+// Returns a 'check_fseek' function object that behaves like the above. This can
+// be used when lots of sequential seeks are needed.
+//
+inline auto make_check_fseek_func(const std::string& module_name,
+                                  const std::string& file_description,
+                                  const std_fs::path& filepath)
+{
+	// Use the lambda copy-operator to keep copies of the arguments inside
+	// the lambda, as these arguments would normally go out of scope with
+	// respect to the lifetime of the lamda.
+	//
+	auto check_fseek_lambda = [=](FILE*& stream,
+	                              const long long offset,
+	                              const int whence) -> bool {
+		return check_fseek(module_name.c_str(),
+		                   file_description.c_str(),
+		                   filepath.string().c_str(),
+		                   stream,
+		                   offset,
+		                   whence);
+	};
+	return check_fseek_lambda;
+}
+
 // Convert a filesystem time to a raw time_t value
 std::time_t to_time_t(const std_fs::file_time_type &fs_time);
 

--- a/src/hardware/pcspeaker_discrete.cpp
+++ b/src/hardware/pcspeaker_discrete.cpp
@@ -284,7 +284,8 @@ void PcSpeakerDiscrete::SetCounter(int count, const PitMode mode)
 		return;
 	}
 	// Activate the channel after queuing new speaker entries
-	channel->WakeUp();
+	// We don't care about the return-code, so explicitly ignore it.
+	(void)channel->WakeUp();
 }
 
 // Returns the amp_neutral voltage if the speaker's  fully faded,
@@ -334,8 +335,8 @@ void PcSpeakerDiscrete::SetType(const PpiPortB &b)
 		AddDelayEntry(newindex, NeutralLastPitOr(amp_positive));
 		break;
 	};
-
-	channel->WakeUp();
+	// We don't care about the return-code, so explicitly ignore it.
+	(void)channel->WakeUp();
 }
 
 void PcSpeakerDiscrete::ChannelCallback(const uint16_t frames)

--- a/src/misc/fs_utils.cpp
+++ b/src/misc/fs_utils.cpp
@@ -22,7 +22,9 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cerrno>
 #include <chrono>
+#include <cstring>
 #include <fstream>
 
 #include "checks.h"
@@ -31,6 +33,30 @@
 #include "std_filesystem.h"
 
 CHECK_NARROWING();
+
+bool check_fseek(const char* module_name, const char* file_description,
+                 const char* filename, FILE*& stream, const long long offset,
+                 const int whence)
+{
+	assert(stream);
+	if (cross_fseeko(stream, offset, whence) == 0) {
+		return true;
+	}
+
+	assert(module_name);
+	assert(file_description);
+	assert(filename);
+	LOG_ERR("%s: Failed seeking to byte %lld in %s file '%s': %s",
+	        module_name,
+	        offset,
+	        file_description,
+	        filename,
+	        strerror(errno));
+
+	fclose(stream);
+	stream = nullptr;
+	return false;
+}
 
 bool is_directory(const std::string& candidate)
 {

--- a/src/shell/command_line.cpp
+++ b/src/shell/command_line.cpp
@@ -408,7 +408,7 @@ std::string CommandLine::FindRemoveSingleString(const char* name)
 		if (is_valid) {
 			++it_next;
 		}
-		cmds.erase(it, it_next);
+		it = cmds.erase(it, it_next);
 		if (is_valid) {
 			return value;
 		}

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -359,7 +359,10 @@ void DOS_Shell::ParseLine(char *line)
 			LOG_MSG("SHELL: Failed to write pipe content to temporary file");
 		}
 		if (DOS_FindFirst(pipe_tempfile, FatAttributeFlags::NotVolume)) {
-			DOS_UnlinkFile(pipe_tempfile);
+			if (!DOS_UnlinkFile(pipe_tempfile)) {
+				LOG_WARNING("SHELL: Failed to delete the pipe's temporary file, '%s'",
+				            pipe_tempfile);
+			}
 		}
 	}
 }


### PR DESCRIPTION
# Description

Fix a handful of unchecked return-code issues flagged by the updated Coverity scanner.

## Related issues

![2023-12-05_17-09](https://github.com/dosbox-staging/dosbox-staging/assets/1557255/6355d824-a37e-4055-9836-ea32c4ed9845)

# Manual testing

Tested shell command line handling and booting floppy and HDD images.

Also tested with UBSAN and ASAN builds.

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

