### PR TITLE
Fix a couple more corner cases when using zlib-ng

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -123,7 +123,7 @@ jobs:
 
       - name: Summarize report
         env:
-          MAX_BUGS: 7
+          MAX_BUGS: 3
         run: |
           # summary
           echo "Full report is included in build Artifacts"

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -97,7 +97,7 @@ jobs:
 
           - name: GCC, Debian 10, ARMv7
             os: ubuntu-20.04
-            build_flags: -Dbuildtype=debug --cross-file dosbox-cross
+            build_flags: -Dbuildtype=debug -Duse_zlib_ng=false --cross-file dosbox-cross
             max_warnings: 21
             run_tests: true
             cross: true
@@ -107,7 +107,7 @@ jobs:
 
           - name: GCC, Debian 11, ARMv7
             os: ubuntu-20.04
-            build_flags: -Dbuildtype=debug --cross-file dosbox-cross
+            build_flags: -Dbuildtype=debug -Duse_zlib_ng=false --cross-file dosbox-cross
             max_warnings: 0
             run_tests: true
             cross: true
@@ -320,7 +320,7 @@ jobs:
         run: |
           meson setup \
             -Duse_xinput2=false \
-            -Duse_zlib_ng=built-in,sse2,ssse3,neon \
+            -Duse_zlib_ng=sse2,ssse3,neon \
             -Ddefault_library=static \
             --wrap-mode=forcefallback \
             -Db_lto=true -Db_lto_threads=$(nproc) \

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -249,7 +249,7 @@ jobs:
             -Ddefault_library=static \
             -Dwrap_mode=forcefallback \
             -Dtry_static_libs=sdl2,sdl2_net \
-            -Duse_zlib_ng=built-in,sse2,ssse3,neon \
+            -Duse_zlib_ng=sse2,ssse3,neon \
             build
           meson compile -C build
 

--- a/.github/workflows/windows-msys2.yml
+++ b/.github/workflows/windows-msys2.yml
@@ -207,6 +207,7 @@ jobs:
           install: |
             git
             mingw-w64-clang-${{matrix.conf.arch}}-clang
+            mingw-w64-clang-${{matrix.conf.arch}}-cmake
             mingw-w64-clang-${{matrix.conf.arch}}-meson
             mingw-w64-clang-${{matrix.conf.arch}}-ccache
             mingw-w64-clang-${{matrix.conf.arch}}-pkgconf
@@ -291,7 +292,7 @@ jobs:
             -Db_lto=true \
             -Db_lto_threads=$(nproc) \
             -Dtry_static_libs=mt32emu \
-            -Duse_zlib_ng=built-in,sse2,ssse3 \
+            -Duse_zlib_ng=sse2,ssse3 \
             $BUILD_RELEASE_DIR
 
       - name: Setup debugger build
@@ -299,9 +300,9 @@ jobs:
           meson setup \
             -Db_lto=true \
             -Db_lto_threads=$(nproc) \
-            -Denable_debugger=normal \
+            -Denable_debugger=heavy \
             -Dtry_static_libs=mt32emu \
-            -Duse_zlib_ng=built-in,sse2,ssse3 \
+            -Duse_zlib_ng=sse2,ssse3 \
             $BUILD_DEBUGGER_DIR
 
       - name: Build release

--- a/meson.build
+++ b/meson.build
@@ -601,6 +601,8 @@ optional_dep = dependency('', required: false)
 msg = 'You can disable this dependency with: -D@0@=false'
 
 default_wrap_options = ['default_library=static', 'warning_level=0']
+wraps_forced = get_option('wrap_mode') == 'forcefallback'
+wraps_disabled = get_option('wrap_mode') in ['nodownload', 'nofallback']
 
 dl_dep = cc.find_library('dl', required: false)
 stdcppfs_dep = cxx.find_library('stdc++fs', required: false)
@@ -644,8 +646,14 @@ sdl2_dep = dependency(
 zlib_dep = disabler()
 zlib_is_static = 'zlib' in static_libs_list or prefers_static_libs
 
-try_system_zlib_ng = 'auto' in zlib_ng_options or 'system' in zlib_ng_options
-try_builtin_zlib_ng = 'auto' in zlib_ng_options or 'built-in' in zlib_ng_options
+try_system_zlib_ng = (
+    not wraps_forced
+    and 'zlib-ng' not in get_option('force_fallback_for')
+)
+try_builtin_zlib_ng = (
+    not wraps_disabled
+    or 'zlib-ng' in get_option('force_fallback_for')
+)
 
 system_zlib_ng_dep = disabler()
 if try_system_zlib_ng

--- a/meson.build
+++ b/meson.build
@@ -265,92 +265,102 @@ if is_optimized_buildtype and zlib_ng_is_native
     extra_flags += '-march=native'
     simd_summary = 'native'
     message('Enabling native SIMD optimizations')
+endif
 
-elif is_optimized_buildtype and zlib_ng_wants_native
-    # Wanted native SIMD but couldn't get it, so
-    # lets test and enable some basic ones for them.
-    #
-    # NEON
-    # ~~~~~
+# NEON on Aarch64
+# ~~~~~~~~~~~~~~~
+if target_machine.cpu_family() == 'aarch64'
+    # aarch64 always supports NEON:
+    # ref: https://developer.arm.com/documentation/den0024/a/AArch64-Floating-point-and-NEON
+    zlib_ng_options += ['neon']
+    simd_summary = 'NEON'
+    message('Using the ARM NEON instruction set')
+endif
+
+# NEON on Aarch32
+# ~~~~~~~~~~~~~~~
+if (
+    target_machine.cpu_family() == 'arm'
+    and (zlib_ng_is_native
+    or zlib_ng_wants_native
+    or 'neon' in zlib_ng_options)
+)
+    neon_test_code = '''
+                #include <arm_neon.h>
+                int main() {
+                uint8x16_t a = vdupq_n_u8(0);
+                uint8x16_t b = vdupq_n_u8(0);
+                uint8x16_t result = vaddq_u8(a, b);
+                return 0;
+                }
+            '''
     neon_cflag = '-mfpu=neon-vfpv4'
-    if target_machine.cpu_family() == 'aarch64'
-        # aarch64 always supports NEON:
-        # ref: https://developer.arm.com/documentation/den0024/a/AArch64-Floating-point-and-NEON
-        zlib_ng_options += ['neon']
+    neon_test = cc.run(
+        neon_test_code,
+        args: neon_cflag,
+        name: 'ARM NEON instruction set test',
+    )
+    if (neon_test.compiled() and neon_test.returncode() == 0)
+        zlib_ng_options += 'neon'
         extra_flags += neon_cflag
         simd_summary = 'NEON'
-        message('Host supports ARM NEON instruction set')
+        message('Enabling the ARM NEON instruction set')
+    endif
+endif
 
-    elif host_machine.cpu_family() == 'arm'
-        neon_test_code = '''
-            #include <arm_neon.h>
-            int main() {
-            uint8x16_t a = vdupq_n_u8(0);
-            uint8x16_t b = vdupq_n_u8(0);
-            uint8x16_t result = vaddq_u8(a, b);
-            return 0;
-            }
-        '''
-        neon_test = cc.run(
-            neon_test_code,
-            args: neon_cflag,
-            name: 'ARM NEON instruction set test',
-        )
-        if (neon_test.compiled() and neon_test.returncode() == 0)
-            zlib_ng_options += ['neon']
-            extra_flags += neon_cflag
-            simd_summary = 'NEON'
-            message('Enabling the ARM NEON instruction set')
-        endif
+# SSE2 and SSSE3 on x86
+# ~~~~~~~~~~~~~~~~~~~~~
+if (
+    target_machine.cpu_family().startswith('x86')
+    and (
+        zlib_ng_is_native
+        or zlib_ng_wants_native
+        or 'sse2' in zlib_ng_options
+        or 'ssse3' in zlib_ng_options
+    )
+)
+    sse2_test_code = '''
+                #include <emmintrin.h>
+                int main() {
+                __m128i a = _mm_setzero_si128();
+                __m128i b = _mm_setzero_si128();
+                __m128i result = _mm_add_epi32(a, b);
+                return 0;
+                }
+            '''
+    sse2_cflags = '-msse2'
+    sse2_test = cc.run(
+        sse2_test_code,
+        args: sse2_cflags,
+        name: 'SSE2 instruction set test',
+    )
+    if (sse2_test.compiled() and sse2_test.returncode() == 0)
+        zlib_ng_options += 'sse2'
+        extra_flags += sse2_cflags
+        simd_summary = 'SSE2'
+        message('Enabling the SSE2 instruction set')
+    endif
 
-    elif target_machine.cpu_family().startswith('x86')
-        # SSE2
-        # ~~~~
-        sse2_test_code = '''
-            #include <emmintrin.h>
-            int main() {
-            __m128i a = _mm_setzero_si128();
-            __m128i b = _mm_setzero_si128();
-            __m128i result = _mm_add_epi32(a, b);
-            return 0;
-            }
-        '''
-        sse2_cflag = '-msse2'
-        sse2_test = cc.run(
-            sse2_test_code,
-            args: sse2_cflag,
-            name: 'SSE2 instruction set test',
-        )
-        if (sse2_test.compiled() and sse2_test.returncode() == 0)
-            zlib_ng_options += ['sse2']
-            extra_flags += sse2_cflag
-            simd_summary = 'SSE2'
-            message('Enabling the SSE2 instruction set')
-        endif
-
-        # SSSE3
-        # ~~~~~
-        ssse3_test_code = '''
-            #include <tmmintrin.h>
-            int main() {
-            __m128i a = _mm_setzero_si128();
-            __m128i b = _mm_setzero_si128();
-            __m128i result = _mm_hadd_epi16(a, b);
-            return 0;
-            }
-        '''
-        ssse3_cflag = '-mssse3'
-        ssse3_test = cc.run(
-            ssse3_test_code,
-            args: ssse3_cflag,
-            name: 'SSSE3 instruction set test',
-        )
-        if (ssse3_test.compiled() and ssse3_test.returncode() == 0)
-            zlib_ng_options += ['ssse3']
-            extra_flags += ssse3_cflag
-            simd_summary = 'SSE2 and SSSE3'
-            message('Enabling the SSSE3 instruction set')
-        endif
+    ssse3_test_code = '''
+                #include <tmmintrin.h>
+                int main() {
+                __m128i a = _mm_setzero_si128();
+                __m128i b = _mm_setzero_si128();
+                __m128i result = _mm_hadd_epi16(a, b);
+                return 0;
+                }
+            '''
+    ssse3_cflag = '-mssse3'
+    ssse3_test = cc.run(
+        ssse3_test_code,
+        args: ssse3_cflag,
+        name: 'SSSE3 instruction set test',
+    )
+    if (ssse3_test.compiled() and ssse3_test.returncode() == 0)
+        zlib_ng_options += 'ssse3'
+        extra_flags += ssse3_cflag
+        simd_summary = 'SSE2 and SSSE3'
+        message('Enabling the SSSE3 instruction set')
     endif
 endif
 summary('SIMD instruction set', simd_summary, section: 'Build Summary')

--- a/meson.build
+++ b/meson.build
@@ -356,20 +356,14 @@ endif
 summary('SIMD instruction set', simd_summary, section: 'Build Summary')
 
 # Allow-list the flags against the compiler, and add them to the project
-foreach flag : extra_flags
-    if cc.has_argument(flag)
-        add_project_arguments(flag, language: 'c')
-    endif
-    if cxx.has_argument(flag)
-        add_project_arguments(flag, language: 'cpp')
-    endif
-endforeach
-foreach flag : extra_link_flags
-    if cxx.has_link_argument(flag)
-        add_project_link_arguments(flag, language: 'cpp')
-    endif
-endforeach
+cc_supported_arguments = cc.get_supported_arguments(extra_flags)
+add_project_arguments(cc_supported_arguments, language: 'c')
 
+cxx_supported_arguments = cxx.get_supported_arguments(extra_flags)
+add_project_arguments(cxx_supported_arguments, language: 'cpp')
+
+link_supported_arguments = cxx.get_supported_link_arguments(extra_link_flags)
+add_project_link_arguments(link_supported_arguments, language: 'cpp')
 
 # Gather data to populate config.h
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -677,6 +671,7 @@ elif (
             'ZLIB_ENABLE_TESTS': false,
             'WITH_NATIVE_INSTRUCTIONS': zlib_ng_is_native,
             'WITH_SANITIZER': get_option('b_sanitize'),
+            'CMAKE_C_FLAGS': ' '.join(cc_supported_arguments),
         }
 
         foreach instruction_set : [

--- a/meson.build
+++ b/meson.build
@@ -217,9 +217,9 @@ else
     extra_flags += [
         '-shared-libstdc++',
         '-shared-libgcc',
-        '-lstdc++_s',
         '-fPIC',
     ]
+    extra_link_flags += '-lstdc++_s'
 endif
 
 if get_option('narrowing_warnings')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -67,53 +67,22 @@ option(
     description: 'Let ManyMouse use the X Input 2.0 protocol.',
 )
 
-# The built-in zlib-ng is available when compiling with optimizations
-# such as when -Dbuildtype is set to 'release','minsize', or
-# 'debugoptimized'.
+# The meson.build either uses zlib-ng if its found as a system library or
+# compiles it as a built-in (provided CMake is available and Meson is at
+# least version 1.3.0), in that order.
 #
-# You will need CMake(*) and Meson 1.3.0. If your package manager's
-# version of Meson is too old, you can install it using pip.
+# The built-in will use native SIMD instructions by default, however if you're
+# targeting a range of hardware then set this to the most conservative set of
+# SIMD instructions for your needs. For example, if you want to be sure your
+# binary runs on Intel's Core 2 Duo, set: meson setup -Duse_zlib_ng=sse2,ssse3
 #
-# If you're compiling from sources just for your own local system,
-# then you can leave this setting as-is for excellent performance.
-#
-# If you're compiling a package targeting a range of hardware
-# and you have no qualms with built-ins, then set this to the
-# most conservative set of SIMD instructions for your supported
-# range of hardware. For example, if your binary needs to run on
-# Intel's Core 2 Duo (and newer), then:
-#  meson setup -Duse_zlib_ng=built-in,sse2,ssse3
-#
-# If you're a repo packager that dislikes built-ins or are
-# working under a policy that prohibits them, then use:
-#  meson setup -Duse_zlib_ng=false
-#
-# Note: As zlib-ng is, itself, an optimization that adds time
-# and complexity to the build process, we therefore only use it
-# for optimized build types. Maintainers, developers, and CI
-# jobs compiling debug builds aren't burdened with this as
-# these builds aren't concerned with maximizing performance.
-#
-# (*) A Meson project that depends on CMake!? Well, zlib-ng
-#     is a CMake project and thankfully Meson has a module
-#     that can both configure it build it. To eliminate this
-#     dependency on CMake, feel free to contribute a wrap
-#     for zlib-ng here: https://github.com/mesonbuild/wrapdb
+# To disable zlib-ng use -Duse_zlib_ng=false
+# To only use the built-in: --wrap-mode=forcefallback or --force-fallback-for=zlib-ng
 #
 option(
     'use_zlib_ng',
     type: 'array',
     choices: [
-        # Auto (default) try zlib-ng from the system
-        # and then built-in, in that order.
-        'auto',
-
-        # Only try using zlib-ng from the system.
-        'system',
-
-        # Only try using zlib-ng from built-in.
-        'built-in',
-
         # Disable zlib-ng; use good old zlib.
         'false',
         
@@ -155,8 +124,8 @@ option(
         'dfltcc_deflate',
         'dfltcc_inflate',
     ],
-    value: ['auto', 'native'],
-    description: 'Enable zlib-ng either from the system or built-in',
+    value: ['native'],
+    description: 'Enable zlib-ng with SIMD optimizations',
 )
 
 option(


### PR DESCRIPTION
# Description

- Adds `-mfpu=neon` flag to zlib-ng's CMake arguments, otherwise it fails to use Neon even when native optimizations are requested (affects gcc on arm Linux platforms).
- Drops the `auto / system / built-in` options for zlib-ng in favour of Meson's standardized wrap fallback controls (`--wrap-mode` and `--force-fallback-for=[list]`)
- Fixes a small `CFLAG` vs. `LDFLAG` typo.
- Fixes zlib-ng not being enabled for MSYS2 builds (now it is).

## Related issues

https://github.com/zlib-ng/zlib-ng/issues/1621

# Manual testing

Tested on the Pi 4, x86-64, Apple M1, and confirmed zlib-ng is being built and used under MSYS2.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [ ] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

