### PR TITLE
Use zlib-ng, a faster drop-in replacement for zlib, when found

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -528,6 +528,7 @@ sdl2_dep = dependency(
 
 zlib_dep = dependency(
     'zlib',
+    fallback: ['zlib-ng', 'zlib'],
     version: ['>= 1.2.11', '< 2'],
     default_options: default_wrap_options,
     static: ('zlib' in static_libs_list or prefers_static_libs),


### PR DESCRIPTION
# Description

zlib-ng makes use of host SIMD calls and so can speed deflate times by about 50% or better based on my timings.

## Related issues

This is an optional mitigation for the slower ZMBV performance @weirddan455 investigated due to the move to 32-bit pixels #2812.

# Manual testing

Try it:
```shell
git clone --depth 1 https://github.com/zlib-ng/zlib-ng
cd zlib-ng
cmake -DZLIB_COMPAT=1 -DWITH_NATIVE_INSTRUCTIONS=1 .
cmake --build . --config Release
ctest --verbose -C Release && sudo cmake --build . --target install
```

Run a `meson setup ...`, and look for `zlib found: YES 1.3.0.zlib-ng`:

![2023-12-06_19-28](https://github.com/dosbox-staging/dosbox-staging/assets/1557255/ac2f7433-cc53-44e0-a763-5b6bea1c2045)

Tested and measured image capture and video frame compression times. The results are roughly a 50% (or better) speed up.

# Checklist

I have:

- [ ] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [ ] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [ ] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

