### PR TITLE
Use versioned action/upload key names in CI workflows

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -114,10 +114,18 @@ jobs:
           ninja -C build scan-build
           mv build/meson-logs/scanbuild report
 
+      - name: Inject version string
+        run: |
+          set -x
+          git fetch --prune --unshallow
+          git fetch --all --tags --force
+          export VERSION=$(git describe --abbrev=5)
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+
       - name: Upload report
         uses: actions/upload-artifact@v4
         with:
-          name: clang-analysis-report
+          name: clang-analysis-report-${{ env.VERSION }}
           path: report
 
       - name: Summarize report

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -337,10 +337,10 @@ jobs:
           ./scripts/create-package.sh \
             -p linux \
             build \
-            "dosbox-staging-linux-$VERSION"
+            "dosbox-staging-linux-x86_64-$VERSION"
 
       - name: Create tarball
-        run: tar -cJf "dosbox-staging-linux-$VERSION.tar.xz" "dosbox-staging-linux-$VERSION"
+        run: tar -cJf "dosbox-staging-linux-x86_64-$VERSION.tar.xz" "dosbox-staging-linux-x86_64-$VERSION"
 
       - name:  Prepare Clam AV DB cache
         id:    prep-clamdb
@@ -373,8 +373,9 @@ jobs:
         # a tarball), and it removes all executable flags while zipping.
         # Letting it zip a tarball preserves flags in the compressed files.
         with:
-          name: dosbox-staging-linux-x86_64
-          path: dosbox-staging-linux-${{ env.VERSION }}.tar.xz
+          name: dosbox-staging-linux-x86_64-${{ env.VERSION }}
+          path: dosbox-staging-linux-x86_64-${{ env.VERSION }}.tar.xz
+          compression-level: 0
 
 
   # This job exists only to publish an artifact with version info when building

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -255,14 +255,20 @@ jobs:
       - name: Upload binary
         uses: actions/upload-artifact@v4
         with:
-          name: dosbox-${{ matrix.runner.arch }}
+          name: dosbox-staging-macOS-${{ matrix.runner.arch }}-${{ env.VERSION }}
           path: build/dosbox
+
+      - name: Zip resources
+        run: |
+          tar -c Resources \
+          | zstd --adapt -T0 --long -v --force -o Resources.tar.zst
 
       - name: Upload resources
         uses: actions/upload-artifact@v4
         with:
-          name: Resources
-          path: Resources
+          name: Resources-macOS-${{ matrix.runner.arch }}-${{ env.VERSION }}
+          path: Resources.tar.zst
+          compression-level: 0
 
   publish_universal_build:
     name: Publish universal build
@@ -285,8 +291,23 @@ jobs:
       - name: Install brew depedencies
         run: brew install --overwrite librsvg
 
-      - name: Download binaries
+      - name: Download artifacts
         uses: actions/download-artifact@v4
+
+      - name: List local files resources
+        run: |
+
+      - name: Unpack and normalize the resources and executable paths
+        # The create-package.sh script expects to find a 'Resources/' directory and
+        # the 'dosbox' executables sitting in 'dosbox-arm64/' and 'dosbox-x86_64/'
+        # directories. So we need to eliminate the unique version wrapping.
+        run: |
+          ls -1la
+          ls Resources*/*
+          ls dosbox-staging-macOS*/*
+          zstd -dc Resources-macOS-arm64-${{ env.VERSION }}/Resources.tar.zst | tar x
+          mv dosbox-staging-macOS-arm64-${{ env.VERSION }} dosbox-arm64
+          mv dosbox-staging-macOS-x86_64-${{ env.VERSION }} dosbox-x86_64
 
       - name: Package
         run: |
@@ -322,8 +343,9 @@ jobs:
         # GitHub automatically zips the artifacts, and there's no option
         # to skip it or upload a file only.
         with:
-          name: dosbox-staging-macOS-universal
+          name: dosbox-staging-macOS-universal-${{ env.VERSION }}
           path: dosbox-staging-macOS-${{ env.VERSION }}.dmg
+          compression-level: 0
 
   # This job exists only to publish an artifact with version info when building
   # from main branch, so snapshot build version will be visible on:
@@ -354,3 +376,4 @@ jobs:
           # version info via GitHub REST API
           name: changelog-${{ env.VERSION }}.txt
           path: changelog-${{ env.VERSION }}.txt
+          compression-level: 1

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -289,7 +289,7 @@ jobs:
           echo "VERSION=$VERSION" >> $GITHUB_ENV
 
       - name: Install brew depedencies
-        run: brew install --overwrite librsvg
+        run: HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 brew install --overwrite librsvg
 
       - name: Download artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/pvs-studio.yml
+++ b/.github/workflows/pvs-studio.yml
@@ -103,10 +103,18 @@ jobs:
           mv -f "${reportdir}/pvs-report.fullhtml"/* "${reportdir}/"
           rm -rf "${reportdir}/pvs-report.fullhtml"
 
+      - name: Inject version string
+        run: |
+          set -x
+          git fetch --prune --unshallow
+          git fetch --all --tags --force
+          export VERSION=$(git describe --abbrev=5)
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+
       - name: Upload report
         uses: actions/upload-artifact@v4
         with:
-          name: pvs-analysis-report
+          name: pvs-analysis-report-${{ env.VERSION }}
           path: pvs-report
 
       - name: Summarize report

--- a/.github/workflows/windows-msvc.yml
+++ b/.github/workflows/windows-msvc.yml
@@ -218,12 +218,12 @@ jobs:
         with:
           name: ${{ steps.set_pkg_dir.outputs.pkg_dir }}
           path: ${{ steps.set_pkg_dir.outputs.pkg_dir }}
-      
+
       - name: Upload debugger artifact
         if:   ${{ matrix.conf.debugger }}
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ steps.set_pkg_dir.outputs.pkg_dir }}
+          name: ${{ steps.set_pkg_dir.outputs.pkg_dir }}-debugger
           path: ${{ steps.set_pkg_dir.outputs.pkg_dir }}/dosbox_with_debugger.exe
 
   # This job exists only to publish an artifact with version info when building

--- a/.github/workflows/windows-msys2.yml
+++ b/.github/workflows/windows-msys2.yml
@@ -415,8 +415,9 @@ jobs:
       - name: Upload installer
         uses: actions/upload-artifact@v4
         with:
-          name: dosbox-staging-${{ env.version_number }}-setup.exe
+          name: dosbox-staging-windows-${{ env.version_number }}-setup.exe
           path: ${{ github.workspace }}\out\dosbox-staging-${{ env.version_number }}-setup.exe
+          compression-level: 0
 
   # This job exists only to publish an artifact with version info when building
   # from main branch, so snapshot build version will be visible on:


### PR DESCRIPTION
# Description

GitHub's upgraded upload/artifacts@v4 API fixed a bug where uploads with the same key name could mutate each other, which several of our CI workflows were doing.

> Previously the behavior allowed for the artifact names to be the same which resulted in unexpected mutations and accidental corruption. Artifacts created by upload-artifact@v4 are immutable.

v4 makes uploads idempotent and therefore they always need a unique key name:

> Artifact names must be unique since each created artifact is idempotent so multiple jobs cannot modify the same artifact.

Refs: 
- https://github.blog/changelog/2023-12-14-github-actions-artifacts-v4-is-now-generally-available/
- https://github.com/actions/upload-artifact#not-uploading-to-the-same-artifact

# Manual testing

Need to check the following:

- [x] Linux release package contains x86-64 build
- [x] macOS universal package contains combo-arm64+x86-64 binary
- [x] Windows zip contains normal and debugger builds
- [x] Windows setup.exe contains normal and debugger builds

# Checklist


I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

