### PR TITLE
Setup the BIOS Tandy DAC only after critical BIOS features are setup first

### DIFF
--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -308,9 +308,12 @@ static void DSP_SetSpeaker(bool requested_state)
 	sb.chan->Enable(requested_state);
 	sb.speaker = requested_state;
 
+#if 0
+	// This can be very noisy as some games toggle the speaker for every effect
 	LOG_MSG("%s: Speaker-output has been toggled %s",
 	        CardType(),
 	        (requested_state ? "on" : "off"));
+#endif
 }
 
 static void InitializeSpeakerState()

--- a/src/ints/bios.cpp
+++ b/src/ints/bios.cpp
@@ -34,6 +34,9 @@
 #include "setup.h"
 #include <time.h>
 
+// Constants
+constexpr uint32_t BiosMachineSignatureAddress = 0xfffff;
+
 #if defined(HAVE_CLOCK_GETTIME) && !defined(WIN32)
 // time.h is already included
 #else
@@ -1303,11 +1306,10 @@ public:
 		i = 0;
 		for (const auto c : "01/01/92")
 			phys_writeb(0xffff5 + i++, static_cast<uint8_t>(c));
-		
+
 		// write machine signature
-		constexpr uint32_t machine_signature_location = 0xfffff;
 		const uint8_t machine_signature = (machine == MCH_TANDY) ? 0xff : 0x55;
-		phys_writeb(machine_signature_location, machine_signature);
+		phys_writeb(BiosMachineSignatureAddress, machine_signature);
 
 		// Note: The BIOS 0x40 segment (Tandy DAC) callbacks are
 		// configured when the Tandy Sound card is initialized followed

--- a/src/ints/bios.cpp
+++ b/src/ints/bios.cpp
@@ -83,15 +83,16 @@ static Bitu INT70_Handler(void) {
 
 CALLBACK_HandlerObject* tandy_DAC_callback[2];
 static struct {
-	uint16_t port;
-	uint8_t irq;
-	uint8_t dma;
-} tandy_sb;
+	uint16_t port = 0;
+	uint8_t irq   = 0;
+	uint8_t dma   = 0;
+} tandy_sb = {};
+
 static struct {
-	uint16_t port;
-	uint8_t irq;
-	uint8_t dma;
-} tandy_dac;
+	uint16_t port = 0;
+	uint8_t irq   = 0;
+	uint8_t dma   = 0;
+} tandy_dac = {};
 
 static bool Tandy_InitializeSB() {
 	/* see if soundblaster module available and at what port/IRQ/DMA */


### PR DESCRIPTION
# Description

The BIOS Tandy DAC handling relies on the BIOS's IRQ vectors, however these aren't guaranteed to be available until after the BIOS sets up the basic machine configuration.

So this PR defers setting up the BIOS Tandy DAC handling until after the BIOS finishes setting up the machine (and includes a check as well as notes this dependency as a comment in the code).

Suggest reviewing commit-by-commit.

## Related issues

Fixes #3198 

# Manual testing

Tested cold-start configurations:
 - Tandy DAC via `tandy = off` (Tandy unavailable)
 - Tandy DAC via `tandy = on`
 - Tandy DAC via `tandy = psg` + `sbtype = sbpro2`
 
Tested off-to-on re-configurations:
 - Tandy turned on: `tandy = off` -> `on`
 - SB to Tandy: `tandy = off` -> `sbtype = sbpro2` -> `tandy = on`

Tested already-on re-configurations:
 - Tandy cycled: `tandy = on` -> `off` -> `on`
 - Tandy to SB: `tandy = on` -> `sbtype = sbpro2`

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

