### PR TITLE
Add a memory read breakpoint feature to the builtin debugger

### DIFF
--- a/.github/workflows/windows-msvc.yml
+++ b/.github/workflows/windows-msvc.yml
@@ -23,7 +23,7 @@ jobs:
             max_warnings: 17
           - name: MSVC 64-bit
             arch: x64
-            max_warnings: 882
+            max_warnings: 687
 
     steps:
       - name: Checkout repository

--- a/include/cpu.h
+++ b/include/cpu.h
@@ -169,10 +169,12 @@ bool CPU_SetSegGeneral(SegNames seg,Bitu value);
 bool CPU_PopSeg(SegNames seg,bool use32);
 
 bool CPU_CPUID(void);
-Bitu CPU_Pop16(void);
-Bitu CPU_Pop32(void);
-void CPU_Push16(Bitu value);
-void CPU_Push32(Bitu value);
+
+uint16_t CPU_Pop16();
+uint32_t CPU_Pop32();
+
+void CPU_Push16(const uint16_t value);
+void CPU_Push32(const uint32_t value);
 
 #define EXCEPTION_DB			1
 #define EXCEPTION_UD			6

--- a/include/debug.h
+++ b/include/debug.h
@@ -20,22 +20,33 @@
 #define DOSBOX_DEBUG_H
 
 #include "dosbox.h"
+#include "mem.h"
 
-void DEBUG_DrawScreen(void);
-bool DEBUG_Breakpoint(void);
+#if C_DEBUG
+void DEBUG_DrawScreen();
+bool DEBUG_Breakpoint();
 bool DEBUG_IntBreakpoint(uint8_t intNum);
 void DEBUG_Enable(bool pressed);
 void DEBUG_CheckExecuteBreakpoint(uint16_t seg, uint32_t off);
 bool DEBUG_ExitLoop(void);
 void DEBUG_RefreshPage(int scroll);
-Bitu DEBUG_EnableDebugger(void);
+Bitu DEBUG_EnableDebugger();
 
 extern Bitu cycle_count;
 extern Bitu debugCallback;
+#else  // Empty debugging replacements
+#endif // C_DEBUG
 
-#if C_HEAVY_DEBUG
-bool DEBUG_HeavyIsBreakpoint(void);
-void DEBUG_HeavyWriteLogInstruction(void);
-#endif
+#if C_DEBUG && C_HEAVY_DEBUG
+bool DEBUG_HeavyIsBreakpoint();
+void DEBUG_HeavyWriteLogInstruction();
+template <typename T>
+void DEBUG_UpdateMemoryReadBreakpoints(const PhysPt addr);
+#else  // Empty heavy debugging replacements
+template <typename T>
+constexpr void DEBUG_UpdateMemoryReadBreakpoints(const PhysPt)
+{ /* no-op */
+}
+#endif // C_DEBUG && C_HEAVY_DEBUG
 
-#endif
+#endif // DOSBOX_DEBUG_H

--- a/include/debug.h
+++ b/include/debug.h
@@ -33,7 +33,7 @@ Bitu DEBUG_EnableDebugger(void);
 extern Bitu cycle_count;
 extern Bitu debugCallback;
 
-#ifdef C_HEAVY_DEBUG
+#if C_HEAVY_DEBUG
 bool DEBUG_HeavyIsBreakpoint(void);
 void DEBUG_HeavyWriteLogInstruction(void);
 #endif

--- a/include/mem.h
+++ b/include/mem.h
@@ -99,10 +99,22 @@ static inline uint64_t var_read(uint64_t* var)
 /* The Following six functions are slower but they recognize the paged memory
  * system */
 
-uint8_t mem_readb(PhysPt pt);
-uint16_t mem_readw(PhysPt pt);
-uint32_t mem_readd(PhysPt pt);
-uint64_t mem_readq(PhysPt pt);
+enum class MemOpMode {
+	WithBreakpoints,
+	SkipBreakpoints,
+};
+
+template <MemOpMode op_mode = MemOpMode::WithBreakpoints>
+uint8_t mem_readb(const PhysPt pt);
+
+template <MemOpMode op_mode = MemOpMode::WithBreakpoints>
+uint16_t mem_readw(const PhysPt pt);
+
+template <MemOpMode op_mode = MemOpMode::WithBreakpoints>
+uint32_t mem_readd(const PhysPt pt);
+
+template <MemOpMode op_mode = MemOpMode::WithBreakpoints>
+uint64_t mem_readq(const PhysPt pt);
 
 void mem_writeb(PhysPt pt, uint8_t val);
 void mem_writew(PhysPt pt, uint16_t val);

--- a/include/paging.h
+++ b/include/paging.h
@@ -20,7 +20,7 @@
 #define DOSBOX_PAGING_H
 
 #include "dosbox.h"
-
+#include "debug.h"
 #include <vector>
 
 #include "mem.h"
@@ -291,7 +291,7 @@ static inline PhysPt PAGING_GetPhysicalAddress(PhysPt linAddr) {
 	return (paging.tlb.phys_page[linAddr>>12]<<12)|(linAddr&0xfff);
 }
 
-#else
+#else  // not USE_FULL_TLB
 
 void PAGING_InitTLBBank(tlb_entry **bank);
 
@@ -341,19 +341,7 @@ static inline PhysPt PAGING_GetPhysicalAddress(PhysPt linAddr) {
 	tlb_entry *entry = get_tlb_entry(linAddr);
 	return (entry->phys_page<<12)|(linAddr&0xfff);
 }
-#endif
-
-/* Special inlined memory reading/writing */
-
-template <typename T>
-#if C_DEBUG && C_HEAVY_DEBUG
-// forwarded from debug
-void DEBUG_UpdateMemoryReadBreakpoints(const PhysPt addr);
-#else
-static void DEBUG_UpdateMemoryReadBreakpoints([[maybe_unused]] const PhysPt addr)
-{ /* no-op */
-}
-#endif
+#endif // USE_FULL_TLB
 
 template <MemOpMode op_mode = MemOpMode::WithBreakpoints>
 static inline uint8_t mem_readb_inline(const PhysPt address)

--- a/include/paging.h
+++ b/include/paging.h
@@ -345,24 +345,54 @@ static inline PhysPt PAGING_GetPhysicalAddress(PhysPt linAddr) {
 
 /* Special inlined memory reading/writing */
 
-static inline uint8_t mem_readb_inline(PhysPt address) {
-	HostPt tlb_addr=get_tlb_read(address);
-	if (tlb_addr) return host_readb(tlb_addr+address);
-	else
-		return (get_tlb_readhandler(address))->readb(address);
+template <typename T>
+#if C_DEBUG && C_HEAVY_DEBUG
+// forwarded from debug
+void DEBUG_UpdateMemoryReadBreakpoints(const PhysPt addr);
+#else
+static void DEBUG_UpdateMemoryReadBreakpoints([[maybe_unused]] const PhysPt addr)
+{ /* no-op */
 }
+#endif
 
-static inline uint16_t mem_readw_inline(PhysPt address) {
-	if ((address & 0xfff)<0xfff) {
-		HostPt tlb_addr=get_tlb_read(address);
-		if (tlb_addr) return host_readw(tlb_addr+address);
-		else
-			return (get_tlb_readhandler(address))->readw(address);
-	} else return mem_unalignedreadw(address);
-}
-
-static inline uint32_t mem_readd_inline(PhysPt address)
+template <MemOpMode op_mode = MemOpMode::WithBreakpoints>
+static inline uint8_t mem_readb_inline(const PhysPt address)
 {
+	if constexpr (op_mode == MemOpMode::WithBreakpoints) {
+		DEBUG_UpdateMemoryReadBreakpoints<uint8_t>(address);
+	}
+	HostPt tlb_addr = get_tlb_read(address);
+	if (tlb_addr) {
+		return host_readb(tlb_addr + address);
+	} else {
+		return (get_tlb_readhandler(address))->readb(address);
+	}
+}
+
+template <MemOpMode op_mode = MemOpMode::WithBreakpoints>
+static inline uint16_t mem_readw_inline(const PhysPt address)
+{
+	if constexpr (op_mode == MemOpMode::WithBreakpoints) {
+		DEBUG_UpdateMemoryReadBreakpoints<uint16_t>(address);
+	}
+	if ((address & 0xfff) < 0xfff) {
+		HostPt tlb_addr = get_tlb_read(address);
+		if (tlb_addr) {
+			return host_readw(tlb_addr + address);
+		} else {
+			return (get_tlb_readhandler(address))->readw(address);
+		}
+	} else {
+		return mem_unalignedreadw(address);
+	}
+}
+
+template <MemOpMode op_mode = MemOpMode::WithBreakpoints>
+static inline uint32_t mem_readd_inline(const PhysPt address)
+{
+	if constexpr (op_mode == MemOpMode::WithBreakpoints) {
+		DEBUG_UpdateMemoryReadBreakpoints<uint32_t>(address);
+	}
 	if ((address & 0xfff) < 0xffd) {
 		HostPt tlb_addr = get_tlb_read(address);
 		if (tlb_addr)
@@ -374,8 +404,12 @@ static inline uint32_t mem_readd_inline(PhysPt address)
 	}
 }
 
+template <MemOpMode op_mode = MemOpMode::WithBreakpoints>
 static inline uint64_t mem_readq_inline(PhysPt address)
 {
+	if constexpr (op_mode == MemOpMode::WithBreakpoints) {
+		DEBUG_UpdateMemoryReadBreakpoints<uint64_t>(address);
+	}
 	if ((address & 0xfff) < 0xff9) {
 		HostPt tlb_addr = get_tlb_read(address);
 		if (tlb_addr) {

--- a/src/cpu/core_dyn_x86/decoder.h
+++ b/src/cpu/core_dyn_x86/decoder.h
@@ -1051,9 +1051,15 @@ static void dyn_pop(DynReg * dynreg,bool checked=true) {
 		gen_mov_host(&core_dyn.readdata,dynreg,decode.big_op?4:2);
 	} else {
 		if (decode.big_op) {
-			gen_call_function((void *)&mem_readd,"%Rd%Drd",dynreg,DREG(STACK));
+			gen_call_function((void*)&mem_readd<MemOpMode::WithBreakpoints>,
+			                  "%Rd%Drd",
+			                  dynreg,
+			                  DREG(STACK));
 		} else {
-			gen_call_function((void *)&mem_readw,"%Rw%Drd",dynreg,DREG(STACK));
+			gen_call_function((void*)&mem_readw<MemOpMode::WithBreakpoints>,
+			                  "%Rw%Drd",
+			                  dynreg,
+			                  DREG(STACK));
 		}
 	}
 	if (dynreg!=DREG(ESP)) {

--- a/src/cpu/core_full/load.h
+++ b/src/cpu/core_full/load.h
@@ -46,34 +46,43 @@ l_MODRMswitch:
 			inst_op1_d=Fetchb();
 			break;
 		case M_Ebx:
-			if (inst.rm<0xc0) inst_op1_ds=(int8_t)LoadMb(inst.rm_eaa);
-			else inst_op1_ds=(int8_t)reg_8(inst.rm_eai);
+			if (inst.rm<0xc0) inst_op1_ds= static_cast<int8_t>(LoadMb(inst.rm_eaa));
+			else {
+				inst_op1_ds = static_cast<int8_t>(reg_8(
+						static_cast<uint8_t>(inst.rm_eai)));
+			}
 			break;
 		case M_EbIb:
 			inst_op2_d=Fetchb();
 			[[fallthrough]];
 		case M_Eb:
 			if (inst.rm<0xc0) inst_op1_d=LoadMb(inst.rm_eaa);
-			else inst_op1_d=reg_8(inst.rm_eai);
+			else {
+				inst_op1_d = reg_8(static_cast<uint8_t>(inst.rm_eai));
+			}
 			break;
 		case M_EbGb:
 			if (inst.rm<0xc0) inst_op1_d=LoadMb(inst.rm_eaa);
-			else inst_op1_d=reg_8(inst.rm_eai);
-			inst_op2_d=reg_8(inst.rm_index);
+			else {
+				inst_op1_d = reg_8(static_cast<uint8_t>(inst.rm_eai));
+			}
+			inst_op2_d = reg_8(static_cast<uint8_t>(inst.rm_index));
 			break;
 		case M_GbEb:
 			if (inst.rm<0xc0) inst_op2_d=LoadMb(inst.rm_eaa);
-			else inst_op2_d=reg_8(inst.rm_eai);
+			else {
+				inst_op2_d = reg_8(static_cast<uint8_t>(inst.rm_eai));
+			}
 			[[fallthrough]];
 		case M_Gb:
-			inst_op1_d=reg_8(inst.rm_index);;
+			inst_op1_d = reg_8(static_cast<uint8_t>(inst.rm_index));;
 			break;
 /* Word */
 		case M_Iw:
 			inst_op1_d=Fetchw();
 			break;
 		case M_EwxGwx:
-			inst_op2_ds=(int16_t)reg_16(inst.rm_index);
+			inst_op2_ds = static_cast<int16_t>(reg_16(static_cast<uint8_t>(inst.rm_index)));
 			goto l_M_Ewx;
 		case M_EwxIbx:
 			inst_op2_ds=Fetchbs();
@@ -83,8 +92,11 @@ l_MODRMswitch:
 			[[fallthrough]];
 		case M_Ewx:
 l_M_Ewx:
-			if (inst.rm<0xc0) inst_op1_ds=(int16_t)LoadMw(inst.rm_eaa);
-			else inst_op1_ds=(int16_t)reg_16(inst.rm_eai);
+			if (inst.rm<0xc0) inst_op1_ds = static_cast<int16_t>(LoadMw(inst.rm_eaa));
+			else {
+				inst_op1_ds = static_cast<int16_t>(reg_16(
+						static_cast<uint8_t>(inst.rm_eai)));
+			}
 			break;
 		case M_EwIb:
 			inst_op2_d=Fetchb();
@@ -102,35 +114,42 @@ l_M_Ewx:
 			inst_imm_d=Fetchb();
 			goto l_M_EwGw;
 		case M_EwGwt:
-			inst_op2_d=reg_16(inst.rm_index);
+			inst_op2_d=reg_16(static_cast<uint8_t>(inst.rm_index));
 			inst.rm_eaa+=((int16_t)inst_op2_d >> 4) * 2;
 			goto l_M_Ew;
 		case M_EwGw:
 l_M_EwGw:
-			inst_op2_d=reg_16(inst.rm_index);
+			inst_op2_d=reg_16(static_cast<uint8_t>(inst.rm_index));
 			[[fallthrough]];
 		case M_Ew:
 l_M_Ew:
 			if (inst.rm<0xc0) inst_op1_d=LoadMw(inst.rm_eaa);
-			else inst_op1_d=reg_16(inst.rm_eai);
+			else {
+				inst_op1_d = reg_16(static_cast<uint8_t>(inst.rm_eai));
+			}
 			break;
 		case M_GwEw:
 			if (inst.rm<0xc0) inst_op2_d=LoadMw(inst.rm_eaa);
-			else inst_op2_d=reg_16(inst.rm_eai);
+			else {
+				inst_op2_d = reg_16(static_cast<uint8_t>(inst.rm_eai));
+			}
 			[[fallthrough]];
 		case M_Gw:
-			inst_op1_d=reg_16(inst.rm_index);;
+			inst_op1_d=reg_16(static_cast<uint8_t>(inst.rm_index));;
 			break;
 /* DWord */
 		case M_Id:
 			inst_op1_d=Fetchd();
 			break;
 		case M_EdxGdx:
-			inst_op2_ds=(int32_t)reg_32(inst.rm_index);
+			inst_op2_ds = static_cast<int32_t>(reg_32(static_cast<uint8_t>(inst.rm_index)));
 			[[fallthrough]];
 		case M_Edx:
-			if (inst.rm<0xc0) inst_op1_d=(int32_t)LoadMd(inst.rm_eaa);
-			else inst_op1_d=(int32_t)reg_32(inst.rm_eai);
+			if (inst.rm<0xc0) inst_op1_d=static_cast<int32_t>(LoadMd(inst.rm_eaa));
+			else {
+				inst_op1_d = static_cast<int32_t>(reg_32(
+					static_cast<uint8_t>(inst.rm_eai)));
+			}
 			break;
 		case M_EdIb:
 			inst_op2_d=Fetchb();
@@ -145,7 +164,7 @@ l_M_Ew:
 			inst_imm_d=reg_cl;
 			goto l_M_EdGd;
 		case M_EdGdt:
-			inst_op2_d=reg_32(inst.rm_index);
+			inst_op2_d = reg_32(static_cast<uint8_t>(inst.rm_index));
 			inst.rm_eaa+=((int32_t)inst_op2_d >> 5) * 4;
 			goto l_M_Ed;
 		case M_EdGdIb:
@@ -153,19 +172,23 @@ l_M_Ew:
 			goto l_M_EdGd;
 		case M_EdGd:
 l_M_EdGd:
-			inst_op2_d=reg_32(inst.rm_index);
+			inst_op2_d = reg_32(static_cast<uint8_t>(inst.rm_index));
 			[[fallthrough]];
 		case M_Ed:
 l_M_Ed:
 			if (inst.rm<0xc0) inst_op1_d=LoadMd(inst.rm_eaa);
-			else inst_op1_d=reg_32(inst.rm_eai);
+			else {
+				inst_op1_d = reg_32(static_cast<uint8_t>(inst.rm_eai));
+			}
 			break;
 		case M_GdEd:
 			if (inst.rm<0xc0) inst_op2_d=LoadMd(inst.rm_eaa);
-			else inst_op2_d=reg_32(inst.rm_eai);
+			else {
+				inst_op2_d = reg_32(static_cast<uint8_t>(inst.rm_eai));
+			}
 			[[fallthrough]];
 		case M_Gd:
-			inst_op1_d=reg_32(inst.rm_index);
+			inst_op1_d = reg_32(static_cast<uint8_t>(inst.rm_index));
 			break;
 /* Others */
 		case M_SEG:
@@ -261,19 +284,19 @@ l_M_Ed:
 		inst_op2_d=Fetchb();
 		[[fallthrough]];
 	case L_REGb:
-		inst_op1_d=reg_8(inst.code.extra);
+		inst_op1_d = reg_8(inst.code.extra);
 		break;
 	case L_REGwIw:
 		inst_op2_d=Fetchw();
 		[[fallthrough]];
 	case L_REGw:
-		inst_op1_d=reg_16(inst.code.extra);
+		inst_op1_d = reg_16(inst.code.extra);
 		break;
 	case L_REGdId:
 		inst_op2_d=Fetchd();
 		[[fallthrough]];
 	case L_REGd:
-		inst_op1_d=reg_32(inst.code.extra);
+		inst_op1_d = reg_32(inst.code.extra);
 		break;
 	case L_SEG:
 		inst_op1_d=SegValue((SegNames)inst.code.extra);

--- a/src/cpu/core_full/op.h
+++ b/src/cpu/core_full/op.h
@@ -615,7 +615,7 @@ switch (inst.code.op) {
 		if (CPU_ArchitectureType<ArchitectureType::Intel486NewSlow) goto illegalopcode;
 		FillFlags();
 		if (inst_op1_d==reg_eax) {
-			inst_op1_d=reg_32(inst.rm_index);
+			inst_op1_d=reg_32(static_cast<uint8_t>(inst.rm_index));
 			if (inst.rm<0xc0) SaveMd(inst.rm_eaa,inst_op1_d);	// early write-pf
 			SETFLAGBIT(ZF,1);
 		} else {

--- a/src/cpu/core_full/save.h
+++ b/src/cpu/core_full/save.h
@@ -24,45 +24,45 @@ switch (inst.code.save) {
 		[[fallthrough]];
 	case S_Eb:
 		if (inst.rm<0xc0) SaveMb(inst.rm_eaa,inst_op1_b);
-		else reg_8(inst.rm_eai)=inst_op1_b;
+		else reg_8(static_cast<uint8_t>(inst.rm_eai))=inst_op1_b;
 		break;
 	case S_Gb:
-		reg_8(inst.rm_index)=inst_op1_b;
+		reg_8(static_cast<uint8_t>(inst.rm_index))=inst_op1_b;
 		break;
 	case S_EbGb:
 		if (inst.rm<0xc0) SaveMb(inst.rm_eaa,inst_op1_b);
-		else reg_8(inst.rm_eai)=inst_op1_b;
-		reg_8(inst.rm_index)=inst_op2_b;
+		else reg_8(static_cast<uint8_t>(inst.rm_eai))=inst_op1_b;
+		reg_8(static_cast<uint8_t>(inst.rm_index))=inst_op2_b;
 		break;
 /* Word */
 	case S_Ew:
 		if (inst.rm<0xc0) SaveMw(inst.rm_eaa,inst_op1_w);
-		else reg_16(inst.rm_eai)=inst_op1_w;
+		else reg_16(static_cast<uint8_t>(inst.rm_eai))=inst_op1_w;
 		break;
 	case S_Gw:
-		reg_16(inst.rm_index)=inst_op1_w;
+		reg_16(static_cast<uint8_t>(inst.rm_index))=inst_op1_w;
 		break;
 	case S_EwGw:
 		if (inst.rm<0xc0) SaveMw(inst.rm_eaa,inst_op1_w);
-		else reg_16(inst.rm_eai)=inst_op1_w;
-		reg_16(inst.rm_index)=inst_op2_w;
+		else reg_16(static_cast<uint8_t>(inst.rm_eai))=inst_op1_w;
+		reg_16(static_cast<uint8_t>(inst.rm_index))=inst_op2_w;
 		break;
 /* Dword */
 	case S_Ed:
 		if (inst.rm<0xc0) SaveMd(inst.rm_eaa,inst_op1_d);
-		else reg_32(inst.rm_eai)=inst_op1_d;
+		else reg_32(static_cast<uint8_t>(inst.rm_eai))=inst_op1_d;
 		break;
 	case S_EdMw:		/* Special one 16 to memory, 32 zero extend to reg */
 		if (inst.rm<0xc0) SaveMw(inst.rm_eaa,inst_op1_w);
-		else reg_32(inst.rm_eai)=inst_op1_d;
+		else reg_32(static_cast<uint8_t>(inst.rm_eai))=inst_op1_d;
 		break;
 	case S_Gd:
-		reg_32(inst.rm_index)=inst_op1_d;
+		reg_32(static_cast<uint8_t>(inst.rm_index))=inst_op1_d;
 		break;
 	case S_EdGd:
 		if (inst.rm<0xc0) SaveMd(inst.rm_eaa,inst_op1_d);
-		else reg_32(inst.rm_eai)=inst_op1_d;
-		reg_32(inst.rm_index)=inst_op2_d;
+		else reg_32(static_cast<uint8_t>(inst.rm_eai))=inst_op1_d;
+		reg_32(static_cast<uint8_t>(inst.rm_index))=inst_op2_d;
 		break;
 
 	case S_REGb:
@@ -79,11 +79,11 @@ switch (inst.code.save) {
 		break;
 	case S_SEGGw:
 		if (CPU_SetSegGeneral((SegNames)inst.code.extra,inst_op2_w)) RunException();
-		reg_16(inst.rm_index)=inst_op1_w;
+		reg_16(static_cast<uint8_t>(inst.rm_index))=inst_op1_w;
 		break;
 	case S_SEGGd:
 		if (CPU_SetSegGeneral((SegNames)inst.code.extra,inst_op2_w)) RunException();
-		reg_32(inst.rm_index)=inst_op1_d;
+		reg_32(static_cast<uint8_t>(inst.rm_index))=inst_op1_d;
 		break;
 	case S_PUSHw:
 		Push_16(inst_op1_w);

--- a/src/cpu/core_full/string.h
+++ b/src/cpu/core_full/string.h
@@ -17,8 +17,6 @@
  */
 
 {
-	Bits	add_index;
-
 	const auto si_base = (inst.prefix & PREFIX_SEG) ? inst.seg.base
 	                                                : SegBase(ds);
 	const auto di_base = SegBase(es);
@@ -48,7 +46,7 @@
 			count_left=0;
 		}
 	}
-	add_index=cpu.direction;
+	auto add_index = cpu.direction;
 	if (count) switch (inst.code.op) {
 	case R_OUTSB:
 		for (;count>0;count--) {

--- a/src/cpu/core_full/string.h
+++ b/src/cpu/core_full/string.h
@@ -17,7 +17,7 @@
  */
 
 {
-	Bitu si_index, di_index;
+	Bitu di_index;
 	Bitu count, count_left = 0;
 	Bits	add_index;
 
@@ -28,13 +28,12 @@
 	const auto is_32bit_addr = (inst.prefix & PREFIX_ADDR) != 0;
 
 	const uint32_t add_mask = is_32bit_addr ? 0xFFFFFFFF : 0xFFFF;
+	uint32_t si_index       = is_32bit_addr ? reg_esi : reg_si;
 
 	if (is_32bit_addr) {
-		si_index = reg_esi;
 		di_index=reg_edi;
 		count=reg_ecx;
 	} else {
-		si_index=reg_si;
 		di_index=reg_di;
 		count=reg_cx;
 	}

--- a/src/cpu/core_full/string.h
+++ b/src/cpu/core_full/string.h
@@ -25,7 +25,9 @@
 	const auto si_base = (inst.prefix & PREFIX_SEG) ? inst.seg.base
 	                                                : SegBase(ds);
 	const auto di_base = SegBase(es);
-	if (inst.prefix & PREFIX_ADDR) {
+
+	const auto is_32bit_addr = (inst.prefix & PREFIX_ADDR) != 0;
+	if (is_32bit_addr) {
 		add_mask=0xFFFFFFFF;
 		si_index=reg_esi;
 		di_index=reg_edi;

--- a/src/cpu/core_full/string.h
+++ b/src/cpu/core_full/string.h
@@ -17,15 +17,16 @@
  */
 
 {
-	EAPoint si_base,di_base;
+	EAPoint di_base;
 	Bitu	si_index,di_index;
 	Bitu	add_mask;
 	Bitu count, count_left = 0;
 	Bits	add_index;
-	
-	if (inst.prefix & PREFIX_SEG) si_base=inst.seg.base;
-	else si_base=SegBase(ds);
-	di_base=SegBase(es);
+
+	const auto si_base = (inst.prefix & PREFIX_SEG) ? inst.seg.base
+	                                                : SegBase(ds);
+
+	di_base = SegBase(es);
 	if (inst.prefix & PREFIX_ADDR) {
 		add_mask=0xFFFFFFFF;
 		si_index=reg_esi;

--- a/src/cpu/core_full/string.h
+++ b/src/cpu/core_full/string.h
@@ -17,8 +17,7 @@
  */
 
 {
-	Bitu	si_index,di_index;
-	Bitu	add_mask;
+	Bitu si_index, di_index;
 	Bitu count, count_left = 0;
 	Bits	add_index;
 
@@ -27,13 +26,14 @@
 	const auto di_base = SegBase(es);
 
 	const auto is_32bit_addr = (inst.prefix & PREFIX_ADDR) != 0;
+
+	const uint32_t add_mask = is_32bit_addr ? 0xFFFFFFFF : 0xFFFF;
+
 	if (is_32bit_addr) {
-		add_mask=0xFFFFFFFF;
-		si_index=reg_esi;
+		si_index = reg_esi;
 		di_index=reg_edi;
 		count=reg_ecx;
 	} else {
-		add_mask=0xFFFF;
 		si_index=reg_si;
 		di_index=reg_di;
 		count=reg_cx;

--- a/src/cpu/core_full/string.h
+++ b/src/cpu/core_full/string.h
@@ -17,7 +17,6 @@
  */
 
 {
-	Bitu count, count_left = 0;
 	Bits	add_index;
 
 	const auto si_base = (inst.prefix & PREFIX_SEG) ? inst.seg.base
@@ -29,17 +28,16 @@
 	const uint32_t add_mask = is_32bit_addr ? 0xFFFFFFFF : 0xFFFF;
 	uint32_t si_index       = is_32bit_addr ? reg_esi : reg_si;
 	uint32_t di_index       = is_32bit_addr ? reg_edi : reg_di;
-	if (is_32bit_addr) {
-		count=reg_ecx;
-	} else {
-		count=reg_cx;
-	}
+
+	int32_t count = check_cast<int32_t>(is_32bit_addr ? reg_ecx : reg_cx);
+	int32_t count_left = 0;
+
 	if (!(inst.prefix & PREFIX_REP)) {
 		count=1;
 	} else {
 		/* Calculate amount of ops to do before cycles run out */
 		CPU_Cycles++;
-		if ((count>(Bitu)CPU_Cycles) && (inst.code.op<R_SCASB)) {
+		if ((count > CPU_Cycles) && (inst.code.op < R_SCASB)) {
 			count_left=count-CPU_Cycles;
 			count=CPU_Cycles;
 			CPU_Cycles=0;

--- a/src/cpu/core_full/string.h
+++ b/src/cpu/core_full/string.h
@@ -17,7 +17,6 @@
  */
 
 {
-	Bitu di_index;
 	Bitu count, count_left = 0;
 	Bits	add_index;
 
@@ -29,12 +28,10 @@
 
 	const uint32_t add_mask = is_32bit_addr ? 0xFFFFFFFF : 0xFFFF;
 	uint32_t si_index       = is_32bit_addr ? reg_esi : reg_si;
-
+	uint32_t di_index       = is_32bit_addr ? reg_edi : reg_di;
 	if (is_32bit_addr) {
-		di_index=reg_edi;
 		count=reg_ecx;
 	} else {
-		di_index=reg_di;
 		count=reg_cx;
 	}
 	if (!(inst.prefix & PREFIX_REP)) {

--- a/src/cpu/core_full/string.h
+++ b/src/cpu/core_full/string.h
@@ -17,7 +17,6 @@
  */
 
 {
-	EAPoint di_base;
 	Bitu	si_index,di_index;
 	Bitu	add_mask;
 	Bitu count, count_left = 0;
@@ -25,8 +24,7 @@
 
 	const auto si_base = (inst.prefix & PREFIX_SEG) ? inst.seg.base
 	                                                : SegBase(ds);
-
-	di_base = SegBase(es);
+	const auto di_base = SegBase(es);
 	if (inst.prefix & PREFIX_ADDR) {
 		add_mask=0xFFFFFFFF;
 		si_index=reg_esi;

--- a/src/cpu/core_normal/prefix_none.h
+++ b/src/cpu/core_normal/prefix_none.h
@@ -872,29 +872,29 @@
 		JumpCond16_b(!(reg_ecx & AddrMaskTable[core.prefixes& PREFIX_ADDR]));
 		break;
 	CASE_B(0xe4)												/* IN AL,Ib */
-		{	
-			Bitu port=Fetchb();
+		{
+			const auto port = Fetchb();
 			if (CPU_IO_Exception(port,1)) RUNEXCEPTION();
 			reg_al=IO_ReadB(port);
 			break;
 		}
 	CASE_W(0xe5)												/* IN AX,Ib */
-		{	
-			Bitu port=Fetchb();
+		{
+			const auto port = Fetchb();
 			if (CPU_IO_Exception(port,2)) RUNEXCEPTION();
 			reg_ax=IO_ReadW(port);
 			break;
 		}
 	CASE_B(0xe6)												/* OUT Ib,AL */
 		{
-			Bitu port=Fetchb();
+			const auto port = Fetchb();
 			if (CPU_IO_Exception(port,1)) RUNEXCEPTION();
 			IO_WriteB(port,reg_al);
 			break;
 		}		
 	CASE_W(0xe7)												/* OUT Ib,AX */
 		{
-			Bitu port=Fetchb();
+			const auto port = Fetchb();
 			if (CPU_IO_Exception(port,2)) RUNEXCEPTION();
 			IO_WriteW(port,reg_ax);
 			break;

--- a/src/cpu/core_prefetch.cpp
+++ b/src/cpu/core_prefetch.cpp
@@ -103,8 +103,8 @@ static struct {
 } core;
 
 #define GETIP		(core.cseip-SegBase(cs))
-#define SAVEIP		reg_eip=GETIP;
-#define LOADIP		core.cseip=(SegBase(cs)+reg_eip);
+#define SAVEIP          reg_eip = static_cast<uint32_t>(GETIP);
+#define LOADIP          core.cseip = static_cast<PhysPt>((SegBase(cs) + reg_eip));
 
 #define SegBase(c)	SegPhys(c)
 #define BaseDS		core.base_ds

--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -133,28 +133,43 @@ void Descriptor:: Save(PhysPt address) {
 	cpu.mpl=03;
 }
 
+void CPU_Push16(const uint16_t value)
+{
+	const uint32_t new_esp = (reg_esp & cpu.stack.notmask) |
+	                         ((reg_esp - 2) & cpu.stack.mask);
 
-void CPU_Push16(Bitu value) {
-	uint32_t new_esp=(reg_esp&cpu.stack.notmask)|((reg_esp-2)&cpu.stack.mask);
-	mem_writew(SegPhys(ss) + (new_esp & cpu.stack.mask) ,value);
-	reg_esp=new_esp;
+	mem_writew(SegPhys(ss) + (new_esp & cpu.stack.mask), value);
+
+	reg_esp = new_esp;
 }
 
-void CPU_Push32(Bitu value) {
-	uint32_t new_esp=(reg_esp&cpu.stack.notmask)|((reg_esp-4)&cpu.stack.mask);
-	mem_writed(SegPhys(ss) + (new_esp & cpu.stack.mask) ,value);
-	reg_esp=new_esp;
+void CPU_Push32(const uint32_t value)
+{
+	const uint32_t new_esp = (reg_esp & cpu.stack.notmask) |
+	                         ((reg_esp - 4) & cpu.stack.mask);
+
+	mem_writed(SegPhys(ss) + (new_esp & cpu.stack.mask), value);
+
+	reg_esp = new_esp;
 }
 
-Bitu CPU_Pop16(void) {
-	Bitu val=mem_readw(SegPhys(ss) + (reg_esp & cpu.stack.mask));
-	reg_esp=(reg_esp&cpu.stack.notmask)|((reg_esp+2)&cpu.stack.mask);
+uint16_t CPU_Pop16()
+{
+	const auto val = check_cast<uint16_t>(
+	        mem_readw(SegPhys(ss) + (reg_esp & cpu.stack.mask)));
+
+	reg_esp = (reg_esp & cpu.stack.notmask) | ((reg_esp + 2) & cpu.stack.mask);
+
 	return val;
 }
 
-Bitu CPU_Pop32(void) {
-	Bitu val=mem_readd(SegPhys(ss) + (reg_esp & cpu.stack.mask));
-	reg_esp=(reg_esp&cpu.stack.notmask)|((reg_esp+4)&cpu.stack.mask);
+uint32_t CPU_Pop32()
+{
+	const auto val = check_cast<uint32_t>(
+	        mem_readd(SegPhys(ss) + (reg_esp & cpu.stack.mask)));
+
+	reg_esp = (reg_esp & cpu.stack.notmask) | ((reg_esp + 4) & cpu.stack.mask);
+
 	return val;
 }
 

--- a/src/debug/debug_disasm.cpp
+++ b/src/debug/debug_disasm.cpp
@@ -468,8 +468,9 @@ static char *addr_to_hex(UINT32 addr, int splitup) {
 static PhysPt getbyte_mac;
 static PhysPt startPtr;
 
-static UINT8 getbyte(void) {
-	return mem_readb(getbyte_mac++);
+static UINT8 getbyte()
+{
+	return mem_readb<MemOpMode::SkipBreakpoints>(getbyte_mac++);
 }
 
 /*

--- a/src/hardware/memory.cpp
+++ b/src/hardware/memory.cpp
@@ -608,27 +608,46 @@ bool mem_unalignedwriteq_checked(PhysPt address, uint64_t val)
 	return false;
 }
 
-uint8_t mem_readb(PhysPt address)
+template <MemOpMode op_mode>
+uint8_t mem_readb(const PhysPt address)
 {
-	return mem_readb_inline(address);
+	return mem_readb_inline<op_mode>(address);
 }
 
-uint16_t mem_readw(PhysPt address) {
-	return mem_readw_inline(address);
+template <MemOpMode op_mode>
+uint16_t mem_readw(const PhysPt address)
+{
+	return mem_readw_inline<op_mode>(address);
 }
 
-uint32_t mem_readd(PhysPt address) {
-	return mem_readd_inline(address);
+template <MemOpMode op_mode>
+uint32_t mem_readd(const PhysPt address)
+{
+	return mem_readd_inline<op_mode>(address);
 }
 
+template <MemOpMode op_mode>
 uint64_t mem_readq(PhysPt address)
 {
-	return mem_readq_inline(address);
+	return mem_readq_inline<op_mode>(address);
 }
+
+// Explicit instantiations for mem_readb, mem_readw, and mem_readd
+template uint8_t mem_readb<MemOpMode::WithBreakpoints>(const PhysPt address);
+template uint8_t mem_readb<MemOpMode::SkipBreakpoints>(const PhysPt address);
+
+template uint16_t mem_readw<MemOpMode::WithBreakpoints>(const PhysPt address);
+template uint16_t mem_readw<MemOpMode::SkipBreakpoints>(const PhysPt address);
+
+template uint32_t mem_readd<MemOpMode::WithBreakpoints>(const PhysPt address);
+template uint32_t mem_readd<MemOpMode::SkipBreakpoints>(const PhysPt address);
+
+template uint64_t mem_readq<MemOpMode::WithBreakpoints>(const PhysPt address);
+template uint64_t mem_readq<MemOpMode::SkipBreakpoints>(const PhysPt address);
 
 void mem_writeb(PhysPt address, uint8_t val)
 {
-	mem_writeb_inline(address, val);
+	mem_writeb_inline(address,val);
 }
 
 void mem_writew(PhysPt address,uint16_t val) {


### PR DESCRIPTION
# Description

(PR body below is from @LowLevelMahn in #3082)

adds a C_HEAVY_DEBUG feature for breaking on memory reads - memory write breakpoints were already available in dosbox svn long time

* will break on read of the memory using F5-run or just show accessing code point on F10 single-step
* only working so far for non-protected realmode, and as most of the debug features only reliable when using core=normal (or as i was told on vogons years ago)

![bpmr](https://github.com/dosbox-staging/dosbox-staging/assets/580819/ce7e54ba-c7c4-48b5-b44d-7ac86673ab85)

use in debugger with: BPMR seg:ofs

# Manual testing

tested the feature with a simple nasm DOS COM executable aka clean environment

assemble with recent nasm using `nasm -f bin bpmr.asm -o bpmr.com`

```
; nasm -f bin bpmr.asm -o bpmr.com
org 100h

mov si,test1
lodsb
lodsb
lodsb

mov byte [test2],'z'

mov al,byte [test1]

mov cx,3
mov si,test1
rep lodsb

mov si,test1
mov di,test2
movsb
movsb
movsb

mov cx,3 
mov si,test1
mov di,test2
rep movsb

mov ax,4C00h
int 21h

test1 db 'ABC'
test2 db 'abc'
```

# Checklist

I have:
 
* [x]  followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
* [x]  performed a self-review of my code.
* [x]  commented on the particularly hard-to-understand areas of my code.
* [x]  split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
* [x]  applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
* [x]  [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
* [x]  confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
* [ ]  added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
* [ ]  made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
* [ ]  [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.
