### PR TITLE
Do not read shell history if secure mode is enabled

### DIFF
--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -470,9 +470,6 @@ static std_fs::path get_shell_history_path()
 
 void DOS_Shell::ReadShellHistory()
 {
-	if (control->SecureMode()) {
-		return;
-	}
 	const auto history_path = get_shell_history_path();
 	if (history_path.empty()) {
 		return;
@@ -492,9 +489,6 @@ void DOS_Shell::ReadShellHistory()
 
 void DOS_Shell::WriteShellHistory()
 {
-	if (control->SecureMode()) {
-		return;
-	}
 	const auto history_path = get_shell_history_path();
 	if (history_path.empty()) {
 		return;
@@ -1447,9 +1441,19 @@ void SHELL_Init() {
 	// first_shell is only setup here, so may as well invoke
 	// it's constructor directly
 	first_shell = new DOS_Shell;
-	first_shell->ReadShellHistory();
+
+	// Must check arguments directly as control->SwitchToSecureMode()
+	// will not be called until the first shell is run
+	if (!control->arguments.securemode) {
+		first_shell->ReadShellHistory();
+	}
 	first_shell->Run();
-	first_shell->WriteShellHistory();
+
+	// Secure mode can be enabled from the shell during runtime.
+	// On exit, we must check this value instead.
+	if (!control->SecureMode()) {
+		first_shell->WriteShellHistory();
+	}
 	delete first_shell;
 	first_shell = nullptr; // Make clear that it shouldn't be used anymore
 }


### PR DESCRIPTION
# Description

The `control->SecureMode()` variable does not get set until the shell gets run.  I backtraced it to the following code:

https://github.com/dosbox-staging/dosbox-staging/blob/3f783e293c4c30cd2ebec3e4c7bed54a377f4ab8/src/misc/programs.cpp#L851-L855

This got called after the shell history file got read in (so it did not see that it was in secure mode).

Fix to check the command line arguments directly on read.  Writing to the history file was already correctly disabled in secure mode.

I pulled the checks for these two functions out into the caller along with some comments to clarify why this is being done.

## Related issues

Fixes #3229

# Manual testing

- Started with `dosbox --securemode`
- Verified any existing history file does not get read
- Verified history file does not get written to on exit.

- Started dosbox normally
- Verified History file does get read
- Executed `config -securemode` to switch to secure mode dynamically
- Verified history file does not get written

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

