### PR TITLE
Logging improvements

### DIFF
--- a/src/dos/dos_keyboard_layout.cpp
+++ b/src/dos/dos_keyboard_layout.cpp
@@ -1079,7 +1079,9 @@ bool DOS_LayoutKey(const uint8_t key, const uint8_t flags1,
 		return false;
 }
 
-KeyboardErrorCode DOS_LoadKeyboardLayout(const char *layoutname, const int32_t codepage, const char *codepagefile)
+static KeyboardErrorCode load_keyboard_layout(const char* layoutname,
+                                              const int32_t codepage,
+                                              const char* codepagefile)
 {
 	auto temp_layout = std::make_unique<KeyboardLayout>();
 
@@ -1098,7 +1100,19 @@ KeyboardErrorCode DOS_LoadKeyboardLayout(const char *layoutname, const int32_t c
 	return KEYB_NOERROR;
 }
 
-KeyboardErrorCode DOS_SwitchKeyboardLayout(const char *new_layout, int32_t &tried_cp)
+KeyboardErrorCode DOS_LoadKeyboardLayout(const char* layoutname,
+                                         const int32_t codepage,
+                                         const char* codepagefile)
+{
+	const auto result = load_keyboard_layout(layoutname, codepage, codepagefile);
+	if (!result) {
+		LOG_MSG("DOS: Loaded codepage %d", codepage); // success!
+	}
+
+	return result;
+}
+
+KeyboardErrorCode DOS_SwitchKeyboardLayout(const char* new_layout, int32_t& tried_cp)
 {
 	if (loaded_layout) {
 		KeyboardLayout *changed_layout = nullptr;
@@ -1154,7 +1168,7 @@ KeyboardErrorCode DOS_LoadKeyboardLayoutFromLanguage(const char * language_pref)
 	// Regardless of the above, carry on with setting up the layout
 	const auto codepage = DOS_GetCodePageFromCountry(country);
 	const auto layout   = DOS_CheckLanguageToLayoutException(language);
-	const auto result = DOS_LoadKeyboardLayout(layout.c_str(), codepage, "auto");
+	const auto result   = load_keyboard_layout(layout.c_str(), codepage, "auto");
 
 	if (result == KEYB_NOERROR) {
 		LOG_MSG("DOS: Loaded codepage %d for detected language '%s'",

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -2870,7 +2870,7 @@ static void QueryJoysticks()
 
 	// The user doesn't want to use joysticks at all (not even for mapping)
 	if (joytype == JOY_DISABLED) {
-		LOG_INFO("MAPPER: joystick subsystem disabled");
+		LOG_INFO("MAPPER: Joystick subsystem disabled");
 		return;
 	}
 


### PR DESCRIPTION
# Description

- always log newly loaded code page, not only if it was auto detected from the language
- fixed capitalization issue in one mapper log


## Related issues

Improves https://github.com/dosbox-staging/dosbox-staging/issues/3233 a little, but does not fix it


# Manual testing

Try commands `keyb pl`, `keyb pl 852`, and `keyb pl 667` - each of them should now log newly loaded code page.


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

