### PR TITLE
Fix icon install path

### DIFF
--- a/contrib/icons/meson.build
+++ b/contrib/icons/meson.build
@@ -7,7 +7,7 @@ png_files = {
     'icon_32.png': '32x32',
     'icon_48.png': '48x48',
     'icon_96.png': '96x96',
-    'icon_128.png': '128X128',
+    'icon_128.png': '128x128',
     'icon_256.png': '256x256',
     'icon_512.png': '512x512',
     'icon_1024.png': '1024x1024',


### PR DESCRIPTION
Was installing to /usr/share/icons/hicolor/128X128 (X is capitalized).

Should install to /usr/share/icons/hicolor/128x128 (x is NOT capitalized).

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [ ] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] ~~confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).~~ N/A
- [ ] ~~added unit tests where applicable to prove the correctness of my code and to avoid future regressions.~~ N/A
- [ ] ~~made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).~~ N/A
- [ ] ~~[locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.~~ N/A