### PR TITLE
Log warning to console when not using full FPU 80-bit precision

### DIFF
--- a/src/fpu/fpu.cpp
+++ b/src/fpu/fpu.cpp
@@ -651,6 +651,9 @@ void FPU_ESC7_Normal(Bitu rm) {
 
 
 void FPU_Init(Section*) {
+#if !C_FPU_X86
+	LOG_WARNING("FPU: Using reduced-precision floating-point emulation");
+#endif
 	FPU_FINIT();
 }
 


### PR DESCRIPTION
# Description

Just a quick idea I had to print a warning to the console if we are running on a system with non-x87-conformant floating point:

![CleanShot 2023-12-18 at 17 20 29@2x](https://github.com/dosbox-staging/dosbox-staging/assets/541026/98646151-4623-4f2d-9894-27364cf70b11)

# Manual testing

I've downloaded and tested the artifacts for macOS ARM, macOS x64, and MSYS2 Windows x64.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

