### PR TITLE
Remove obsolete check for forbidden paths on POSIX systems

### DIFF
--- a/include/cross.h
+++ b/include/cross.h
@@ -146,7 +146,9 @@ bool read_directory_first(dir_information* dirp, char* entry_name, bool& is_dire
 bool read_directory_next(dir_information* dirp, char* entry_name, bool& is_directory);
 void close_directory(dir_information* dirp);
 
-FILE *fopen_wrap(const char *path, const char *mode);
+bool is_path_allowed(const std_fs::path& path);
+
+FILE* fopen_wrap(const char* path, const char* mode);
 FILE *fopen_wrap_ro_fallback(const std::string &filename, bool &is_readonly);
 
 bool wild_match(const char *haystack, const char *needle);

--- a/include/cross.h
+++ b/include/cross.h
@@ -146,9 +146,6 @@ bool read_directory_first(dir_information* dirp, char* entry_name, bool& is_dire
 bool read_directory_next(dir_information* dirp, char* entry_name, bool& is_directory);
 void close_directory(dir_information* dirp);
 
-bool is_path_allowed(const std_fs::path& path);
-
-FILE* fopen_wrap(const char* path, const char* mode);
 FILE *fopen_wrap_ro_fallback(const std::string &filename, bool &is_readonly);
 
 bool wild_match(const char *haystack, const char *needle);

--- a/meson.build
+++ b/meson.build
@@ -465,10 +465,6 @@ if cxx.has_function(
     conf_data.set10('HAVE_PTHREAD_SETNAME_NP', true)
 endif
 
-if cc.has_function('realpath', prefix: '#include <stdlib.h>')
-    conf_data.set10('HAVE_REALPATH', true)
-endif
-
 # strnlen was originally a Linux-only function
 if cc.has_function('strnlen', prefix: '#include <string.h>')
     conf_data.set10('HAVE_STRNLEN', true)

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -202,9 +202,6 @@
 // Defined if function pthread_setname_np is available
 #mesondefine HAVE_PTHREAD_SETNAME_NP
 
-// Defined if function realpath is available
-#mesondefine HAVE_REALPATH
-
 // Defind if function setpriority is available
 #mesondefine HAVE_SETPRIORITY
 

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -25,7 +25,6 @@
 
 #include "bios.h"
 #include "bios_disk.h"
-#include "cross.h"
 #include "dos_inc.h"
 #include "string_utils.h"
 #include "support.h"

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -177,7 +177,7 @@ bool localDrive::FileOpen(DOS_File **file, char *name, uint32_t flags)
 	// RW access.  So check if this is the case:
 	if (!fhandle && flags & (OPEN_READWRITE | OPEN_WRITE)) {
 		// If yes, check if the file can be opened with Read-only access:
-		fhandle = fopen_wrap(newname, "rb");
+		fhandle = fopen(newname, "rb");
 		if (fhandle) {
 			if (!always_open_ro_files) {
 				fclose(fhandle);
@@ -243,7 +243,7 @@ FILE* localDrive::GetSystemFilePtr(const char* const name, const char* const typ
 	CROSS_FILENAME(newname);
 	dirCache.ExpandNameAndNormaliseCase(newname);
 
-	return fopen_wrap(newname,type);
+	return fopen(newname,type);
 }
 
 bool localDrive::GetSystemFilename(char* sysName, const char* const dosName)

--- a/src/dos/drive_overlay.cpp
+++ b/src/dos/drive_overlay.cpp
@@ -254,7 +254,7 @@ std::pair<FILE*, std_fs::path> Overlay_Drive::create_file_in_overlay(
 	                                    // Linux TODO
 	CROSS_FILENAME(newname);
 
-	FILE* f = fopen_wrap(newname,mode);
+	FILE* f = fopen(newname,mode);
 	//Check if a directories are part of the name:
 	const char *dir = strrchr(dos_filename, '\\');
 
@@ -263,7 +263,7 @@ std::pair<FILE*, std_fs::path> Overlay_Drive::create_file_in_overlay(
 		//ensure they exist, else make them in the overlay if they exist in the original....
 		Sync_leading_dirs(dos_filename);
 		//try again
-		f = fopen_wrap(newname,mode);
+		f = fopen(newname,mode);
 	}
 
 	return {f, newname};
@@ -496,7 +496,7 @@ bool Overlay_Drive::FileOpen(DOS_File * * file,char * name,uint32_t flags) {
 	safe_strcat(newname, name);
 	CROSS_FILENAME(newname);
 
-	FILE * hand = fopen_wrap(newname,type);
+	FILE * hand = fopen(newname,type);
 	bool fileopened = false;
 	if (hand) {
 		if (logoverlay) LOG_MSG("overlay file opened %s",newname);
@@ -967,7 +967,7 @@ bool Overlay_Drive::FileUnlink(char * name) {
 		}
 
 		//Do we have access?
-		FILE* file_writable = fopen_wrap(overlayname,"rb+");
+		FILE* file_writable = fopen(overlayname,"rb+");
 		if(!file_writable) {
 			DOS_SetError(DOSERR_ACCESS_DENIED);
 			return false;
@@ -1089,10 +1089,10 @@ void Overlay_Drive::add_special_file_to_disk(const char* dosname, const char* op
 	safe_strcpy(overlayname, overlaydir);
 	safe_strcat(overlayname, name.c_str());
 	CROSS_FILENAME(overlayname);
-	FILE* f = fopen_wrap(overlayname,"wb+");
+	FILE* f = fopen(overlayname,"wb+");
 	if (!f) {
 		Sync_leading_dirs(dosname);
-		f = fopen_wrap(overlayname,"wb+");
+		f = fopen(overlayname,"wb+");
 	}
 	if (!f) E_Exit("Failed creation of %s",overlayname);
 	char buf[5] = {'e','m','p','t','y'};
@@ -1284,7 +1284,7 @@ bool Overlay_Drive::Rename(char * oldname,char * newname) {
 		safe_strcat(newold, oldname);
 		CROSS_FILENAME(newold);
 		dirCache.ExpandNameAndNormaliseCase(newold);
-		FILE* o = fopen_wrap(newold,"rb");
+		FILE* o = fopen(newold,"rb");
 		if (!o) return false;
 		auto [n, path] = create_file_in_overlay(newname, "wb+");
 		if (!n) {

--- a/src/dos/program_boot.cpp
+++ b/src/dos/program_boot.cpp
@@ -27,7 +27,6 @@
 #include "bios_disk.h"
 #include "callback.h"
 #include "control.h"
-#include "cross.h"
 #include "dma.h"
 #include "drives.h"
 #include "fs_utils.h"
@@ -99,12 +98,12 @@ FILE* BOOT::getFSFile(const char* filename, uint32_t* ksize, uint32_t* bsize,
 		return tmpfile;
 	// File not found on mounted filesystem. Try regular filesystem
 	const auto filename_s = resolve_home(filename).string();
-	tmpfile = fopen_wrap(filename_s.c_str(), "rb+");
+	tmpfile = fopen(filename_s.c_str(), "rb+");
 
 	auto fseek_in_tmpfile = make_check_fseek_func("BOOT", "image", filename);
 
 	if (!tmpfile) {
-		if ((tmpfile = fopen_wrap(filename_s.c_str(), "rb"))) {
+		if ((tmpfile = fopen(filename_s.c_str(), "rb"))) {
 			// File exists; So can't be opened in correct mode =>
 			// error 2
 			//				fclose(tmpfile);

--- a/src/hardware/reelmagic/driver.cpp
+++ b/src/hardware/reelmagic/driver.cpp
@@ -314,8 +314,6 @@ public:
 		assert(hostFilepath);
 		_fileName = std::string("HOST:") + hostFilepath;
 
-		// not using fopen_wrap() as this class is really intended for
-		// debug...
 		_fp = fopen(hostFilepath, "rb");
 		if (!_fp) {
 			throw RMException("Host File: fopen(\"%s\")failed: %s",

--- a/src/misc/fs_utils_posix.cpp
+++ b/src/misc/fs_utils_posix.cpp
@@ -299,13 +299,16 @@ static bool set_xattr([[maybe_unused]] const int file_descriptor,
 FILE* local_drive_create_file(const std_fs::path& path,
                               const FatAttributeFlags attributes)
 {
-	FILE* file_pointer         = nullptr;
-	const auto file_descriptor = open(path.c_str(),
-	                                  O_CREAT | O_RDWR | O_TRUNC,
-	                                  PermissionsRW);
-	if (file_descriptor != -1) {
-		set_xattr(file_descriptor, attributes);
-		file_pointer = fdopen(file_descriptor, "wb+");
+	FILE* file_pointer = nullptr;
+
+	if (is_path_allowed(path)) {
+		const auto file_descriptor = open(path.c_str(),
+		                                  O_CREAT | O_RDWR | O_TRUNC,
+		                                  PermissionsRW);
+		if (file_descriptor != -1) {
+			set_xattr(file_descriptor, attributes);
+			file_pointer = fdopen(file_descriptor, "wb+");
+		}
 	}
 
 	return file_pointer;

--- a/src/misc/fs_utils_posix.cpp
+++ b/src/misc/fs_utils_posix.cpp
@@ -35,7 +35,6 @@
 #include <sys/xattr.h>
 #endif
 
-#include "cross.h"
 #include "dos_inc.h"
 #include "logging.h"
 #include "string_utils.h"
@@ -301,14 +300,12 @@ FILE* local_drive_create_file(const std_fs::path& path,
 {
 	FILE* file_pointer = nullptr;
 
-	if (is_path_allowed(path)) {
-		const auto file_descriptor = open(path.c_str(),
-		                                  O_CREAT | O_RDWR | O_TRUNC,
-		                                  PermissionsRW);
-		if (file_descriptor != -1) {
-			set_xattr(file_descriptor, attributes);
-			file_pointer = fdopen(file_descriptor, "wb+");
-		}
+	const auto file_descriptor = open(path.c_str(),
+	                                  O_CREAT | O_RDWR | O_TRUNC,
+	                                  PermissionsRW);
+	if (file_descriptor != -1) {
+		set_xattr(file_descriptor, attributes);
+		file_pointer = fdopen(file_descriptor, "wb+");
 	}
 
 	return file_pointer;

--- a/src/misc/fs_utils_win32.cpp
+++ b/src/misc/fs_utils_win32.cpp
@@ -72,7 +72,7 @@ FILE* local_drive_create_file(const std_fs::path& path,
 	// game was producing FILE ERROR - see the issue:
 	// https://github.com/dosbox-staging/dosbox-staging/issues/3262
 
-	FILE* file_pointer = fopen_wrap(path.string().c_str(), "wb+");
+	FILE* file_pointer = fopen(path.string().c_str(), "wb+");
 	if (file_pointer) {
 		if (!SetFileAttributesW(path.c_str(), attributes._data)) {
 			fclose(file_pointer);


### PR DESCRIPTION
# Description

DOSBox contains code that prevents accessing files/directories within the `/proc` filesystem on certain Unix-like OS'es; it is realized by `fopen_wrap`, which does the checks and calls `fopen` if everything is OK. 

~~To support file attributes on POSIX systems, creating new files is now realized in a different way (so that we can use extended attributes), which causes the checks to be omitted. This PR restores the checks when creating new files.~~

It was decided to remove these checks, as they are considered incomplete (no check for `/sys`, for example) and not needed (we have a permission system, and DOSBox Staging is not supposed to be run as root).


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

