### PR TITLE
Fix lookup of mapper files from resources

### DIFF
--- a/src/misc/support.cpp
+++ b/src/misc/support.cpp
@@ -419,22 +419,23 @@ std::map<std_fs::path, std::vector<std_fs::path>> GetFilesInResource(
 }
 
 // Get resource lines from a text file
-std::vector<std::string> GetResourceLines(const std_fs::path &name,
+std::vector<std::string> GetResourceLines(const std_fs::path& name,
                                           const ResourceImportance importance)
 {
-	auto lines = get_lines(name);
-	if (lines)
-		return std::move(*lines);
-
+	const auto resource_path = GetResourcePath(name);
+	if (auto maybe_lines = get_lines(resource_path); maybe_lines) {
+		return std::move(*maybe_lines);
+	}
 	// the resource didn't exist but it's optional
-	if (importance == ResourceImportance::Optional)
+	if (importance == ResourceImportance::Optional) {
 		return {};
+	}
 
 	// the resource didn't exist and it was mandatory, so verbosely quit
 	assert(importance == ResourceImportance::Mandatory);
 	LOG_ERR("RESOURCE: Could not open mandatory resource '%s', tried:",
 	        name.string().c_str());
-	for (const auto &path : GetResourceParentPaths()) {
+	for (const auto& path : GetResourceParentPaths()) {
 		LOG_WARNING("RESOURCE:  - '%s'", (path / name).string().c_str());
 	}
 	E_Exit("RESOURCE: Mandatory resource failure (see detailed message)");


### PR DESCRIPTION
# Description

The resource helper function `GetResourceLines()` wasn't leveraging the resource lookup system and so only found files literally.

# Manual testing

Tested positive scenarios:

Previously running `mapperfile xbox/duke3d.map` fails, but now it finds it in the shipped (or installed) `resources/`.

Save a new mapper file to your binary's `resources/mapperfiles/` area. Try loading it at runtime with `mapperfile your_new.map`. Previously this failed but now it finds it.

Because resources includes the compile-time install areas as well as XDG areas, this lookup now works for those that package and ship custom mapper files, as well.

Tested negative scenarios:

Lookup for missing files still works as expected and reports a warning.

```
MAPPER: Failed loading mapperfile 'missing.map' directly or from resources
```

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

