### PR TITLE
Enable expect_death tests only in debug builds

### DIFF
--- a/tests/rect_tests.cpp
+++ b/tests/rect_tests.cpp
@@ -500,7 +500,7 @@ TEST(Rect, CenterTo_zero_size)
 		const DosBox::Rect a = {1.1f, 5.5f, 0.0f, 0.0f};
 		a.Copy().CenterTo(10.0f, -12.0f);
 	};
-	EXPECT_DEATH(test(), "");
+	EXPECT_DEBUG_DEATH(test(), "");
 }
 
 TEST(Rect, CenterTo_positive_size)
@@ -520,7 +520,7 @@ TEST(Rect, CenterTo_negative_size)
 		const DosBox::Rect a = {1.1f, 5.5f, 4.6f, -8.4f};
 		a.Copy().CenterTo(10.0f, -12.0f);
 	};
-	EXPECT_DEATH(test(), "");
+	EXPECT_DEBUG_DEATH(test(), "");
 }
 
 // Contains()
@@ -592,7 +592,7 @@ TEST(Rect, Contains_source_negative_size)
 		const DosBox::Rect b = {1.1f, 5.5f};
 		a.Contains(b);
 	};
-	EXPECT_DEATH(test(), "");
+	EXPECT_DEBUG_DEATH(test(), "");
 }
 
 TEST(Rect, Contains_target_negative_size)
@@ -602,7 +602,7 @@ TEST(Rect, Contains_target_negative_size)
 		const DosBox::Rect b = {1.1f, -5.5f};
 		a.Contains(b);
 	};
-	EXPECT_DEATH(test(), "");
+	EXPECT_DEBUG_DEATH(test(), "");
 }
 
 // Overlaps()
@@ -662,7 +662,7 @@ TEST(Rect, Overlaps_source_negative_size)
 		const DosBox::Rect b = {1.1f, 5.5f};
 		a.Overlaps(b);
 	};
-	EXPECT_DEATH(test(), "");
+	EXPECT_DEBUG_DEATH(test(), "");
 }
 
 TEST(Rect, Overlaps_target_negative_size)
@@ -672,7 +672,7 @@ TEST(Rect, Overlaps_target_negative_size)
 		const DosBox::Rect b = {1.1f, -5.5f};
 		a.Overlaps(b);
 	};
-	EXPECT_DEATH(test(), "");
+	EXPECT_DEBUG_DEATH(test(), "");
 }
 
 // Intersect()
@@ -739,7 +739,7 @@ TEST(Rect, Intersect_source_negative_size)
 		DosBox::Rect a = {-1.0f, -2.0f};
 		a.Intersect(b);
 	};
-	EXPECT_DEATH(test(), "");
+	EXPECT_DEBUG_DEATH(test(), "");
 }
 
 TEST(Rect, Intersect_target_negative_size)
@@ -750,7 +750,7 @@ TEST(Rect, Intersect_target_negative_size)
 		DosBox::Rect a = {1.0f, 2.0f};
 		a.Intersect(b);
 	};
-	EXPECT_DEATH(test(), "");
+	EXPECT_DEBUG_DEATH(test(), "");
 }
 
 // ScaleSizeToFit()
@@ -789,7 +789,7 @@ TEST(Rect, ScaleSizeToFit_source_zero_size)
 		DosBox::Rect src = {};
 		src.ScaleSizeToFit(dest);
 	};
-	EXPECT_DEATH(test(), "");
+	EXPECT_DEBUG_DEATH(test(), "");
 }
 
 TEST(Rect, ScaleSizeToFit_target_zero_size)
@@ -800,7 +800,7 @@ TEST(Rect, ScaleSizeToFit_target_zero_size)
 		DosBox::Rect src = {1.0f, 2.0f};
 		src.ScaleSizeToFit(dest);
 	};
-	EXPECT_DEATH(test(), "");
+	EXPECT_DEBUG_DEATH(test(), "");
 }
 
 TEST(Rect, ScaleSizeToFit_source_negative_size)
@@ -811,7 +811,7 @@ TEST(Rect, ScaleSizeToFit_source_negative_size)
 		DosBox::Rect src = {-1.0f, -2.0f};
 		src.ScaleSizeToFit(dest);
 	};
-	EXPECT_DEATH(test(), "");
+	EXPECT_DEBUG_DEATH(test(), "");
 }
 
 TEST(Rect, ScaleSizeToFit_target_negative_size)
@@ -822,7 +822,7 @@ TEST(Rect, ScaleSizeToFit_target_negative_size)
 		DosBox::Rect src = {1.0f, 2.0f};
 		src.ScaleSizeToFit(dest);
 	};
-	EXPECT_DEATH(test(), "");
+	EXPECT_DEBUG_DEATH(test(), "");
 }
 
 // ToString()


### PR DESCRIPTION
# Description

Allow all the except_death tests to only run on _real_ debug builds

Running `plain` builds will apply the full unit test suite, but it will fail the except_death tests (see initial issue)

## Related issues

_Related issues can be listed here (remove the section if not applicable.)_
#3273 

# Manual testing

_Please describe the tests that you ran to verify your changes._

```bash
meson setup --buildtype=debug . debug
meson compile -C debug
# Still runs and succeeds
meson test -C debug --print-errorlogs

meson setup --buildtype=plain . plain
meson compile -C plain
# Used to fail, now doesn't fail
meson test -C plain --print-errorlogs
```

_Include relevant details for your test configuration, operating system, etc._

Ran on openSUSE Tumbleweed host (20231211, meson 1.3.0), and [OpenBuildService](https://build.opensuse.org) Tumbleweed and Leap 15.5 runners.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [ ] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [ ] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.
