### PR TITLE
Fix macOS Info.plist template so the actual version is shown

### DIFF
--- a/contrib/macos/Info.plist.template
+++ b/contrib/macos/Info.plist.template
@@ -27,7 +27,7 @@
 	<string>APPL</string>
 
 	<key>CFBundleShortVersionString</key>
-	<string>0.82.0-alpha</string>
+	<string>%VERSION%</string>
 
 	<key>CFBundleVersion</key>
 	<string>%VERSION%</string>


### PR DESCRIPTION
# Description

In the v0.81.0-rc1 macOS app bundle, this is what we have in the Info.plist file:

<img width="446" alt="image" src="https://github.com/dosbox-staging/dosbox-staging/assets/698770/ca7c99ae-8113-404f-b244-5ab8c53ff9fb">

So we're only substituting one of the version strings at build time, and it turns out the least important internal one. If you check out the version of the app in Finder, it still shows the old version :

<img width="398" alt="image" src="https://github.com/dosbox-staging/dosbox-staging/assets/698770/01ed948b-16af-4084-af56-fdeb52cbc16b">

---


The simplest thing for us to do is just to set both to the same string at build time as this guy is doing it:

> Think of it this way: The "short version" (CFBundleShortVersionString) is the public version number. The "version" (CFBundleVersion) is more of an internal version number that could change far more frequently than the public "short version". Personally I use the same for both but many people update the "version" on every build. Either way you typically update the "short version" when you release to Apple. How often you update the "version" is up to you and your needs.

(source: https://stackoverflow.com/a/19728342)


# Manual testing

We'll find out next time an app bundle is built 😄 

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

