### PR TITLE
Improve the "mode 1" deinterlace method

### DIFF
--- a/contrib/resources/glshaders/misc/fixvideo.glsl
+++ b/contrib/resources/glshaders/misc/fixvideo.glsl
@@ -46,6 +46,12 @@
 #define SAMPLE_POINT_3 0.75
 #define SAMPLE_POINT_4 1.00
 
+//   Intensity of the deinterlaced odd & even scanlines.
+//   Use values above 1.0 for extra brightness boost.
+//   1.00 = full intensity, 0.0 = zero intensity (black)
+#define ODD_LINE_INTENSITY  1.10
+#define EVEN_LINE_INTENSITY 0.90
+
 
 #define texCoord v_texCoord
 
@@ -134,12 +140,28 @@ void main() {
         vec4 c31 = tex2D(s_p, vec2(SAMPLE_POINT_3, tex_center.y));
         vec4 c41 = tex2D(s_p, vec2(SAMPLE_POINT_4, tex_center.y));
 
-        vec4 sum = c01 + c11 + c21 + c31 + c41;
-        color = c01;
+        vec4 sum1 = c01 + c11 + c21 + c31 + c41;
 
-        if (sum.rgb == vec3(0.0, 0.0, 0.0)) {
-            color = c00;
-        }
+        vec4 c12 = tex2D(s_p, vec2(SAMPLE_POINT_1, (tex_center + dy).y));
+        vec4 c22 = tex2D(s_p, vec2(SAMPLE_POINT_2, (tex_center + dy).y));
+        vec4 c32 = tex2D(s_p, vec2(SAMPLE_POINT_3, (tex_center + dy).y));
+        vec4 c42 = tex2D(s_p, vec2(SAMPLE_POINT_4, (tex_center + dy).y));
+
+        vec4 sum2 = c02 + c12 + c22 + c32 + c42;
+
+        vec4 odd_color  = c01 * ODD_LINE_INTENSITY;
+        vec4 even_color = c00 * EVEN_LINE_INTENSITY;
+
+        color = mix(
+            mix(
+                c01,
+                even_color,
+                vec4(step(1.0, 1.0 - (sum1.r + sum1.g + sum1.b)))
+            ),
+            odd_color,
+            vec4(step(1.0, 1.0 - (sum2.r + sum2.g + sum2.b)))
+        );
+
     }
 
     FragColor = vec4(color.rgb, 1.0);


### PR DESCRIPTION
# Description

Previously, the "mode 1" deinterlace method simply doubled non-blank lines. This has been improved so now it uses different intensities for the the odd and even deinterlaced lines, bringing a subtle scanline effect back. This makes the output appear less blocky, a little bit more interesting to look at, and it adds the subjective perception of extra detail.

I've also converted the algorithm to branchless to potentially improve the performance.

Open example images in browser tabs at 100% magnification and switch between them to appreciate the differences.

## Interlaced raw output

![image](https://github.com/dosbox-staging/dosbox-staging/assets/698770/608cf91d-986e-4da5-b5a2-3349382a17ea)

## Previous "mode 1" deinterlace method

![image](https://github.com/dosbox-staging/dosbox-staging/assets/698770/a2e132ac-54b9-4f83-bfa6-47bab1d8c100)

## New "mode 1" deinterlace method

![image](https://github.com/dosbox-staging/dosbox-staging/assets/698770/cd1eea7d-0ca0-48bc-af2f-5930d21adab5)



# Manual testing

Tested with Shivers as per above and with the Windows 3.x desktop.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

