### PR TITLE
Fix description of the `imfc_filter` setting

### DIFF
--- a/src/hardware/imfc.cpp
+++ b/src/hardware/imfc.cpp
@@ -13455,8 +13455,8 @@ void init_imfc_dosbox_settings(Section_prop& secprop)
 	assert(str_prop);
 	str_prop->Set_help(
 	        "Filter for the IBM Music Feature Card output:\n"
-	        "  on:        Filter the output.\n"
-	        "  off:       Don't filter the output (default).\n"
+	        "  on:        Filter the output (default).\n"
+	        "  off:       Don't filter the output.\n"
 	        "  <custom>:  Custom filter definition; see 'sb_filter' for details.");
 }
 


### PR DESCRIPTION
Trivial change, skipping the checklist.