### PR TITLE
Restore the previous behaviour of pixel art upscaler shaders

### DIFF
--- a/contrib/resources/glshaders/scaler/advinterp2x.glsl
+++ b/contrib/resources/glshaders/scaler/advinterp2x.glsl
@@ -27,6 +27,8 @@
 
 #pragma use_srgb_texture
 #pragma use_srgb_framebuffer
+#pragma force_single_scan
+#pragma force_no_pixel_doubling
 
 varying vec2 v_texCoord;
 uniform sampler2D rubyTexture;

--- a/contrib/resources/glshaders/scaler/advinterp3x.glsl
+++ b/contrib/resources/glshaders/scaler/advinterp3x.glsl
@@ -27,6 +27,8 @@
 
 #pragma use_srgb_texture
 #pragma use_srgb_framebuffer
+#pragma force_single_scan
+#pragma force_no_pixel_doubling
 
 varying vec2 v_texCoord;
 uniform sampler2D rubyTexture;

--- a/contrib/resources/glshaders/scaler/advmame2x.glsl
+++ b/contrib/resources/glshaders/scaler/advmame2x.glsl
@@ -27,6 +27,8 @@
 
 #pragma use_srgb_texture
 #pragma use_srgb_framebuffer
+#pragma force_single_scan
+#pragma force_no_pixel_doubling
 
 varying vec2 v_texCoord;
 uniform sampler2D rubyTexture;

--- a/contrib/resources/glshaders/scaler/advmame3x.glsl
+++ b/contrib/resources/glshaders/scaler/advmame3x.glsl
@@ -27,6 +27,8 @@
 
 #pragma use_srgb_texture
 #pragma use_srgb_framebuffer
+#pragma force_single_scan
+#pragma force_no_pixel_doubling
 
 varying vec2 v_texCoord;
 uniform sampler2D rubyTexture;


### PR DESCRIPTION
# Description

Fixes https://github.com/dosbox-staging/dosbox-staging/issues/3227

Smoothing pixel-art upscaler shaders need the non-double-scanned and non-pixel-doubled source images to work as intended.

# Manual testing

Open the before/after images in two tabs and switch between them to see the difference. Looks for smoother curves in the fixed good version; the bad version looks more blocky (closer to the original blocky pixel art).  

## advmame3x

### Before (bad)

![image0005-rendered](https://github.com/dosbox-staging/dosbox-staging/assets/698770/2bfec9c4-8016-4e58-abb8-5ecd9059cc05)

### After (good)

![image0004-rendered](https://github.com/dosbox-staging/dosbox-staging/assets/698770/9eecbaad-4f78-4d4b-bd1e-7b0e484b055e)

## advinterp3x

### Before (bad)

![image0003-rendered](https://github.com/dosbox-staging/dosbox-staging/assets/698770/c0516232-a576-498b-87c9-85fc03557018)

### After (good)

![image0002-rendered](https://github.com/dosbox-staging/dosbox-staging/assets/698770/4e8a6d9a-27c9-4e00-aab0-c817e1e20923)

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

