### PR TITLE
Log display mode correctly on fullscreen/windowed switch & window resize

### DIFF
--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3817,7 +3817,7 @@ bool GFX_Events()
 				focus_input();
 				continue;
 
-			case SDL_WINDOWEVENT_RESIZED:
+			case SDL_WINDOWEVENT_RESIZED: {
 				// TODO pixels or logical unit?
 				// LOG_DEBUG("SDL: Window has been resized to
 				// %dx%d",
@@ -3832,11 +3832,27 @@ bool GFX_Events()
 				assert(sdl.desktop.window.width > 0 &&
 				       sdl.desktop.window.height > 0);
 
-				log_display_properties(sdl.draw.render_width_px,
-				                       sdl.draw.render_height_px,
-				                       sdl.video_mode,
-				                       sdl.rendering_backend);
-				continue;
+				// SDL_WINDOWEVENT_RESIZED events are sent twice on macOS when
+				// resizing the window, so we're only logging the display
+				// settings if there is a change since the last window resized
+				// event.
+				static int prev_width  = 0;
+				static int prev_height = 0;
+
+				const auto new_width  = event.window.data1;
+				const auto new_height = event.window.data2;
+
+				if (prev_width != new_width ||
+				    prev_height != new_height) {
+					log_display_properties(sdl.draw.render_width_px,
+					                       sdl.draw.render_height_px,
+					                       sdl.video_mode,
+					                       sdl.rendering_backend);
+				}
+
+				prev_width  = new_width;
+				prev_height = new_height;
+			}	continue;
 
 			case SDL_WINDOWEVENT_FOCUS_GAINED:
 				apply_active_settings();

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -2416,12 +2416,6 @@ void GFX_SwitchFullScreen()
 	                                 sdl.rendering_backend))
 	                       : canvas_size_px;
 
-	log_display_properties(sdl.draw.render_width_px,
-	                       sdl.draw.render_height_px,
-	                       sdl.video_mode,
-	                       canvas_size_px,
-	                       sdl.rendering_backend);
-
 	sdl.desktop.switching_fullscreen = false;
 }
 
@@ -3844,10 +3838,11 @@ bool GFX_Events()
 
 			case SDL_WINDOWEVENT_RESIZED:
 				// TODO pixels or logical unit?
-				// LOG_DEBUG("SDL: Window has been resized to %dx%d",
-				//               event.window.data1,
-				//               event.window.data2);
-				//
+				// LOG_DEBUG("SDL: Window has been resized to
+				// %dx%d",
+				//           event.window.data1,
+				//           event.window.data2);
+
 				// When going from an initial fullscreen to
 				// windowed state, this event will be called
 				// moments before SDL's windowed mode is
@@ -3855,6 +3850,12 @@ bool GFX_Events()
 				// already been established:
 				assert(sdl.desktop.window.width > 0 &&
 				       sdl.desktop.window.height > 0);
+
+				log_display_properties(sdl.draw.render_width_px,
+				                       sdl.draw.render_height_px,
+				                       sdl.video_mode,
+				                       {},
+				                       sdl.rendering_backend);
 				continue;
 
 			case SDL_WINDOWEVENT_FOCUS_GAINED:

--- a/src/gui/shader_manager.cpp
+++ b/src/gui/shader_manager.cpp
@@ -22,7 +22,6 @@
 
 #include <algorithm>
 #include <cassert>
-#include <chrono>
 #include <fstream>
 #include <map>
 #include <optional>


### PR DESCRIPTION
# Description

Before this change, if you switched to fullscreen, then back to windowed mode, the display mode params were logged "too early". Specifically, the scaled pixel dimensions were off; the _previous_ pixel dimensions you had in fullscreen mode were logged again after going back to windowed. This is because the logging happened too early in the event handling chain.

Now we're also logging the changed display dimensions on window size changes. The way I'm doing it shouldn't spam the logs _while_ resizing the window on any Linux window manager, just log _once_ when you stop resizing, but we'll see.

Windows and macOS are fine; they don't send continuous resize events (it's a challenge to get continuous resize events on these platforms, in fact, but Linux tends to do this differently).

One drawback of this approach is that on window resizes, the display settings get logged _twice_, at least on macOS, because there are _two_ `SDL_WINDOWEVENT_RESIZED` events in a row. Why, that's anyone's guess 🤷🏻 Maybe SDL bug. Personally, I'd rather have two log messages in those cases than zero and this is something we could perhaps improve later on but it's hardly a deal-breaker.

# Manual testing

## Before fix

Use the defaults by staring DOSBox with `--noprimaryconf`.

1. Switch to fullscreen. The `DISPLAY: ...` log message contains something like `scaled to 2667x2000 pixels` in the middle.
2. Switch back to windowed. The display log message still contains the same dimensions, but clearly that can't be true.

Changing the window size does _not_ log the new display settings.

## After fix

1. Switch to fullscreen. The `DISPLAY: ...` log message contains something like `scaled to 2667x2000 pixels` in the middle.
2. Switch back to windowed. The display log message contains smaller pixel dimensions such as `scaled to 1600x1200 pixels` in my case.

Changing the window size _does_ log the new display settings when you stop resizing.


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

