### PR TITLE
Flatten the zlib-ng checks and add explanations

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -659,16 +659,37 @@ sdl2_dep = dependency(
 
 # zlib
 # ~~~~
+zlib_provider = 'none'
+zlib_ng_provider = 'none'
+
 zlib_dep = disabler()
 zlib_is_static = 'zlib' in static_libs_list or prefers_static_libs
 
+zlib_ng_is_allowed = 'false' not in zlib_ng_options
+if not zlib_ng_is_allowed
+    zlib_ng_provider = 'disabled'
+endif
+
+# Try using the system-provided zlib-ng library so long as the wrap isn't
+# forced. Using the system-provided library is a free upgrade for all the build
+# types, so we always prefer this first if the user allows it.
+#
 try_system_zlib_ng = (
-    not wraps_forced
+    zlib_ng_is_allowed
+    and not wraps_forced
     and 'zlib-ng' not in get_option('force_fallback_for')
 )
+
+# The zlib-ng wrap, on the other hand, is a costly endeavour because it
+# single-handedly quadruples the 'meson setup' time for the entire project (6.1s
+# to 25.8s) due to the use of the much slower CMake build system, therefore we
+# only expend this effort (to optimize zlib) for commensurate optimized builds.
+# This nuance is also explained in meson_options.txt for packagers.
+#
 try_builtin_zlib_ng = (
-    not wraps_disabled
-    or 'zlib-ng' in get_option('force_fallback_for')
+    zlib_ng_is_allowed
+    and (not wraps_disabled
+    or 'zlib-ng' in get_option('force_fallback_for'))
 )
 
 system_zlib_ng_dep = disabler()
@@ -680,73 +701,108 @@ if try_system_zlib_ng
         static: zlib_is_static,
         include_type: 'system',
     )
-endif
-if (system_zlib_ng_dep.found())
-    summary('zlib-ng provider', 'system library')
-    conf_data.set10('C_SYSTEM_ZLIB_NG', system_zlib_ng_dep.found())
-elif (
-    # Otherwise consider the built-in, which is a whole-sale replacement for zlib
-    try_builtin_zlib_ng
-    and is_optimized_buildtype
-    and meson.version() >= '1.3.0'
-)
-    cmake_bin = find_program('cmake', required: false)
-    cmake_module = import('cmake', required: false)
-    if cmake_bin.found() and cmake_module.found()
-        cmake_options = cmake_module.subproject_options()
-
-        zlib_ng_defines = {
-            'ZLIB_COMPAT': true,
-            'WITH_OPTIM': true,
-            'ZLIB_BUILD_STATIC': true,
-            'PIC': get_option('b_staticpic'),
-            'BUILD_SHARED_LIBS': false,
-            'WITH_GTEST': false,
-            'ZLIB_ENABLE_TESTS': false,
-            'WITH_NATIVE_INSTRUCTIONS': zlib_ng_is_native,
-            'WITH_SANITIZER': get_option('b_sanitize'),
-            'CMAKE_C_FLAGS': ' '.join(cc_supported_arguments),
-        }
-
-        foreach instruction_set : [
-            'avx2',
-            'avx512',
-            'avx512vnni',
-            'sse2',
-            'ssse3',
-            'sse42',
-            'pclmulqdq',
-            'vpclmulqdq',
-            'acle',
-            'neon',
-            'armv6',
-            'altivec',
-            'power8',
-            'rvv',
-            'crc32_vx',
-            'dfltcc_deflate',
-            'dfltcc_inflate',
-        ]
-            cmake_define_key = 'WITH_' + instruction_set.to_upper()
-            cmake_define_value = (
-                zlib_ng_is_native
-                or zlib_ng_options.contains(instruction_set)
-            )
-            zlib_ng_defines += {cmake_define_key: cmake_define_value}
-        endforeach
-
-        cmake_options.add_cmake_defines(zlib_ng_defines)
-
-        zlib_ng_subproject = cmake_module.subproject(
-            'zlib-ng',
-            options: cmake_options,
-        )
-        zlib_dep = zlib_ng_subproject.get_variable('zlib_dep')
-        summary('zlib provider', 'built-in (zlib-ng)')
+    if (system_zlib_ng_dep.found())
+        zlib_ng_provider = 'system library'
+        conf_data.set10('C_SYSTEM_ZLIB_NG', true)
+        try_builtin_zlib_ng = false
+    else
+        zlib_ng_provider = 'skipped (system library not found)'
     endif
 endif
 
-# Otherwise Use the system's zlib or fallback
+# We only justify the extra time to setup zlib-ng (using CMake) if
+# the user wants an optimized build, so check if we can skip it:
+#
+if try_builtin_zlib_ng and not is_optimized_buildtype
+    zlib_ng_provider = 'skipped (non-optimized build)'
+    try_builtin_zlib_ng = false
+endif
+
+# Meson needs to be new enough to setup the zlib-ng CMake project, so
+# check if Meson is too old:
+#
+if try_builtin_zlib_ng and meson.version() < '1.3.0'
+    zlib_ng_provider = 'skipped (meson is < 1.3.0)'
+    try_builtin_zlib_ng = false
+endif
+
+# CMake needs to be available both on the host and in Meson as a module to
+# setup the zlib-ng CMake project, so check if we're missing either:
+#
+cmake_module = disabler()
+if try_builtin_zlib_ng
+    cmake_bin = find_program('cmake', required: false)
+    cmake_module = import('cmake', required: false)
+    if not cmake_bin.found()
+        zlib_ng_provider = 'skipped (CMake not found)'
+        try_builtin_zlib_ng = false
+
+    elif not cmake_module.found()
+        zlib_ng_provider = 'skipped (Meson\'s CMake module not found)'
+        try_builtin_zlib_ng = false
+    endif
+endif
+
+# If we passed all the above checks, everything is in place to use the wrap!
+if try_builtin_zlib_ng
+    cmake_options = cmake_module.subproject_options()
+
+    zlib_ng_defines = {
+        'ZLIB_COMPAT': true,
+        'WITH_OPTIM': true,
+        'ZLIB_BUILD_STATIC': true,
+        'PIC': get_option('b_staticpic'),
+        'BUILD_SHARED_LIBS': false,
+        'WITH_GTEST': false,
+        'ZLIB_ENABLE_TESTS': false,
+        'WITH_NATIVE_INSTRUCTIONS': zlib_ng_is_native,
+        'WITH_SANITIZER': get_option('b_sanitize'),
+        'CMAKE_C_FLAGS': ' '.join(cc_supported_arguments),
+    }
+
+    foreach instruction_set : [
+        'avx2',
+        'avx512',
+        'avx512vnni',
+        'sse2',
+        'ssse3',
+        'sse42',
+        'pclmulqdq',
+        'vpclmulqdq',
+        'acle',
+        'neon',
+        'armv6',
+        'altivec',
+        'power8',
+        'rvv',
+        'crc32_vx',
+        'dfltcc_deflate',
+        'dfltcc_inflate',
+    ]
+        cmake_define_key = 'WITH_' + instruction_set.to_upper()
+        cmake_define_value = (
+            zlib_ng_is_native
+            or zlib_ng_options.contains(instruction_set)
+        )
+        zlib_ng_defines += {cmake_define_key: cmake_define_value}
+    endforeach
+
+    cmake_options.add_cmake_defines(zlib_ng_defines)
+
+    zlib_ng_subproject = cmake_module.subproject(
+        'zlib-ng',
+        options: cmake_options,
+    )
+    zlib_ng_provider = 'built-in'
+
+    # We configure zlib-ng to be a drop in replacement for zlib, so we
+    # can directly assign the zlib_dep from the zlib-ng subproject:
+    #
+    zlib_dep = zlib_ng_subproject.get_variable('zlib_dep')
+    zlib_provider = 'built-in (zlib-ng)'
+endif
+
+# Otherwise use the system's zlib
 if not zlib_dep.found()
     zlib_dep = dependency(
         'zlib',
@@ -756,8 +812,11 @@ if not zlib_dep.found()
         static: zlib_is_static,
         include_type: 'system',
     )
-    summary('zlib provider', 'system library')
+    zlib_provider = 'system library'
 endif
+
+summary('zlib-ng provider', zlib_ng_provider)
+summary('zlib provider', zlib_provider)
 
 # PNG
 # ~~~

--- a/meson.build
+++ b/meson.build
@@ -469,7 +469,13 @@ if cc.has_member('struct dirent', 'd_type', prefix: '#include <dirent.h>')
     conf_data.set10('HAVE_STRUCT_DIRENT_D_TYPE', true)
 endif
 
-foreach header : ['libgen.h', 'pwd.h', 'strings.h', 'sys/xattr.h', 'netinet/in.h']
+foreach header : [
+    'libgen.h',
+    'pwd.h',
+    'strings.h',
+    'sys/xattr.h',
+    'netinet/in.h',
+]
     if cc.has_header(header)
         conf_data.set10('HAVE_' + header.underscorify().to_upper(), true)
     endif
@@ -529,7 +535,11 @@ else
     endif
 endif
 conf_data.set('PAGESIZE', pagesize)
-summary('Host page size (bytes)', pagesize.to_string(), section: 'Build Summary')
+summary(
+    'Host page size (bytes)',
+    pagesize.to_string(),
+    section: 'Build Summary',
+)
 
 
 set_prio_code = '''

--- a/meson.build
+++ b/meson.build
@@ -252,7 +252,7 @@ endif
 # Note that these build flags needs to be defined before adding
 # subpackages because the flags are used when compiling them.
 
-simd_summary = 'none'
+simd_instruction_sets = []
 
 zlib_ng_options = get_option('use_zlib_ng')
 zlib_ng_wants_native = zlib_ng_options.contains('native')
@@ -260,7 +260,7 @@ zlib_ng_is_native = zlib_ng_wants_native and cc.has_argument('-march=native')
 
 if is_optimized_buildtype and zlib_ng_is_native
     extra_flags += '-march=native'
-    simd_summary = 'native'
+    simd_instruction_sets += 'native'
     message('Enabling native SIMD optimizations')
 endif
 
@@ -269,8 +269,8 @@ endif
 if target_machine.cpu_family() == 'aarch64'
     # aarch64 always supports NEON:
     # ref: https://developer.arm.com/documentation/den0024/a/AArch64-Floating-point-and-NEON
-    zlib_ng_options += ['neon']
-    simd_summary = 'NEON'
+    zlib_ng_options += 'neon'
+    simd_instruction_sets += 'NEON'
     message('Using the ARM NEON instruction set')
 endif
 
@@ -300,7 +300,7 @@ if (
     if (neon_test.compiled() and neon_test.returncode() == 0)
         zlib_ng_options += 'neon'
         extra_flags += neon_cflag
-        simd_summary = 'NEON'
+        simd_instruction_sets += 'NEON'
         message('Enabling the ARM NEON instruction set')
     endif
 endif
@@ -334,7 +334,7 @@ if (
     if (sse2_test.compiled() and sse2_test.returncode() == 0)
         zlib_ng_options += 'sse2'
         extra_flags += sse2_cflags
-        simd_summary = 'SSE2'
+        simd_instruction_sets += 'SSE2'
         message('Enabling the SSE2 instruction set')
     endif
 
@@ -356,11 +356,20 @@ if (
     if (ssse3_test.compiled() and ssse3_test.returncode() == 0)
         zlib_ng_options += 'ssse3'
         extra_flags += ssse3_cflag
-        simd_summary = 'SSE2 and SSSE3'
+        simd_instruction_sets += 'SSSE3'
         message('Enabling the SSSE3 instruction set')
     endif
 endif
-summary('SIMD instruction set', simd_summary, section: 'Build Summary')
+
+if simd_instruction_sets.length() == 0
+    simd_instruction_sets = ['none']
+endif
+
+summary(
+    'SIMD instruction sets',
+    ', '.join(simd_instruction_sets),
+    section: 'Build Summary',
+)
 
 # Allow-list the flags against the compiler, and add them to the project
 cc_supported_arguments = cc.get_supported_arguments(extra_flags)


### PR DESCRIPTION
# Description

The previous logic performed all the zlib-ng prerequisite checks in a single conditional statement, which made it impossible to explain which criteria disqualified it.

Now, every reason for disqualifying the zlib-ng wrap is provided in the meson build summary. The reasons are:

 - Manually disabling zlib-ng
 - Manually disabling wraps
 - Performing a non-optimized build
 - Not having a new-enough Meson (>= 1.3.0)
 - Not having CMake installed locally
 - Not having the Meson CMake module (should be rare/impossible)


# Manual testing

All of the above exclusion scenarios were tested:

## Manually disabling zlib-ng

```shell
rm -rf build
meson setup -Duse_zlib_ng=false build
```

```
  Build Summary
    zlib-ng provider      : disabled
    zlib provider         : system library
  User defined options
    use_zlib_ng           : false
```

## Manually disabling wraps

```shell
rm -rf build
meson setup --wrap-mode=nofallback build
```

```
  Build Summary
    zlib-ng provider      : skipped (system library not found)
    zlib provider         : system library
  User defined options
    wrap_mode             : nofallback
```

## Performing a non-optimized build

```shell
rm -rf build
meson setup --wrap-mode=nofallback build
```

```
  Build Summary
    zlib-ng provider      : skipped (non-optimized build)
    zlib provider         : system library

  User defined options
    buildtype             : debug
```

## Not having a new-enough Meson (>= 1.3.0)

```shell
rm -rf build
meson --version : confirm < 1.3.0
meson setup build
```

```
  Build Summary
    zlib-ng provider      : skipped (meson is < 1.3.0)
    zlib provider         : system library
```

## Not having CMake installed locally

```shell
rm -rf build
cmake : confirm `bash: cmake: command not found`
meson setup build
```

```
  Build Summary
    zlib-ng provider      : skipped (CMake not found)
    zlib provider         : system library
```

## Not having the Meson CMake module (should be rare/impossible)

(Only a logical test in the code.. didn't actually damage Meson to get this code path :laughing: )

```shell
rm -rf build
meson setup build
```

```
  Build Summary
    zlib-ng provider      : skipped (Meson's CMake module not found)
    zlib provider         : system library
```

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

