### PR TITLE
Fix infinite recursion problem at startup on Pop OS 22.04 and SDL 2.0.20

### DIFF
--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3984,10 +3984,7 @@ bool GFX_Events()
 
 				finalise_window_state();
 
-				const auto shader_switched = maybe_auto_switch_shader();
-				if (!shader_switched) {
-					GFX_ResetScreen();
-				}
+				maybe_auto_switch_shader();
 				continue;
 			}
 


### PR DESCRIPTION
# Description

It turns out resetting the renderer is not needed on window size change events, and this somehow caused an infinite regression on Pop OS 22.04 running SDL 2.0.20 which manifested in high CPU load and a (mostly) black DOSBos Staging screen at startup.

# Manual testing

Regression tested on Windows 10 and macOS Sonoma 14.0:

- Confirmed that the shader auto-switching still works fine when changing the window size.
- Confirmed that the new pixel aspect ratios are still propagated downstream and the updated PAR gets logged when switching the `aspect` setting (e.g., `aspect = stretch` with integer scaling disabled).

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

