### PR TITLE
Remove GCC_LIKELY/GCC_UNLIKELY

### DIFF
--- a/include/compiler.h
+++ b/include/compiler.h
@@ -57,23 +57,6 @@
 #define GCC_ATTRIBUTE(x) /* attribute not supported */
 #endif
 
-// GCC_LIKELY macro is incorrectly named, because other compilers support
-// this feature as well (e.g. Clang, Intel); leave it be for now, at
-// least until full support for C++20 [[likely]] attribute will start arriving
-// in new compilers.
-//
-// Note: '!!' trick is used, to convert non-boolean values to 1 or 0
-// to prevent accidental incorrect usage (e.g. when user wraps macro
-// around a pointer or an integer, expecting usual C semantics).
-
-#if C_HAS_BUILTIN_EXPECT
-#define GCC_LIKELY(x)   __builtin_expect(!!(x), 1)
-#define GCC_UNLIKELY(x) __builtin_expect(!!(x), 0)
-#else
-#define GCC_LIKELY(x)   (x)
-#define GCC_UNLIKELY(x) (x)
-#endif
-
 // XSTR and STR macros can be used for turning defines into string literals:
 //
 // #define FOO 4

--- a/src/cpu/core_dyn_x86.cpp
+++ b/src/cpu/core_dyn_x86.cpp
@@ -330,7 +330,7 @@ restart_core:
 #endif
 #endif
 	CodePageHandler * chandler=nullptr;
-	if (GCC_UNLIKELY(MakeCodePage(ip_point,chandler))) {
+	if (MakeCodePage(ip_point, chandler)) {
 		CPU_Exception(cpu.exception.which,cpu.exception.error);
 		goto restart_core;
 	}

--- a/src/cpu/core_dyn_x86/risc_x64.h
+++ b/src/cpu/core_dyn_x86/risc_x64.h
@@ -247,9 +247,11 @@ public:
 	bool notusable;
 	void Load(DynReg * _dynreg,bool stale=false) {
 		if (!_dynreg) return;
-		if (GCC_UNLIKELY((Bitu)dynreg)) Clear();
-		dynreg=_dynreg;
-		last_used=x64gen.last_used;
+		if ((Bitu)dynreg) {
+			Clear();
+		}
+		dynreg    = _dynreg;
+		last_used = x64gen.last_used;
 		dynreg->flags&=~DYNFLG_CHANGED;
 		dynreg->genreg=this;
 		if ((!stale) && (dynreg->flags & (DYNFLG_LOAD|DYNFLG_ACTIVE))) {
@@ -258,13 +260,17 @@ public:
 		dynreg->flags|=DYNFLG_ACTIVE;
 	}
 	void Save(void) {
-		if (GCC_UNLIKELY(!((Bitu)dynreg))) IllegalOption("GenReg->Save");
-		dynreg->flags&=~DYNFLG_CHANGED;
+		if (!((Bitu)dynreg)) {
+			IllegalOption("GenReg->Save");
+		}
+		dynreg->flags &= ~DYNFLG_CHANGED;
 		opcode(index).setabsaddr(dynreg->data).Emit8(0x89); // mov [], r32
 	}
 	void Release(void) {
-		if (GCC_UNLIKELY(!((Bitu)dynreg))) return;
-		if (dynreg->flags&DYNFLG_CHANGED && dynreg->flags&DYNFLG_SAVE) {
+		if (!((Bitu)dynreg)) {
+			return;
+		}
+		if (dynreg->flags & DYNFLG_CHANGED && dynreg->flags & DYNFLG_SAVE) {
 			Save();
 		}
 		dynreg->flags&=~(DYNFLG_CHANGED|DYNFLG_ACTIVE);
@@ -466,8 +472,9 @@ static void gen_synchreg(DynReg * dnew,DynReg * dsynch) {
 	if ((dnew->flags ^ dsynch->flags) & DYNFLG_CHANGED) {
 		/* Ensure the changed value gets saved */	
 		if (dnew->flags & DYNFLG_CHANGED) {
-			if (GCC_LIKELY(dnew->genreg != nullptr))
+			if (dnew->genreg != nullptr) {
 				dnew->genreg->Save();
+			}
 		} else dnew->flags|=DYNFLG_CHANGED;
 	}
 }
@@ -1075,9 +1082,13 @@ static void gen_call_function(void * func,const char* ops,...) {
 	char rettype='\0';
 
 	/* Save the flags */
-	if (GCC_LIKELY(!skip_flags)) gen_protectflags();
-	if (ops==nullptr) IllegalOption("gen_call_function NULL format");
-	va_start(params,ops);
+	if (!skip_flags) {
+		gen_protectflags();
+	}
+	if (ops == nullptr) {
+		IllegalOption("gen_call_function NULL format");
+	}
+	va_start(params, ops);
 	while (*ops) {
 		if (*ops++=='%') {
 			GenReg *gen;
@@ -1218,14 +1229,18 @@ static void gen_jmp_ptr(void * _ptr,int32_t imm=0) {
 }
 
 static void gen_save_flags(DynReg * dynreg) {
-	if (GCC_UNLIKELY(x64gen.flagsactive)) IllegalOption("gen_save_flags");
-	opcode(FindDynReg(dynreg)->index).setea(4,-1,0,CALLSTACK).Emit8(0x8B); // mov reg32, [rsp+8/40]
-	dynreg->flags|=DYNFLG_CHANGED;
+	if (x64gen.flagsactive) {
+		IllegalOption("gen_save_flags");
+	}
+	opcode(FindDynReg(dynreg)->index).setea(4, -1, 0, CALLSTACK).Emit8(0x8B); // mov reg32, [rsp+8/40]
+	dynreg->flags |= DYNFLG_CHANGED;
 }
 
 static void gen_load_flags(DynReg * dynreg) {
-	if (GCC_UNLIKELY(x64gen.flagsactive)) IllegalOption("gen_load_flags");
-	opcode(FindDynReg(dynreg)->index).setea(4,-1,0,CALLSTACK).Emit8(0x89); // mov [rsp+8/40],reg32
+	if (x64gen.flagsactive) {
+		IllegalOption("gen_load_flags");
+	}
+	opcode(FindDynReg(dynreg)->index).setea(4, -1, 0, CALLSTACK).Emit8(0x89); // mov [rsp+8/40],reg32
 }
 
 static void gen_save_host_direct(void *data,Bitu imm) {
@@ -1249,7 +1264,9 @@ static void gen_return(BlockReturn retcode) {
 }
 
 static void gen_return_fast(BlockReturn retcode,bool ret_exception=false) {
-	if (GCC_UNLIKELY(x64gen.flagsactive)) IllegalOption("gen_return_fast");
+	if (x64gen.flagsactive) {
+		IllegalOption("gen_return_fast");
+	}
 	opcode(1).setabsaddr(&reg_flags).Emit8(0x8B); // mov ECX, [cpu_regs.flags]
 	if (!ret_exception) {
 		opcode(0).set64().setrm(4).setimm(CALLSTACK+8,1).Emit8(0x83); // add rsp,16/48

--- a/src/cpu/core_dynrec.cpp
+++ b/src/cpu/core_dynrec.cpp
@@ -240,14 +240,16 @@ Bits CPU_Core_Dynrec_Run() noexcept
 
 		CodePageHandler *chandler = nullptr;
 		// see if the current page is present and contains code
-		if (GCC_UNLIKELY(MakeCodePage(ip_point,chandler))) {
+		if (MakeCodePage(ip_point, chandler)) {
 			// page not present, throw the exception
 			CPU_Exception(cpu.exception.which,cpu.exception.error);
 			continue;
 		}
 
 		// page doesn't contain code or is special
-		if (GCC_UNLIKELY(!chandler)) return CPU_Core_Normal_Run();
+		if (!chandler) {
+			return CPU_Core_Normal_Run();
+		}
 
 		// find correct Dynamic Block to run
 		CacheBlock *block = chandler->FindCacheBlock(ip_point & 4095);

--- a/src/cpu/core_dynrec/decoder.h
+++ b/src/cpu/core_dynrec/decoder.h
@@ -78,13 +78,17 @@ restart_prefix:
 			// some entries in the invalidation map, see if the next
 			// instruction is known to be modified a lot
 			if (decode.page.index<4096) {
-				if (GCC_UNLIKELY(decode.page.invmap[decode.page.index]>=4)) goto illegalopcode;
-				opcode=decode_fetchb();
+				if (decode.page.invmap[decode.page.index] >= 4) {
+					goto illegalopcode;
+				}
+				opcode = decode_fetchb();
 			} else {
 				// switch to the next page
 				opcode=decode_fetchb();
-				if (GCC_UNLIKELY(decode.page.invmap && 
-					(decode.page.invmap[decode.page.index-1]>=4))) goto illegalopcode;
+				if (decode.page.invmap &&
+				    (decode.page.invmap[decode.page.index - 1] >= 4)) {
+					goto illegalopcode;
+				}
 			}
 		}
 		switch (opcode) {
@@ -227,15 +231,19 @@ restart_prefix:
 				// lfs
 				case 0xb4:
 					dyn_get_modrm();
-					if (GCC_UNLIKELY(decode.modrm.mod==3)) goto illegalopcode;
-					dyn_load_seg_off_ea(DRC_SEG_FS);
-					break;
+				        if (decode.modrm.mod == 3) {
+					        goto illegalopcode;
+				        }
+				        dyn_load_seg_off_ea(DRC_SEG_FS);
+				        break;
 				// lgs
-				case 0xb5:
+			        case 0xb5:
 					dyn_get_modrm();
-					if (GCC_UNLIKELY(decode.modrm.mod==3)) goto illegalopcode;
-					dyn_load_seg_off_ea(DRC_SEG_GS);
-					break;
+				        if (decode.modrm.mod == 3) {
+					        goto illegalopcode;
+				        }
+				        dyn_load_seg_off_ea(DRC_SEG_GS);
+				        break;
 
 				// zero-extending moves
 				case 0xb6:dyn_movx_ev_gb(false);break;
@@ -334,7 +342,9 @@ restart_prefix:
 		// load effective address
 		case 0x8d:
 			dyn_get_modrm();
-			if (GCC_UNLIKELY(decode.modrm.mod==3)) goto illegalopcode;
+			if (decode.modrm.mod == 3) {
+				goto illegalopcode;
+			}
 			dyn_lea();
 			break;
 
@@ -434,14 +444,19 @@ restart_prefix:
 		// les
 		case 0xc4:
 			dyn_get_modrm();
-			if (GCC_UNLIKELY(decode.modrm.mod==3)) goto illegalopcode;
+			if (decode.modrm.mod == 3) {
+				goto illegalopcode;
+			}
 			dyn_load_seg_off_ea(DRC_SEG_ES);
 			break;
 		// lds
 		case 0xc5:
 			dyn_get_modrm();
-			if (GCC_UNLIKELY(decode.modrm.mod==3)) goto illegalopcode;
-			dyn_load_seg_off_ea(DRC_SEG_DS);break;
+			if (decode.modrm.mod == 3) {
+				goto illegalopcode;
+			}
+			dyn_load_seg_off_ea(DRC_SEG_DS);
+			break;
 
 		// 'mov []/reg8/16/32,imm8/16/32'
 		case 0xc6:dyn_dop_ebib_mov();break;

--- a/src/cpu/core_dynrec/decoder_basic.h
+++ b/src/cpu/core_dynrec/decoder_basic.h
@@ -121,7 +121,9 @@ static bool MakeCodePage(Bitu lin_addr, CodePageHandler *&cph)
 	uint8_t rdval;
 	const Bitu cflag = cpu.code.big ? PFLAG_HASCODE32:PFLAG_HASCODE16;
 	//Ensure page contains memory:
-	if (GCC_UNLIKELY(mem_readb_checked(lin_addr,&rdval))) return true;
+	if (mem_readb_checked(lin_addr, &rdval)) {
+		return true;
+	}
 
 	PageHandler * handler=get_tlb_readhandler(lin_addr);
 	if (handler->flags & PFLAG_HASCODE) {
@@ -213,7 +215,7 @@ static void decode_advancepage(void) {
 
 // fetch the next byte of the instruction stream
 static uint8_t decode_fetchb(void) {
-	if (GCC_UNLIKELY(decode.page.index>=4096)) {
+	if (decode.page.index >= 4096) {
 		decode_advancepage();
 	}
 	decode.page.wmap[decode.page.index]+=0x01;
@@ -223,9 +225,9 @@ static uint8_t decode_fetchb(void) {
 }
 // fetch the next word of the instruction stream
 static uint16_t decode_fetchw(void) {
-	if (GCC_UNLIKELY(decode.page.index>=4095)) {
-   		uint16_t val=decode_fetchb();
-		val|=decode_fetchb() << 8;
+	if (decode.page.index >= 4095) {
+		uint16_t val = decode_fetchb();
+		val |= decode_fetchb() << 8;
 		return val;
 	}
 	add_to_unaligned_uint16(&decode.page.wmap[decode.page.index], 0x0101);
@@ -234,10 +236,10 @@ static uint16_t decode_fetchw(void) {
 }
 // fetch the next dword of the instruction stream
 static uint32_t decode_fetchd(void) {
-	if (GCC_UNLIKELY(decode.page.index>=4093)) {
-   		uint32_t val=decode_fetchb();
-		val|=decode_fetchb() << 8;
-		val|=decode_fetchb() << 16;
+	if (decode.page.index >= 4093) {
+		uint32_t val = decode_fetchb();
+		val |= decode_fetchb() << 8;
+		val |= decode_fetchb() << 16;
 		val|=decode_fetchb() << 24;
 		return val;
         /* Advance to the next page */
@@ -250,7 +252,7 @@ static uint32_t decode_fetchd(void) {
 // fetch a byte, val points to the code location if possible,
 // otherwise val contains the current value read from the position
 static bool decode_fetchb_imm(Bitu & val) {
-	if (GCC_UNLIKELY(decode.page.index>=4096)) {
+	if (decode.page.index >= 4096) {
 		decode_advancepage();
 	}
 	// see if position is directly accessible

--- a/src/cpu/core_dynrec/decoder_opcodes.h
+++ b/src/cpu/core_dynrec/decoder_opcodes.h
@@ -472,15 +472,17 @@ static void dyn_pop_ev(void) {
 
 
 static void dyn_segprefix(uint8_t seg) {
-//	if (GCC_UNLIKELY(decode.seg_prefix_used)) IllegalOptionDynrec("dyn_segprefix");
+	//	if (decode.seg_prefix_used) IllegalOptionDynrec("dyn_segprefix");
 	decode.seg_prefix=seg;
 	decode.seg_prefix_used=true;
 }
 
  static void dyn_mov_seg_ev(void) {
 	dyn_get_modrm();
-	if (GCC_UNLIKELY(decode.modrm.reg==DRC_SEG_CS)) IllegalOptionDynrec("dyn_mov_seg_ev");
-	if (decode.modrm.mod<3) {
+	if (decode.modrm.reg == DRC_SEG_CS) {
+		IllegalOptionDynrec("dyn_mov_seg_ev");
+	}
+	if (decode.modrm.mod < 3) {
 		dyn_fill_ea(FC_ADDR);
 		dyn_read_word(FC_ADDR,FC_RETOP,false);
 	} else {

--- a/src/cpu/core_dynrec/risc_armv4le-o3.h
+++ b/src/cpu/core_dynrec/risc_armv4le-o3.h
@@ -204,7 +204,7 @@ static void gen_mov_regs(HostReg reg_dst,HostReg reg_src) {
 static bool val_is_operand2(uint32_t value, uint32_t *val_shift) {
 	uint32_t shift;
 
-	if (GCC_UNLIKELY(value == 0)) {
+	if (value == 0) {
 		*val_shift = 0;
 		return true;
 	}

--- a/src/cpu/core_dynrec/risc_armv4le-thumb-iw.h
+++ b/src/cpu/core_dynrec/risc_armv4le-thumb-iw.h
@@ -237,7 +237,7 @@ static void cache_checkinstr(uint32_t size) {
 // returns address of item
 static const uint8_t * cache_reservedata(void) {
 	// if data pool not yet initialized, then initialize data pool
-	if (GCC_UNLIKELY(cache_datapos == NULL)) {
+	if (cache_datapos == NULL) {
 		if (cache.pos + CACHE_DATA_MIN + CACHE_DATA_ALIGN < cache.block.active->cache.start + CACHE_DATA_MAX) {
 			cache_datapos = (const uint8_t *) (((Bitu)cache.block.active->cache.start + CACHE_DATA_MAX) & ~(CACHE_DATA_ALIGN - 1));
 		}
@@ -303,7 +303,7 @@ static void gen_mov_regs(HostReg reg_dst,HostReg reg_src) {
 static bool val_single_shift(uint32_t value, uint32_t *val_shift) {
 	uint32_t shift;
 
-	if (GCC_UNLIKELY(value == 0)) {
+	if (value == 0) {
 		*val_shift = 0;
 		return true;
 	}

--- a/src/cpu/core_dynrec/risc_armv4le-thumb-niw.h
+++ b/src/cpu/core_dynrec/risc_armv4le-thumb-niw.h
@@ -234,7 +234,7 @@ static void cache_checkinstr(uint32_t size) {
 // returns address of item
 static const uint8_t * cache_reservedata(void) {
 	// if data pool not yet initialized, then initialize data pool
-	if (GCC_UNLIKELY(cache_datapos == NULL)) {
+	if (cache_datapos == NULL) {
 		if (cache.pos + CACHE_DATA_MIN + CACHE_DATA_ALIGN < cache.block.active->cache.start + CACHE_DATA_MAX) {
 			cache_datapos = (const uint8_t *) (((Bitu)cache.block.active->cache.start + CACHE_DATA_MAX) & ~(CACHE_DATA_ALIGN - 1));
 		}
@@ -300,7 +300,7 @@ static void gen_mov_regs(HostReg reg_dst,HostReg reg_src) {
 static bool val_single_shift(uint32_t value, uint32_t *val_shift) {
 	uint32_t shift;
 
-	if (GCC_UNLIKELY(value == 0)) {
+	if (value == 0) {
 		*val_shift = 0;
 		return true;
 	}

--- a/src/cpu/core_dynrec/risc_armv4le-thumb.h
+++ b/src/cpu/core_dynrec/risc_armv4le-thumb.h
@@ -181,7 +181,7 @@ static void gen_mov_regs(HostReg reg_dst,HostReg reg_src) {
 static bool val_single_shift(uint32_t value, uint32_t *val_shift) {
 	uint32_t shift;
 
-	if (GCC_UNLIKELY(value == 0)) {
+	if (value == 0) {
 		*val_shift = 0;
 		return true;
 	}

--- a/src/cpu/core_normal/prefix_none.h
+++ b/src/cpu/core_normal/prefix_none.h
@@ -433,19 +433,24 @@
 			if (rm >= 0xc0 ) {GetEArb;*earb=*rmrb;}
 			else {
 				if (cpu.pmode) {
-					if (GCC_UNLIKELY((rm==0x05) && (!cpu.code.big))) {
-						Descriptor desc;
-						cpu.gdt.GetDescriptor(SegValue(core.base_val_ds),desc);
-						if ((desc.Type()==DESC_CODE_R_NC_A) || (desc.Type()==DESC_CODE_R_NC_NA)) {
-							CPU_Exception(EXCEPTION_GP,SegValue(core.base_val_ds) & 0xfffc);
-							continue;
-						}
-					}
-				}
-				GetEAa;SaveMb(eaa,*rmrb);
-			}
-			break;
-		}
+			                if ((rm == 0x05) && (!cpu.code.big)) {
+				                Descriptor desc;
+				                cpu.gdt.GetDescriptor(SegValue(core.base_val_ds),
+				                                      desc);
+				                if ((desc.Type() == DESC_CODE_R_NC_A) ||
+				                    (desc.Type() == DESC_CODE_R_NC_NA)) {
+					                CPU_Exception(EXCEPTION_GP,
+					                              SegValue(core.base_val_ds) &
+					                                      0xfffc);
+					                continue;
+				                }
+			                }
+		                }
+		                GetEAa;
+		                SaveMb(eaa, *rmrb);
+	                }
+	                break;
+                }
 	CASE_W(0x89)												/* MOV Ew,Gw */
 		{	
 			GetRMrw;

--- a/src/cpu/dyn_cache.h
+++ b/src/cpu/dyn_cache.h
@@ -227,8 +227,9 @@ public:
 	{
 		constexpr size_t map_size = 4096;
 		uint8_t *map = new (std::nothrow) uint8_t[map_size];
-		if (GCC_UNLIKELY(!map))
+		if (!map) {
 			E_Exit("failed to allocate invalidation_map");
+		}
 		memset(map, 0, map_size);
 		return map;
 	}
@@ -238,8 +239,10 @@ public:
 
 	void writeb(PhysPt addr, const uint8_t val) override
 	{
-		if (GCC_UNLIKELY(old_pagehandler->flags&PFLAG_HASROM)) return;
-		if (GCC_UNLIKELY((old_pagehandler->flags&PFLAG_READABLE)!=PFLAG_READABLE)) {
+		if (old_pagehandler->flags & PFLAG_HASROM) {
+			return;
+		}
+		if ((old_pagehandler->flags & PFLAG_READABLE) != PFLAG_READABLE) {
 			E_Exit("wb:non-readable code page found that is no ROM page");
 		}
 		addr&=4095;
@@ -264,8 +267,10 @@ public:
 
 	void writew(PhysPt addr, const uint16_t val) override
 	{
-		if (GCC_UNLIKELY(old_pagehandler->flags&PFLAG_HASROM)) return;
-		if (GCC_UNLIKELY((old_pagehandler->flags&PFLAG_READABLE)!=PFLAG_READABLE)) {
+		if (old_pagehandler->flags & PFLAG_HASROM) {
+			return;
+		}
+		if ((old_pagehandler->flags & PFLAG_READABLE) != PFLAG_READABLE) {
 			E_Exit("ww:non-readable code page found that is no ROM page");
 		}
 		addr&=4095;
@@ -290,8 +295,10 @@ public:
 
 	void writed(PhysPt addr, const uint32_t val) override
 	{
-		if (GCC_UNLIKELY(old_pagehandler->flags&PFLAG_HASROM)) return;
-		if (GCC_UNLIKELY((old_pagehandler->flags&PFLAG_READABLE)!=PFLAG_READABLE)) {
+		if (old_pagehandler->flags & PFLAG_HASROM) {
+			return;
+		}
+		if ((old_pagehandler->flags & PFLAG_READABLE) != PFLAG_READABLE) {
 			E_Exit("wd:non-readable code page found that is no ROM page");
 		}
 		addr&=4095;
@@ -316,8 +323,10 @@ public:
 
 	bool writeb_checked(PhysPt addr, const uint8_t val) override
 	{
-		if (GCC_UNLIKELY(old_pagehandler->flags&PFLAG_HASROM)) return false;
-		if (GCC_UNLIKELY((old_pagehandler->flags&PFLAG_READABLE)!=PFLAG_READABLE)) {
+		if (old_pagehandler->flags & PFLAG_HASROM) {
+			return false;
+		}
+		if ((old_pagehandler->flags & PFLAG_READABLE) != PFLAG_READABLE) {
 			E_Exit("cb:non-readable code page found that is no ROM page");
 		}
 		addr&=4095;
@@ -347,8 +356,10 @@ public:
 
 	bool writew_checked(PhysPt addr, const uint16_t val) override
 	{
-		if (GCC_UNLIKELY(old_pagehandler->flags&PFLAG_HASROM)) return false;
-		if (GCC_UNLIKELY((old_pagehandler->flags&PFLAG_READABLE)!=PFLAG_READABLE)) {
+		if (old_pagehandler->flags & PFLAG_HASROM) {
+			return false;
+		}
+		if ((old_pagehandler->flags & PFLAG_READABLE) != PFLAG_READABLE) {
 			E_Exit("cw:non-readable code page found that is no ROM page");
 		}
 		addr&=4095;
@@ -378,8 +389,10 @@ public:
 
 	bool writed_checked(PhysPt addr, const uint32_t val) override
 	{
-		if (GCC_UNLIKELY(old_pagehandler->flags&PFLAG_HASROM)) return false;
-		if (GCC_UNLIKELY((old_pagehandler->flags&PFLAG_READABLE)!=PFLAG_READABLE)) {
+		if (old_pagehandler->flags & PFLAG_HASROM) {
+			return false;
+		}
+		if ((old_pagehandler->flags & PFLAG_READABLE) != PFLAG_READABLE) {
 			E_Exit("cd:non-readable code page found that is no ROM page");
 		}
 		addr&=4095;
@@ -443,7 +456,7 @@ public:
 		*where = block->hash.next;
 
 		// remove the cleared block from the write map
-		if (GCC_UNLIKELY(block->cache.wmapmask)) {
+		if (block->cache.wmapmask) {
 			// first part is not influenced by the mask
 			for (Bitu i = block->page.start; i < block->cache.maskstart;
 			     i++) {
@@ -606,7 +619,7 @@ size_t CacheBlock::Cache::GrowMaskForTypeAt(const uint8_t type_size,
 	size_t map_offset = 0;
 
 	// Make the map mask if needed
-	if (GCC_UNLIKELY(!wmapmask)) {
+	if (!wmapmask) {
 		constexpr uint8_t initial_mask_len = 64;
 		GrowWriteMask(initial_mask_len);
 		maskstart = check_cast<uint16_t>(page_index);
@@ -615,7 +628,7 @@ size_t CacheBlock::Cache::GrowMaskForTypeAt(const uint8_t type_size,
 	else {
 		map_offset = page_index - maskstart;
 		const size_t map_offset_end = map_offset + type_size;
-		if (GCC_UNLIKELY(map_offset_end >= masklen)) {
+		if (map_offset_end >= masklen) {
 			size_t new_mask_len = masklen * 4;
 			if (new_mask_len < map_offset_end) {
 				new_mask_len = ((map_offset_end) & ~3) * 2;
@@ -1062,7 +1075,7 @@ static void cache_init(bool enable) {
 		// setup the code pages
 		for (int i=0;i<CACHE_PAGES;i++) {
 			auto newpage = new (std::nothrow) CodePageHandler();
-			if (GCC_UNLIKELY(!newpage)) {
+			if (!newpage) {
 				E_Exit("DYN_CACHE: Failed to allocate code-page handler");
 			}
 			newpage->next = cache.free_pages;

--- a/src/cpu/paging.cpp
+++ b/src/cpu/paging.cpp
@@ -217,7 +217,7 @@ static inline void InitPageCheckPresence(PhysPt lin_addr,bool writing,X86PageEnt
 		PAGING_PageFault(lin_addr,table_addr,
 			(writing?0x02:0x00) | (((cpu.cpl&cpu.mpl)==0)?0x00:0x04));
 		table.set(phys_readd(table_addr));
-		if (GCC_UNLIKELY(!table.p)) {
+		if (!table.p) {
 			E_Exit("Pagefault didn't correct table");
 		}
 	}
@@ -228,7 +228,7 @@ static inline void InitPageCheckPresence(PhysPt lin_addr,bool writing,X86PageEnt
 		PAGING_PageFault(lin_addr,entry_addr,
 			(writing?0x02:0x00) | (((cpu.cpl&cpu.mpl)==0)?0x00:0x04));
 		entry.set(phys_readd(entry_addr));
-		if (GCC_UNLIKELY(!entry.p)) {
+		if (!entry.p) {
 			E_Exit("Pagefault didn't correct page");
 		}
 	}
@@ -992,10 +992,11 @@ void PAGING_Enable(bool enabled) {
 	if (paging.enabled==enabled) return;
 	paging.enabled=enabled;
 	if (enabled) {
-		if (GCC_UNLIKELY(cpudecoder==CPU_Core_Simple_Run)) {
-//			LOG_MSG("CPU core simple won't run this game,switching to normal");
-			cpudecoder=CPU_Core_Normal_Run;
-			CPU_CycleLeft+=CPU_Cycles;
+		if (cpudecoder == CPU_Core_Simple_Run) {
+			// LOG_MSG("CPU core simple won't
+			// run this game,switching to normal");
+			cpudecoder = CPU_Core_Normal_Run;
+			CPU_CycleLeft += CPU_Cycles;
 			CPU_Cycles=0;
 		}
 //		LOG(LOG_PAGING,LOG_NORMAL)("Enabled");

--- a/src/debug/debug.cpp
+++ b/src/debug/debug.cpp
@@ -1931,10 +1931,11 @@ uint32_t DEBUG_CheckKeys(void) {
 		}
 		if (ret<0) return ret;
 		if (ret>0) {
-			if (GCC_UNLIKELY(ret >= CB_MAX))
+			if (ret >= CB_MAX) {
 				ret = 0;
-			else
+			} else {
 				ret = (*CallBack_Handlers[ret])();
+			}
 			if (ret) {
 				exitLoop=true;
 				CPU_Cycles=CPU_CycleLeft=0;
@@ -2759,7 +2760,9 @@ bool DEBUG_HeavyIsBreakpoint(void) {
 			if (value == 0) zero_count++;
 			else zero_count = 0;
 		}
-		if (GCC_UNLIKELY(zero_count == 10)) E_Exit("running zeroed code");
+		if (zero_count == 10) {
+			E_Exit("running zeroed code");
+		}
 	}
 
 	if (skipFirstInstruction) {

--- a/src/dos/dos_memory.cpp
+++ b/src/dos/dos_memory.cpp
@@ -310,7 +310,7 @@ bool DOS_ResizeMemory(uint16_t segment,uint16_t * blocks) {
 	uint16_t total=mcb.GetSize();
 	DOS_MCB	mcb_next(segment+total);
 	if (*blocks<=total) {
-		if (GCC_UNLIKELY(*blocks==total)) {
+		if (*blocks == total) {
 			/* Nothing to do */
 			return true;
 		}

--- a/src/dos/drive_cache.cpp
+++ b/src/dos/drive_cache.cpp
@@ -386,8 +386,9 @@ bool DOS_Drive_Cache::GetShortName(const char* fullname, char* shortname) {
 		return false;
 
 	std::vector<CFileInfo*>::size_type filelist_size = curDir->longNameList.size();
-	if (GCC_UNLIKELY(filelist_size<=0))
+	if (filelist_size <= 0) {
 		return false;
+	}
 
 	// The orgname part of the list is not sorted (shortname is)! So we can only walk through it.
 	for(Bitu i = 0; i < filelist_size; i++) {
@@ -558,7 +559,9 @@ static Bits wine_hash_short_file_name( char* name, char* buffer )
 
 Bits DOS_Drive_Cache::GetLongName(CFileInfo* curDir, char* shortName, const size_t shortName_len) {
 	std::vector<CFileInfo*>::size_type filelist_size = curDir->fileList.size();
-	if (GCC_UNLIKELY(filelist_size<=0)) return -1;
+	if (filelist_size <= 0) {
+		return -1;
+	}
 
 	// Remove dot, if no extension...
 	RemoveTrailingDot(shortName);
@@ -654,7 +657,9 @@ void DOS_Drive_Cache::CreateShortName(CFileInfo* curDir, CFileInfo* info) {
 		// TODO: modify MOUNT/IMGMOUNT to exit with an error when encountering
 		// a directory having more than 65534 files, which is FAT32's limit.
 		char short_nr[8] = {'\0'};
-		if (GCC_UNLIKELY(info->shortNr > 9999999)) E_Exit("~9999999 same name files overflow");
+		if (info->shortNr > 9999999) {
+			E_Exit("~9999999 same name files overflow");
+		}
 		safe_sprintf(short_nr, "%u", info->shortNr);
 
 		// Copy first letters

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -144,11 +144,17 @@ static Bitu Normal_Loop() {
 	while (1) {
 		if (PIC_RunQueue()) {
 			ret = (*cpudecoder)();
-			if (GCC_UNLIKELY(ret<0)) return 1;
-			if (ret>0) {
-				if (GCC_UNLIKELY(ret >= CB_MAX)) return 0;
+			if (ret < 0) {
+				return 1;
+			}
+			if (ret > 0) {
+				if (ret >= CB_MAX) {
+					return 0;
+				}
 				Bitu blah = (*CallBack_Handlers[ret])();
-				if (GCC_UNLIKELY(blah)) return blah;
+				if (blah) {
+					return blah;
+				}
 			}
 #if C_DEBUG
 			if (DEBUG_ExitLoop()) return 0;
@@ -166,7 +172,7 @@ static Bitu Normal_Loop() {
 
 void increaseticks() { //Make it return ticksRemain and set it in the function above to remove the global variable.
 	ZoneScoped;
-	if (GCC_UNLIKELY(ticksLocked)) { // For Fast Forward Mode
+	if (ticksLocked) { // For Fast Forward Mode
 		ticksRemain=5;
 		/* Reset any auto cycle guessing for this frame */
 		ticksLast = GetTicks();

--- a/src/fpu/fpu_instructions.h
+++ b/src/fpu/fpu_instructions.h
@@ -58,7 +58,7 @@ static void FPU_FNOP(void){
 static void FPU_PREP_PUSH(void){
 	TOP = (TOP - 1) &7;
 #if DB_FPU_STACK_CHECK_PUSH > DB_FPU_STACK_CHECK_NONE
-	if (GCC_UNLIKELY(fpu.tags[TOP] != TAG_Empty)) {
+	if (fpu.tags[TOP] != TAG_Empty) {
 #if DB_FPU_STACK_CHECK_PUSH == DB_FPU_STACK_CHECK_EXIT
 		E_Exit("FPU stack overflow");
 #else
@@ -88,7 +88,7 @@ static void FPU_PUSH(double in){
 
 static void FPU_FPOP(void){
 #if DB_FPU_STACK_CHECK_POP > DB_FPU_STACK_CHECK_NONE
-	if (GCC_UNLIKELY(fpu.tags[TOP] == TAG_Empty)) {
+	if (fpu.tags[TOP] == TAG_Empty) {
 #if DB_FPU_STACK_CHECK_POP == DB_FPU_STACK_CHECK_EXIT
 		E_Exit("FPU stack underflow");
 #else

--- a/src/fpu/fpu_instructions_x86.h
+++ b/src/fpu/fpu_instructions_x86.h
@@ -963,7 +963,7 @@ static void FPU_FNOP(void){
 static void FPU_PREP_PUSH(void){
 	TOP = (TOP - 1) &7;
 #if DB_FPU_STACK_CHECK_PUSH > DB_FPU_STACK_CHECK_NONE
-	if (GCC_UNLIKELY(fpu.tags[TOP] != TAG_Empty)) {
+	if (fpu.tags[TOP] != TAG_Empty) {
 #if DB_FPU_STACK_CHECK_PUSH == DB_FPU_STACK_CHECK_EXIT
 		E_Exit("FPU stack overflow");
 #else
@@ -984,7 +984,7 @@ static void FPU_PREP_PUSH(void){
 
 static void FPU_FPOP(void){
 #if DB_FPU_STACK_CHECK_POP > DB_FPU_STACK_CHECK_NONE
-	if (GCC_UNLIKELY(fpu.tags[TOP] == TAG_Empty)) {
+	if (fpu.tags[TOP] == TAG_Empty) {
 #if DB_FPU_STACK_CHECK_POP == DB_FPU_STACK_CHECK_EXIT
 		E_Exit("FPU stack underflow");
 #else

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -142,7 +142,7 @@ static void start_line_handler(const void* s)
 		for (Bits x = render.src_start; x > 0;) {
 			const auto src_ptr = reinterpret_cast<const uint8_t*>(src);
 			const auto src_val = read_unaligned_size_t(src_ptr);
-			if (GCC_UNLIKELY(src_val != cache[0])) {
+			if (src_val != cache[0]) {
 				if (!GFX_StartUpdate(render.scale.outWrite,
 				                     render.scale.outPitch)) {
 					RENDER_DrawLine = empty_line_handler;
@@ -195,10 +195,10 @@ static void clear_cache_handler(const void* src)
 
 bool RENDER_StartUpdate(void)
 {
-	if (GCC_UNLIKELY(render.updating)) {
+	if (render.updating) {
 		return false;
 	}
-	if (GCC_UNLIKELY(!render.active)) {
+	if (!render.active) {
 		return false;
 	}
 	if (render.scale.inMode == scalerMode8) {
@@ -214,13 +214,12 @@ bool RENDER_StartUpdate(void)
 
 	// Clearing the cache will first process the line to make sure it's
 	// never the same
-	if (GCC_UNLIKELY(render.scale.clearCache)) {
+	if (render.scale.clearCache) {
 		// LOG_MSG("Clearing cache");
 
 		// Will always have to update the screen with this one anyway,
 		// so let's update already
-		if (GCC_UNLIKELY(!GFX_StartUpdate(render.scale.outWrite,
-		                                  render.scale.outPitch))) {
+		if (!GFX_StartUpdate(render.scale.outWrite, render.scale.outPitch)) {
 			return false;
 		}
 		render.fullFrame        = true;
@@ -230,16 +229,16 @@ bool RENDER_StartUpdate(void)
 		if (render.pal.changed) {
 			// Assume pal changes always do a full screen update
 			// anyway
-			if (GCC_UNLIKELY(!GFX_StartUpdate(render.scale.outWrite,
-			                                  render.scale.outPitch))) {
+			if (!GFX_StartUpdate(render.scale.outWrite,
+			                     render.scale.outPitch)) {
 				return false;
 			}
 			RENDER_DrawLine  = render.scale.linePalHandler;
 			render.fullFrame = true;
 		} else {
 			RENDER_DrawLine = start_line_handler;
-			if (GCC_UNLIKELY(CAPTURE_IsCapturingImage() ||
-			                 CAPTURE_IsCapturingVideo())) {
+			if (CAPTURE_IsCapturingImage() ||
+			    CAPTURE_IsCapturingVideo()) {
 				render.fullFrame = true;
 			} else {
 				render.fullFrame = false;
@@ -262,13 +261,13 @@ extern uint32_t PIC_Ticks;
 
 void RENDER_EndUpdate(bool abort)
 {
-	if (GCC_UNLIKELY(!render.updating)) {
+	if (!render.updating) {
 		return;
 	}
 
 	RENDER_DrawLine = empty_line_handler;
 
-	if (GCC_UNLIKELY((CAPTURE_IsCapturingImage() || CAPTURE_IsCapturingVideo()))) {
+	if (CAPTURE_IsCapturingImage() || CAPTURE_IsCapturingVideo()) {
 		bool double_width  = false;
 		bool double_height = false;
 		if (render.src.double_width != render.src.double_height) {

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -790,7 +790,9 @@ public:
 	}
 
 	void ActivateJoystickBoundEvents() {
-		if (GCC_UNLIKELY(sdl_joystick==nullptr)) return;
+		if (sdl_joystick == nullptr) {
+			return;
+		}
 
 		bool button_pressed[MAXBUTTON];
 		std::fill_n(button_pressed, MAXBUTTON, false);

--- a/src/hardware/input/mouse_interfaces.cpp
+++ b/src/hardware/input/mouse_interfaces.cpp
@@ -597,7 +597,7 @@ bool MouseInterface::ChangedButtonsJoined() const
 
 bool MouseInterface::ChangedButtonsSquished() const
 {
-	if (GCC_LIKELY(old_buttons_12._data != buttons_12._data)) {
+	if (old_buttons_12._data != buttons_12._data) {
 		return true;
 	}
 
@@ -656,7 +656,7 @@ void InterfaceDos::NotifyMoved(const float x_rel, const float y_rel,
 void InterfaceDos::NotifyButton(const MouseButtonId button_id, const bool pressed)
 {
 	UpdateButtons(button_id, pressed);
-	if (GCC_UNLIKELY(!ChangedButtonsSquished())) {
+	if (!ChangedButtonsSquished()) {
 		return;
 	}
 
@@ -725,7 +725,7 @@ void InterfacePS2::NotifyMoved(const float x_rel, const float y_rel,
 void InterfacePS2::NotifyButton(const MouseButtonId button_id, const bool pressed)
 {
 	UpdateButtons(button_id, pressed);
-	if (GCC_UNLIKELY(!ChangedButtonsJoined())) {
+	if (!ChangedButtonsJoined()) {
 		return;
 	}
 
@@ -790,7 +790,7 @@ void InterfaceCOM::NotifyButton(const MouseButtonId button_id, const bool presse
 	assert(listener);
 
 	UpdateButtons(button_id, pressed);
-	if (GCC_UNLIKELY(!ChangedButtonsSquished())) {
+	if (!ChangedButtonsSquished()) {
 		return;
 	}
 

--- a/src/hardware/input/mouse_manymouse.cpp
+++ b/src/hardware/input/mouse_manymouse.cpp
@@ -369,11 +369,13 @@ bool ManyMouseGlue::IsMappingInEffect() const
 
 void ManyMouseGlue::HandleEvent(const ManyMouseEvent &event, const bool critical_only)
 {
-	if (GCC_UNLIKELY(event.device >= mouse_info.physical.size()))
+	if (event.device >= mouse_info.physical.size()) {
 		return; // device ID out of supported range
-	if (GCC_UNLIKELY(mouse_config.capture == MouseCapture::NoMouse &&
-	                 event.type != MANYMOUSE_EVENT_DISCONNECT))
+	}
+	if (mouse_config.capture == MouseCapture::NoMouse &&
+	    event.type != MANYMOUSE_EVENT_DISCONNECT) {
 		return; // mouse control disabled in GUI
+	}
 
 	const auto device_idx = static_cast<uint8_t>(event.device);
 	const auto interface_id = physical_devices[device_idx].GetMappedInterfaceId();

--- a/src/hardware/input/mouseif_virtual_machines.cpp
+++ b/src/hardware/input/mouseif_virtual_machines.cpp
@@ -292,7 +292,7 @@ void MOUSEVMM_NotifyMoved(const float x_rel, const float y_rel,
 
 	// Filter out unneeded events (like sub-pixel mouse movements,
 	// which won't change guest side mouse state)
-	if (GCC_UNLIKELY(old_scaled_x == scaled_x && old_scaled_y == scaled_y)) {
+	if (old_scaled_x == scaled_x && old_scaled_y == scaled_y) {
 		return;
 	}
 
@@ -314,7 +314,7 @@ void MOUSEVMM_NotifyButton(const MouseButtons12S buttons_12S)
 	vmware.buttons.right  = static_cast<bool>(buttons_12S.right);
 	vmware.buttons.middle = static_cast<bool>(buttons_12S.middle);
 
-	if (GCC_UNLIKELY(old_buttons._data == vmware.buttons._data)) {
+	if (old_buttons._data == vmware.buttons._data) {
 		return;
 	}
 
@@ -332,7 +332,7 @@ void MOUSEVMM_NotifyWheel(const int16_t w_rel)
 	const auto new_counter_w = vmware.counter_w + w_rel;
 	vmware.counter_w = clamp_to_int8(static_cast<int32_t>(new_counter_w));
 
-	if (GCC_UNLIKELY(old_counter_w == vmware.counter_w)) {
+	if (old_counter_w == vmware.counter_w) {
 		return;
 	}
 

--- a/src/hardware/iohandler.cpp
+++ b/src/hardware/iohandler.cpp
@@ -87,16 +87,18 @@ constexpr int32_t IODELAY_WRITE_MICROSk = static_cast<int32_t>(
 
 inline void IO_USEC_read_delay() {
 	auto delaycyc = CPU_CycleMax / IODELAY_READ_MICROSk;
-	if (GCC_UNLIKELY(delaycyc > CPU_Cycles))
+	if (delaycyc > CPU_Cycles) {
 		delaycyc = CPU_Cycles;
+	}
 	CPU_Cycles -= delaycyc;
 	CPU_IODelayRemoved += delaycyc;
 }
 
 inline void IO_USEC_write_delay() {
 	auto delaycyc = CPU_CycleMax / IODELAY_WRITE_MICROSk;
-	if (GCC_UNLIKELY(delaycyc > CPU_Cycles))
+	if (delaycyc > CPU_Cycles) {
 		delaycyc = CPU_Cycles;
+	}
 	CPU_Cycles -= delaycyc;
 	CPU_IODelayRemoved += delaycyc;
 }
@@ -166,7 +168,7 @@ void log_io(io_width_t width, bool write, io_port_t port, io_val_t val)
 void IO_WriteB(io_port_t port, uint8_t val)
 {
 	log_io(io_width_t::byte, true, port, val);
-	if (GCC_UNLIKELY(GETFLAG(VM) && (CPU_IO_Exception(port,1)))) {
+	if (GETFLAG(VM) && (CPU_IO_Exception(port, 1))) {
 		const auto old_lflags = lflags;
 		const auto old_cpudecoder=cpudecoder;
 		cpudecoder=&IOFaultCore;
@@ -191,8 +193,7 @@ void IO_WriteB(io_port_t port, uint8_t val)
 		reg_dx = old_dx;
 		lflags = old_lflags;
 		cpudecoder=old_cpudecoder;
-	}
-	else {
+	} else {
 		IO_USEC_write_delay();
 		write_byte_to_port(port, val);
 	}
@@ -201,7 +202,7 @@ void IO_WriteB(io_port_t port, uint8_t val)
 void IO_WriteW(io_port_t port, uint16_t val)
 {
 	log_io(io_width_t::word, true, port, val);
-	if (GCC_UNLIKELY(GETFLAG(VM) && (CPU_IO_Exception(port,2)))) {
+	if (GETFLAG(VM) && (CPU_IO_Exception(port, 2))) {
 		const auto old_lflags = lflags;
 		const auto old_cpudecoder=cpudecoder;
 		cpudecoder=&IOFaultCore;
@@ -226,8 +227,7 @@ void IO_WriteW(io_port_t port, uint16_t val)
 		reg_dx = old_dx;
 		lflags = old_lflags;
 		cpudecoder=old_cpudecoder;
-	}
-	else {
+	} else {
 		IO_USEC_write_delay();
 		write_word_to_port(port, val);
 	}
@@ -236,7 +236,7 @@ void IO_WriteW(io_port_t port, uint16_t val)
 void IO_WriteD(io_port_t port, uint32_t val)
 {
 	log_io(io_width_t::dword, true, port, val);
-	if (GCC_UNLIKELY(GETFLAG(VM) && (CPU_IO_Exception(port,4)))) {
+	if (GETFLAG(VM) && (CPU_IO_Exception(port, 4))) {
 		const auto old_lflags = lflags;
 		const auto old_cpudecoder=cpudecoder;
 		cpudecoder=&IOFaultCore;
@@ -269,7 +269,7 @@ void IO_WriteD(io_port_t port, uint32_t val)
 uint8_t IO_ReadB(io_port_t port)
 {
 	uint8_t retval;
-	if (GCC_UNLIKELY(GETFLAG(VM) && (CPU_IO_Exception(port,1)))) {
+	if (GETFLAG(VM) && (CPU_IO_Exception(port, 1))) {
 		const auto old_lflags = lflags;
 		const auto old_cpudecoder=cpudecoder;
 		cpudecoder=&IOFaultCore;
@@ -295,8 +295,7 @@ uint8_t IO_ReadB(io_port_t port)
 		lflags = old_lflags;
 		cpudecoder=old_cpudecoder;
 		return retval;
-	}
-	else {
+	} else {
 		IO_USEC_read_delay();
 		retval = read_byte_from_port(port);
 	}
@@ -307,7 +306,7 @@ uint8_t IO_ReadB(io_port_t port)
 uint16_t IO_ReadW(io_port_t port)
 {
 	uint16_t retval;
-	if (GCC_UNLIKELY(GETFLAG(VM) && (CPU_IO_Exception(port,2)))) {
+	if (GETFLAG(VM) && (CPU_IO_Exception(port, 2))) {
 		const auto old_lflags = lflags;
 		const auto old_cpudecoder=cpudecoder;
 		cpudecoder=&IOFaultCore;
@@ -332,8 +331,7 @@ uint16_t IO_ReadW(io_port_t port)
 		reg_dx = old_dx;
 		lflags = old_lflags;
 		cpudecoder=old_cpudecoder;
-	}
-	else {
+	} else {
 		IO_USEC_read_delay();
 		retval = read_word_from_port(port);
 	}
@@ -344,7 +342,7 @@ uint16_t IO_ReadW(io_port_t port)
 uint32_t IO_ReadD(io_port_t port)
 {
 	uint32_t retval;
-	if (GCC_UNLIKELY(GETFLAG(VM) && (CPU_IO_Exception(port,4)))) {
+	if (GETFLAG(VM) && (CPU_IO_Exception(port, 4))) {
 		const auto old_lflags = lflags;
 		const auto old_cpudecoder=cpudecoder;
 		cpudecoder=&IOFaultCore;

--- a/src/hardware/opl.cpp
+++ b/src/hardware/opl.cpp
@@ -788,8 +788,9 @@ uint8_t OPL::PortRead(const io_port_t port, const io_width_t)
 	// roughly half a micro (as we already do 1 micro on each port read and
 	// some tests revealed it taking 1.5 micros to read an adlib port)
 	auto delaycyc = (CPU_CycleMax / 2048);
-	if (GCC_UNLIKELY(delaycyc > CPU_Cycles))
+	if (delaycyc > CPU_Cycles) {
 		delaycyc = CPU_Cycles;
+	}
 
 	CPU_Cycles -= delaycyc;
 	CPU_IODelayRemoved += delaycyc;

--- a/src/hardware/timer.cpp
+++ b/src/hardware/timer.cpp
@@ -185,7 +185,7 @@ static void PIT0_Event(uint32_t /*val*/)
 	if (channel_0.mode != PitMode::InterruptOnTerminalCount) {
 		channel_0.start += channel_0.delay;
 
-		if (GCC_UNLIKELY(channel_0.update_count)) {
+		if (channel_0.update_count) {
 			update_channel_delay(channel_0);
 			channel_0.update_count = false;
 		}
@@ -276,7 +276,7 @@ static void counter_latch(PIT_Block &channel)
 		channel.read_latch = check_cast<uint16_t>(wrapped);
 	};
 
-	if (GCC_UNLIKELY(channel.mode_changed)) {
+	if (channel.mode_changed) {
 		// if (channel.mode== PitMode::SquareWave) ticks_since_then /=
 		// 2; //
 		// TODO figure this out on real hardware
@@ -422,7 +422,7 @@ static uint8_t read_latch(io_port_t port, io_width_t)
 	const uint16_t channel_num = check_cast<uint8_t>(port - 0x40);
 	auto &channel = pit.at(channel_num);
 	uint8_t ret = 0;
-	if (GCC_UNLIKELY(channel.counterstatus_set)) {
+	if (channel.counterstatus_set) {
 		channel.counterstatus_set = false;
 		latched_timerstatus_locked = false;
 		ret = latched_timerstatus;

--- a/src/hardware/vga_crtc.cpp
+++ b/src/hardware/vga_crtc.cpp
@@ -269,7 +269,7 @@ void vga_write_p3d5(io_port_t, io_val_t value, io_width_t)
 
 		if (IS_EGAVGA_ARCH && !(val & 0x10)) {
 			vga.draw.vret_triggered = false;
-			if (GCC_UNLIKELY(machine == MCH_EGA)) {
+			if (machine == MCH_EGA) {
 				PIC_DeActivateIRQ(9);
 			}
 		}

--- a/src/hardware/vga_dac.cpp
+++ b/src/hardware/vga_dac.cpp
@@ -226,7 +226,7 @@ static void write_p3c9(io_port_t, io_val_t value, io_width_t)
 		case M_LIN8:
 			vga_dac_update_color(vga.dac.write_index);
 
-			if (GCC_UNLIKELY(vga.dac.pel_mask != 0xff)) {
+			if (vga.dac.pel_mask != 0xff) {
 				const auto index = vga.dac.write_index;
 
 				if ((index & vga.dac.pel_mask) == index) {

--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -320,7 +320,7 @@ static uint8_t * VGA_Draw_Changes_Line(Bitu vidstart, Bitu line) {
 				memcpy(vga.draw.linear_base+vga.draw.linear_mask+1, vga.draw.linear_base, vga.draw.line_length);
 			uint8_t *ret = &vga.draw.linear_base[ offset ];
 #if !defined(C_UNALIGNED_MEMORY)
-			if (GCC_UNLIKELY( ((Bitu)ret) & (sizeof(Bitu)-1)) ) {
+			if (((Bitu)ret) & (sizeof(Bitu) - 1)) {
 				memcpy( TempLine, ret, vga.draw.line_length );
 				return TempLine;
 			}
@@ -341,7 +341,7 @@ static uint8_t * VGA_Draw_Linear_Line(Bitu vidstart, Bitu /*line*/) {
 
 	// in case (vga.draw.line_length + offset) has bits set that
 	// are not set in the mask: ((x|y)!=y) equals (x&~y)
-	if (GCC_UNLIKELY((vga.draw.line_length + offset)& ~vga.draw.linear_mask)) {
+	if ((vga.draw.line_length + offset) & ~vga.draw.linear_mask) {
 		// this happens, if at all, only once per frame (1 of 480 lines)
 		// in some obscure games
 		Bitu end = (offset + vga.draw.line_length) & vga.draw.linear_mask;
@@ -359,7 +359,7 @@ static uint8_t * VGA_Draw_Linear_Line(Bitu vidstart, Bitu /*line*/) {
 	}
 
 #if !defined(C_UNALIGNED_MEMORY)
-	if (GCC_UNLIKELY( ((Bitu)ret) & (sizeof(Bitu)-1)) ) {
+	if (((Bitu)ret) & (sizeof(Bitu) - 1)) {
 		memcpy( TempLine, ret, vga.draw.line_length );
 		return TempLine;
 	}
@@ -428,13 +428,13 @@ static uint8_t* draw_linear_line_from_dac_palette(Bitu vidstart, Bitu /*line*/)
 
 	// If the screen is disabled, just paint black. This fixes screen
 	// fades in titles like Alien Carnage.
-	if (GCC_UNLIKELY(vga.seq.clocking_mode.is_screen_disabled)) {
+	if (vga.seq.clocking_mode.is_screen_disabled) {
 		memset(line_addr, 0, vga.draw.line_length);
 		return TempLine;
 	}
 
 	// see VGA_Draw_Linear_Line
-	if (GCC_UNLIKELY((vga.draw.line_length + offset) & ~vga.draw.linear_mask)) {
+	if ((vga.draw.line_length + offset) & ~vga.draw.linear_mask) {
 		// Note: To exercise these wrapped scenarios, run:
 		// 1. Dangerous Dave: jump on the tree at the start.
 		// 2. Commander Keen 4: move to left of the first hill on stage 1.
@@ -686,7 +686,7 @@ static uint8_t * VGA_Draw_LIN32_Line_HWMouse(Bitu vidstart, Bitu /*line*/) {
 static const uint8_t* VGA_Text_Memwrap(Bitu vidstart) {
 	vidstart = vidstart & vga.draw.linear_mask;
 	Bitu line_end = 2 * vga.draw.blocks;
-	if (GCC_UNLIKELY((vidstart + line_end) > vga.draw.linear_mask)) {
+	if ((vidstart + line_end) > vga.draw.linear_mask) {
 		// wrapping in this line
 		Bitu break_pos = (vga.draw.linear_mask - vidstart) + 1;
 		// need a temporary storage - TempLine/2 is ok for a bit more than 132 columns
@@ -763,10 +763,12 @@ static uint8_t *VGA_TEXT_Herc_Draw_Line(Bitu vidstart, Bitu line)
 				else fg = TXT_FG_Table[0x7];
 			}
 			uint32_t mask1, mask2;
-			if (GCC_UNLIKELY(underline)) mask1 = mask2 = FontMask[attrib >> 7];
-			else {
-				Bitu font=vga.draw.font_tables[0][chr*32+line];
-				mask1=TXT_Font_Table[font>>4] & FontMask[attrib >> 7]; // blinking
+			if (underline) {
+				mask1 = mask2 = FontMask[attrib >> 7];
+			} else {
+				Bitu font = vga.draw.font_tables[0][chr * 32 + line];
+				mask1 = TXT_Font_Table[font >> 4] &
+				        FontMask[attrib >> 7]; // blinking
 				mask2=TXT_Font_Table[font&0xf] & FontMask[attrib >> 7];
 			}
 			write_unaligned_uint32_at(TempLine, i++, (fg & mask1) | (bg & ~mask1));
@@ -831,9 +833,10 @@ static uint8_t* draw_text_line_from_dac_palette(Bitu vidstart, Bitu line)
 		                                     : bg_palette_idx;
 
 		// underline: all foreground [freevga: 0x77, previous 0x7]
-		if (GCC_UNLIKELY(((attr&0x77) == 0x01) &&
-			(vga.crtc.underline_location&0x1f)==line))
+		if (((attr & 0x77) == 0x01) &&
+		    (vga.crtc.underline_location & 0x1f) == line) {
 			bg_palette_idx = fg_palette_idx;
+		}
 
 		// The font's bits will indicate which color is used per pixel
 		const auto fg_colour = palette_map[fg_palette_idx];
@@ -928,7 +931,7 @@ static void VGA_ProcessSplit()
 static uint8_t bg_color_index = 0; // screen-off black index
 static void VGA_DrawSingleLine(uint32_t /*blah*/)
 {
-	if (GCC_UNLIKELY(vga.attr.disabled)) {
+	if (vga.attr.disabled) {
 		switch(machine) {
 		case MCH_PCJR:
 			// Displays the border color when screen is disabled
@@ -1026,7 +1029,7 @@ static void VGA_DrawSingleLine(uint32_t /*blah*/)
 
 static void VGA_DrawEGASingleLine(uint32_t /*blah*/)
 {
-	if (GCC_UNLIKELY(vga.attr.disabled)) {
+	if (vga.attr.disabled) {
 		std::fill(templine_buffer.begin(), templine_buffer.end(), 0);
 		ReelMagic_RENDER_DrawLine(TempLine);
 	} else {
@@ -1129,7 +1132,9 @@ static void VGA_VertInterrupt(uint32_t /*val*/)
 	if ((!vga.draw.vret_triggered) &&
 	    ((vga.crtc.vertical_retrace_end & 0x30) == 0x10)) {
 		vga.draw.vret_triggered=true;
-		if (GCC_UNLIKELY(machine==MCH_EGA)) PIC_ActivateIRQ(9);
+		if (machine == MCH_EGA) {
+			PIC_ActivateIRQ(9);
+		}
 	}
 }
 
@@ -1288,14 +1293,16 @@ static void VGA_VerticalTimer(uint32_t /*val*/)
 	default:
 		break;
 	}
-	if (GCC_UNLIKELY(vga.draw.split_line==0)) VGA_ProcessSplit();
+	if (vga.draw.split_line == 0) {
+		VGA_ProcessSplit();
+	}
 #ifdef VGA_KEEP_CHANGES
 	if (startaddr_changed) VGA_ChangesStart();
 #endif
 
 	// check if some lines at the top off the screen are blanked
 	double draw_skip = 0.0;
-	if (GCC_UNLIKELY(vga.draw.vblank_skip)) {
+	if (vga.draw.vblank_skip) {
 		draw_skip = vga.draw.delay.htotal * static_cast<double>(vga.draw.vblank_skip);
 		vga.draw.address += vga.draw.address_add * vga.draw.vblank_skip / vga.draw.address_line_total;
 	}
@@ -1303,7 +1310,7 @@ static void VGA_VerticalTimer(uint32_t /*val*/)
 	// add the draw event
 	switch (vga.draw.mode) {
 	case PART:
-		if (GCC_UNLIKELY(vga.draw.parts_left)) {
+		if (vga.draw.parts_left) {
 			LOG(LOG_VGAMISC, LOG_NORMAL)("Parts left: %u", vga.draw.parts_left);
 			PIC_RemoveEvents(VGA_DrawPart);
 			RENDER_EndUpdate(true);
@@ -1314,7 +1321,7 @@ static void VGA_VerticalTimer(uint32_t /*val*/)
 		break;
 	case DRAWLINE:
 	case EGALINE:
-		if (GCC_UNLIKELY(vga.draw.lines_done < vga.draw.lines_total)) {
+		if (vga.draw.lines_done < vga.draw.lines_total) {
 			LOG(LOG_VGAMISC, LOG_NORMAL)("Lines left: %d",
 			                             static_cast<int>(vga.draw.lines_total - vga.draw.lines_done));
 			if (vga.draw.mode == EGALINE)

--- a/src/hardware/vga_memory.cpp
+++ b/src/hardware/vga_memory.cpp
@@ -353,7 +353,7 @@ public:
 	static inline void WriteCache_template(func_t host_write, PhysPt addr, val_t val)
 	{
 		host_write(&vga.fastmem[addr], val);
-		if (GCC_UNLIKELY(addr < 320)) {
+		if (addr < 320) {
 			// And replicate the first line
 			host_write(&vga.fastmem[addr + 64 * 1024], val);
 		}
@@ -404,12 +404,13 @@ public:
 		addr = PAGING_GetPhysicalAddress(addr) & vgapages.mask;
 		addr += vga.svga.bank_read_full;
 		addr = CHECKED(addr);
-		if (GCC_UNLIKELY(addr & 1)) {
+		if (addr & 1) {
 			return static_cast<uint16_t>(
 			        (readHandler_byte(addr + 0) << 0) |
 			        (readHandler_byte(addr + 1) << 8));
-		} else
+		} else {
 			return readHandler_word(addr);
+		}
 	}
 
 	uint32_t readd(PhysPt addr) override
@@ -417,15 +418,16 @@ public:
 		addr = PAGING_GetPhysicalAddress(addr) & vgapages.mask;
 		addr += vga.svga.bank_read_full;
 		addr = CHECKED(addr);
-		if (GCC_UNLIKELY(addr & 3)) {
+		if (addr & 3) {
 			return static_cast<uint32_t>(
 			        (readHandler_byte(addr + 0) << 0) |
 			        (readHandler_byte(addr + 1) << 8) |
 			        (readHandler_byte(addr + 2) << 16) |
 			        (readHandler_byte(addr + 3) << 24));
 
-		} else
+		} else {
 			return readHandler_dword(addr);
+		}
 	}
 
 	void writeb(PhysPt addr, uint8_t val) override
@@ -445,7 +447,7 @@ public:
 		addr = CHECKED(addr);
 		MEM_CHANGED( addr );
 //		MEM_CHANGED( addr + 1);
-		if (GCC_UNLIKELY(addr & 1)) {
+		if (addr & 1) {
 			writeHandler_byte(addr + 0, val >> 0);
 			writeHandler_byte(addr + 1, val >> 8);
 		} else {
@@ -461,7 +463,7 @@ public:
 		addr = CHECKED(addr);
 		MEM_CHANGED( addr );
 //		MEM_CHANGED( addr + 3);
-		if (GCC_UNLIKELY(addr & 3)) {
+		if (addr & 3) {
 			writeHandler_byte(addr + 0, val >> 0);
 			writeHandler_byte(addr + 1, val >> 8);
 			writeHandler_byte(addr + 2, val >> 16);
@@ -546,8 +548,8 @@ public:
 	void writeb(PhysPt addr, uint8_t val) override
 	{
 		addr = PAGING_GetPhysicalAddress(addr) & vgapages.mask;
-		
-		if (GCC_LIKELY(vga.seq.map_mask == 0x4)) {
+
+		if (vga.seq.map_mask == 0x4) {
 			vga.draw.font[addr] = val;
 		} else {
 			if (vga.seq.map_mask & 0x4) // font map

--- a/src/hardware/vga_xga.cpp
+++ b/src/hardware/vga_xga.cpp
@@ -157,23 +157,30 @@ void XGA_DrawPoint(Bitu x, Bitu y, Bitu c) {
 	   during windows dragging. */
 	switch(XGA_COLOR_MODE) {
 		case M_LIN8:
-			if (GCC_UNLIKELY(memaddr >= vga.vmemsize)) break;
-			vga.mem.linear[memaddr] = c;
-			break;
-		case M_LIN15:
-			if (GCC_UNLIKELY(memaddr*2 >= vga.vmemsize)) break;
-			((uint16_t*)(vga.mem.linear))[memaddr] = (uint16_t)(c&0x7fff);
-			break;
-		case M_LIN16:
-			if (GCC_UNLIKELY(memaddr*2 >= vga.vmemsize)) break;
-			((uint16_t*)(vga.mem.linear))[memaddr] = (uint16_t)(c&0xffff);
-			break;
-		case M_LIN32:
-			if (GCC_UNLIKELY(memaddr*4 >= vga.vmemsize)) break;
-			((uint32_t*)(vga.mem.linear))[memaddr] = c;
-			break;
-		default:
-			break;
+		        if (memaddr >= vga.vmemsize) {
+			        break;
+		        }
+		        vga.mem.linear[memaddr] = c;
+		        break;
+	        case M_LIN15:
+		        if (memaddr * 2 >= vga.vmemsize) {
+			        break;
+		        }
+		        ((uint16_t*)(vga.mem.linear))[memaddr] = (uint16_t)(c & 0x7fff);
+		        break;
+	        case M_LIN16:
+		        if (memaddr * 2 >= vga.vmemsize) {
+			        break;
+		        }
+		        ((uint16_t*)(vga.mem.linear))[memaddr] = (uint16_t)(c & 0xffff);
+		        break;
+	        case M_LIN32:
+		        if (memaddr * 4 >= vga.vmemsize) {
+			        break;
+		        }
+		        ((uint32_t*)(vga.mem.linear))[memaddr] = c;
+		        break;
+	        default: break;
 	}
 
 }
@@ -183,14 +190,20 @@ Bitu XGA_GetPoint(Bitu x, Bitu y) {
 
 	switch(XGA_COLOR_MODE) {
 	case M_LIN8:
-		if (GCC_UNLIKELY(memaddr >= vga.vmemsize)) break;
+		if (memaddr >= vga.vmemsize) {
+			break;
+		}
 		return vga.mem.linear[memaddr];
 	case M_LIN15:
 	case M_LIN16:
-		if (GCC_UNLIKELY(memaddr*2 >= vga.vmemsize)) break;
+		if (memaddr * 2 >= vga.vmemsize) {
+			break;
+		}
 		return ((uint16_t*)(vga.mem.linear))[memaddr];
 	case M_LIN32:
-		if (GCC_UNLIKELY(memaddr*4 >= vga.vmemsize)) break;
+		if (memaddr * 4 >= vga.vmemsize) {
+			break;
+		}
 		return ((uint32_t*)(vga.mem.linear))[memaddr];
 	default:
 		break;
@@ -1244,8 +1257,9 @@ uint32_t XGA_Read(io_port_t port, io_width_t width)
 		break;
 	case 0x83da: {
 		Bits delaycyc = CPU_CycleMax / 5000;
-		if (GCC_UNLIKELY(CPU_Cycles < 3 * delaycyc))
+		if (CPU_Cycles < 3 * delaycyc) {
 			delaycyc = 0;
+		}
 		CPU_Cycles -= delaycyc;
 		CPU_IODelayRemoved += delaycyc;
 		return vga_read_p3da(0, io_width_t::byte);

--- a/src/hardware/voodoo.cpp
+++ b/src/hardware/voodoo.cpp
@@ -1067,8 +1067,7 @@ inline int64_t fast_reciplog(int64_t value, int32_t* log_2)
 	}
 
 	/* if the resulting value is 0, the reciprocal is infinite */
-	if (GCC_UNLIKELY(temp == 0))
-	{
+	if (temp == 0) {
 		*log_2 = 1000 << LOG_OUTPUT_PREC;
 		return neg ? 0x80000000 : 0x7fffffff;
 	}

--- a/src/ints/int10_char.cpp
+++ b/src/ints/int10_char.cpp
@@ -219,8 +219,8 @@ void INT10_ScrollWindow(uint8_t rul,uint8_t cul,uint8_t rlr,uint8_t clr,int8_t n
 	PhysPt base=CurMode->pstart;
 	if (page==0xff) base+=real_readw(BIOSMEM_SEG,BIOSMEM_CURRENT_START);
 	else base+=page*real_readw(BIOSMEM_SEG,BIOSMEM_PAGE_SIZE);
-	
-	if (GCC_UNLIKELY(machine==MCH_PCJR)) {
+
+	if (machine == MCH_PCJR) {
 		if (real_readb(BIOSMEM_SEG, BIOSMEM_CURRENT_MODE) >= 9) {
 			// PCJr cannot handle these modes at 0xb800
 			// See INT10_PutPixel M_TANDY16
@@ -572,9 +572,9 @@ void WriteChar(uint16_t col,uint16_t row,uint8_t page,uint8_t chr,uint8_t attr,b
 	}
 	fontdata=RealMake(RealSegment(fontdata),RealOffset(fontdata)+chr*cheight);
 
-	if(GCC_UNLIKELY(!useattr)) { //Set attribute(color) to a sensible value
+	if (!useattr) { // Set attribute(color) to a sensible value
 		static bool warned_use = false;
-		if(GCC_UNLIKELY(!warned_use)){ 
+		if (!warned_use) {
 			LOG(LOG_INT10,LOG_ERROR)("writechar used without attribute in non-textmode %c %X",chr,chr);
 			warned_use = true;
 		}

--- a/src/ints/int10_modes.cpp
+++ b/src/ints/int10_modes.cpp
@@ -641,7 +641,7 @@ static void SetTextLines(void) {
 
 void INT10_SetCurMode(void) {
 	uint16_t bios_mode=(uint16_t)real_readb(BIOSMEM_SEG,BIOSMEM_CURRENT_MODE);
-	if (GCC_UNLIKELY(CurMode->mode!=bios_mode)) {
+	if (CurMode->mode != bios_mode) {
 		bool mode_changed=false;
 
 		switch (machine) {

--- a/src/ints/int10_put_pixel.cpp
+++ b/src/ints/int10_put_pixel.cpp
@@ -198,7 +198,7 @@ void INT10_PutPixel(uint16_t x,uint16_t y,uint8_t page,uint8_t color) {
 			break;
 		}
 	default:
-		if(GCC_UNLIKELY(!putpixelwarned)) {
+		if (!putpixelwarned) {
 			putpixelwarned = true;		
 			LOG(LOG_INT10,LOG_ERROR)("PutPixel unhandled mode type %d",CurMode->type);
 		}

--- a/src/misc/unicode.cpp
+++ b/src/misc/unicode.cpp
@@ -544,16 +544,16 @@ static bool utf8_to_wide(const std::string& str_in, std::vector<uint16_t>& str_o
 		// symbols, etc. More bytes are needed mainly for historic
 		// scripts, emoji, etc.
 
-		if (GCC_UNLIKELY(byte_1 >= decode_threshold_6_bytes)) {
+		if (byte_1 >= decode_threshold_6_bytes) {
 			// 6-byte code point (>= 31 bits), no support
 			advance(5);
-		} else if (GCC_UNLIKELY(byte_1 >= decode_threshold_5_bytes)) {
+		} else if (byte_1 >= decode_threshold_5_bytes) {
 			// 5-byte code point (>= 26 bits), no support
 			advance(4);
-		} else if (GCC_UNLIKELY(byte_1 >= decode_threshold_4_bytes)) {
+		} else if (byte_1 >= decode_threshold_4_bytes) {
 			// 4-byte code point (>= 21 bits), no support
 			advance(3);
-		} else if (GCC_UNLIKELY(byte_1 >= decode_threshold_3_bytes)) {
+		} else if (byte_1 >= decode_threshold_3_bytes) {
 			// 3-byte code point - decode 1st byte
 			code_point = static_cast<uint8_t>(
 			        byte_1 - decode_threshold_3_bytes);
@@ -579,7 +579,7 @@ static bool utf8_to_wide(const std::string& str_in, std::vector<uint16_t>& str_o
 			} else {
 				status = false; // code point encoding too short
 			}
-		} else if (GCC_UNLIKELY(byte_1 >= decode_threshold_2_bytes)) {
+		} else if (byte_1 >= decode_threshold_2_bytes) {
 			// 2-byte code point - decode 1st byte
 			code_point = static_cast<uint8_t>(
 			        byte_1 - decode_threshold_2_bytes);
@@ -866,7 +866,7 @@ static void dos_to_wide(const std::string& str_in,
 
 	for (const auto character : str_in) {
 		const auto byte = static_cast<uint8_t>(character);
-		if (GCC_UNLIKELY(byte >= decode_threshold_non_ascii)) {
+		if (byte >= decode_threshold_non_ascii) {
 			// Character above 0x07f - take from code page mapping
 			auto& mappings = per_code_page_mappings[code_page];
 
@@ -878,7 +878,7 @@ static void dos_to_wide(const std::string& str_in,
 			}
 
 		} else {
-			if (GCC_UNLIKELY(byte == 0x7f)) {
+			if (byte == 0x7f) {
 				str_out.push_back(codepoint_7f);
 			} else if (byte >= 0x20) {
 				str_out.push_back(byte);
@@ -1000,9 +1000,9 @@ static bool get_ascii(const std::string& token, uint8_t& out)
 {
 	if (token.length() == 1) {
 		out = static_cast<uint8_t>(token[0]);
-	} else if (GCC_UNLIKELY(token == "SPC")) {
+	} else if (token == "SPC") {
 		out = ' ';
-	} else if (GCC_UNLIKELY(token == "HSH")) {
+	} else if (token == "HSH") {
 		out = '#';
 	} else if (token == "NNN") {
 		out = unknown_character;
@@ -1015,18 +1015,18 @@ static bool get_ascii(const std::string& token, uint8_t& out)
 
 static bool get_code_page(const std::string& token, uint16_t& code_page)
 {
-	if (GCC_UNLIKELY(token.empty() || token.length() > 5)) {
+	if (token.empty() || token.length() > 5) {
 		return false;
 	}
 
 	for (const auto character : token) {
-		if (GCC_UNLIKELY(character < '0' || character > '9')) {
+		if (character < '0' || character > '9') {
 			return false;
 		}
 	}
 
 	const auto tmp = std::atoi(token.c_str());
-	if (GCC_UNLIKELY(tmp < 1 || tmp > UINT16_MAX)) {
+	if (tmp < 1 || tmp > UINT16_MAX) {
 		return false;
 	}
 
@@ -1174,7 +1174,7 @@ static bool import_mapping_code_page(const std_fs::path& path_root,
 			return false;
 		}
 
-		if (GCC_UNLIKELY(tokens.size() == 1)) {
+		if (tokens.size() == 1) {
 			// Handle undefined character entry, ignore 7-bit ASCII
 			// codes
 			if (character_code >= decode_threshold_non_ascii) {
@@ -1255,7 +1255,7 @@ static void import_config_main(const std_fs::path& path_root)
 			continue; // empty line
 		uint8_t character_code = 0;
 
-		if (GCC_UNLIKELY(tokens[0] == "ALIAS")) {
+		if (tokens[0] == "ALIAS") {
 			if ((tokens.size() != 3 && tokens.size() != 4) ||
 			    (tokens.size() == 4 && tokens[3] != "BIDIRECTIONAL")) {
 				error_parsing(file_name, line_num);
@@ -1279,7 +1279,7 @@ static void import_config_main(const std_fs::path& path_root)
 
 			curent_code_page = 0;
 
-		} else if (GCC_UNLIKELY(tokens[0] == "CODEPAGE")) {
+		} else if (tokens[0] == "CODEPAGE") {
 			auto check_no_code_page = [&](const uint16_t code_page) {
 				if ((new_config_mappings.find(code_page) != new_config_mappings.end() && new_config_mappings[code_page].valid) ||
 				    new_config_duplicates.find(code_page) != new_config_duplicates.end()) {
@@ -1323,7 +1323,7 @@ static void import_config_main(const std_fs::path& path_root)
 				curent_code_page = code_page;
 			}
 
-		} else if (GCC_UNLIKELY(tokens[0] == "EXTENDS")) {
+		} else if (tokens[0] == "EXTENDS") {
 			if (!curent_code_page) {
 				error_code_page_none(file_name, line_num);
 				return;


### PR DESCRIPTION
This is just to performance test the removal of the GCC_LIKELY/GCC_UNLIKELY macros. If no one sees any performance loss over this, I'll remove the noise from the codebase entirely.

EDIT: I lied, I removed it from the codebase entirely. I've noticed zero performance difference on macOS or Windows from cleaning these out entirely.