### PR TITLE
Use std math functions in `compressor.cpp`

### DIFF
--- a/src/hardware/compressor.cpp
+++ b/src/hardware/compressor.cpp
@@ -24,7 +24,7 @@
 #include <array>
 #include <cassert>
 #include <cmath>
- 
+
 #include "checks.h"
 #include "mixer.h"
 
@@ -54,11 +54,15 @@ void Compressor::Configure(const uint16_t _sample_rate_hz,
 	scale_in  = 1.0f / _0dbfs_sample_value;
 	scale_out = _0dbfs_sample_value;
 
-	threshold_value = expf(threshold_db * db_to_log);
+	threshold_value = std::exp(threshold_db * db_to_log);
 	ratio           = _ratio;
-	attack_coeff    = expf(-1.0f / (attack_time_ms * sample_rate_hz));
-	release_coeff   = expf(-millis_in_second_f / (release_time_ms * sample_rate_hz));
-	rms_coeff       = expf(-millis_in_second_f / (rms_window_ms * sample_rate_hz));
+
+	attack_coeff = std::exp(-1.0f / (attack_time_ms * sample_rate_hz));
+
+	release_coeff = std::exp(-millis_in_second_f /
+	                         (release_time_ms * sample_rate_hz));
+
+	rms_coeff = std::exp(-millis_in_second_f / (rms_window_ms * sample_rate_hz));
 
 	Reset();
 }
@@ -75,19 +79,20 @@ void Compressor::Reset()
 
 AudioFrame Compressor::Process(const AudioFrame in)
 {
-	const float left  = in.left  * scale_in;
+	const float left  = in.left * scale_in;
 	const float right = in.right * scale_in;
 
 	const auto sum_squares = (left * left) + (right * right);
 	run_sum_squares = sum_squares + rms_coeff * (run_sum_squares - sum_squares);
-	const auto det = sqrtf(fmaxf(0.0f, run_sum_squares));
+	const auto det = std::sqrt(std::max(0.0f, run_sum_squares));
 
-	over_db = 2.08136898f * logf(det / threshold_value) * log_to_db;
+	over_db = 2.08136898f * std::log(det / threshold_value) * log_to_db;
 
-	if (over_db > max_over_db)
+	if (over_db > max_over_db) {
 		max_over_db = over_db;
+	}
 
-	over_db = fmaxf(0.0f, over_db);
+	over_db = std::max(0.0f, over_db);
 
 	run_db = over_db + (run_db - over_db) * (over_db > run_db ? attack_coeff
 	                                                          : release_coeff);
@@ -95,11 +100,11 @@ AudioFrame Compressor::Process(const AudioFrame in)
 	over_db = run_db;
 
 	constexpr auto ratio_threshold_db = 6.0f;
-	comp_ratio = 1.0f + ratio * fminf(over_db, ratio_threshold_db) /
+	comp_ratio = 1.0f + ratio * std::min(over_db, ratio_threshold_db) /
 	                            ratio_threshold_db;
 
 	const auto gain_reduction_db = -over_db * (comp_ratio - 1.0f) / comp_ratio;
-	const auto gain_reduction_factor = expf(gain_reduction_db * db_to_log);
+	const auto gain_reduction_factor = std::exp(gain_reduction_db * db_to_log);
 
 	run_max_db  = max_over_db + release_coeff * (run_max_db - max_over_db);
 	max_over_db = run_max_db;


### PR DESCRIPTION
# Description

Standard C functions are best to be avoided if we don't specifically need exact conformance with what the C standard mandates. In particular, the `std::min` and `std::max` functions are potentially more performant as they can be compiled to branchless code as opposed to `fmin/fmax`.

Key point from this [extremely informative post](https://stackoverflow.com/a/40870480):

> In C++, use std::min and std::max, which are defined in terms of > or <, and don't have the same requirements on NaN behaviour that fmin and fmax do. Avoid [fmin and fmax](http://en.cppreference.com/w/c/numeric/math/fmin) for performance unless you need their NaN behaviour.

# Manual testing

Space Quest III still works and there is sound 😎 🤘🏻 

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

