### PR TITLE
Cleanup a couple unhandled switch cases when OpenGL isn't available

### DIFF
--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -2453,8 +2453,8 @@ bool GFX_StartUpdate(uint8_t * &pixels, int &pitch)
 		pitch = sdl.texture.input_surface->pitch;
 		sdl.updating = true;
 		return true;
-#if C_OPENGL
 	case RenderingBackend::OpenGl:
+#if C_OPENGL
 		pixels = static_cast<uint8_t*>(sdl.opengl.framebuf);
 		OPENGL_ERROR("end of start update");
 		if (pixels == nullptr) {
@@ -2465,7 +2465,10 @@ bool GFX_StartUpdate(uint8_t * &pixels, int &pitch)
 		pitch        = sdl.opengl.pitch;
 		sdl.updating = true;
 		return true;
-#endif
+#else
+		// Should never occur
+		E_Exit("SDL: OpenGL is not supported by this executable");
+#endif // C_OPENGL
 	}
 	return false;
 }

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -2738,10 +2738,8 @@ uint32_t GFX_GetRGB(const uint8_t red, const uint8_t green, const uint8_t blue)
 	case RenderingBackend::Texture:
 		assert(sdl.texture.pixelFormat);
 		return SDL_MapRGB(sdl.texture.pixelFormat, red, green, blue);
-#if C_OPENGL
 	case RenderingBackend::OpenGl:
 		return ((blue << 0) | (green << 8) | (red << 16)) | (255 << 24);
-#endif
 	}
 	return 0;
 }

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1866,8 +1866,8 @@ uint8_t GFX_SetSize(const int render_width_px, const int render_height_px,
 
 		break; // RenderingBackend::Texture
 	}
-#if C_OPENGL
 	case RenderingBackend::OpenGl: {
+#if C_OPENGL
 		free(sdl.opengl.framebuf);
 		sdl.opengl.framebuf = nullptr;
 		if (!(flags & GFX_CAN_32)) {
@@ -2207,9 +2207,16 @@ uint8_t GFX_SetSize(const int render_width_px, const int render_height_px,
 		retFlags          = GFX_CAN_32 | GFX_CAN_RANDOM;
 		sdl.frame.update  = update_frame_gl;
 		sdl.frame.present = present_frame_gl;
+#else
+		// Should never occur, but fallback to texture in release builds
+		assertm(false, "OpenGL is not supported by this executable");
+		LOG_ERR("SDL: OpenGL is not supported by this executable, "
+		        "falling back to texture output");
+		goto fallback_texture;
+
+#endif // C_OPENGL
 		break; // RenderingBackend::OpenGl
 	}
-#endif // C_OPENGL
 	}
 	// Ensure mouse emulation knows the current parameters
 	notify_new_mouse_screen_params();


### PR DESCRIPTION
# Description

Cleanup a couple unhandled switch cases when OpenGL isn't available; flagged by GCC on the power10 system.

The added `#else` error handling only touches the code path if OpenGL isn't available at compile time.

![2023-12-11_13-36](https://github.com/dosbox-staging/dosbox-staging/assets/1557255/a41722f6-22ea-4073-95af-9d61c24bd660)


```text
../../src/gui/sdlmain.cpp: In function ‘uint8_t GFX_SetSize(int, int, const Fraction&, uint8_t, const VideoMode&, GFX_CallBack_t)’:
../../src/gui/sdlmain.cpp:1767:16: warning: enumeration value ‘OpenGl’ not handled in switch [-Wswitch]
 1767 |         switch (sdl.want_rendering_backend ) {
      |                ^
../../src/gui/sdlmain.cpp:1769:9: warning: label ‘fallback_texture’ defined but not used [-Wunused-label]
 1769 |         fallback_texture: // FIXME: Must be replaced with a proper fallback system.
      |         ^~~~~~~~~~~~~~~~
../../src/gui/sdlmain.cpp: In function ‘bool GFX_StartUpdate(uint8_t*&, int&)’:
../../src/gui/sdlmain.cpp:2449:16: warning: enumeration value ‘OpenGl’ not handled in switch [-Wswitch]
 2449 |         switch (sdl.rendering_backend) {
      |                ^
../../src/gui/sdlmain.cpp: In function ‘uint32_t GFX_GetRGB(uint8_t, uint8_t, uint8_t)’:
../../src/gui/sdlmain.cpp:2720:16: warning: enumeration value ‘OpenGl’ not handled in switch [-Wswitch]
 2720 |         switch (sdl.rendering_backend) {

```

This is zero-risk and small cleanup ahead of the RC phase.

# Manual testing

- Tested with OpenGL on/off at compile time
- Tested with OpenGL on/off at runtime (output = ...)
- Tested on x86-64 and Apple M1
- Confirmed it's compiling clean on the Power10 and passing unit tests

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

