### PR TITLE
Detect a fatal build combination in Meson

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -183,6 +183,8 @@ if get_option('buildtype').startswith('debug')
             '-D_GLIBCXX_DEBUG_PEDANTIC=1',
             '-D_GLIBCXX_SANITIZE_VECTOR=1',
             '-D_LIBCPP_DEBUG=1',
+            '-D_LIBCPP_ENABLE_THREAD_SAFETY_ANNOTATIONS=1',
+            '-D_LIBCPP_ENABLE_HARDENED_MODE=1',
         ]
     endif
 endif

--- a/meson.build
+++ b/meson.build
@@ -140,6 +140,27 @@ else
     )
 endif
 
+# As of commit e73aaa57, overriding CXXFLAGS with -Os produces a binary that hangs
+# when using a relase build with GCC.
+#
+# CXXFLAGS="-Os" meson setup --buildtype=release --native-file=.github/meson/native-gcc.ini build
+#
+# This is most likely a GCC bug because the optimization level should not change
+# functionality. All other -O-levels work. Clang also handles this (replace
+# native-gcc.ini with native-clang.ini to test it).
+#
+if get_option('buildtype') == 'release' and cxx.get_id() == 'gcc'
+    cxxflags_env = run_command('sh', '-c', 'echo "$CXXFLAGS"', check: false)
+    if cxxflags_env.returncode() == 0 and cxxflags_env.stdout().contains('-Os')
+        error(
+            '\n\n',
+            'Overriding CXXFLAGS with the size-optimization flag, "-Os", when\n',
+            'performing a release build with GCC produces a binary that hangs.\n',
+            'Use the "minsize" buildtype instead.',
+        )
+    endif
+endif
+
 is_optimized_buildtype = (
     get_option('buildtype') in ['release', 'minsize', 'debugoptimized']
 )


### PR DESCRIPTION
# Description

Thanks to Milan P. Stanić from the Alpine packaging and test team for reporting that 0.81.0-rc0 hangs in their environment. 

As of commit e73aaa57, overriding `CXXFLAGS` with `-Os` produces a binary that hangs when using a release build type with GCC.

```shell
CXXFLAGS="-Os" meson setup --buildtype=release \
 --native-file=.github/meson/native-gcc.ini build
```

This is most likely a GCC bug because the optimization level should not change the binary's functionality. All other `-O`-levels work. Clang also handles this correctly, and can be confirmed by replacnig `native-gcc.ini` with `native-clang.ini`.

This also standardizes how we handle our extra warning flags in Meson.

## Related issues

# Manual testing

Tested all the `--buildtype`s with GCC and Clang.

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

