### PR TITLE
Fallback to GitHub's v3 artifact upload/download APIs

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -115,7 +115,7 @@ jobs:
           mv build/meson-logs/scanbuild report
 
       - name: Upload report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: clang-analysis-report
           path: report

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -114,18 +114,10 @@ jobs:
           ninja -C build scan-build
           mv build/meson-logs/scanbuild report
 
-      - name: Inject version string
-        run: |
-          set -x
-          git fetch --prune --unshallow
-          git fetch --all --tags --force
-          export VERSION=$(git describe --abbrev=5)
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
-
       - name: Upload report
         uses: actions/upload-artifact@v4
         with:
-          name: clang-analysis-report-${{ env.VERSION }}
+          name: clang-analysis-report
           path: report
 
       - name: Summarize report

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -368,7 +368,7 @@ jobs:
           clamscan --heuristic-scan-precedence=yes --recursive --infected .
 
       - name: Upload tarball
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         # GitHub automatically zips the artifacts (there's no way to create
         # a tarball), and it removes all executable flags while zipping.
         # Letting it zip a tarball preserves flags in the compressed files.
@@ -400,7 +400,7 @@ jobs:
           echo "VERSION=$VERSION" >> $GITHUB_ENV
           NEWEST_TAG=$(git describe --abbrev=0)
           git log "$NEWEST_TAG..HEAD" > changelog-$VERSION.txt
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v3
         with:
           # Keep exactly this artifact name; it's being used to propagate
           # version info via GitHub REST API

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -337,10 +337,10 @@ jobs:
           ./scripts/create-package.sh \
             -p linux \
             build \
-            "dosbox-staging-linux-x86_64-$VERSION"
+            "dosbox-staging-linux-$VERSION"
 
       - name: Create tarball
-        run: tar -cJf "dosbox-staging-linux-x86_64-$VERSION.tar.xz" "dosbox-staging-linux-x86_64-$VERSION"
+        run: tar -cJf "dosbox-staging-linux-$VERSION.tar.xz" "dosbox-staging-linux-$VERSION"
 
       - name:  Prepare Clam AV DB cache
         id:    prep-clamdb
@@ -373,9 +373,8 @@ jobs:
         # a tarball), and it removes all executable flags while zipping.
         # Letting it zip a tarball preserves flags in the compressed files.
         with:
-          name: dosbox-staging-linux-x86_64-${{ env.VERSION }}
-          path: dosbox-staging-linux-x86_64-${{ env.VERSION }}.tar.xz
-          compression-level: 0
+          name: dosbox-staging-linux-x86_64
+          path: dosbox-staging-linux-${{ env.VERSION }}.tar.xz
 
 
   # This job exists only to publish an artifact with version info when building

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -255,20 +255,14 @@ jobs:
       - name: Upload binary
         uses: actions/upload-artifact@v4
         with:
-          name: dosbox-staging-macOS-${{ matrix.runner.arch }}-${{ env.VERSION }}
+          name: dosbox-${{ matrix.runner.arch }}
           path: build/dosbox
-
-      - name: Zip resources
-        run: |
-          tar -c Resources \
-          | zstd --adapt -T0 --long -v --force -o Resources.tar.zst
 
       - name: Upload resources
         uses: actions/upload-artifact@v4
         with:
-          name: Resources-macOS-${{ matrix.runner.arch }}-${{ env.VERSION }}
-          path: Resources.tar.zst
-          compression-level: 0
+          name: Resources
+          path: Resources
 
   publish_universal_build:
     name: Publish universal build
@@ -291,23 +285,8 @@ jobs:
       - name: Install brew depedencies
         run: HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 brew install --overwrite librsvg
 
-      - name: Download artifacts
+      - name: Download binaries
         uses: actions/download-artifact@v4
-
-      - name: List local files resources
-        run: |
-
-      - name: Unpack and normalize the resources and executable paths
-        # The create-package.sh script expects to find a 'Resources/' directory and
-        # the 'dosbox' executables sitting in 'dosbox-arm64/' and 'dosbox-x86_64/'
-        # directories. So we need to eliminate the unique version wrapping.
-        run: |
-          ls -1la
-          ls Resources*/*
-          ls dosbox-staging-macOS*/*
-          zstd -dc Resources-macOS-arm64-${{ env.VERSION }}/Resources.tar.zst | tar x
-          mv dosbox-staging-macOS-arm64-${{ env.VERSION }} dosbox-arm64
-          mv dosbox-staging-macOS-x86_64-${{ env.VERSION }} dosbox-x86_64
 
       - name: Package
         run: |
@@ -343,9 +322,8 @@ jobs:
         # GitHub automatically zips the artifacts, and there's no option
         # to skip it or upload a file only.
         with:
-          name: dosbox-staging-macOS-universal-${{ env.VERSION }}
+          name: dosbox-staging-macOS-universal
           path: dosbox-staging-macOS-${{ env.VERSION }}.dmg
-          compression-level: 0
 
   # This job exists only to publish an artifact with version info when building
   # from main branch, so snapshot build version will be visible on:
@@ -376,4 +354,3 @@ jobs:
           # version info via GitHub REST API
           name: changelog-${{ env.VERSION }}.txt
           path: changelog-${{ env.VERSION }}.txt
-          compression-level: 1

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -286,7 +286,7 @@ jobs:
         run: HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 brew install --overwrite librsvg
 
       - name: Download binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
 
       - name: Package
         run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -253,13 +253,13 @@ jobs:
           meson compile -C build
 
       - name: Upload binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: dosbox-${{ matrix.runner.arch }}
           path: build/dosbox
 
       - name: Upload resources
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: Resources
           path: Resources
@@ -318,7 +318,7 @@ jobs:
           clamscan --heuristic-scan-precedence=yes --recursive --infected dist || true
 
       - name: Upload disk image
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         # GitHub automatically zips the artifacts, and there's no option
         # to skip it or upload a file only.
         with:
@@ -348,7 +348,7 @@ jobs:
           echo "VERSION=$VERSION" >> $GITHUB_ENV
           NEWEST_TAG=$(git describe --abbrev=0)
           git log "$NEWEST_TAG..HEAD" > changelog-$VERSION.txt
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v3
         with:
           # Keep exactly this artifact name; it's being used to propagate
           # version info via GitHub REST API

--- a/.github/workflows/pvs-studio.yml
+++ b/.github/workflows/pvs-studio.yml
@@ -104,7 +104,7 @@ jobs:
           rm -rf "${reportdir}/pvs-report.fullhtml"
 
       - name: Upload report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: pvs-analysis-report
           path: pvs-report

--- a/.github/workflows/pvs-studio.yml
+++ b/.github/workflows/pvs-studio.yml
@@ -103,18 +103,10 @@ jobs:
           mv -f "${reportdir}/pvs-report.fullhtml"/* "${reportdir}/"
           rm -rf "${reportdir}/pvs-report.fullhtml"
 
-      - name: Inject version string
-        run: |
-          set -x
-          git fetch --prune --unshallow
-          git fetch --all --tags --force
-          export VERSION=$(git describe --abbrev=5)
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
-
       - name: Upload report
         uses: actions/upload-artifact@v4
         with:
-          name: pvs-analysis-report-${{ env.VERSION }}
+          name: pvs-analysis-report
           path: pvs-report
 
       - name: Summarize report

--- a/.github/workflows/windows-msvc.yml
+++ b/.github/workflows/windows-msvc.yml
@@ -214,14 +214,14 @@ jobs:
 
       - name: Upload package
         if:   ${{ !matrix.conf.debugger }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ steps.set_pkg_dir.outputs.pkg_dir }}
           path: ${{ steps.set_pkg_dir.outputs.pkg_dir }}
       
       - name: Upload debugger artifact
         if:   ${{ matrix.conf.debugger }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ steps.set_pkg_dir.outputs.pkg_dir }}
           path: ${{ steps.set_pkg_dir.outputs.pkg_dir }}/dosbox_with_debugger.exe
@@ -250,7 +250,7 @@ jobs:
           echo "VERSION=$VERSION" >> $GITHUB_ENV
           NEWEST_TAG=$(git describe --abbrev=0)
           git log "$NEWEST_TAG..HEAD" > changelog-$VERSION.txt
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v3
         with:
           # Keep exactly this artifact name; it's being used to propagate
           # version info via GitHub REST API

--- a/.github/workflows/windows-msvc.yml
+++ b/.github/workflows/windows-msvc.yml
@@ -218,12 +218,12 @@ jobs:
         with:
           name: ${{ steps.set_pkg_dir.outputs.pkg_dir }}
           path: ${{ steps.set_pkg_dir.outputs.pkg_dir }}
-
+      
       - name: Upload debugger artifact
         if:   ${{ matrix.conf.debugger }}
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ steps.set_pkg_dir.outputs.pkg_dir }}-debugger
+          name: ${{ steps.set_pkg_dir.outputs.pkg_dir }}
           path: ${{ steps.set_pkg_dir.outputs.pkg_dir }}/dosbox_with_debugger.exe
 
   # This job exists only to publish an artifact with version info when building

--- a/.github/workflows/windows-msys2.yml
+++ b/.github/workflows/windows-msys2.yml
@@ -415,9 +415,8 @@ jobs:
       - name: Upload installer
         uses: actions/upload-artifact@v4
         with:
-          name: dosbox-staging-windows-${{ env.version_number }}-setup.exe
+          name: dosbox-staging-${{ env.version_number }}-setup.exe
           path: ${{ github.workspace }}\out\dosbox-staging-${{ env.version_number }}-setup.exe
-          compression-level: 0
 
   # This job exists only to publish an artifact with version info when building
   # from main branch, so snapshot build version will be visible on:

--- a/.github/workflows/windows-msys2.yml
+++ b/.github/workflows/windows-msys2.yml
@@ -407,13 +407,13 @@ jobs:
           C:\PROGRA~2\INNOSE~1\ISCC.exe DOSBox-Staging-setup.iss
 
       - name: Upload package
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ env.PKG_RELEASE }}
           path: ${{ env.PKG_RELEASE }}
 
       - name: Upload installer
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: dosbox-staging-${{ env.version_number }}-setup.exe
           path: ${{ github.workspace }}\out\dosbox-staging-${{ env.version_number }}-setup.exe
@@ -442,7 +442,7 @@ jobs:
           echo "VERSION=$VERSION" >> $GITHUB_ENV
           NEWEST_TAG=$(git describe --abbrev=0)
           git log "$NEWEST_TAG..HEAD" > changelog-$VERSION.txt
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v3
         with:
           # Keep exactly this artifact name; it's being used to propagate
           # version info via GitHub REST API

--- a/.github/workflows/windows-msys2.yml
+++ b/.github/workflows/windows-msys2.yml
@@ -351,7 +351,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Download MSVC artifact
-        uses: dawidd6/action-download-artifact@v3
+        uses: dawidd6/action-download-artifact@v2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           workflow: windows-msvc.yml


### PR DESCRIPTION
# Description

Insurmountable problems were hit when trying to making one CI workflow job depend on another's versioned outputs. 

The closest I got was being able to pull the prior run's outputs (one version being current). 

So for now, we'll revert the v4 API CI commits and go back to v3.


## Related issues

None.


# Manual testing

Will need to verify that we're getting similar CI outputs as before.

# Checklist


I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

