### PR TITLE
Fix CI hand-over of the MSVC binaries to MSYS2 packaging

### DIFF
--- a/.github/workflows/windows-msvc.yml
+++ b/.github/workflows/windows-msvc.yml
@@ -182,7 +182,7 @@ jobs:
         id:    set_pkg_dir
         shell: bash
         run: |
-          echo "pkg_dir=dosbox-staging-windows-${{ matrix.conf.arch }}-${{ env.VERSION }}" >> $GITHUB_OUTPUT
+          echo "pkg_dir=dosbox-staging-windows-${{ matrix.conf.arch }}" >> $GITHUB_OUTPUT
 
       - name: Package standard build
         if: ${{ !matrix.conf.debugger }}
@@ -200,31 +200,29 @@ jobs:
             -p msvc \
             vs/${{ matrix.conf.vs-release-dirname }}/Release \
             "${{ steps.set_pkg_dir.outputs.pkg_dir }}"
-      
-      - name:  Package the debugger
-        if:    ${{ matrix.conf.debugger }}
-        shell: bash
-        run: |
-          set -x
-          mkdir -p ${{ steps.set_pkg_dir.outputs.pkg_dir }}
-          # Move the debugger build into the release area
-          readonly RELEASE_DIR=${{ matrix.conf.vs-release-dirname }}/Release
-          ls "vs/$RELEASE_DIR"
-          cp vs/$RELEASE_DIR/dosbox.exe   ${{ steps.set_pkg_dir.outputs.pkg_dir }}/dosbox_with_debugger.exe
 
-      - name: Upload package
+      - name: Upload ${{ matrix.conf.arch }} package
         if:   ${{ !matrix.conf.debugger }}
         uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.set_pkg_dir.outputs.pkg_dir }}
           path: ${{ steps.set_pkg_dir.outputs.pkg_dir }}
 
-      - name: Upload debugger artifact
+      - name: Upload ${{ matrix.conf.arch }} debugger executable
         if:   ${{ matrix.conf.debugger }}
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ steps.set_pkg_dir.outputs.pkg_dir }}-debugger
-          path: ${{ steps.set_pkg_dir.outputs.pkg_dir }}/dosbox_with_debugger.exe
+          name: dosbox-staging-windows-addon-debugger-${{ matrix.conf.arch }}
+          path: vs/${{ matrix.conf.vs-release-dirname }}/Release/dosbox.exe
+
+  msvc_release_done:
+    name: Windows MSVC release builds done
+    needs: build_windows_vs_release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - run: true
 
   # This job exists only to publish an artifact with version info when building
   # from main branch, so snapshot build version will be visible on:

--- a/.github/workflows/windows-msys2.yml
+++ b/.github/workflows/windows-msys2.yml
@@ -329,9 +329,16 @@ jobs:
             "$PKG_RELEASE"
           mv "${PKG_RELEASE}/dosbox.exe" "${PKG_RELEASE}/dosbox_with_debugger.exe"
           install -DT "${BUILD_RELEASE_DIR}/dosbox.exe" "${PKG_RELEASE}/dosbox.exe"
-          echo "artifact_name=dosbox-staging-windows-x64-`git describe --abbrev=4`" >> $GITHUB_ENV
-          echo "artifact_path=${{ github.workspace }}\msvc" >> $GITHUB_ENV
 
+          # Generate the MSVC package name matching the MSVC workflow's package upload name.
+          # This let us download that artifact in this workflow so we can add it to the installer.
+          echo "msvc_artifact_package_name=dosbox-staging-windows-x64`" >> $GITHUB_ENV
+          echo "msvc_artifact_package_path=${{ github.workspace }}\msvc" >> $GITHUB_ENV
+
+          # Generate the MSVC debugger name matching the MSVC workflow's addon debugger upload name.
+          # This let us download that artifact in this workflow so we can add it to the installer.
+          echo "msvc_debugger_binary_name=dosbox-staging-windows-addon-debugger-x64" >> $GITHUB_ENV
+          echo "msvc_debugger_binary_path=${{ github.workspace }}\msvc-debugger" >> $GITHUB_ENV
       - name: Windows Defender AV Scan
         shell: powershell
         run: |
@@ -347,21 +354,37 @@ jobs:
         uses: fountainhead/action-wait-for-check@v1.1.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          checkName: Publish additional Windows artifacts
+          checkName: Windows MSVC release builds done
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
-      - name: Download MSVC artifact
+      - name: Download MSVC package
         uses: dawidd6/action-download-artifact@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           workflow: windows-msvc.yml
-          name: ${{ env.artifact_name }}
-          path: ${{ env.artifact_path }}
+          workflow_conclusion: ""
+          commit: ${{ github.event.pull_request.head.sha || github.sha }}
+          name: ${{ env.msvc_artifact_package_name }}
+          path: ${{ env.msvc_artifact_package_path }}
+          check_artifacts: true
+          if_no_artifact_found: warn
+
+      - name: Download MSVC debugger binary
+        uses: dawidd6/action-download-artifact@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          workflow: windows-msvc.yml
+          workflow_conclusion: ""
+          commit: ${{ github.event.pull_request.head.sha || github.sha }}
+          name: ${{ env.msvc_debugger_binary_name }}
+          path: ${{ env.msvc_debugger_binary_path }}
+          check_artifacts: true
           if_no_artifact_found: warn
 
       - name: Prepare Windows installer
         shell: bash
         run: |
+          set -euo pipefail
           if [[ "${{ github.ref }}" == "refs/tags/"* ]] && [[ "${{ github.ref }}" != *"-"* ]]; then
             version_tag=`echo ${{ github.ref }} | sed -r 's/([^\/]*\/){2}//'`
             packageinfo="release $version_tag"
@@ -382,13 +405,15 @@ jobs:
           echo @echo off >out/dosbox_with_console.bat
           echo \"%~dp0\\dosbox.exe\" %* >>out/dosbox_with_console.bat
           echo if errorlevel 1 pause >>out/dosbox_with_console.bat
-          if [ -d msvc ]; then
-            cp msvc/dosbox*.exe out
-            mv out/dosbox.exe out/dosbox_msvc.exe
-            mv out/dosbox_with_debugger.exe out/dosbox_msvc_with_debugger.exe
+
+          # Include the MSVC executables in the installer
+          if [ -f msvc/dosbox.exe ] && [ msvc-debugger/dosbox.exe ]; then
+              cp msvc/dosbox.exe out/dosbox_msvc.exe
+              cp  out/dosbox_msvc_with_debugger.exe
           else
-            echo Note: MSVC build will not be included in the Windows installer.
-            sed -i -e 's|^\(Name: \"defaultmsvc\"\)|;\1|;s|^\(Source: \"{#DOSBoxAppExeMSVC\)|;\1|;s|; Tasks: not defaultmsvc$||' contrib/windows_installer/DOSBox-Staging-setup.iss
+
+              echo Note: MSVC build will not be included in the Windows installer.
+              sed -i -e 's|^\(Name: \"defaultmsvc\"\)|;\1|;s|^\(Source: \"{#DOSBoxAppExeMSVC\)|;\1|;s|; Tasks: not defaultmsvc$||' contrib/windows_installer/DOSBox-Staging-setup.iss
           fi
 
       - name: Build Windows installer

--- a/scripts/create-package.sh
+++ b/scripts/create-package.sh
@@ -242,8 +242,17 @@ done
 
 shift "$((OPTIND - 1))"
 
-build_dir=$1
-pkg_dir=$2
+# After parsing the flagged options, we need:
+# - The platform variable set
+# - Two arguments, the build_dir and pkg_dir
+# Both are validated later
+#
+if [ -n "${platform:-}" ] && [ "$#" -eq 2 ]; then
+    build_dir=$1
+    pkg_dir=$2
+else
+    print_usage="true"
+fi
 
 if [ "$print_usage" = "true" ]; then
     usage

--- a/scripts/create-package.sh
+++ b/scripts/create-package.sh
@@ -93,10 +93,10 @@ install_doc()
     esac
     # Fill template variables in README.template
     if [[ "$git_branch" == "refs/tags/"* ]] && [[ "$git_branch" != *"-"* ]]; then
-        version_tag=`echo $git_branch | awk '{print substr($0,11);exit}'`
+        version_tag=$(echo "$git_branch" | awk '{print substr($0,11);exit}')
         package_information="release $version_tag"
     elif [[ "$git_branch" == "release/"* ]]; then
-        version_tag=`git describe --tags | cut -f1 -d"-"`
+        version_tag=$(git describe --tags | cut -f1 -d"-")
         package_information="release $version_tag"
     elif [ -n "$git_branch" ] && [ -n "$git_commit" ]; then
         package_information="a development branch named $git_branch with commit $git_commit"
@@ -124,7 +124,7 @@ install_resources()
         ;;
     esac
 
-    find $src_dir -type f |
+    find "$src_dir" -type f |
         while IFS= read -r src; do
             install_file "$src" "$dest_dir/${src#*$src_dir/}"
         done
@@ -216,7 +216,7 @@ pkg_msvc()
 # Get GitHub CI environment variables if available. The CLI options
 # '-c', '-b', '-r' will override these if set.
 if [ -n "${GITHUB_REPOSITORY:-}" ]; then
-    git_commit=`echo ${GITHUB_SHA} | awk '{print substr($0,1,9);exit}'`
+    git_commit=$(echo "${GITHUB_SHA}" | awk '{print substr($0,1,9);exit}')
     git_branch=${GITHUB_REF#refs/heads/}
     git_repo=${GITHUB_REPOSITORY}
 else

--- a/scripts/create-package.sh
+++ b/scripts/create-package.sh
@@ -191,6 +191,19 @@ pkg_msys2()
 {
     install -DT "${build_dir}/dosbox.exe" "${pkg_dir}/dosbox.exe"
 
+    # Something is CI is breaking: 
+    #  + ntldd -R dosbox-staging-windows-msys2-x86_64-v0.81.0-alpha-2215-gc6a18/dosbox.exe
+    #  + sed -e 's/^[[:blank:]]*//g'
+    #  + cut -d ' ' -f 3
+    # + grep -E -i '(mingw|clang)(32|64)'
+    # + sed -e 's|\\|/|g'
+    # + xargs cp --target-directory=dosbox-staging-windows-msys2-x86_64-v0.81.0-alpha-2215-gc6a18/
+    # D:\a\_temp\f223e865-ceb6-48de-a81a-a56343838add: line 11: unexpected EOF while looking for matching ``'
+    # Error: Process completed with exit code 2.
+
+    # Allow pipe failures
+    set +o pipefail
+
     # Discover and copy required dll files
     ntldd -R "${pkg_dir}/dosbox.exe" \
         | sed -e 's/^[[:blank:]]*//g' \
@@ -198,6 +211,9 @@ pkg_msys2()
         | grep -E -i '(mingw|clang)(32|64)' \
         | sed -e 's|\\|/|g' \
         | xargs cp --target-directory="${pkg_dir}/"
+ 
+    # Reactivate
+    set -o pipefail
 }
 
 pkg_msvc()

--- a/scripts/create-package.sh
+++ b/scripts/create-package.sh
@@ -1,10 +1,14 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
-set -e
+# Note: Although this script is POSIX-sh compatible, we use Bash's more robust
+# error detection features because this script often runs in a CI environment,
+# which are hard to debug.
+#
+set -euo pipefail
 
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
-# Copyright (C) 2020-2022  Sherman Perry and the DOSBox Staging Team
+# Copyright (C) 2020-2023  Sherman Perry and the DOSBox Staging Team
 
 usage()
 {


### PR DESCRIPTION
# Description

A race condition in the MSVC CI artifact upload step meant we could upload the MSVC package with (or without) the debugger present.

If the MSVC debugger build job took longer than the non-debugger job, then the debugger would "miss the boat", leading to a warning-but-passing result on the MSYS2 side.

This PR splits out the debugger executable upload into its own step, so it's no longer dependent on the non-debugger package.

# Manual testing

I've inspected the packages and CI output, and it appears that everything is working - however we need to test setup.exe package to see if it has both the MSYS2 and MSVC executables.

@johnnovak, @shermp - can you check the installer?



# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

