### PR TITLE
Render video lines one-by-one even in high resolution modes

### DIFF
--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -1442,7 +1442,7 @@ PixelFormat VGA_ActivateHardwareCursor()
 // A single point to set total drawn lines and update affected delay values
 static void setup_line_drawing_delays(const uint32_t total_lines)
 {
-	vga.draw.parts_total = total_lines > 480 ? 1 : total_lines;
+	vga.draw.parts_total = total_lines;
 
 	vga.draw.delay.parts = vga.draw.delay.vdend / vga.draw.parts_total;
 


### PR DESCRIPTION
# Description

Previously, high resolution (800×600 and up) video modes were rendered out from the emulated video card as whole frames. That is, we waited until vblank at which point the entire block of the emulated video card's memory (as indicated by the game) was rendered out by the emulated card.

The _rendering out_ process emulates the video card's DAC pipeline by reading a row from memory (written by the DOS application) and scanning it out to the CRT. This is where line and row doubling may happen, such as when VGA 320×200 modes are doubled at the analog signal level up to 640×400 which hits the CRT.

(To clarify for readers: the above is all still in hardware emulation - the vga_draw* and render* code, and comes before any involvement with the host presentation side such as SDL, OpenGL, shaders, etc.)

This commit changes that behaviour to render out at the row level (per row of digital pixel data in the video card's memory). Each row has a PIC timer setup to render the row as soon as the time comes when it would be drawn to the CRT. This is similar to how lower resolutions are handled.  It allows sophisticated games to start writing the next frame's line data “behind the beam”.

This fixes a regression in Microsoft's Space Simulator that was flickering at 800×600 with the previous whole frame approach.

There's a performance hit on memory-limited systems like the Pi 4: Quake at 800×600 drops from 11.5 fps to 7.8 fps, but this is simply the cost of doing things correctly (and it's critical for games that rely on this more accurate behaviour).

On faster systems, the performance hit is in the noise, so overall users won't be affected because Pi 4 users typically run games in their lowest, highest performance resolution anyway.

## Related issues

Fixes #3248 

# Manual testing

## Microsoft Space Simulator

Microsoft Space Simulator is an early 1994 real-mode game with only 386 CPU requirements. In addition to this rendering issue, its physics engine can run away at high cycle counts, so needs to be held back to reasonable period-correct rates.

https://github.com/dosbox-staging/dosbox-staging/assets/1557255/ba07e066-ba2c-46ac-9d8c-765818255063


- **`dosbox.conf`**:
    
    ```ini
    [cpu]
    cycles = max 100% limit 60000
    ```

- **`SETUP.EXE` configured**:

    1. 800×600
    2. VESA 1.2

- **In-game settings**:
    Preferences -> precision -> max level 8

    [SPACESIM/SPACESIM.INI](https://github.com/dosbox-staging/dosbox-staging/files/13745230/SPACESIM.INI.ZIP)

    The precision can be directly set on line 34 of the `SPACESIM/SPACESIM.INI` text file. A host tool, like GNU `sed`, can be used to set it:

    ```shell
    sed -i '34s/.*/08/' SPACESIM/SPACESIM.INI
    ```

---

Regression tested Quake, VBETEST, and Screamer without issue.

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

