### PR TITLE
Minor country and help fixes

### DIFF
--- a/contrib/resources/translations/nl.lng
+++ b/contrib/resources/translations/nl.lng
@@ -417,6 +417,7 @@ Oezbekistan
 .
 :DOSBOX_HELP_LIST_GLSHADERS_1
 Lijst met beschikbare GLSL-shaders
+----------------------------------
 .
 :DOSBOX_HELP_LIST_GLSHADERS_2
 Bovenstaande shaders kunnen precies worden gebruikt zoals vermeld in de

--- a/contrib/resources/translations/pl.lng
+++ b/contrib/resources/translations/pl.lng
@@ -67,6 +67,7 @@ Lista dostępnych opcji:
 .
 :DOSBOX_HELP_LIST_COUNTRIES_1
 Kody krajów, często takie same jak telefoniczny numer kierunkowy
+----------------------------------------------------------------
 .
 :DOSBOX_HELP_LIST_COUNTRIES_2
 Powyższych kodów numerycznych należy użyć w ustawieniu 'country'

--- a/src/dos/dos_locale.cpp
+++ b/src/dos/dos_locale.cpp
@@ -2486,11 +2486,8 @@ static std::string get_country_name(const Country country)
 
 std::string DOS_GenerateListCountriesMessage()
 {
-	const std::string heading = MSG_GetRaw("DOSBOX_HELP_LIST_COUNTRIES_1");
 	std::string message = "\n";
-	message += heading;
-	message += "\n";
-	message += std::string(heading.size(), '-');
+	message += MSG_GetRaw("DOSBOX_HELP_LIST_COUNTRIES_1");
 	message += "\n\n";
 
 	for (auto it = CountryData.begin(); it != CountryData.end(); ++it) {
@@ -3508,7 +3505,8 @@ void DOS_Locale_Init(Section* sec)
 void DOS_Locale_AddMessages()
 {
 	MSG_Add("DOSBOX_HELP_LIST_COUNTRIES_1",
-	        "List of country codes (mostly same as telephone call codes)");
+	        "List of country codes (mostly same as telephone call codes)\n"
+	        "-----------------------------------------------------------");
 	MSG_Add("DOSBOX_HELP_LIST_COUNTRIES_2",
 	        "The above numeric country codes can be used exactly as listed\n"
 	        "in the 'country' config setting.");

--- a/src/gui/shader_manager.cpp
+++ b/src/gui/shader_manager.cpp
@@ -193,7 +193,7 @@ std::deque<std::string> ShaderManager::GenerateShaderInventoryMessage() const
 	std::deque<std::string> inventory;
 	inventory.emplace_back("");
 	inventory.emplace_back(MSG_GetRaw("DOSBOX_HELP_LIST_GLSHADERS_1"));
-	inventory.emplace_back(inventory.back().size(), '-');
+	inventory.emplace_back("");
 
 	const std::string file_prefix = "        ";
 
@@ -231,7 +231,8 @@ std::deque<std::string> ShaderManager::GenerateShaderInventoryMessage() const
 void ShaderManager::AddMessages()
 {
 	MSG_Add("DOSBOX_HELP_LIST_GLSHADERS_1",
-	        "List of available GLSL shaders");
+	        "List of available GLSL shaders\n"
+	        "------------------------------");
 	MSG_Add("DOSBOX_HELP_LIST_GLSHADERS_2",
 	        "The above shaders can be used exactly as listed in the 'glshader'\n"
 	        "config setting, without the need for the resource path or .glsl extension.");


### PR DESCRIPTION
# Description

1. Fix two comments in country data definitions (data is OK; it is the comments which are wrong) - noticed by @rderooy 
2. Fix problem I have discovered while updating Polish translation - to determine UTF-8 string length in characters we need something much more sophisticated than `strlen` or C++ counterparts (they give us length in bytes, and a single Unicode character might need many bytes to be encoded); it is much easier to rely on the translator to put a proper number of minuses (as a title underscore). 

![Screenshot-Bug](https://github.com/dosbox-staging/dosbox-staging/assets/48332137/10ef16a7-b767-4f9f-ba31-aa1f9000edd4)

# Manual testing

Execute `dosbox --list-countries` and `dosbox --list-glshaders` commands


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

