### PR TITLE
Display 'max limit' cycles setting properly in the title bar

### DIFF
--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -312,22 +312,41 @@ void GFX_SetTitle(const int32_t new_num_cycles, const bool is_paused = false)
 	auto &hint_mouse_str  = sdl.title_bar.hint_mouse_str;
 	auto &hint_paused_str = sdl.title_bar.hint_paused_str;
 
-	if (new_num_cycles != -1)
+	if (new_num_cycles != -1) {
 		num_cycles = new_num_cycles;
+	}
 
 	if (cycles_ms_str.empty()) {
 		cycles_ms_str   = MSG_GetRaw("TITLEBAR_CYCLES_MS");
 		hint_paused_str = std::string(" ") + MSG_GetRaw("TITLEBAR_HINT_PAUSED");
 	}
 
-	if (CPU_CycleAutoAdjust)
-		safe_sprintf(title_buf, "%8s - max %d%% - " APP_NAME_STR "%s",
-		             RunningProgram, num_cycles,
-		             is_paused ? hint_paused_str.c_str() : hint_mouse_str.c_str());
-	else
-		safe_sprintf(title_buf, "%8s - %d %s - " APP_NAME_STR "%s",
-		             RunningProgram, num_cycles, cycles_ms_str.c_str(),
-		             is_paused ? hint_paused_str.c_str() : hint_mouse_str.c_str());
+	const auto& hint_str = is_paused ? hint_paused_str : hint_mouse_str;
+	if (CPU_CycleAutoAdjust) {
+		if (CPU_CycleLimit > 0) {
+			safe_sprintf(title_buf,
+			             "%8s - max %d%% limit %d %s - " APP_NAME_STR "%s",
+			             RunningProgram,
+			             num_cycles,
+			             CPU_CycleLimit,
+			             cycles_ms_str.c_str(),
+			             hint_str.c_str());
+		} else {
+			safe_sprintf(title_buf,
+			             "%8s - max %d%% %s - " APP_NAME_STR "%s",
+			             RunningProgram,
+			             num_cycles,
+			             cycles_ms_str.c_str(),
+			             hint_str.c_str());
+		}
+	} else {
+		safe_sprintf(title_buf,
+		             "%8s - %d %s - " APP_NAME_STR "%s",
+		             RunningProgram,
+		             num_cycles,
+		             cycles_ms_str.c_str(),
+		             hint_str.c_str());
+	}
 
 	SDL_SetWindowTitle(sdl.window, title_buf);
 }


### PR DESCRIPTION
# Description

I have noticed that with `cycles = max limit <value>` the title bar only displays `max` value, without telling about the limit. This is very misleading and it might lead to mistake when running benchmark.

This PR fixes the problem. ~~I have set the project to _0.82_, as we are after code soft freeze - but if you think this should go to _0.81_, I have no objections.~~

![Screenshot-NewTitleBar](https://github.com/dosbox-staging/dosbox-staging/assets/48332137/060677ee-5c0c-4ebf-b942-aa87e50bcd57)


# Manual testing

Try different `cycles = <value>` settings, use internal command `config -set cycles="<value>"`.


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

