### PR TITLE
Only capture the visible image in rendered image capture mode

### DIFF
--- a/include/sdlmain.h
+++ b/include/sdlmain.h
@@ -93,6 +93,11 @@
 //   shaders, which is the image that is displayed on the host monitor with
 //   1:1 physical pixel mapping.
 //
+//   Because the viewport can be larger than the canvas, the draw area can be
+//   larger too. In other words, the draw rectangle can extend beyond the
+//   edges of the window or the screen in fullscreen mode, in which case the
+//   image is centered and the overhanging areas are clipped.
+//
 
 #define SDL_NOFRAME 0x00000020
 


### PR DESCRIPTION
# Description

When using the `relative` viewport mode to stretch the image beyond the extents of the window or screen (e.g., when aspect ratio correcting Hercules games), rendered image captures contained the _whole_ stretched texture, not just the visible parts when using the OpenGL backend. This is wrong—rendered captures should always work in a WYSIWYG manner.

With the texture backend, the rendered capture action outright failed; at least on macOS I was getting the following error:

```
AGX: Texture read/write assertion failed: (xoffset + width) <= ALIGNGRAN_NPOT(getViewLevelWidth(mipmapLevel), block_width) && "Region width OOB"
```

So this PR fixes that and makes rendered captures fully WYSIWYG again. Upscaled captures still save the entire image. This is probably fine for now, but we might rethink it in the future. That would be a more involved change, though.

## Before

Prince of Persia, Hercules mode, image corrected to fill the whole 4:3 "emulated monitor" with the following config:

```ini
[render]
aspect = stretch
viewport = relative 112% 173%
```

This is what we see on the screen:

<img width="1215" alt="image" src="https://github.com/dosbox-staging/dosbox-staging/assets/698770/e1d304fc-c479-4bf5-80c2-433c93ed8bc3">

And this is the rendered capture; the whole stretched texture gets saved, it's not clipped to the extents of the viewport:

![image0010-rendered](https://github.com/dosbox-staging/dosbox-staging/assets/698770/a1ee595d-a799-4439-8739-de928b6070b7)

## After

The rendered capture is correctly clipped to the extents of the viewport and it works with the texture backend too:

### OpenGL

![image0009-rendered](https://github.com/dosbox-staging/dosbox-staging/assets/698770/5e78088d-7bb7-4d15-88b5-3f53a8a5c44a)

### Texture

<img width="1215" alt="image" src="https://github.com/dosbox-staging/dosbox-staging/assets/698770/1a49def9-1293-40ea-b41c-c5b385583790">

![image0002-rendered](https://github.com/dosbox-staging/dosbox-staging/assets/698770/da4077b5-d73a-402d-97a8-37fd04c547ba)


# Manual testing

Only posting the texture results as that output mode is more "sensitive", but I've tested with OpenGL as well.

## Case 1

```ini
[render]
aspect = stretch
viewport = relative 50% 200%
```

<img width="1215" alt="image" src="https://github.com/dosbox-staging/dosbox-staging/assets/698770/87b28e01-971b-4b7b-94f7-df73d7e72221">

![image0003-rendered](https://github.com/dosbox-staging/dosbox-staging/assets/698770/ea7bd030-2b72-4d6d-b62d-3f65d23aaf23)


## Case 2

```ini
[render]
aspect = stretch
viewport = relative 200% 50% 
```

<img width="1215" alt="image" src="https://github.com/dosbox-staging/dosbox-staging/assets/698770/789c2dfe-d8e3-46c8-bafc-41fc7986a2ff">

![image0005-rendered](https://github.com/dosbox-staging/dosbox-staging/assets/698770/f787a44c-27aa-4837-b04d-876037151778)


## Case 3

```ini
[render]
aspect = stretch
viewport = relative 50% 50% 
```

<img width="1215" alt="image" src="https://github.com/dosbox-staging/dosbox-staging/assets/698770/cc745d86-8a5c-4457-ae14-e4e9eef478af">

![image0008-rendered](https://github.com/dosbox-staging/dosbox-staging/assets/698770/62487dc5-8990-4dd9-a805-2ea084bc4c81)


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

