### PR TITLE
Add header guard to semaphore.h

### DIFF
--- a/include/semaphore.h
+++ b/include/semaphore.h
@@ -18,6 +18,9 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
+#ifndef DOSBOX_SEMAPHORE_H
+#define DOSBOX_SEMAPHORE_H
+
 #include <condition_variable>
 #include <mutex>
 
@@ -65,3 +68,5 @@ private:
     std::condition_variable cv = {};    // Condition variable for the count.
     int count                  = 0;     // Current count.
 };
+
+#endif // DOSBOX_SEMAPHORE_H


### PR DESCRIPTION
# Description

Oops, I had overlooked this when creating `semaphore.h`

# Manual testing

Ran `Blood`, which uses `voodoo.cpp`, which uses `semaphore.h`, and all is good.

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

