### PR TITLE
Do not record successive duplicate commands in the history

### DIFF
--- a/src/shell/shell_misc.cpp
+++ b/src/shell/shell_misc.cpp
@@ -78,7 +78,7 @@ void DOS_Shell::InputCommand(char* line)
 {
 	std::string command = ReadCommand();
 	trim(command);
-	if (!command.empty()) {
+	if (!command.empty() && (history.empty() || command != history.back())) {
 		history.emplace_back(command);
 	}
 


### PR DESCRIPTION
# Description

If the user inputs two identical commands in a row, do not record the second into the history.

## Related issues

Fixes #3259 


# Manual testing

Input a command multiple times.  Hit up and down arrow to scroll through history to confirm the duplicates do not get saved.  The duplicates also do not get saved to `shell_history.txt`.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

