### PR TITLE
Remove PSP name from window titlebar

### DIFF
--- a/src/dos/dos_execute.cpp
+++ b/src/dos/dos_execute.cpp
@@ -32,8 +32,6 @@
 #include "regs.h"
 #include "string_utils.h"
 
-const char * RunningProgram="DOSBOX";
-
 #ifdef _MSC_VER
 #pragma pack(1)
 #endif
@@ -65,23 +63,7 @@ struct EXE_Header {
 #define LOAD    1
 #define OVERLAY 3
 
-
-extern void GFX_RefreshTitle(const bool is_paused = false);
 extern void GFX_SetTitle(const int32_t cycles, const bool is_paused = false);
-
-void DOS_UpdatePSPName(void) {
-	DOS_MCB mcb(dos.psp()-1);
-	static char name[9];
-	mcb.GetFileName(name);
-	name[8] = 0;
-	if (!strlen(name)) strcpy(name,"DOSBOX");
-	for(Bitu i = 0;i < 8;i++) { //Don't put garbage in the title bar. Mac OS X doesn't like it
-		if (name[i] == 0) break;
-		if ( !isprint(*reinterpret_cast<unsigned char*>(&name[i])) ) name[i] = '?';
-	}
-	RunningProgram = name;
-	GFX_RefreshTitle();
-}
 
 void DOS_Terminate(uint16_t pspseg,bool tsr,uint8_t exitcode) {
 
@@ -123,7 +105,6 @@ void DOS_Terminate(uint16_t pspseg,bool tsr,uint8_t exitcode) {
 	real_writew(SegValue(ss),reg_sp+4,0x7202);
 	// Free memory owned by process
 	if (!tsr) DOS_FreeProcessMemory(pspseg);
-	DOS_UpdatePSPName();
 
 	if ((!(CPU_AutoDetermineMode>>CPU_AUTODETERMINE_SHIFT)) || (cpu.pmode)) return;
 
@@ -134,8 +115,6 @@ void DOS_Terminate(uint16_t pspseg,bool tsr,uint8_t exitcode) {
 		CPU_Cycles=0;
 		CPU_CycleMax=CPU_OldCycleMax;
 		GFX_SetTitle(CPU_OldCycleMax);
-	} else {
-		GFX_RefreshTitle();
 	}
 #if (C_DYNAMIC_X86) || (C_DYNREC)
 	if (CPU_AutoDetermineMode&CPU_AUTODETERMINE_CORE) {
@@ -466,7 +445,6 @@ bool DOS_Execute(char * name,PhysPt block_pt,uint8_t flags) {
 		memset(&stripname[index],0,8-index);
 		DOS_MCB pspmcb(dos.psp()-1);
 		pspmcb.SetFileName(stripname);
-		DOS_UpdatePSPName();
 	}
 
 	if (flags==LOAD) {

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -291,21 +291,19 @@ static void QuitSDL()
 	}
 }
 
-extern const char* RunningProgram;
-extern bool CPU_CycleAutoAdjust;
 //Globals for keyboard initialisation
 bool startup_state_numlock=false;
 bool startup_state_capslock=false;
 
+#if !defined(NDEBUG)
+#define APP_NAME_STR DOSBOX_NAME " (debug build)"
+#else
+#define APP_NAME_STR DOSBOX_NAME
+#endif
+
 void GFX_SetTitle(const int32_t new_num_cycles, const bool is_paused = false)
 {
 	char title_buf[200] = {0};
-
-#if !defined(NDEBUG)
-	#define APP_NAME_STR DOSBOX_NAME " (debug build)"
-#else
-	#define APP_NAME_STR DOSBOX_NAME
-#endif
 
 	auto &num_cycles      = sdl.title_bar.num_cycles;
 	auto &cycles_ms_str   = sdl.title_bar.cycles_ms_str;
@@ -318,31 +316,28 @@ void GFX_SetTitle(const int32_t new_num_cycles, const bool is_paused = false)
 
 	if (cycles_ms_str.empty()) {
 		cycles_ms_str   = MSG_GetRaw("TITLEBAR_CYCLES_MS");
-		hint_paused_str = std::string(" ") + MSG_GetRaw("TITLEBAR_HINT_PAUSED");
+		hint_paused_str = MSG_GetRaw("TITLEBAR_HINT_PAUSED");
 	}
 
 	const auto& hint_str = is_paused ? hint_paused_str : hint_mouse_str;
 	if (CPU_CycleAutoAdjust) {
 		if (CPU_CycleLimit > 0) {
 			safe_sprintf(title_buf,
-			             "%8s - max %d%% limit %d %s - " APP_NAME_STR "%s",
-			             RunningProgram,
+			             APP_NAME_STR " - max %d%% limit %d %s %s",
 			             num_cycles,
 			             CPU_CycleLimit,
 			             cycles_ms_str.c_str(),
 			             hint_str.c_str());
 		} else {
 			safe_sprintf(title_buf,
-			             "%8s - max %d%% %s - " APP_NAME_STR "%s",
-			             RunningProgram,
+			             APP_NAME_STR " - max %d%% %s %s",
 			             num_cycles,
 			             cycles_ms_str.c_str(),
 			             hint_str.c_str());
 		}
 	} else {
 		safe_sprintf(title_buf,
-		             "%8s - %d %s - " APP_NAME_STR "%s",
-		             RunningProgram,
+		             APP_NAME_STR " - %d %s %s",
 		             num_cycles,
 		             cycles_ms_str.c_str(),
 		             hint_str.c_str());
@@ -2249,7 +2244,7 @@ void GFX_SetShader([[maybe_unused]] const ShaderInfo& shader_info,
 
 void GFX_SetMouseHint(const MouseHint hint_id)
 {
-	static const std::string prexix = " - ";
+	static const std::string prexix = "- ";
 
 	auto create_hint_str = [](const char *requested_name) {
 		char hint_buffer[200] = {0};


### PR DESCRIPTION
# Description

Follow-up of the discussion here: https://github.com/dosbox-staging/dosbox-staging/pull/3214

This removes the application executable name from the title bar; it is not useful and in many cases cryptic to the end user.


# Manual testing

Checked title bard with different values of `cycles` setting (`max`, `max 60%`, `max limit 10000`, `10000`), in debug and release builds.


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.
