### PR TITLE
Fix raw image & video capture for 160x200 16-colour Tandy/PCjr modes 

### DIFF
--- a/include/video.h
+++ b/include/video.h
@@ -308,6 +308,12 @@ struct ImageInfo {
 	// (doubled post-render by setting `double_height` to true).
 	bool rendered_double_scan = false;
 
+	// If true, the image has been rendered doubled horizontally. This is only
+	// used to "normalise" the 160x200 16-colour Tandy and PCjr modes to
+	// 320-pixel-wide rendered output (it simplifies rendering the host video
+	// output downstream, but slightly complicates raw captures).
+	bool rendered_pixel_doubling = false;
+
 	// Pixel aspect ratio to be applied to the final image, *after*
 	// optional width and height doubling, so it appears as intended.
 	// (`video_mode.pixel_aspect_ratio` holds the "nominal" pixel

--- a/src/capture/image/image_decoder.cpp
+++ b/src/capture/image/image_decoder.cpp
@@ -24,7 +24,8 @@
 
 CHECK_NARROWING();
 
-void ImageDecoder::Init(const RenderedImage& image, const uint8_t row_skip_count)
+void ImageDecoder::Init(const RenderedImage& image, const uint8_t row_skip_count,
+                        const uint8_t pixel_skip_count)
 {
 	assert(image.params.width > 0);
 	assert(image.params.height > 0);
@@ -45,8 +46,9 @@ void ImageDecoder::Init(const RenderedImage& image, const uint8_t row_skip_count
 	}
 	pos = curr_row_start;
 
-	this->image          = image;
-	this->row_skip_count = row_skip_count;
+	this->image            = image;
+	this->row_skip_count   = row_skip_count;
+	this->pixel_skip_count = pixel_skip_count;
 }
 
 void ImageDecoder::AdvanceRow()

--- a/src/capture/image/image_saver.cpp
+++ b/src/capture/image/image_saver.cpp
@@ -154,15 +154,15 @@ void ImageSaver::SaveRawImage(const RenderedImage& image)
 {
 	PngWriter png_writer = {};
 
+	const auto& src = image.params;
+
 	// To reconstruct the raw image, we must skip every second row when
 	// dealing with "baked-in" double scanning.
-	const uint8_t row_skip_count = (image.params.rendered_double_scan ? 1 : 0);
+	const uint8_t row_skip_count = (src.rendered_double_scan ? 1 : 0);
 
 	// To reconstruct the raw image, we must skip every second pixel when
 	// dealing with "baked-in" pixel doubling.
-	const uint8_t pixel_skip_count = (image.params.rendered_pixel_doubling ? 1 : 0);
-
-	const auto& src = image.params;
+	const uint8_t pixel_skip_count = (src.rendered_pixel_doubling ? 1 : 0);
 
 	const auto output_width = check_cast<uint16_t>(src.width /
 	                                               (pixel_skip_count + 1));

--- a/src/capture/image/image_scaler.cpp
+++ b/src/capture/image/image_scaler.cpp
@@ -34,10 +34,18 @@ void ImageScaler::Init(const RenderedImage& image)
 {
 	input = image;
 
-	// To reconstruct the raw image, we must skip every second row if we're
-	// dealing with "baked in" double scanning.
+	// To reconstruct the raw image, we must skip every second row when
+	// dealing with "baked-in" double scanning. "De-double-scanning" VGA
+	// images has the beneficial side effect that we can use finer vertical
+	// integer scaling steps, so it's worthwhile doing it.
 	const uint8_t row_skip_count = (image.params.rendered_double_scan ? 1 : 0);
-	input_decoder.Init(image, row_skip_count);
+
+	// "Baked-in" pixel doubling is only used for the 160x200 16-colour
+	// Tandy/PCjr modes. We wouldn't gain anything by reconstructing the raw
+	// 160-pixel-wide image when upscaling, so we'll just leave it be.
+	const uint8_t pixel_skip_count = 0;
+
+	input_decoder.Init(image, row_skip_count, pixel_skip_count);
 
 	UpdateOutputParamsUpscale();
 

--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -1989,6 +1989,10 @@ ImageInfo setup_drawing()
 	// 320x200 is rendered as 320x400.
 	bool rendered_double_scan = false;
 
+	// If true, we're dealing with "baked-in" pixel doubling, i.e. when 
+	// 160x200 is rendered as 320x200.
+	bool rendered_pixel_doubling = false;
+
 	Fraction render_pixel_aspect_ratio = {1};
 
 	VideoMode video_mode = {};
@@ -2322,6 +2326,7 @@ ImageInfo setup_drawing()
 			double_width     = vga.draw.pixel_doubling_enabled;
 			video_mode.width = horiz_end * 4;
 			render_width     = video_mode.width * 2;
+			rendered_pixel_doubling = true;
 
 			VGA_DrawLine = VGA_Draw_4BPP_Line_Double;
 		}
@@ -2800,9 +2805,10 @@ ImageInfo setup_drawing()
 	          render_pixel_aspect_ratio.Denom(),
 	          render_pixel_aspect_ratio.Inverse().ToDouble());
 
-	LOG_DEBUG("VGA: forced_single_scan: %d, rendered_double_scan: %d",
+	LOG_DEBUG("VGA: forced_single_scan: %d, rendered_double_scan: %d, rendered_pixel_doubling: %d",
 	          forced_single_scan,
-	          rendered_double_scan);
+	          rendered_double_scan,
+	          rendered_pixel_doubling);
 
 	LOG_DEBUG("VGA: VIDEO_MODE: width: %d, height: %d, PAR: %lld:%lld (1:%g)",
 	          video_mode.width,
@@ -2830,15 +2836,16 @@ ImageInfo setup_drawing()
 
 	ImageInfo render = {};
 
-	render.width                = render_width;
-	render.height               = render_height;
-	render.double_width         = double_width;
-	render.double_height        = double_height;
-	render.forced_single_scan   = forced_single_scan;
-	render.rendered_double_scan = rendered_double_scan;
-	render.pixel_aspect_ratio   = render_pixel_aspect_ratio;
-	render.pixel_format         = pixel_format;
-	render.video_mode           = video_mode;
+	render.width                   = render_width;
+	render.height                  = render_height;
+	render.double_width            = double_width;
+	render.double_height           = double_height;
+	render.forced_single_scan      = forced_single_scan;
+	render.rendered_double_scan    = rendered_double_scan;
+	render.rendered_pixel_doubling = rendered_pixel_doubling;
+	render.pixel_aspect_ratio      = render_pixel_aspect_ratio;
+	render.pixel_format            = pixel_format;
+	render.video_mode              = video_mode;
 
 	return render;
 }


### PR DESCRIPTION
# Description

Before this change, raw image and video captures of the 160x200 16-colour Tandy/PCjr video modes were written width-doubled as 320x200. This is because this special mode is rendered with "baked-in" pixel doubling (we're not doing this for any other mode).

With this fix, raw image & video captures work 100% consistently with our definition of raw captures for all video modes on all emulated adapters 🎉 

See the end of this post for a list of games that use the 160x200 Tandy/PCjr mode:

http://nerdlypleasures.blogspot.com/2015/10/advantages-of-160x200-16-color.html


## Related issues

https://github.com/dosbox-staging/dosbox-staging/pull/3177

# Manual testing

Regression tested raw image & video capture with a couple of VGA and EGA games—all good.

Tested 160x200 16-colour Tandy/PCjr mode with Maniac Mansion v1.

<img width="948" alt="image" src="https://github.com/dosbox-staging/dosbox-staging/assets/698770/b5c2cc49-8ee4-4366-bd8b-f093eb7f3345">

<img width="1215" alt="image" src="https://github.com/dosbox-staging/dosbox-staging/assets/698770/28794f42-a375-4114-b91d-52fb212b3453">

### Raw image capture

<img width="320" alt="image" src="https://github.com/dosbox-staging/dosbox-staging/assets/698770/89202f99-9422-4976-8112-2e8b97853265">

### Raw video capture

<img width="1136" alt="image" src="https://github.com/dosbox-staging/dosbox-staging/assets/698770/6d1fb02a-b2c0-43bd-ac58-304636e64f16">





# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

