### PR TITLE
Fix two PVS Studio warnings

### DIFF
--- a/.github/workflows/pvs-studio.yml
+++ b/.github/workflows/pvs-studio.yml
@@ -111,7 +111,7 @@ jobs:
 
       - name: Summarize report
         env:
-          MAX_BUGS: 141
+          MAX_BUGS: 139
         run: |
           echo "Full report is included in build Artifacts"
           echo

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1412,8 +1412,8 @@ static SDL_Window* SetWindowMode(const RenderingBackend rendering_backend,
 		}
 		SDL_SetWindowFullscreen(sdl.window,
 		                        sdl.desktop.full.display_res
-		                                ? SDL_WINDOW_FULLSCREEN_DESKTOP
-		                                : SDL_WINDOW_FULLSCREEN);
+		                                ? enum_val(SDL_WINDOW_FULLSCREEN_DESKTOP)
+		                                : enum_val(SDL_WINDOW_FULLSCREEN));
 	} else {
 		// we're switching down from fullscreen, so let SDL use the
 		// previously-set window size

--- a/src/hardware/vga_s3.cpp
+++ b/src/hardware/vga_s3.cpp
@@ -755,7 +755,7 @@ void filter_s3_modes_to_oem_only()
 		}
 
 		// Does the S3 OEM list have this mode for the given DRAM size?
-		const auto it = oem_modes.find(hash(m.swidth, m.sheight, m.type));
+		const auto it = oem_modes.find(hash(m.swidth, m.sheight, enum_val(m.type)));
 		const bool is_an_oem_mode = (it != oem_modes.end()) && (it->second & dram_size);
 
 		// LOG_MSG("S3: %x: %ux%u - m.type=%d is_vesa_mode=%d is_an_oem_mode=%d",


### PR DESCRIPTION
# Description

Fix two PVS Studio warnings - enum to integer conversion, trivial change in both cases.


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

