### PR TITLE
Always clamp `frames_needed` to the allowed mix/max range in the mixer

### DIFF
--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -219,16 +219,6 @@ StereoLine MixerChannel::GetLineoutMap() const
 	return output_map;
 }
 
-// TODO Once the mixer code is thorougly refactored, revisit whether this is
-// still necessary (i.e., we might be able to be more precise with our
-// 'frames_needed' calculation so we never under or overshoot).
-static int clamp_frames_needed(const int frames_needed)
-{
-	return clamp(frames_needed,
-	             mixer.min_frames_needed.load(),
-	             mixer.max_frames_needed.load());
-}
-
 static Section_prop* get_mixer_section()
 {
 	assert(control);
@@ -1037,7 +1027,7 @@ void MixerChannel::Mix(const uint16_t frames_requested)
 		return;
 	}
 
-	frames_needed = clamp_frames_needed(frames_requested);
+	frames_needed = frames_requested;
 
 	while (frames_needed > frames_done) {
 		auto frames_remaining = frames_needed - frames_done;
@@ -2359,7 +2349,7 @@ static void handle_mix_samples()
 
 	const auto frames_needed = mixer.frames_needed +
 	                           (mixer.tick_counter >> TickShift);
-	mixer.frames_needed = clamp_frames_needed(frames_needed);
+	mixer.frames_needed = frames_needed;
 
 	mixer.tick_counter &= TickMask;
 
@@ -2391,7 +2381,7 @@ static void handle_mix_no_sound()
 
 	/* Set values for next tick */
 	mixer.tick_counter += mixer.tick_add;
-	mixer.frames_needed = clamp_frames_needed(mixer.tick_counter >> TickShift);
+	mixer.frames_needed = mixer.tick_counter >> TickShift;
 	mixer.tick_counter &= TickMask;
 	mixer.frames_done = 0;
 
@@ -2523,7 +2513,7 @@ static void SDLCALL mixer_callback([[maybe_unused]] void* userdata,
 	mixer.frames_done -= reduce_frames;
 
 	const auto frames_needed = mixer.frames_needed - reduce_frames;
-	mixer.frames_needed      = clamp_frames_needed(frames_needed);
+	mixer.frames_needed      = frames_needed;
 
 	pos       = mixer.pos;
 	mixer.pos = check_cast<work_index_t>((mixer.pos + reduce_frames) &
@@ -2803,7 +2793,7 @@ void MIXER_Init(Section* sec)
 
 	mixer.pos           = 0;
 	mixer.frames_done   = 0;
-	mixer.frames_needed = clamp_frames_needed(mixer.min_frames_needed + 1);
+	mixer.frames_needed = mixer.min_frames_needed + 1;
 	mixer.min_frames_needed = 0;
 	mixer.max_frames_needed = mixer.blocksize * 2 + 2 * prebuffer_frames;
 


### PR DESCRIPTION
# Description

This fixes a regression by reverting commit a25af54. The clamping causes the audio to become out of sync when using fast-forward mode in _release_ mode (debug mode is not fast enough, but you can still get the audio out-of-sync by fast forwarding, but to a much lesser extent). Tested with OPL and MT-32 output, but probably all sound devices are affected.

The lack of clamping doesn't cause issues in release builds; it just helped not to trip an assert in debug builds when putting your laptop to sleep while running Staging, then waking the machine up a few seconds later. But this was never a proper fix anyway, just a workaround, so it's no great loss.

The problem should be properly addressed when the whole mixer gets refactored. I really don't have the time for that, and we definitely don't want to break the sound sync when fast-forwarding.

## Related issues

Reverts https://github.com/dosbox-staging/dosbox-staging/pull/2843

# Manual testing

## Before fix

1. Start Space Quest 3 with OPL or MT-32 sound (but any game will do).
2. Press fast-forward for a few seconds.
3. When you release the fast-forward hotkey, the audio will "rush" to catch up with the "current time". This sounds quite comical and quite wrong 😄 

## After fix

Repeat the same steps—the audio always stays in perfect sync, no matter for how long you've been fast-forwarding.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

