### PR TITLE
Fix broken check for existing file in `localDrive::FileCreate`

### DIFF
--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -55,8 +55,6 @@ bool localDrive::FileCreate(DOS_File** file, char* name, FatAttributeFlags attri
 		return false;
 	}
 
-	const bool file_exists = FileExists(name);
-
 	char newname[CROSS_LEN];
 	safe_strcpy(newname, basedir);
 	safe_strcat(newname, name);
@@ -67,6 +65,8 @@ bool localDrive::FileCreate(DOS_File** file, char* name, FatAttributeFlags attri
 	// calls.
 	char expanded_name[CROSS_LEN];
 	safe_strcpy(expanded_name, dirCache.GetExpandNameAndNormaliseCase(newname));
+
+	const bool file_exists = FileExists(expanded_name);
 
 	attributes.archive = true;
 	FILE* file_pointer = local_drive_create_file(expanded_name, attributes);


### PR DESCRIPTION
# Description

The `localDrive::FileCreate` function checks whether the file exists - if so, it omits adding it to the internal cache. At least it did so (see https://github.com/dosbox-staging/dosbox-staging/blob/bc4731fb7f2ff6b61b4f5890ca8839d93a5b74d9/src/dos/drive_local.cpp) - the code got broken in 0.81.0 development cycle, it now checks for the file existing before expanding the file name (this process translates the guest file path+name to the host one).

This PR fixes the problem.


# Manual testing

Tried to save file (both in used and unused slots) in several games, including _Civilization_ and _Crystal Caves_ - no problems found.


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

