### PR TITLE
Use C++ system headers

### DIFF
--- a/src/cpu/callback.cpp
+++ b/src/cpu/callback.cpp
@@ -17,9 +17,9 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
+#include <cstdlib>
+#include <cstring>
 #include <limits>
-#include <stdlib.h>
-#include <string.h>
 #include <string>
 
 #include "dosbox.h"

--- a/src/cpu/core_dyn_x86.cpp
+++ b/src/cpu/core_dyn_x86.cpp
@@ -36,7 +36,7 @@
 #if defined(HAVE_MPROTECT) || defined(HAVE_MMAP)
 #include <sys/mman.h>
 
-#include <limits.h>
+#include <climits>
 
 #endif // HAVE_MPROTECT
 

--- a/src/cpu/core_dyn_x86/dyn_fpu.h
+++ b/src/cpu/core_dyn_x86/dyn_fpu.h
@@ -23,13 +23,12 @@
 
 #if C_FPU
 
-#include <math.h>
-#include <float.h>
-#include "cross.h"
-#include "mem.h"
-#include "fpu.h"
 #include "cpu.h"
-
+#include "cross.h"
+#include "fpu.h"
+#include "mem.h"
+#include <cfloat>
+#include <cmath>
 
 static void FPU_FDECSTP(){
 	TOP = (TOP - 1) & 7;

--- a/src/cpu/core_dynrec.cpp
+++ b/src/cpu/core_dynrec.cpp
@@ -39,7 +39,7 @@
 #if defined(HAVE_MPROTECT) || defined(HAVE_MMAP)
 #include <sys/mman.h>
 
-#include <limits.h>
+#include <climits>
 
 #endif // HAVE_MPROTECT
 

--- a/src/cpu/core_prefetch.cpp
+++ b/src/cpu/core_prefetch.cpp
@@ -16,8 +16,7 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-
-#include <stdio.h>
+#include <cstdio>
 
 #include "dosbox.h"
 #include "mem.h"

--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -19,9 +19,9 @@
 
 #include "cpu.h"
 
-#include <assert.h>
+#include <cassert>
+#include <cstddef>
 #include <sstream>
-#include <stddef.h>
 
 #include "memory.h"
 #include "debug.h"

--- a/src/debug/debug.cpp
+++ b/src/debug/debug.cpp
@@ -21,14 +21,14 @@
 
 #if C_DEBUG
 
-#include <string.h>
-#include <list>
-#include <vector>
-#include <ctype.h>
+#include <cctype>
+#include <cstring>
 #include <fstream>
 #include <iomanip>
-#include <string>
+#include <list>
 #include <sstream>
+#include <string>
+#include <vector>
 using namespace std;
 
 #include "debug.h"

--- a/src/debug/debug_disasm.cpp
+++ b/src/debug/debug_disasm.cpp
@@ -64,11 +64,11 @@ Any comments/updates/bug reports to:
 */
 #include "dosbox.h"
 #if C_DEBUG
-#include <stdio.h>
-#include <string.h>
-#include <stdarg.h>
-#include <stdlib.h>
 #include "mem.h"
+#include <cstdarg>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 
 typedef uint8_t  UINT8;
 typedef uint16_t UINT16;

--- a/src/debug/debug_gui.cpp
+++ b/src/debug/debug_gui.cpp
@@ -21,11 +21,11 @@
 
 #if C_DEBUG
 #include "control.h"
-#include <stdlib.h>
-#include <stdarg.h>
-#include <stdio.h>
+#include <cstdarg>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 #include <curses.h>
-#include <string.h>
 
 #include "cross.h"
 #include "string_utils.h"

--- a/src/debug/debug_win32.cpp
+++ b/src/debug/debug_win32.cpp
@@ -20,9 +20,9 @@
 #if C_DEBUG
 #ifdef WIN32
 
+#include <cstdarg>
+#include <cstdio>
 #include <windows.h>
-#include <stdio.h>
-#include <stdarg.h>
 
 #ifndef min
 #define min(a,b) ((a)<(b)?(a):(b))

--- a/src/dos/cdrom_ioctl_linux.cpp
+++ b/src/dos/cdrom_ioctl_linux.cpp
@@ -16,8 +16,8 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-#include <assert.h>
-#include <string.h>
+#include <cassert>
+#include <cstring>
 
 #include "cdrom.h"
 #include "channel_names.h"

--- a/src/dos/dos_devices.cpp
+++ b/src/dos/dos_devices.cpp
@@ -19,7 +19,7 @@
 
 #include "dos_system.h"
 
-#include <string.h>
+#include <cstring>
 
 #include "dosbox.h"
 #include "callback.h"

--- a/src/dos/dos_execute.cpp
+++ b/src/dos/dos_execute.cpp
@@ -19,8 +19,8 @@
 
 #include "dosbox.h"
 
-#include <string.h>
-#include <ctype.h>
+#include <cctype>
+#include <cstring>
 
 #include "callback.h"
 #include "cpu.h"

--- a/src/dos/dos_files.cpp
+++ b/src/dos/dos_files.cpp
@@ -20,11 +20,11 @@
 #include "dos_inc.h"
 
 #include <array>
+#include <cctype>
 #include <climits>
-#include <ctype.h>
-#include <stdlib.h>
-#include <string.h>
-#include <time.h>
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
 
 #include "dosbox.h"
 #include "bios.h"

--- a/src/dos/dos_ioctl.cpp
+++ b/src/dos/dos_ioctl.cpp
@@ -17,13 +17,12 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-
-#include <string.h>
-#include "dosbox.h"
 #include "callback.h"
+#include "dos_inc.h"
+#include "dosbox.h"
 #include "mem.h"
 #include "regs.h"
-#include "dos_inc.h"
+#include <cstring>
 
 bool DOS_IOCTL(void) {
 //	LOG(LOG_IOCTL,LOG_WARN)("%X %X %X %X",reg_ax,reg_bx,reg_cx,reg_dx);

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -18,10 +18,10 @@
 
 #include "drives.h"
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <time.h>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
 
 #include "bios.h"
 #include "bios_disk.h"

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -27,10 +27,10 @@
 #include <cerrno>
 #include <climits>
 #include <cstdio>
+#include <cstdlib>
+#include <cstring>
 #include <ctime>
 #include <limits>
-#include <stdlib.h>
-#include <string.h>
 #include <sys/types.h>
 
 #ifdef _MSC_VER

--- a/src/dos/drive_overlay.cpp
+++ b/src/dos/drive_overlay.cpp
@@ -19,14 +19,14 @@
 #include "drives.h"
 
 #include <algorithm>
+#include <cerrno>
 #include <cinttypes>
-#include <vector>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
 #include <string>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <time.h>
-#include <errno.h>
+#include <vector>
 
 #include "dos_inc.h"
 #include "string_utils.h"

--- a/src/dos/drive_virtual.cpp
+++ b/src/dos/drive_virtual.cpp
@@ -19,10 +19,10 @@
 
 #include "drives.h"
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <time.h>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
 
 #include "cross.h"
 #include "dos_inc.h"

--- a/src/dos/program_biostest.cpp
+++ b/src/dos/program_biostest.cpp
@@ -23,8 +23,8 @@
 
 #if C_DEBUG
 
-#include <stdio.h>
-#include <string.h>
+#include <cstdio>
+#include <cstring>
 
 #include <string>
 

--- a/src/dos/program_boot.cpp
+++ b/src/dos/program_boot.cpp
@@ -21,8 +21,8 @@
 
 #include "program_boot.h"
 
+#include <cstdio>
 #include <limits>
-#include <stdio.h>
 
 #include "bios_disk.h"
 #include "callback.h"

--- a/src/dos/program_loadrom.cpp
+++ b/src/dos/program_loadrom.cpp
@@ -23,7 +23,7 @@
 
 #include "dosbox.h"
 
-#include <stdio.h>
+#include <cstdio>
 
 #include "callback.h"
 #include "drives.h"

--- a/src/gui/render_scalers.cpp
+++ b/src/gui/render_scalers.cpp
@@ -24,7 +24,7 @@
 
 #include "dosbox.h"
 #include "render.h"
-#include <string.h>
+#include <cstring>
 
 uint8_t Scaler_Aspect[SCALER_MAXHEIGHT]        = {};
 uint16_t Scaler_ChangedLines[SCALER_MAXHEIGHT] = {};

--- a/src/hardware/dma.cpp
+++ b/src/hardware/dma.cpp
@@ -20,7 +20,7 @@
 #include "dosbox.h"
 
 #include <algorithm>
-#include <string.h>
+#include <cstring>
 #include <memory>
 
 #include "dma.h"

--- a/src/hardware/ipxserver.cpp
+++ b/src/hardware/ipxserver.cpp
@@ -20,11 +20,11 @@
 
 #if C_IPX
 
+#include "ipx.h"
 #include "ipxserver.h"
 #include "timer.h"
-#include <stdlib.h>
-#include <string.h>
-#include "ipx.h"
+#include <cstdlib>
+#include <cstring>
 
 constexpr int UDP_UNICAST = -1; // SDLNet magic number
 

--- a/src/hardware/joystick.cpp
+++ b/src/hardware/joystick.cpp
@@ -19,8 +19,8 @@
 #include "joystick.h"
 
 #include <cfloat>
-#include <string.h>
-#include <math.h>
+#include <cmath>
+#include <cstring>
 
 #include "control.h"
 #include "inout.h"

--- a/src/hardware/memory.cpp
+++ b/src/hardware/memory.cpp
@@ -19,7 +19,7 @@
 
 #include "mem.h"
 
-#include <string.h>
+#include <cstring>
 
 #include "inout.h"
 #include "paging.h"

--- a/src/hardware/mpu401.cpp
+++ b/src/hardware/mpu401.cpp
@@ -18,7 +18,7 @@
 
 #include "dosbox.h"
 
-#include <string.h>
+#include <cstring>
 
 #include "cpu.h"
 #include "inout.h"

--- a/src/hardware/ps1audio.cpp
+++ b/src/hardware/ps1audio.cpp
@@ -23,9 +23,9 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cstring>
 #include <memory>
 #include <queue>
-#include <string.h>
 
 #include "channel_names.h"
 #include "control.h"

--- a/src/hardware/serialport/libserial.cpp
+++ b/src/hardware/serialport/libserial.cpp
@@ -24,7 +24,7 @@
 // clang-format off
 // 'windows.h' must be included first, otherwise we'll get compilation errors
 #include <windows.h>
-#include <stdio.h>
+#include <cstdio>
 // clang-format on
 
 #include "string_utils.h"
@@ -264,8 +264,8 @@ bool SERIAL_setCommParameters(COMPORT port,
 
 #include "logging.h"
 
-#include <string.h> // safe_strlen
-#include <stdlib.h>
+#include <cstdlib>
+#include <cstring> // safe_strlen
 
 #include <termios.h>
 #include <unistd.h>
@@ -274,9 +274,9 @@ bool SERIAL_setCommParameters(COMPORT port,
 #include <sys/stat.h>
 #include <sys/ioctl.h>
 
-#include <errno.h>
+#include <cerrno>
+#include <cstdio> // sprinf
 #include <fcntl.h>
-#include <stdio.h> // sprinf
 
 struct _COMPORT {
 	int porthandle;

--- a/src/hardware/serialport/misc_util.h
+++ b/src/hardware/serialport/misc_util.h
@@ -37,12 +37,12 @@
 #elif defined HAVE_STDLIB_H && defined HAVE_SYS_TYPES_H && defined HAVE_SYS_SOCKET_H && defined HAVE_NETINET_IN_H
  #define NATIVESOCKETS
  #define SOCKET int
- #include <stdio.h> //darwin
- #include <stdlib.h> //darwin
- #include <sys/types.h>
- #include <sys/socket.h>
- #include <netinet/in.h>
- //socklen_t should be handled by configure
+#include <cstdio>  //darwin
+#include <cstdlib> //darwin
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+// socklen_t should be handled by configure
 #endif
 
 // Using a non-blocking connection routine really should

--- a/src/hardware/serialport/serialport.cpp
+++ b/src/hardware/serialport/serialport.cpp
@@ -20,9 +20,9 @@
 #include "dosbox.h"
 
 #include <algorithm>
+#include <cctype>
 #include <cstdarg>
-#include <ctype.h>
-#include <string.h>
+#include <cstring>
 #include <tuple>
 
 #include "../../capture/capture.h"

--- a/src/hardware/serialport/softmodem.cpp
+++ b/src/hardware/serialport/softmodem.cpp
@@ -20,12 +20,12 @@
 
 #if C_MODEM
 
-#include <ctype.h>
-#include <stdlib.h>
-#include <string.h>
-#include <utility>
+#include <cctype>
+#include <cstdlib>
+#include <cstring>
 #include <fstream>
 #include <sstream>
+#include <utility>
 
 #include "string_utils.h"
 #include "serialport.h"

--- a/src/hardware/vga_memory.cpp
+++ b/src/hardware/vga_memory.cpp
@@ -21,8 +21,8 @@
 
 #include "dosbox.h"
 
-#include <stdlib.h>
-#include <string.h>
+#include <cstdlib>
+#include <cstring>
 #include <vector>
 
 #include "inout.h"

--- a/src/hardware/vga_misc.cpp
+++ b/src/hardware/vga_misc.cpp
@@ -23,7 +23,7 @@
 #include "inout.h"
 #include "pic.h"
 #include "vga.h"
-#include <math.h>
+#include <cmath>
 
 void vga_write_p3d4(io_port_t port, io_val_t value, io_width_t);
 uint8_t vga_read_p3d4(io_port_t port, io_width_t);

--- a/src/hardware/vga_xga.cpp
+++ b/src/hardware/vga_xga.cpp
@@ -22,9 +22,9 @@
 #include "dosbox.h"
 
 #include <cassert>
-#include <math.h>
-#include <stdio.h>
-#include <string.h>
+#include <cmath>
+#include <cstdio>
+#include <cstring>
 
 #include "bitops.h"
 #include "callback.h"

--- a/src/ints/bios.cpp
+++ b/src/ints/bios.cpp
@@ -33,8 +33,8 @@
 #include "serialport.h"
 #include "setup.h"
 
+#include <ctime>
 #include <memory>
-#include <time.h>
 
 // Constants
 constexpr uint32_t BiosMachineSignatureAddress = 0xfffff;

--- a/src/ints/int10_vesa.cpp
+++ b/src/ints/int10_vesa.cpp
@@ -19,8 +19,8 @@
 
 #include "int10.h"
 
-#include <string.h>
-#include <stddef.h>
+#include <cstddef>
+#include <cstring>
 
 #include "callback.h"
 #include "dos_inc.h"

--- a/src/ints/xms.cpp
+++ b/src/ints/xms.cpp
@@ -32,9 +32,9 @@
 #include "setup.h"
 #include "support.h"
 
-#include <stddef.h>
-#include <stdlib.h>
-#include <string.h>
+#include <cstddef>
+#include <cstdlib>
+#include <cstring>
 
 CHECK_NARROWING();
 

--- a/src/misc/cross.cpp
+++ b/src/misc/cross.cpp
@@ -22,9 +22,9 @@
 #include "cross.h"
 
 #include <cerrno>
+#include <climits>
 #include <clocale>
-#include <limits.h>
-#include <stdlib.h>
+#include <cstdlib>
 #include <string>
 #include <sys/types.h>
 #include <unistd.h>

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -19,12 +19,12 @@
 
 #include "shell.h"
 
+#include <cstdarg>
+#include <cstdlib>
+#include <cstring>
 #include <fstream>
 #include <list>
 #include <memory>
-#include <stdarg.h>
-#include <stdlib.h>
-#include <string.h>
 
 #include "../dos/program_more_output.h"
 #include "../dos/program_setver.h"


### PR DESCRIPTION
# Description

A long-overdue chore, I went and replaced the old C library .h files with the C++ equivalents.

I left `src/libs` alone for now, and the reelmagic `mgeg_decoder.h` as well (open to discussion).

As an interesting note, the C++ headers provide additional functionality in some cases. For example, Apple's Xcode 15.1 `ctime` provides the following:

```cpp
// TODO: Remove once rdar://101515782 is resolved
#ifdef _LIBCPP_ON_SEP
inline size_t strftime(char *, size_t, const char *, const struct tm *) { return 0; }
#endif
```

`cstring` provides:

```cpp
inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 size_t __constexpr_strlen(const char* __str) {
  // GCC currently doesn't support __builtin_strlen for heap-allocated memory during constant evaluation.
  // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=70816
#ifdef _LIBCPP_COMPILER_GCC
  if (__libcpp_is_constant_evaluated()) {
    size_t __i = 0;
    for (; __str[__i] != '\0'; ++__i)
      ;
    return __i;
  }
#endif
  return __builtin_strlen(__str);
}
```

# Manual testing

Ran the build artifacts for:

- macOS x86-64
- macOS arm64
- Windows MSYS2 x86-64

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

