### PR TITLE
Fix a couple of FPU emulation issues

### DIFF
--- a/include/fpu.h
+++ b/include/fpu.h
@@ -84,8 +84,10 @@ enum FPU_Round : uint8_t {
 
 struct FPU_rec {
 	FPU_Reg regs[9]         = {};
+#if !C_FPU_X86
 	int64_t regs_memcpy[9]  = {}; // for FILD/FIST 64-bit memcpy fix
 	bool use_regs_memcpy[9] = {};
+#endif
 	FPU_P_Reg p_regs[9]     = {};
 	FPU_Tag tags[9]         = {};
 	uint16_t cw             = 0;

--- a/src/cpu/core_dynrec/dyn_fpu.h
+++ b/src/cpu/core_dynrec/dyn_fpu.h
@@ -20,13 +20,11 @@
 
 #if C_FPU
 
-#include <math.h>
-#include <float.h>
-#include "cross.h"
-#include "mem.h"
-#include "fpu.h"
 #include "cpu.h"
-
+#include "cross.h"
+#include "fpu.h"
+#include "mem.h"
+#include <cmath>
 
 static void FPU_FDECSTP(){
 	TOP = (TOP - 1) & 7;
@@ -41,9 +39,11 @@ static void FPU_FNSTCW(PhysPt addr){
 }
 
 static void FPU_FFREE(Bitu st) {
-	fpu.tags[st]=TAG_Empty;
+	fpu.tags[st] = TAG_Empty;
+#if !C_FPU_X86
+	fpu.use_regs_memcpy[st] = false;
+#endif
 }
-
 
 #if C_FPU_X86
 #include "../../fpu/fpu_instructions_x86.h"

--- a/src/fpu/fpu.cpp
+++ b/src/fpu/fpu.cpp
@@ -20,12 +20,11 @@
 #include "dosbox.h"
 #if C_FPU
 
-#include <math.h>
-#include <float.h>
-#include "cross.h"
-#include "mem.h"
-#include "fpu.h"
 #include "cpu.h"
+#include "cross.h"
+#include "fpu.h"
+#include "mem.h"
+#include <cmath>
 
 FPU_rec fpu = {};
 
@@ -503,7 +502,10 @@ void FPU_ESC5_Normal(Bitu rm) {
 	Bitu sub=(rm & 7);
 	switch(group){
 	case 0x00: /* FFREE STi */
-		fpu.tags[STV(sub)]=TAG_Empty;
+		fpu.tags[STV(sub)] = TAG_Empty;
+#if !C_FPU_X86
+		fpu.use_regs_memcpy[STV(sub)] = false;
+#endif
 		break;
 	case 0x01: /* FXCH STi*/
 		FPU_FXCH(TOP,STV(sub));
@@ -621,7 +623,10 @@ void FPU_ESC7_Normal(Bitu rm) {
 	Bitu sub=(rm & 7);
 	switch (group){
 	case 0x00: /* FFREEP STi*/
-		fpu.tags[STV(sub)]=TAG_Empty;
+		fpu.tags[STV(sub)] = TAG_Empty;
+#if !C_FPU_X86
+		fpu.use_regs_memcpy[STV(sub)] = false;
+#endif
 		FPU_FPOP();
 		break;
 	case 0x01: /* FXCH STi*/


### PR DESCRIPTION
# Description

Since the memcpy trick fix for vertical bars is only required when `C_FPU_X86` is false, don't compile in the extra arrays and associated logic when they aren't needed.

There were also a couple of places where I had missed setting the `use_regs_memcpy[]` array element to `false` when the corresponding`fpu.tags[]` element is set to `TAG_Empty`, specifically with the `FFREE` instruction, which so far I've only seen used by `PERF_DOS`.

# Manual testing

I tested Carmageddon, Sunflower, and MCPDIAG on:

- macOS arm64, normal and dynamic cores
- macos x86-64, normal and dynamic cores
- Windows MSYS2 x64-86, normal and dynamic core

If anyone can run through the Linux builds for normal and dynamic core, that would be appreciated.

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [ ] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

