### PR TITLE
Add missing defaults to all config settings that still don't have them

### DIFF
--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -571,7 +571,7 @@ void DOSBOX_Init()
 	        "               (default).\n"
 	        "  halfline:    Supports the low-resolution halfline VESA 2.0 mode used by\n"
 	        "               Extreme Assault. Use only if needed, as it's not S3 compatible.\n"
-	        "  all:         All modes for a given video memory size, however some games \n"
+	        "  all:         All modes for a given video memory size, however some games\n"
 	        "               may not use them properly (flickering) or may need\n"
 	        "               more system memory to use them.");
 

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -1109,21 +1109,21 @@ void DOSBOX_Init()
 	pmulti_remain->SetValue("dummy");
 	pstring->Set_values(serials);
 	pmulti_remain->GetSection()->Add_string("parameters", when_idle, "");
-	pmulti_remain->Set_help("See 'serial1'");
+	pmulti_remain->Set_help("See 'serial1' ('dummy' by default).");
 
 	pmulti_remain = secprop->AddMultiValRemain("serial3", when_idle, " ");
 	pstring = pmulti_remain->GetSection()->Add_string("type", when_idle, "disabled");
 	pmulti_remain->SetValue("disabled");
 	pstring->Set_values(serials);
 	pmulti_remain->GetSection()->Add_string("parameters", when_idle, "");
-	pmulti_remain->Set_help("See 'serial1'");
+	pmulti_remain->Set_help("See 'serial1' ('disabled' by default).");
 
 	pmulti_remain = secprop->AddMultiValRemain("serial4", when_idle, " ");
 	pstring = pmulti_remain->GetSection()->Add_string("type", when_idle, "disabled");
 	pmulti_remain->SetValue("disabled");
 	pstring->Set_values(serials);
 	pmulti_remain->GetSection()->Add_string("parameters", when_idle, "");
-	pmulti_remain->Set_help("See 'serial1'");
+	pmulti_remain->Set_help("See 'serial1' ('disabled' by default).");
 
 	pstring = secprop->Add_path("phonebookfile", only_at_start, "phonebook.txt");
 	pstring->Set_help("File used to map fake phone numbers to addresses\n"

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -640,9 +640,10 @@ void DOSBOX_Init()
 
 	pbool = secprop->Add_bool("shell_config_shortcuts", when_idle, true);
 	pbool->Set_help(
-	        "Allow shortcuts for direct configuration management (enabled by default), i.e.\n"
-	        "instead of 'config -set sbtype sb16' it is enough to execute 'sbtype sb16', \n"
-	        "and instead of 'config -get sbtype' it is enough to execute 'sbtype' command.");
+	        "Allow shortcuts for simpler configuration management (enabled by default).\n"
+	        "E.g., instead of 'config -set sbtype sb16', it is enough to execute\n"
+	        "'sbtype sb16', and instead of 'config -get sbtype', you can just execute\n"
+	        "the 'sbtype' command.");
 
 	// Configure render settings
 	RENDER_AddConfigSection(control);

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -1091,18 +1091,18 @@ void DOSBOX_Init()
 	pstring->Set_values(serials);
 	pmulti_remain->GetSection()->Add_string("parameters", when_idle, "");
 	pmulti_remain->Set_help(
-	        "Set type of device connected to COM port.\n"
+	        "Set type of device connected to the COM1 port.\n"
 	        "Can be disabled, dummy, mouse, modem, nullmodem, direct ('dummy' by default).\n"
 	        "Additional parameters must be on the same line in the form of\n"
-	        "parameter:value. Parameter for all types is irq (optional).\n"
-	        "  - for 'mouse':      model, overrides setting from [mouse] section\n"
+	        "parameter:value. The optional 'irq' parameter is common for all types.\n"
+	        "  - for 'mouse':      model (overrides the setting from the [mouse] section)\n"
 	        "  - for 'direct':     realport (required), rxdelay (optional).\n"
-	        "                      (realport:COM1 realport:ttyS0).\n"
+	        "                      (e.g., realport:COM1, realport:ttyS0).\n"
 	        "  - for 'modem':      listenport, sock, bps (all optional).\n"
 	        "  - for 'nullmodem':  server, rxdelay, txdelay, telnet, usedtr,\n"
 	        "                      transparent, port, inhsocket, sock (all optional).\n"
-	        "SOCK parameter specifies the protocol to be used by both sides\n"
-	        "of the conection. 0 for TCP and 1 for ENet reliable UDP.\n"
+	        "The 'sock' parameter specifies the protocol to use at both sides of the\n"
+	        "connection. Valid values are 0 for TCP, and 1 for ENet reliable UDP.\n"
 	        "Example: serial1=modem listenport:5000 sock:1");
 
 	pmulti_remain = secprop->AddMultiValRemain("serial2", when_idle, " ");

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -632,16 +632,17 @@ void DOSBOX_Init()
 
 	pbool = secprop->Add_bool("allow_write_protected_files", only_at_start, true);
 	pbool->Set_help(
-		"Many games open all their files with writable permissions; even files that they\n"
-		"never modify. This setting lets you write-protect those files while still\n"
-		"allowing the game to read them. A second use-case: if you're using a\n"
-		"copy-on-write or network-based filesystem, this setting avoids triggering\n"
-		"write-operations for these write-protected files.");
+	        "Many games open all their files with writable permissions; even files that they\n"
+	        "never modify. This setting lets you write-protect those files while still\n"
+	        "allowing the game to read them (enabled by default). A second use-case: if\n"
+	        "you're using a copy-on-write or network-based filesystem, this setting avoids\n"
+	        "triggering write operations for these write-protected files.");
 
 	pbool = secprop->Add_bool("shell_config_shortcuts", when_idle, true);
-	pbool->Set_help("Allow shortcuts for direct configuration management (enabled by default), i.e.\n"
-	                "instead of 'config -set sbtype sb16' it is enough to execute 'sbtype sb16', \n"
-	                "and instead of 'config -get sbtype' it is enough to execute 'sbtype' command.");
+	pbool->Set_help(
+	        "Allow shortcuts for direct configuration management (enabled by default), i.e.\n"
+	        "instead of 'config -set sbtype sb16' it is enough to execute 'sbtype sb16', \n"
+	        "and instead of 'config -get sbtype' it is enough to execute 'sbtype' command.");
 
 	// Configure render settings
 	RENDER_AddConfigSection(control);

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -1164,7 +1164,7 @@ static void init_render_settings(Section_prop& secprop)
 #if C_OPENGL
 	string_prop = secprop.Add_string("glshader", always, "crt-auto");
 	string_prop->Set_help(
-	        "Set an adaptive CRT monitor emulation shader or a regular GLSL shader in OpenGL \n"
+	        "Set an adaptive CRT monitor emulation shader or a regular GLSL shader in OpenGL\n"
 	        "output modes. Adaptive CRT shader options:\n"
 	        "  crt-auto:               A CRT shader that prioritises developer intent and how\n"
 	        "                          people experienced the game at the time of release\n"

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -4450,10 +4450,11 @@ static void config_add_sdl() {
 
 	pstring = sdl_sec->Add_path("mapperfile", always, MAPPERFILE);
 	pstring->Set_help(
-	        "File used to load/save the key/event mappings.\n"
-	        "Pre-configured maps are bundled in the 'resources/mapperfiles' directory.\n"
-	        "They can be loaded by name, for example: mapperfile = xbox/xenon2.map\n"
-	        "Note: The --resetmapper command line flag only deletes the default mapperfile.");
+	        "Path to the mapper file ('mapper-sdl2-XYZ.map' by default, where XYZ is the\n"
+	        "current version). Pre-configured maps are bundled in 'resources/mapperfiles'.\n"
+	        "These can be loaded by name, e.g., with 'mapperfile = xbox/xenon2.map'.\n"
+	        "Note: The --resetmapper command line option only deletes the default mapper\n"
+	        "      file.");
 
 	pstring = sdl_sec->Add_string("screensaver", on_start, "auto");
 	pstring->Set_help(

--- a/src/hardware/input/mouse_config.cpp
+++ b/src/hardware/input/mouse_config.cpp
@@ -338,7 +338,7 @@ static void config_init(Section_prop &secprop)
 	prop_str->Set_values(list_capture_types);
 	prop_str->Set_help(
 	        "Set the mouse capture behaviour:\n"
-	        "  onclick:   Capture the mouse when clicking any mouse button in the window \n"
+	        "  onclick:   Capture the mouse when clicking any mouse button in the window\n"
 	        "             (default).\n"
 	        "  onstart:   Capture the mouse immediately on start. Might not work correctly\n"
 	        "             on some host operating systems.\n"

--- a/src/hardware/vga_other.cpp
+++ b/src/hardware/vga_other.cpp
@@ -38,6 +38,7 @@
 #include "reelmagic.h"
 #include "render.h"
 #include "rgb888.h"
+#include "string_utils.h"
 #include "vga.h"
 
 // CHECK_NARROWING();
@@ -1455,7 +1456,7 @@ static void composite_init(Section *sec)
 	}
 }
 
-static void composite_settings(Section_prop &secprop)
+static void composite_settings(Section_prop& secprop)
 {
 	constexpr auto when_idle = Property::Changeable::WhenIdle;
 
@@ -1463,10 +1464,10 @@ static void composite_settings(Section_prop &secprop)
 	auto str_prop = secprop.Add_string("composite", when_idle, "auto");
 	str_prop->Set_values(states);
 	str_prop->Set_help(
-	        "Enable composite mode on start ('auto' by default).\n"
-	        "'auto' lets the program decide.\n"
-	        "Note: Fine-tune the settings below (i.e., hue) using the composite hotkeys,\n"
-	        "      then read the new settings from your console and enter them here.");
+	        "Enable composite mode on start (only for 'cga', 'pcjr', and 'tandy' machine\n"
+	        "types; 'auto' by default). 'auto' lets the program decide.\n"
+	        "Note: Fine-tune the settings below (i.e., 'hue') using the composite hotkeys,\n"
+	        "      then copy the new settings from the logs into your config.");
 
 	const char* eras[] = {"auto", "old", "new", nullptr};
 	str_prop           = secprop.Add_string("era", when_idle, "auto");
@@ -1476,23 +1477,29 @@ static void composite_settings(Section_prop &secprop)
 
 	auto int_prop = secprop.Add_int("hue", when_idle, hue.get_default());
 	int_prop->SetMinMax(hue.get_min(), hue.get_max());
-	int_prop->Set_help("Appearance of RGB palette. For example, adjust until the sky is blue.");
+	int_prop->Set_help(format_string("Appearance of RGB palette (%d by default).\n"
+	                                 "For example, adjust until the sky is blue.",
+	                                 hue.get_default()));
 
 	int_prop = secprop.Add_int("saturation", when_idle, saturation.get_default());
 	int_prop->SetMinMax(saturation.get_min(), saturation.get_max());
-	int_prop->Set_help("Intensity of colors, from washed out to vivid.");
+	int_prop->Set_help(format_string("Intensity of colors, from washed out to vivid (%d by default).",
+	                                 saturation.get_default()));
 
 	int_prop = secprop.Add_int("contrast", when_idle, contrast.get_default());
 	int_prop->SetMinMax(contrast.get_min(), contrast.get_max());
-	int_prop->Set_help("Ratio between the dark and light area.");
+	int_prop->Set_help(format_string("Ratio between the dark and light area (%d by default).",
+	                                 contrast.get_default()));
 
 	int_prop = secprop.Add_int("brightness", when_idle, brightness.get_default());
 	int_prop->SetMinMax(brightness.get_min(), brightness.get_max());
-	int_prop->Set_help("Luminosity of the image, from dark to light.");
+	int_prop->Set_help(format_string("Luminosity of the image, from dark to light (%d by default).",
+	                                 brightness.get_default()));
 
 	int_prop = secprop.Add_int("convergence", when_idle, convergence.get_default());
 	int_prop->SetMinMax(convergence.get_min(), convergence.get_max());
-	int_prop->Set_help("Convergence of subpixel elements, from blurry to sharp (CGA and Tandy-only).");
+	int_prop->Set_help(format_string("Convergence of subpixel elements, from blurry to sharp (%d by default).",
+	                                 convergence.get_default()));
 }
 
 static void turn_crt_knob(bool pressed, const int amount)

--- a/src/midi/midi_mt32.cpp
+++ b/src/midi/midi_mt32.cpp
@@ -343,13 +343,13 @@ static void init_mt32_dosbox_settings(Section_prop& sec_prop)
 
 	str_prop = sec_prop.Add_string("romdir", when_idle, "");
 	str_prop->Set_help(
-	        "The directory containing the Roland MT-32/CM-32ML ROMs.\n"
-	        "The directory can be absolute or relative, or leave it blank to\n"
-	        "use the 'mt32-roms' directory in your DOSBox configuration\n"
-	        "directory. Other common system locations will be checked as well.\n"
+	        "The directory containing the Roland MT-32/CM-32ML ROMs (unset by default).\n"
+	        "The directory can be absolute or relative, or leave it unset to use the\n"
+	        "'mt32-roms' directory in your DOSBox configuration directory. Other common\n"
+	        "system locations will be checked as well.\n"
 	        "Notes:\n"
-	        "  - The file names of the ROM files do not matter; the ROMS are identified by\n"
-	        "    their checksums.\n"
+	        "  - The file names of the ROM files do not matter; the ROMS are identified\n"
+	        "    by their checksums.\n"
 	        "  - Both interleaved and non-interlaved ROM files are supported.");
 
 	str_prop = sec_prop.Add_string("mt32_filter", when_idle, "off");


### PR DESCRIPTION
# Description

What the title says. Some config descriptions have also been improved. No functional changes.


# Manual testing

Verified that everything looks good with `config -h` and `config -wcd`.


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

