### PR TITLE
Allow FROUND fix on x64

### DIFF
--- a/src/fpu/fpu_instructions.h
+++ b/src/fpu/fpu_instructions.h
@@ -128,9 +128,6 @@ static double FROUND(double in)
 		// single precision mode.
 		case SinglePrecisionMode:
 			return std::trunc(static_cast<float>(in));
-		// Most x32/x64 builds use fpu_instructions_x86.h.
-		// If we are here on x64, we don't need this fix.
-#if !defined(__x86_64__) && !defined(_M_X64)
 		// This is a fix for rounding to a close integer in extended
 		// precision mode, e.g. 7.999999999999994; an example can be
 		// seen in the Quake options screen size slider. In this case,
@@ -145,7 +142,6 @@ static double FROUND(double in)
 				return upper;
 			}
 		}
-#endif
 		default: break;
 		}
 		return std::trunc(in);


### PR DESCRIPTION
# Description

I tested the Quake screen size slider on Windows 11 x64 using the Normal core, and this fix is definitely required there, so remove the conditional compilation.

# Manual testing

Tested with Quake on x64 Normal and DynX86 cores, as well as dynrec core on macOS with Apple Silicon.

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

