### PR TITLE
Initial attempt to add Lua to the DOSBOX debugger

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -992,6 +992,15 @@ if get_option('use_fluidsynth')
 endif
 summary('FluidSynth support', fluid_dep.found())
 
+# lua
+lua_dep = dependency(
+    'lua',
+    version: ['>= 5.4.6', '< 5.5'],
+    default_options: default_wrap_options,
+    static: true,
+    include_type: 'system',
+)
+
 # mt32emu
 mt32emu_dep = optional_dep
 if get_option('use_mt32emu')
@@ -1246,6 +1255,7 @@ third_party_deps = [
     tracy_dep,
     libwhereami_dep,
     libtalchorus_dep,
+    lua_dep,
 ]
 
 if conf_data.get('C_MANYMOUSE') != 0

--- a/src/debug/debug_lua.cpp
+++ b/src/debug/debug_lua.cpp
@@ -1,0 +1,241 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2023-2023  The DOSBox Staging Team
+ *  Copyright (C) 2002-2021  The DOSBox Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#include "dosbox.h"
+
+#include <utility>
+
+#include "debug_lua.h"
+
+#include "lua.hpp"
+
+namespace {
+
+using LuaStatePtr = std::unique_ptr<lua_State, decltype(&lua_close)>;
+
+// Creates a fresh LuaStatePtr, or aborts if it fails.
+LuaStatePtr CreateRawLuaState()
+{
+	auto lua_state = LuaStatePtr(luaL_newstate(), lua_close);
+	if (!lua_state) {
+		ABORT_F("Could not allocate memory for lua state");
+	}
+	return lua_state;
+}
+
+const char* LuaStringViewReader(lua_State* lua_state, void* data, size_t* size)
+{
+	(void)lua_state; // unused
+	auto* view = static_cast<std::string_view*>(data);
+	if (view->empty()) {
+		*size = 0;
+		return nullptr;
+	} else {
+		*size               = view->size();
+		auto* returned_text = view->data();
+		// Set view to the empty stringview so that we correctly
+		// terminate the reader.
+		*view = std::string_view();
+		return returned_text;
+	}
+}
+
+std::string_view Lua_PushStringView(lua_State* lua_state, std::string_view view)
+{
+	auto* new_data = lua_pushlstring(lua_state, view.data(), view.size());
+	return std::string_view(new_data, view.size());
+}
+
+std::string_view Lua_ToStringView(lua_State* lua_state, int index)
+{
+    size_t size;
+    auto* data = lua_tolstring(lua_state, index, &size);
+    return std::string_view(data, size);
+}
+
+// Creates a new userdata on the lua stack, and returns a pointer to the newly
+// constructed object. Takes arguments similar to std::make_unique<T>, as an
+// addition to the lua state and the nuvalue argument.
+//
+// Returns a pointer to the newly constructed object. This object is owned by
+// the Lua interpreter. It will be destroyed when the variable is garbage
+// collected, or the state is closed.
+template <class T, class... Args>
+T* Lua_NewUserData(lua_State* lua_state, int nuvalue, Args&&... args)
+{
+	// Allocate space for storage of the object
+	void* storage = lua_newuserdatauv(lua_state, sizeof(T), nuvalue);
+	T* ptr        = new (storage) T(std::forward<Args>(args)...);
+
+	if constexpr (!std::is_trivially_destructible_v<T>) {
+		// We need to set the value's metatable so that it can be
+		// deallocated.
+		lua_createtable(lua_state, 0, 1);
+		lua_pushcfunction(lua_state, [](lua_State* lua_state) {
+			// Get the pointer to the object from the userdata
+			auto* storage = static_cast<T*>(lua_touserdata(lua_state, 1));
+			// Call the destructor
+			storage->~T();
+			return 0;
+		});
+		lua_setfield(lua_state, -2, "__gc");
+		lua_setmetatable(lua_state, -2);
+	}
+
+	return ptr;
+}
+
+template <class T>
+T* Lua_GetUserData(lua_State* lua_state, int index)
+{
+	return static_cast<T*>(lua_touserdata(lua_state, index));
+}
+
+class LuaInterpreterImpl : public LuaInterpreter {
+public:
+	static constexpr std::string_view kThisRegistryKey = "_dosbox_interpreter";
+
+	explicit LuaInterpreterImpl(LuaDebugInterface* debug_interface,
+	                            LuaStatePtr lua_state)
+	        : debug_interface_(debug_interface),
+	          lua_state_(std::move(lua_state))
+	{}
+
+	LuaInterpreterImpl(const LuaInterpreterImpl&)            = delete;
+	LuaInterpreterImpl& operator=(const LuaInterpreterImpl&) = delete;
+
+	// Do initial setup of the lua state. This will be called once after
+	// construction. Returns false if the lua state could not be initialized.
+	bool InitLuaState()
+	{
+		// Add this interpreter object to the registry, so it can be
+		// accessed by the lua state.
+		Lua_PushStringView(lua_state_.get(), kThisRegistryKey);
+		Lua_NewUserData<LuaInterpreterImpl*>(lua_state_.get(), 0, this);
+		lua_settable(lua_state_.get(), LUA_REGISTRYINDEX);
+
+        // Register the interpreter functions
+        RegisterInterpreterCall("print", &LuaInterpreterImpl::LM_PrintString);
+
+		return true;
+	}
+
+	bool RunCommand(std::string_view command) override
+	{
+		auto result = lua_load(lua_state_.get(),
+		                       LuaStringViewReader,
+		                       &command,
+		                       "<debugger command>",
+		                       "t");
+		switch (result) {
+		case LUA_OK: break;
+		case LUA_ERRSYNTAX:
+			debug_interface_->WriteToConsole("Syntax error\n");
+			return false;
+		case LUA_ERRMEM:
+			debug_interface_->WriteToConsole("Memory allocation error\n");
+			return false;
+		case LUA_ERRRUN:
+			debug_interface_->WriteToConsole(
+			        "Error during garbage collection\n");
+			return false;
+		case LUA_ERRERR:
+			debug_interface_->WriteToConsole("Recursive error\n");
+			return false;
+		}
+
+		// The command was loaded, and should be a function on top of
+		// the lua stack. Call it.
+		lua_pcall(lua_state_.get(), 0, 0, 0);
+		return false;
+	}
+
+private:
+    // A pointer-to-member-function that can be registered and called from Lua.
+	using LuaMethod = int (LuaInterpreterImpl::*)(lua_State* lua_state);
+
+	static int InterpreterCall(lua_State* lua_state)
+	{
+		auto* interpreter = *Lua_GetUserData<LuaInterpreterImpl*>(
+		        lua_state, lua_upvalueindex(1));
+		auto method = *Lua_GetUserData<LuaMethod>(lua_state,
+		                                          lua_upvalueindex(2));
+		return (interpreter->*method)(lua_state);
+	}
+
+	static void PushInterpreter(lua_State* lua_state)
+	{
+		Lua_PushStringView(lua_state, kThisRegistryKey);
+		lua_gettable(lua_state, LUA_REGISTRYINDEX);
+	}
+
+    // Pushes a function onto the lua stack that will call the given method. That method must
+    // be of the
+	void PushInterpreterCall(LuaMethod lua_method)
+	{
+		// Upvalues:
+		// 1 - The interpreter object
+		// 2 - The method to call
+		PushInterpreter(lua_state_.get());
+		Lua_NewUserData<LuaMethod>(lua_state_.get(), 0, lua_method);
+		lua_pushcclosure(lua_state_.get(), &InterpreterCall, 2);
+	}
+
+	void RegisterInterpreterCall(const char* global_name, LuaMethod lua_method)
+	{
+		PushInterpreterCall(lua_method);
+		lua_setglobal(lua_state_.get(), global_name);
+	}
+
+    // Lua methods
+    int LM_PrintString(lua_State* lua_state)
+    {
+        if (lua_gettop(lua_state) != 1) {
+            debug_interface_->WriteToConsole("print() takes exactly one argument\n");
+            return 0;
+        }
+
+        auto text = Lua_ToStringView(lua_state, 1);
+        if (!text.data()) {
+            debug_interface_->WriteToConsole("print() argument is not a string\n");
+            return 0;
+        }
+
+        debug_interface_->WriteToConsole(text);
+        return 0;
+    }
+
+	LuaDebugInterface* debug_interface_;
+	LuaStatePtr lua_state_;
+};
+
+} // namespace
+
+std::unique_ptr<LuaInterpreter> LuaInterpreter::Create(LuaDebugInterface* debug_interface)
+{
+    auto interpreter = std::make_unique<LuaInterpreterImpl>(debug_interface,
+                                                            CreateRawLuaState());
+    if (!interpreter->InitLuaState()) {
+        ABORT_F("Unable to initialize Lua interpreter");
+    }
+
+	return interpreter;
+}

--- a/src/debug/debug_lua.h
+++ b/src/debug/debug_lua.h
@@ -1,0 +1,40 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2023-2023  The DOSBox Staging Team
+ *  Copyright (C) 2002-2021  The DOSBox Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#include <memory>
+#include <string_view>
+
+// A class providing Lua with an API into the debugger needed to implement its own library.
+class LuaDebugInterface {
+public:
+    virtual ~LuaDebugInterface() = default;
+    virtual void WriteToConsole(std::string_view text) = 0;
+};
+
+class LuaInterpreter
+{
+public:
+    static std::unique_ptr<LuaInterpreter> Create(LuaDebugInterface* debug_interface);
+
+    virtual ~LuaInterpreter() = default;
+
+    virtual bool RunCommand(std::string_view command) = 0;
+};

--- a/src/debug/meson.build
+++ b/src/debug/meson.build
@@ -2,6 +2,7 @@ libdebug_sources = files(
     'debug.cpp',
     'debug_disasm.cpp',
     'debug_gui.cpp',
+    'debug_lua.cpp',
 )
 
 libdebug = static_library(
@@ -14,6 +15,7 @@ libdebug = static_library(
         ghc_dep,
         libiir_dep,
         libloguru_dep,
+        lua_dep,
     ],
     cpp_args: warnings,
 )

--- a/subprojects/lua.wrap
+++ b/subprojects/lua.wrap
@@ -1,0 +1,14 @@
+[wrap-file]
+directory = lua-5.4.6
+source_url = https://www.lua.org/ftp/lua-5.4.6.tar.gz
+source_filename = lua-5.4.6.tar.gz
+source_hash = 7d5ea1b9cb6aa0b59ca3dde1c6adcb57ef83a1ba8e5432c0ecd06bf439b3ad88
+patch_filename = lua_5.4.6-4_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/lua_5.4.6-4/get_patch
+patch_hash = b5a8c9b3673fbe58afaf842041bc9551f1f742c363fd3be8d47db2e6a483b54c
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/lua_5.4.6-4/lua-5.4.6.tar.gz
+wrapdb_version = 5.4.6-4
+
+[provide]
+lua-5.4 = lua_dep
+lua = lua_dep

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -9,6 +9,7 @@
         "iir1",
         "libmt32emu",
         "libpng",
+        "lua",
         "opusfile",
         "sdl2",
         "sdl2-image",


### PR DESCRIPTION


# Description

A draft PR for review to show one approach to adding a Lua interpreter to the debugger.

This does not have much functionality at the moment, but allows for an interpreter class to add functions to the lua environment.


## Related issues

_Related issues can be listed here (remove the section if not applicable.)_


# Manual testing

_Please describe the tests that you ran to verify your changes._

_Provide clear instructions so the reviewers can reproduce and verify your results._

_Include relevant details for your test configuration, operating system, etc._

_Ideally, you would also test your changes with a [sanitizer build](https://github.com/dosbox-staging/dosbox-staging/blob/main/BUILD.md#make-a-sanitizer-build) and confirm no issues were found._


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [ ] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [ ] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [ ] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

