### PR TITLE
Use UTF-8 for shell history

### DIFF
--- a/include/shell.h
+++ b/include/shell.h
@@ -113,7 +113,7 @@ private:
 	[[nodiscard]] std::string Which(std::string_view name) const;
 
 	friend class AutoexecEditor;
-	std::vector<std::string> history{};
+	std::vector<std::string> utf8_history{};
 	std::stack<BatchFile> batchfiles{};
 
 	bool exit_cmd_called                   = false;

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -484,7 +484,7 @@ void DOS_Shell::ReadShellHistory()
 			trim(line);
 			auto len = line.length();
 			if (len > 0 && len <= HistoryMaxLineSize) {
-				history.emplace_back(std::move(line));
+				utf8_history.emplace_back(std::move(line));
 			}
 		}
 	}
@@ -506,8 +506,8 @@ void DOS_Shell::WriteShellHistory()
 		return;
 	}
 	std::vector<std::string> trimmed_history;
-	trimmed_history.reserve(history.size());
-	for (std::string str : history) {
+	trimmed_history.reserve(utf8_history.size());
+	for (std::string str : utf8_history) {
 		trim(str);
 		auto len = str.length();
 		if (len > 0 && len <= HistoryMaxLineSize) {


### PR DESCRIPTION
# Description

Use UTF-8 representation for storing shell history.  This is for both internal representation and for the `shell_history.txt` file.  Probably safe for backport but I'll let the team decide.  If this goes into rc2, then rc1 users using languages requiring extended ASCII will need to manually convert or erase their `shell_history.txt` file.  The history file did not exist in v0.80.1 so previous release users will not be affected.

Uses existing DOS codepage to UTF-8 conversion functions written by @FeralChild64 to make this a pretty quick and easy change.  Very nice work there.

## Related issues

Fixes #3235

# Manual testing

Tested with `keyb bg` as per this comment:  https://github.com/dosbox-staging/dosbox-staging/issues/3235#issuecomment-1868345574

I don't speak the language so my testing was limited but the characters do look correct.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

