### PR TITLE
VGA CRTC regression fixes

### DIFF
--- a/include/vga.h
+++ b/include/vga.h
@@ -257,6 +257,8 @@ struct VgaDraw {
 	Bitu lines_scaled           = 0;
 	Bitu split_line             = 0;
 
+	bool is_double_scanning = false;
+
 	// When drawing in parts, how many many 'chunks' should we draw at a
 	// time? A value of 1 is the entire frame where as a value of 2 will
 	// draw the top then the bottom, 4 will draw in quarters, and so on.

--- a/src/hardware/vga_crtc.cpp
+++ b/src/hardware/vga_crtc.cpp
@@ -19,15 +19,12 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-#include <stdlib.h>
-#include "dosbox.h"
-#include "inout.h"
-#include "vga.h"
-#include "debug.h"
-#include "cpu.h"
-#include "video.h"
-#include "pic.h"
+#include <cstdlib>
 
+#include "cpu.h"
+#include "debug.h"
+#include "pic.h"
+#include "vga.h"
 
 void VGA_MapMMIO(void);
 void VGA_UnmapMMIO(void);

--- a/src/hardware/vga_crtc.cpp
+++ b/src/hardware/vga_crtc.cpp
@@ -28,8 +28,6 @@
 #include "video.h"
 #include "pic.h"
 
-#define crtc(blah) vga.crtc.blah
-
 
 void VGA_MapMMIO(void);
 void VGA_UnmapMMIO(void);
@@ -39,37 +37,37 @@ void vga_write_p3d5(io_port_t port, io_val_t value, io_width_t);
 void vga_write_p3d4(io_port_t, io_val_t value, io_width_t)
 {
 	const auto val = check_cast<uint8_t>(value);
-	crtc(index) = val;
+	vga.crtc.index = val;
 }
 
 uint8_t vga_read_p3d4(io_port_t, io_width_t)
 {
-	return crtc(index);
+	return vga.crtc.index;
 }
 
 void vga_write_p3d5(io_port_t, io_val_t value, io_width_t)
 {
 	const auto val = check_cast<uint8_t>(value);
-	// if (crtc(index) > 0x18) {
-	// 	LOG_MSG("VGA CRCT write %" sBitfs(X) " to reg %X", val, crtc(index))
+	// if (vga.crtc.index > 0x18) {
+	// 	LOG_MSG("VGA crtc write %" sBitfs(X) " to reg %X", val, vga.crtc.index)
 	// }
 
-	switch (crtc(index)) {
+	switch (vga.crtc.index) {
 	case 0x00: // Horizontal Total Register
-		if (crtc(read_only)) {
+		if (vga.crtc.read_only) {
 			break;
 		}
-		crtc(horizontal_total) = val;
+		vga.crtc.horizontal_total = val;
 
 		// 0-7  Horizontal Total Character Clocks minus 5.
 		break;
 
 	case 0x01: // Horizontal Display End Register
-		if (crtc(read_only)) {
+		if (vga.crtc.read_only) {
 			break;
 		}
-		if (val != crtc(horizontal_display_end)) {
-			crtc(horizontal_display_end) = val;
+		if (val != vga.crtc.horizontal_display_end) {
+			vga.crtc.horizontal_display_end = val;
 			VGA_StartResize();
 		}
 
@@ -77,19 +75,19 @@ void vga_write_p3d5(io_port_t, io_val_t value, io_width_t)
 		break;
 
 	case 0x02: // Start Horizontal Blanking Register
-		if (crtc(read_only)) {
+		if (vga.crtc.read_only) {
 			break;
 		}
-		crtc(start_horizontal_blanking) = val;
+		vga.crtc.start_horizontal_blanking = val;
 
 		// 0-7  The count at which Horizontal Blanking starts.
 		break;
 
 	case 0x03: // End Horizontal Blanking Register
-		if (crtc(read_only)) {
+		if (vga.crtc.read_only) {
 			break;
 		}
-		crtc(end_horizontal_blanking) = val;
+		vga.crtc.end_horizontal_blanking = val;
 
 		// 0-4	Horizontal Blanking ends when the last 6 bits of the character
 		// 	    counter equals this field. Bit 5 is at 3d4h index 5 bit 7.
@@ -101,20 +99,20 @@ void vga_write_p3d5(io_port_t, io_val_t value, io_width_t)
 		break;
 
 	case 0x04: // Start Horizontal Retrace Register
-		if (crtc(read_only)) {
+		if (vga.crtc.read_only) {
 			break;
 		}
-		crtc(start_horizontal_retrace) = val;
+		vga.crtc.start_horizontal_retrace = val;
 
 		// 0-7  Horizontal Retrace starts when the Character Counter reaches
 		//      this value.
 		break;
 
 	case 0x05: // End Horizontal Retrace Register
-		if (crtc(read_only)) {
+		if (vga.crtc.read_only) {
 			break;
 		}
-		crtc(end_horizontal_retrace) = val;
+		vga.crtc.end_horizontal_retrace = val;
 
 		// 0-4	Horizontal Retrace ends when the last 5 bits of the character
 		//      counter equals this value.
@@ -125,11 +123,11 @@ void vga_write_p3d5(io_port_t, io_val_t value, io_width_t)
 		break;
 
 	case 0x06: // Vertical Total Register
-		if (crtc(read_only)) {
+		if (vga.crtc.read_only) {
 			break;
 		}
-		if (val != crtc(vertical_total)) {
-			crtc(vertical_total) = val;
+		if (val != vga.crtc.vertical_total) {
+			vga.crtc.vertical_total = val;
 			VGA_StartResize();
 		}
 
@@ -145,14 +143,14 @@ void vga_write_p3d5(io_port_t, io_val_t value, io_width_t)
 		// Line compare bit ignores read only
 		vga.config.line_compare = (vga.config.line_compare & 0x6ff) |
 		                          (val & 0x10) << 4;
-		if (crtc(read_only)) {
+		if (vga.crtc.read_only) {
 			break;
 		}
 		if ((vga.crtc.overflow ^ val) & 0xd6) {
-			crtc(overflow) = val;
+			vga.crtc.overflow = val;
 			VGA_StartResize();
 		} else {
-			crtc(overflow) = val;
+			vga.crtc.overflow = val;
 		}
 
 		// 0  Bit 8 of Vertical Total (3d4h index 6)
@@ -166,7 +164,7 @@ void vga_write_p3d5(io_port_t, io_val_t value, io_width_t)
 		break;
 
 	case 0x08: // Preset Row Scan Register
-		crtc(preset_row_scan)  = val;
+		vga.crtc.preset_row_scan  = val;
 		vga.config.hlines_skip = val & 31;
 
 		if (IS_VGA_ARCH) {
@@ -193,7 +191,7 @@ void vga_write_p3d5(io_port_t, io_val_t value, io_width_t)
 		break;
 
 	case 0x0a: // Cursor Start Register
-		crtc(cursor_start)    = val;
+		vga.crtc.cursor_start    = val;
 		vga.draw.cursor.sline = val & 0x1f;
 		if (IS_VGA_ARCH) {
 			vga.draw.cursor.enabled = !(val & 0x20);
@@ -206,7 +204,7 @@ void vga_write_p3d5(io_port_t, io_val_t value, io_width_t)
 		break;
 
 	case 0x0b: // Cursor End Register
-		crtc(cursor_end)      = val;
+		vga.crtc.cursor_end      = val;
 		vga.draw.cursor.eline = val & 0x1f;
 		vga.draw.cursor.delay = (val >> 5) & 0x3;
 
@@ -215,7 +213,7 @@ void vga_write_p3d5(io_port_t, io_val_t value, io_width_t)
 		break;
 
 	case 0x0c: // Start Address High Register
-		crtc(start_address_high) = val;
+		vga.crtc.start_address_high = val;
 		vga.config.display_start = (vga.config.display_start & 0xFF00FF) |
 		                           (val << 8);
 
@@ -223,14 +221,14 @@ void vga_write_p3d5(io_port_t, io_val_t value, io_width_t)
 		break;
 
 	case 0x0d: // Start Address Low Register
-		crtc(start_address_low) = val;
+		vga.crtc.start_address_low = val;
 		vga.config.display_start = (vga.config.display_start & 0xFFFF00) | val;
 
 		//0-7	Lower 8 bits of the start address of the display buffer.
 		break;
 
 	case 0x0e: // Cursor Location High Register
-		crtc(cursor_location_high) = val;
+		vga.crtc.cursor_location_high = val;
 		vga.config.cursor_start &= 0xff00ff;
 		vga.config.cursor_start |= val << 8;
 
@@ -239,7 +237,7 @@ void vga_write_p3d5(io_port_t, io_val_t value, io_width_t)
 
 	case 0x0f: // Cursor Location Low Register
 		// TODO update cursor on screen
-		crtc(cursor_location_low) = val;
+		vga.crtc.cursor_location_low = val;
 		vga.config.cursor_start &= 0xffff00;
 		vga.config.cursor_start |= val;
 
@@ -247,7 +245,7 @@ void vga_write_p3d5(io_port_t, io_val_t value, io_width_t)
 		break;
 
 	case 0x10: // Vertical Retrace Start Register
-		crtc(vertical_retrace_start) = val;
+		vga.crtc.vertical_retrace_start = val;
 		//
 		// 0-7	Lower 8 bits of Vertical Retrace Start. Vertical Retrace
 		//	    starts when the line counter reaches this value.
@@ -257,7 +255,7 @@ void vga_write_p3d5(io_port_t, io_val_t value, io_width_t)
 		break;
 
 	case 0x11: // Vertical Retrace End Register
-		crtc(vertical_retrace_end) = val;
+		vga.crtc.vertical_retrace_end = val;
 
 		if (IS_EGAVGA_ARCH && !(val & 0x10)) {
 			vga.draw.vret_triggered = false;
@@ -266,9 +264,9 @@ void vga_write_p3d5(io_port_t, io_val_t value, io_width_t)
 			}
 		}
 		if (IS_VGA_ARCH) {
-			crtc(read_only) = (val & 128) > 0;
+			vga.crtc.read_only = (val & 128) > 0;
 		} else {
-			crtc(read_only) = false;
+			vga.crtc.read_only = false;
 		}
 
 		// 0-3	Vertical Retrace ends when the last 4 bits of the line counter
@@ -283,19 +281,19 @@ void vga_write_p3d5(io_port_t, io_val_t value, io_width_t)
 		break;
 
 	case 0x12: // Vertical Display End Register
-		if (val != crtc(vertical_display_end)) {
+		if (val != vga.crtc.vertical_display_end) {
 			if (abs(static_cast<int>(
-			            (Bits)val - (Bits)crtc(vertical_display_end))) <
+			            (Bits)val - (Bits)vga.crtc.vertical_display_end)) <
 			    3) {
 				// delay small vde changes a bit to avoid screen
 				// resizing if they are reverted in a short
 				// timeframe
 				PIC_RemoveEvents(VGA_SetupDrawing);
 				vga.draw.resizing          = false;
-				crtc(vertical_display_end) = val;
+				vga.crtc.vertical_display_end = val;
 				VGA_StartResizeAfter(150);
 			} else {
-				crtc(vertical_display_end) = val;
+				vga.crtc.vertical_display_end = val;
 				VGA_StartResize();
 			}
 		}
@@ -308,7 +306,7 @@ void vga_write_p3d5(io_port_t, io_val_t value, io_width_t)
 		break;
 
 	case 0x13: // Offset register
-		crtc(offset) = val;
+		vga.crtc.offset = val;
 		vga.config.scan_len &= 0x300;
 		vga.config.scan_len |= val;
 		VGA_CheckScanLength();
@@ -318,10 +316,10 @@ void vga_write_p3d5(io_port_t, io_val_t value, io_width_t)
 		break;
 
 	case 0x14: // Underline Location Register
-		crtc(underline_location) = val;
+		vga.crtc.underline_location = val;
 		if (IS_VGA_ARCH) {
 			// Byte,word,dword mode
-			if (crtc(underline_location) & 0x20) {
+			if (vga.crtc.underline_location & 0x20) {
 				vga.config.addr_shift = 2;
 			} else if (vga.crtc.mode_control.word_byte_mode_select) {
 				vga.config.addr_shift = 0;
@@ -339,8 +337,8 @@ void vga_write_p3d5(io_port_t, io_val_t value, io_width_t)
 		break;
 
 	case 0x15: // Start Vertical Blank Register
-		if (val != crtc(start_vertical_blanking)) {
-			crtc(start_vertical_blanking) = val;
+		if (val != vga.crtc.start_vertical_blanking) {
+			vga.crtc.start_vertical_blanking = val;
 			VGA_StartResize();
 		}
 
@@ -351,8 +349,8 @@ void vga_write_p3d5(io_port_t, io_val_t value, io_width_t)
 		break;
 
 	case 0x16: //  End Vertical Blank Register
-		if (val != crtc(end_vertical_blanking)) {
-			crtc(end_vertical_blanking) = val;
+		if (val != vga.crtc.end_vertical_blanking) {
+			vga.crtc.end_vertical_blanking = val;
 			VGA_StartResize();
 		}
 
@@ -387,7 +385,7 @@ void vga_write_p3d5(io_port_t, io_val_t value, io_width_t)
 		break;
 
 	case 0x18: // Line Compare Register
-		crtc(line_compare) = val;
+		vga.crtc.line_compare = val;
 		vga.config.line_compare = (vga.config.line_compare & 0x700) | val;
 
 		// 0-7	Lower 8 bits of the Line Compare. When the Line
@@ -400,10 +398,10 @@ void vga_write_p3d5(io_port_t, io_val_t value, io_width_t)
 
 	default:
 		if (svga.write_p3d5) {
-			svga.write_p3d5(crtc(index), val, io_width_t::byte);
+			svga.write_p3d5(vga.crtc.index, val, io_width_t::byte);
 		} else {
 			LOG(LOG_VGAMISC, LOG_NORMAL)
-			("VGA:CRTC:Write to unknown index %X", crtc(index));
+			("VGA:CRTC:Write to unknown index %X", vga.crtc.index);
 		}
 		break;
 	}
@@ -411,39 +409,39 @@ void vga_write_p3d5(io_port_t, io_val_t value, io_width_t)
 
 uint8_t vga_read_p3d5(io_port_t, io_width_t)
 {
-	//	LOG_MSG("VGA CRCT read from reg %X",crtc(index));
-	switch (crtc(index)) {
-	case 0x00: return crtc(horizontal_total);
-	case 0x01: return crtc(horizontal_display_end);
-	case 0x02: return crtc(start_horizontal_blanking);
-	case 0x03: return crtc(end_horizontal_blanking);
-	case 0x04: return crtc(start_horizontal_retrace);
-	case 0x05: return crtc(end_horizontal_retrace);
-	case 0x06: return crtc(vertical_total);
-	case 0x07: return crtc(overflow);
-	case 0x08: return crtc(preset_row_scan);
+	//	LOG_MSG("VGA crtc read from reg %X",vga.crtc.index);
+	switch (vga.crtc.index) {
+	case 0x00: return vga.crtc.horizontal_total;
+	case 0x01: return vga.crtc.horizontal_display_end;
+	case 0x02: return vga.crtc.start_horizontal_blanking;
+	case 0x03: return vga.crtc.end_horizontal_blanking;
+	case 0x04: return vga.crtc.start_horizontal_retrace;
+	case 0x05: return vga.crtc.end_horizontal_retrace;
+	case 0x06: return vga.crtc.vertical_total;
+	case 0x07: return vga.crtc.overflow;
+	case 0x08: return vga.crtc.preset_row_scan;
 	case 0x09: return vga.crtc.maximum_scan_line.data;
-	case 0x0A: return crtc(cursor_start);
-	case 0x0B: return crtc(cursor_end);
-	case 0x0C: return crtc(start_address_high);
-	case 0x0D: return crtc(start_address_low);
-	case 0x0E: return crtc(cursor_location_high);
-	case 0x0F: return crtc(cursor_location_low);
-	case 0x10: return crtc(vertical_retrace_start);
-	case 0x11: return crtc(vertical_retrace_end);
-	case 0x12: return crtc(vertical_display_end);
-	case 0x13: return crtc(offset);
-	case 0x14: return crtc(underline_location);
-	case 0x15: return crtc(start_vertical_blanking);
-	case 0x16: return crtc(end_vertical_blanking);
+	case 0x0A: return vga.crtc.cursor_start;
+	case 0x0B: return vga.crtc.cursor_end;
+	case 0x0C: return vga.crtc.start_address_high;
+	case 0x0D: return vga.crtc.start_address_low;
+	case 0x0E: return vga.crtc.cursor_location_high;
+	case 0x0F: return vga.crtc.cursor_location_low;
+	case 0x10: return vga.crtc.vertical_retrace_start;
+	case 0x11: return vga.crtc.vertical_retrace_end;
+	case 0x12: return vga.crtc.vertical_display_end;
+	case 0x13: return vga.crtc.offset;
+	case 0x14: return vga.crtc.underline_location;
+	case 0x15: return vga.crtc.start_vertical_blanking;
+	case 0x16: return vga.crtc.end_vertical_blanking;
 	case 0x17: return vga.crtc.mode_control.data;
-	case 0x18: return crtc(line_compare);
+	case 0x18: return vga.crtc.line_compare;
 	default:
 		if (svga.read_p3d5) {
-			return svga.read_p3d5(crtc(index), io_width_t::byte);
+			return svga.read_p3d5(vga.crtc.index, io_width_t::byte);
 		} else {
 			LOG(LOG_VGAMISC, LOG_NORMAL)
-			("VGA:CRTC:Read from unknown index %X", crtc(index));
+			("VGA:CRTC:Read from unknown index %X", vga.crtc.index);
 			return 0x0;
 		}
 	}

--- a/src/hardware/vga_crtc.cpp
+++ b/src/hardware/vga_crtc.cpp
@@ -50,99 +50,139 @@ uint8_t vga_read_p3d4(io_port_t, io_width_t)
 void vga_write_p3d5(io_port_t, io_val_t value, io_width_t)
 {
 	const auto val = check_cast<uint8_t>(value);
-	//	if (crtc(index) > 0x18) LOG_MSG("VGA CRCT write %" sBitfs(X) " to reg %X",val,crtc(index));
+	// if (crtc(index) > 0x18) {
+	// 	LOG_MSG("VGA CRCT write %" sBitfs(X) " to reg %X", val, crtc(index))
+	// }
+
 	switch (crtc(index)) {
-	case 0x00: /* Horizontal Total Register */
-		if (crtc(read_only))
+	case 0x00: // Horizontal Total Register
+		if (crtc(read_only)) {
 			break;
+		}
 		crtc(horizontal_total) = val;
-		/* 	0-7  Horizontal Total Character Clocks-5 */
+
+		// 0-7  Horizontal Total Character Clocks minus 5.
 		break;
-	case 0x01:	/* Horizontal Display End Register */
-		if (crtc(read_only)) break;
+
+	case 0x01: // Horizontal Display End Register
+		if (crtc(read_only)) {
+			break;
+		}
 		if (val != crtc(horizontal_display_end)) {
-			crtc(horizontal_display_end)=val;
+			crtc(horizontal_display_end) = val;
 			VGA_StartResize();
 		}
-		/* 	0-7  Number of Character Clocks Displayed -1 */
+
+		// 0-7  Number of Character Clocks Displayed minus 1.
 		break;
-	case 0x02:	/* Start Horizontal Blanking Register */
-		if (crtc(read_only)) break;
-		crtc(start_horizontal_blanking)=val;
-		/*	0-7  The count at which Horizontal Blanking starts */
+
+	case 0x02: // Start Horizontal Blanking Register
+		if (crtc(read_only)) {
+			break;
+		}
+		crtc(start_horizontal_blanking) = val;
+
+		// 0-7  The count at which Horizontal Blanking starts.
 		break;
-	case 0x03:	/* End Horizontal Blanking Register */
-		if (crtc(read_only)) break;
-		crtc(end_horizontal_blanking)=val;
-		/*
-			0-4	Horizontal Blanking ends when the last 6 bits of the character
-				counter equals this field. Bit 5 is at 3d4h index 5 bit 7.
-			5-6	Number of character clocks to delay start of display after Horizontal
-				Total has been reached.
-			7	Access to Vertical Retrace registers if set. If clear reads to 3d4h
-				index 10h and 11h access the Lightpen read back registers ??
-		*/
+
+	case 0x03: // End Horizontal Blanking Register
+		if (crtc(read_only)) {
+			break;
+		}
+		crtc(end_horizontal_blanking) = val;
+
+		// 0-4	Horizontal Blanking ends when the last 6 bits of the character
+		// 	    counter equals this field. Bit 5 is at 3d4h index 5 bit 7.
+		// 5-6	Number of character clocks to delay start of display after
+		//      Horizontal Total has been reached.
+		// 7 	Access to Vertical Retrace registers if set. If clear reads to
+		//      3d4h index 10h and 11h access the Lightpen read back registers
+		//      (?).
 		break;
-	case 0x04:	/* Start Horizontal Retrace Register */
-		if (crtc(read_only)) break;
-		crtc(start_horizontal_retrace)=val;
-		/*	0-7  Horizontal Retrace starts when the Character Counter reaches this value. */
+
+	case 0x04: // Start Horizontal Retrace Register
+		if (crtc(read_only)) {
+			break;
+		}
+		crtc(start_horizontal_retrace) = val;
+
+		// 0-7  Horizontal Retrace starts when the Character Counter reaches
+		//      this value.
 		break;
-	case 0x05:	/* End Horizontal Retrace Register */
-		if (crtc(read_only)) break;
-		crtc(end_horizontal_retrace)=val;
-		/*
-			0-4	Horizontal Retrace ends when the last 5 bits of the character counter
-				equals this value.
-			5-6	Number of character clocks to delay start of display after Horizontal
-				Retrace.
-			7	bit 5 of the End Horizontal Blanking count (See 3d4h index 3 bit 0-4)
-		*/
+
+	case 0x05: // End Horizontal Retrace Register
+		if (crtc(read_only)) {
+			break;
+		}
+		crtc(end_horizontal_retrace) = val;
+
+		// 0-4	Horizontal Retrace ends when the last 5 bits of the character
+		//      counter equals this value.
+		// 5-6	Number of character clocks to delay start of display after
+		//      Horizontal Retrace.
+		// 7	bit 5 of the End Horizontal Blanking count (See 3d4h index 3
+		//      bit 0-4)
 		break;
-	case 0x06: /* Vertical Total Register */
-		if (crtc(read_only)) break;
+
+	case 0x06: // Vertical Total Register
+		if (crtc(read_only)) {
+			break;
+		}
 		if (val != crtc(vertical_total)) {
-			crtc(vertical_total)=val;
+			crtc(vertical_total) = val;
 			VGA_StartResize();
 		}
-		/*	0-7	Lower 8 bits of the Vertical Total. Bit 8 is found in 3d4h index 7
-				bit 0. Bit 9 is found in 3d4h index 7 bit 5.
-			Note: For the VGA this value is the number of scan lines in the display -2.
-		*/
+
+		// 0-7	Lower 8 bits of the Vertical Total. Bit 8 is
+		// 		found in 3d4h index 7 bit 0. Bit 9 is found in 3d4h index 7
+		//      bit 5.
+		//
+		// Note: For the VGA this value is the number of scan lines in the
+		// display minus 2.
 		break;
-	case 0x07:	/* Overflow Register */
-		//Line compare bit ignores read only */
-		vga.config.line_compare=(vga.config.line_compare & 0x6ff) | (val & 0x10) << 4;
-		if (crtc(read_only)) break;
+
+	case 0x07: // Overflow Register
+		// Line compare bit ignores read only
+		vga.config.line_compare = (vga.config.line_compare & 0x6ff) |
+		                          (val & 0x10) << 4;
+		if (crtc(read_only)) {
+			break;
+		}
 		if ((vga.crtc.overflow ^ val) & 0xd6) {
-			crtc(overflow)=val;
+			crtc(overflow) = val;
 			VGA_StartResize();
-		} else crtc(overflow)=val;
-		/*
-			0  Bit 8 of Vertical Total (3d4h index 6)
-			1  Bit 8 of Vertical Display End (3d4h index 12h)
-			2  Bit 8 of Vertical Retrace Start (3d4h index 10h)
-			3  Bit 8 of Start Vertical Blanking (3d4h index 15h)
-			4  Bit 8 of Line Compare Register (3d4h index 18h)
-			5  Bit 9 of Vertical Total (3d4h index 6)
-			6  Bit 9 of Vertical Display End (3d4h index 12h)
-			7  Bit 9 of Vertical Retrace Start (3d4h index 10h)
-		*/
+		} else {
+			crtc(overflow) = val;
+		}
+
+		// 0  Bit 8 of Vertical Total (3d4h index 6)
+		// 1  Bit 8 of Vertical Display End (3d4h index 12h)
+		// 2  Bit 8 of Vertical Retrace Start (3d4h index 10h)
+		// 3  Bit 8 of Start Vertical Blanking (3d4h index 15h)
+		// 4  Bit 8 of Line Compare Register (3d4h index 18h)
+		// 5  Bit 9 of Vertical Total (3d4h index 6)
+		// 6  Bit 9 of Vertical Display End (3d4h index 12h)
+		// 7  Bit 9 of Vertical Retrace Start (3d4h index 10h)
 		break;
-	case 0x08:	/* Preset Row Scan Register */
-		crtc(preset_row_scan)=val;
-		vga.config.hlines_skip=val&31;
-		if (IS_VGA_ARCH) vga.config.bytes_skip=(val>>5)&3;
-		else vga.config.bytes_skip=0;
-//		LOG_DEBUG("Skip lines %d bytes %d",vga.config.hlines_skip,vga.config.bytes_skip);
-		/*
-			0-4	Number of lines we have scrolled down in the first character row.
-				Provides Smooth Vertical Scrolling.b
-			5-6	Number of bytes to skip at the start of scanline. Provides Smooth
-				Horizontal Scrolling together with the Horizontal Panning Register
-				(3C0h index 13h).
-		*/
+
+	case 0x08: // Preset Row Scan Register
+		crtc(preset_row_scan)  = val;
+		vga.config.hlines_skip = val & 31;
+
+		if (IS_VGA_ARCH) {
+			vga.config.bytes_skip = (val >> 5) & 3;
+		} else {
+			vga.config.bytes_skip = 0;
+		}
+		// LOG_DEBUG("Skip lines %d bytes %d",vga.config.hlines_skip,vga.config.bytes_skip);
+
+		// 0-4	Number of lines we have scrolled down in the
+		//      first character row. Provides Smooth Vertical Scrolling.
+		// 5-6  Number of bytes to skip at the start of scanline. Provides
+		//      Smooth Horizontal Scrolling together with the Horizontal Panning
+		// 		Register (3C0h index 13h).
 		break;
+
 	case 0x09:
 		if (IS_VGA_ARCH) {
 			vga.config.line_compare = (vga.config.line_compare & 0x5ff) |
@@ -152,147 +192,173 @@ void vga_write_p3d5(io_port_t, io_val_t value, io_width_t)
 		VGA_StartResize();
 		break;
 
-	case 0x0A:	/* Cursor Start Register */
-		crtc(cursor_start)=val;
-		vga.draw.cursor.sline=val&0x1f;
-		if (IS_VGA_ARCH) vga.draw.cursor.enabled=!(val&0x20);
-		else vga.draw.cursor.enabled=true;
-		/*
-			0-4	First scanline of cursor within character.
-			5	Turns Cursor off if set
-		*/
-		break;
-	case 0x0B:	/* Cursor End Register */
-		crtc(cursor_end)=val;
-		vga.draw.cursor.eline=val&0x1f;
-		vga.draw.cursor.delay=(val>>5)&0x3;
+	case 0x0a: // Cursor Start Register
+		crtc(cursor_start)    = val;
+		vga.draw.cursor.sline = val & 0x1f;
+		if (IS_VGA_ARCH) {
+			vga.draw.cursor.enabled = !(val & 0x20);
+		} else {
+			vga.draw.cursor.enabled = true;
+		}
 
-		/* 
-			0-4	Last scanline of cursor within character
-			5-6	Delay of cursor data in character clocks.
-		*/
+		// 0-4	First scanline of cursor within character.
+		// 5	Turns Cursor off if set.
 		break;
-	case 0x0C:	/* Start Address High Register */
-		crtc(start_address_high)=val;
-		vga.config.display_start=(vga.config.display_start & 0xFF00FF)| (val << 8);
-		/* 0-7  Upper 8 bits of the start address of the display buffer */
+
+	case 0x0b: // Cursor End Register
+		crtc(cursor_end)      = val;
+		vga.draw.cursor.eline = val & 0x1f;
+		vga.draw.cursor.delay = (val >> 5) & 0x3;
+
+		// 0-4	Last scanline of cursor within character.
+		// 5-6	Delay of cursor data in character clocks.
 		break;
-	case 0x0D:	/* Start Address Low Register */
-		crtc(start_address_low)=val;
-		vga.config.display_start=(vga.config.display_start & 0xFFFF00)| val;
-		/*	0-7	Lower 8 bits of the start address of the display buffer */
+
+	case 0x0c: // Start Address High Register
+		crtc(start_address_high) = val;
+		vga.config.display_start = (vga.config.display_start & 0xFF00FF) |
+		                           (val << 8);
+
+		// 0-7  Upper 8 bits of the start address of the display buffer.
 		break;
-	case 0x0E:	/*Cursor Location High Register */
-		crtc(cursor_location_high)=val;
-		vga.config.cursor_start&=0xff00ff;
-		vga.config.cursor_start|=val << 8;
-		/*	0-7  Upper 8 bits of the address of the cursor */
+
+	case 0x0d: // Start Address Low Register
+		crtc(start_address_low) = val;
+		vga.config.display_start = (vga.config.display_start & 0xFFFF00) | val;
+
+		//0-7	Lower 8 bits of the start address of the display buffer.
 		break;
-	case 0x0F:	/* Cursor Location Low Register */
-//TODO update cursor on screen
-		crtc(cursor_location_low)=val;
-		vga.config.cursor_start&=0xffff00;
-		vga.config.cursor_start|=val;
-		/*	0-7  Lower 8 bits of the address of the cursor */
+
+	case 0x0e: // Cursor Location High Register
+		crtc(cursor_location_high) = val;
+		vga.config.cursor_start &= 0xff00ff;
+		vga.config.cursor_start |= val << 8;
+
+		//0-7  Upper 8 bits of the address of the cursor.
 		break;
-	case 0x10:	/* Vertical Retrace Start Register */
-		crtc(vertical_retrace_start)=val;
-		/*
-			0-7	Lower 8 bits of Vertical Retrace Start. Vertical Retrace starts when
-			the line counter reaches this value. Bit 8 is found in 3d4h index 7
-			bit 2. Bit 9 is found in 3d4h index 7 bit 7.
-		*/
+
+	case 0x0f: // Cursor Location Low Register
+		// TODO update cursor on screen
+		crtc(cursor_location_low) = val;
+		vga.config.cursor_start &= 0xffff00;
+		vga.config.cursor_start |= val;
+
+		//0-7  Lower 8 bits of the address of the cursor.
 		break;
-	case 0x11:	/* Vertical Retrace End Register */
-		crtc(vertical_retrace_end)=val;
+
+	case 0x10: // Vertical Retrace Start Register
+		crtc(vertical_retrace_start) = val;
+		//
+		// 0-7	Lower 8 bits of Vertical Retrace Start. Vertical Retrace
+		//	    starts when the line counter reaches this value.
+		//
+		// Bit 8 is found in 3d4h index 7 bit 2.
+		// Bit 9 is found in 3d4h index 7 bit 7.
+		break;
+
+	case 0x11: // Vertical Retrace End Register
+		crtc(vertical_retrace_end) = val;
 
 		if (IS_EGAVGA_ARCH && !(val & 0x10)) {
-			vga.draw.vret_triggered=false;
-			if (GCC_UNLIKELY(machine==MCH_EGA)) PIC_DeActivateIRQ(9);
+			vga.draw.vret_triggered = false;
+			if (GCC_UNLIKELY(machine == MCH_EGA)) {
+				PIC_DeActivateIRQ(9);
+			}
 		}
-		if (IS_VGA_ARCH) crtc(read_only)=(val & 128)>0;
-		else crtc(read_only)=false;
-		/*
-			0-3	Vertical Retrace ends when the last 4 bits of the line counter equals
-				this value.
-			4	if clear Clears pending Vertical Interrupts.
-			5	Vertical Interrupts (IRQ 2) disabled if set. Can usually be left
-				disabled, but some systems (including PS/2) require it to be enabled.
-			6	If set selects 5 refresh cycles per scanline rather than 3.
-			7	Disables writing to registers 0-7 if set 3d4h index 7 bit 4 is not
-				affected by this bit.
-		*/
+		if (IS_VGA_ARCH) {
+			crtc(read_only) = (val & 128) > 0;
+		} else {
+			crtc(read_only) = false;
+		}
+
+		// 0-3	Vertical Retrace ends when the last 4 bits of the line counter
+		//      equals this value.
+		// 4	if clear Clears pending Vertical Interrupts.
+		// 5	Vertical Interrupts (IRQ 2) disabled if set. Can usually be
+		//      left disabled, but some systems (including PS/2) require it to
+		//      be enabled.
+		// 6	If set selects 5 refresh cycles per scanline rather than 3.
+		// 7	Disables writing to registers 0-7 if set 3d4h index 7 bit 4 is
+		//      not affected by this bit.
 		break;
-	case 0x12:	/* Vertical Display End Register */
-		if (val!=crtc(vertical_display_end)) {
-			if (abs(static_cast<int>((Bits)val-(Bits)crtc(vertical_display_end)))<3) {
-				// delay small vde changes a bit to avoid screen resizing
-				// if they are reverted in a short timeframe
+
+	case 0x12: // Vertical Display End Register
+		if (val != crtc(vertical_display_end)) {
+			if (abs(static_cast<int>(
+			            (Bits)val - (Bits)crtc(vertical_display_end))) <
+			    3) {
+				// delay small vde changes a bit to avoid screen
+				// resizing if they are reverted in a short
+				// timeframe
 				PIC_RemoveEvents(VGA_SetupDrawing);
-				vga.draw.resizing=false;
-				crtc(vertical_display_end)=val;
+				vga.draw.resizing          = false;
+				crtc(vertical_display_end) = val;
 				VGA_StartResizeAfter(150);
 			} else {
-				crtc(vertical_display_end)=val;
+				crtc(vertical_display_end) = val;
 				VGA_StartResize();
 			}
 		}
-		/*
-			0-7	Lower 8 bits of Vertical Display End. The display ends when the line
-				counter reaches this value. Bit 8 is found in 3d4h index 7 bit 1.
-			Bit 9 is found in 3d4h index 7 bit 6.
-		*/
+
+		// 0-7	Lower 8 bits of Vertical Display End. The display ends when
+		// 	    the line counter reaches this value.
+		//
+		// Bit 8 is found in 3d4h index 7 bit 1.
+		// Bit 9 is found in 3d4h index 7 bit 6.
 		break;
-	case 0x13:	/* Offset register */
-		crtc(offset)=val;
-		vga.config.scan_len&=0x300;
-		vga.config.scan_len|=val;
+
+	case 0x13: // Offset register
+		crtc(offset) = val;
+		vga.config.scan_len &= 0x300;
+		vga.config.scan_len |= val;
 		VGA_CheckScanLength();
-		/*
-			0-7	Number of bytes in a scanline / K. Where K is 2 for byte mode, 4 for
-				word mode and 8 for Double Word mode.
-		*/
+
+		// 0-7	Number of bytes in a scanline / K, where K is 2
+		//      for byte mode, 4 for word mode and 8 for Double Word mode.
 		break;
-	case 0x14:	/* Underline Location Register */
-		crtc(underline_location)=val;
+
+	case 0x14: // Underline Location Register
+		crtc(underline_location) = val;
 		if (IS_VGA_ARCH) {
-			//Byte,word,dword mode
-			if ( crtc(underline_location) & 0x20 )
+			// Byte,word,dword mode
+			if (crtc(underline_location) & 0x20) {
 				vga.config.addr_shift = 2;
-			else if (vga.crtc.mode_control.word_byte_mode_select)
+			} else if (vga.crtc.mode_control.word_byte_mode_select) {
 				vga.config.addr_shift = 0;
-			else
+			} else {
 				vga.config.addr_shift = 1;
+			}
 		} else {
 			vga.config.addr_shift = 1;
 		}
-		/*
-			0-4	Position of underline within Character cell.
-			5	If set memory address is only changed every fourth character clock.
-			6	Double Word mode addressing if set
-		*/
+
+		// 0-4	Position of underline within Character cell.
+		// 5	If set memory address is only changed every fourth character
+		// 		clock.
+		// 6	Double Word mode addressing if set.
 		break;
-	case 0x15:	/* Start Vertical Blank Register */
-		if (val!=crtc(start_vertical_blanking)) {
-			crtc(start_vertical_blanking)=val;
+
+	case 0x15: // Start Vertical Blank Register
+		if (val != crtc(start_vertical_blanking)) {
+			crtc(start_vertical_blanking) = val;
 			VGA_StartResize();
 		}
-		/*
-			0-7	Lower 8 bits of Vertical Blank Start. Vertical blanking starts when
-				the line counter reaches this value. Bit 8 is found in 3d4h index 7
-				bit 3.
-		*/
+
+		// 0-7	Lower 8 bits of Vertical Blank Start. Vertical blanking starts
+		//      when the line counter reaches this value.
+		//
+		// Bit 8 is found in 3d4h index 7 bit 3.
 		break;
-	case 0x16:	/*  End Vertical Blank Register */
-		if (val!=crtc(end_vertical_blanking)) {
-			crtc(end_vertical_blanking)=val;
+
+	case 0x16: //  End Vertical Blank Register
+		if (val != crtc(end_vertical_blanking)) {
+			crtc(end_vertical_blanking) = val;
 			VGA_StartResize();
 		}
-		/*
-			0-6	Vertical blanking stops when the lower 7 bits of the line counter
-				equals this field. Some SVGA chips uses all 8 bits!
-				IBM actually says bits 0-7.
-		*/
+
+		// 0-6	Vertical blanking stops when the lower 7 bits of
+		//      the line counter equals this field. Some SVGA chips uses all 8
+		//      bits! IBM actually says bits 0-7.
 		break;
 
 	case 0x17:
@@ -315,25 +381,29 @@ void vga_write_p3d5(io_port_t, io_val_t value, io_width_t)
 			vga.tandy.addr_mask  = ~0;
 			vga.tandy.line_shift = 0;
 		}
+
 		// Should we really need to do a determinemode here?
 		// VGA_DetermineMode();
 		break;
 
-	case 0x18:	/* Line Compare Register */
-		crtc(line_compare)=val;
-		vga.config.line_compare=(vga.config.line_compare & 0x700) | val;
-		/*
-			0-7	Lower 8 bits of the Line Compare. When the Line counter reaches this
-				value, the display address wraps to 0. Provides Split Screen
-				facilities. Bit 8 is found in 3d4h index 7 bit 4.
-				Bit 9 is found in 3d4h index 9 bit 6.
-		*/
+	case 0x18: // Line Compare Register
+		crtc(line_compare) = val;
+		vga.config.line_compare = (vga.config.line_compare & 0x700) | val;
+
+		// 0-7	Lower 8 bits of the Line Compare. When the Line
+		//      counter reaches this value, the display address wraps to 0.
+		//      Provides Split Screen facilities.
+		//
+		// Bit 8 is found in 3d4h index 7 bit 4.
+		// Bit 9 is found in 3d4h index 9 bit 6.
 		break;
+
 	default:
 		if (svga.write_p3d5) {
 			svga.write_p3d5(crtc(index), val, io_width_t::byte);
 		} else {
-			LOG(LOG_VGAMISC,LOG_NORMAL)("VGA:CRTC:Write to unknown index %X",crtc(index));
+			LOG(LOG_VGAMISC, LOG_NORMAL)
+			("VGA:CRTC:Write to unknown index %X", crtc(index));
 		}
 		break;
 	}

--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -1915,6 +1915,9 @@ ImageInfo setup_drawing()
 		vga.draw.address_line_total = vga.other.max_scanline + 1;
 	}
 
+	// We always start from disabled then set the flag to true later if needed
+	vga.draw.is_double_scanning = false;
+
 	const auto vga_timings = calculate_vga_timings();
 
 	if (is_vga_scan_doubling() && !(vga.mode == M_CGA2 || vga.mode == M_CGA4)) {
@@ -2109,7 +2112,9 @@ ImageInfo setup_drawing()
 		if (is_vga_scan_doubling()) {
 			video_mode.is_double_scanned_mode = true;
 
+			vga.draw.is_double_scanning = true;
 			vga.draw.address_line_total /= 2;
+
 			video_mode.height  = vert_end / 2;
 			double_height      = vga.draw.double_scanning_enabled;
 			forced_single_scan = !vga.draw.double_scanning_enabled;
@@ -2170,7 +2175,8 @@ ImageInfo setup_drawing()
 			forced_single_scan = !vga.draw.double_scanning_enabled;
 
 			if (vga.draw.double_scanning_enabled) {
-				render_height = video_mode.height * 2;
+				vga.draw.is_double_scanning = true;
+				render_height        = video_mode.height * 2;
 				rendered_double_scan = true;
 			} else {
 				vga.draw.address_line_total /= 2;
@@ -2265,6 +2271,7 @@ ImageInfo setup_drawing()
 				forced_single_scan = !vga.draw.double_scanning_enabled;
 
 				if (vga.draw.double_scanning_enabled) {
+					vga.draw.is_double_scanning = true;
 					render_height = video_mode.height * 2;
 					rendered_double_scan = true;
 				} else {


### PR DESCRIPTION
# Description

Fixes https://github.com/dosbox-staging/dosbox-staging/issues/3268

I made a simplification earlier in https://github.com/dosbox-staging/dosbox-staging/commit/97f73bf8c6737478837e273e38a5e5fcbe497c8a which was plain wrong. Important functionality was removed, my bad. This PR reverts that, plus I've also done some cleanup and some proactive improvement based on the DOSBox X code (untested as I don't know how to trigger that rather obscure path, but the legacy DOSBox version seemed to be quite broken, so this can only be better, in theory 😅).

Definitely review commit by commit.

While the issue I described in the reverted https://github.com/dosbox-staging/dosbox-staging/commit/97f73bf8c6737478837e273e38a5e5fcbe497c8a commit's comment is true, I overestimated its importance. It can only affect logging, that's the short of it. The worst that can happen is that 320x400 custom modes in some games get logged as 320x200 _if and only if_ the cycles setting is set too low (so low that the games are not really playable anymore), but the graphics appear correctly otherwise. It stands to reason that similar logging issues could happen for other custom modes too that need messing around with the Maximum Scan Line VGA register, but I could not find any other games apart from these 320x400 titles.

Given these are 486/Pentium-era 90s games and the logging issue only happens below a ~5k threshold or much lower (depending on the game), getting the logging correct in those cases is more like a "nice to have" than a strict requirement. Maybe I or someone else will figure out later how to do the logging correctly even in these edge cases, but it's a very minor issue I think.

## Related issues

https://github.com/dosbox-staging/dosbox-staging/issues/3268

https://github.com/dosbox-staging/dosbox-staging/pull/2528

https://github.com/dosbox-staging/dosbox-staging/commit/e7c596b26982e87f85cf3db8f4b4f392da3ac8e9

# Manual testing

The intro scroller in Legend of Kyriandia 1 is fixed.

Regression tested a few games I mentioned in https://github.com/dosbox-staging/dosbox-staging/commit/97f73bf8c6737478837e273e38a5e5fcbe497c8a. The outcome is that the 320x400 tweaked VGA mode indeed gets logged as 320x200 under a certain low cycles threshold (variable per game), but the graphics are otherwise displayed 100% correctly. **It's 100% a logging issue only.** Examples:

**Threat (1995)**
threshold for correct 320x400 logging: ~5200 cycles

**The Summoning (1992)**
threshold for correct 320x400 logging: ~4800 cycles

**Ravenloft: Strahd's Possession (1994)**
threshold for correct 320x400 logging: ~2500 cycles

Realistically, these games need well above 10k cycles, ideally ~25k which corresponds to the legendary 486DX2/66.


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

