### PR TITLE
Make integer scaling calculations 100% robust

### DIFF
--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3139,9 +3139,9 @@ DosBox::Rect GFX_CalcDrawRectInPixels(const DosBox::Rect& canvas_size_px,
 	                .ScaleSizeToFit(viewport_px);
 
 	auto calc_horiz_integer_scaling_dims_in_pixels = [&]() {
-		auto integer_scale_factor = floorf(draw_size_fit_px.w /
-		                                   render_size_px.w);
-		if (integer_scale_factor < 1.0f) {
+		auto integer_scale_factor = iroundf(draw_size_fit_px.w) /
+		                            iroundf(render_size_px.w);
+		if (integer_scale_factor < 1) {
 			// Revert to fit to viewport
 			return draw_size_fit_px;
 		} else {
@@ -3155,9 +3155,9 @@ DosBox::Rect GFX_CalcDrawRectInPixels(const DosBox::Rect& canvas_size_px,
 	};
 
 	auto calc_vert_integer_scaling_dims_in_pixels = [&]() {
-		auto integer_scale_factor = floorf(draw_size_fit_px.h /
-		                                   render_size_px.h);
-		if (integer_scale_factor < 1.0f) {
+		auto integer_scale_factor = iroundf(draw_size_fit_px.h) /
+		                            iroundf(render_size_px.h);
+		if (integer_scale_factor < 1) {
 			// Revert to fit to viewport
 			return draw_size_fit_px;
 		} else {

--- a/src/gui/shader_manager.h
+++ b/src/gui/shader_manager.h
@@ -183,9 +183,10 @@ private:
 
 	std::string shader_name_from_config = {};
 
-	double scale_y                   = 1.0;
-	double scale_y_force_single_scan = 1.0;
-	VideoMode video_mode             = {};
+	int pixels_per_scanline                   = 1;
+	int pixels_per_scanline_force_single_scan = 1;
+
+	VideoMode video_mode = {};
 };
 
 #endif // DOSBOX_SHADER_MANAGER_H


### PR DESCRIPTION
# Description

Fixes https://github.com/dosbox-staging/dosbox-staging/issues/3266

Without this fix, integer scaling calculations could be wrong due to "fast-math" optimisations in release builds (talk about cars without brakes... 🤦🏻)

Also semi-proactively fixing the shader manager which is prone to the exact same issue. I'm pretty sure I saw the auto shader switching misbehave on Windows when the viewport size is an exact multiple of the auto-switching cutoff point (it sometimes goes one step lower). I was perplexed by that, but I'm pretty sure this was the cause. Will test & confirm later.

## Related issues

https://github.com/dosbox-staging/dosbox-staging/issues/3266

https://github.com/dosbox-staging/dosbox-staging/pull/3272

# Manual testing

@shermp can hopefully confirm it's working now.

Regression tested `crt-auto` & integer scaling—no issues.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

