### PR TITLE
Pass button press events to guest side if gaining focus in seamless mode

### DIFF
--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -4801,6 +4801,9 @@ int sdl_main(int argc, char* argv[])
 		}
 #endif
 #endif // WIN32
+		// Seamless mouse integration feels more 'seamless' if mouse
+		// clicks on out-of-focus window are passed to the guest
+		SDL_SetHint(SDL_HINT_MOUSE_FOCUS_CLICKTHROUGH, "1");
 
 		if (const auto err = check_kmsdrm_setting(); err != 0) {
 			return err;


### PR DESCRIPTION
# Description

Provide a hint to the SDL library, resulting in a better seamless mouse integration behavior; see the _Manual testing_ chapter for the use case.

Thanks to @Torinde for signaling the problem.

## Related issues

https://github.com/dosbox-staging/dosbox-staging/discussions/3290


# Manual testing

- set `mouse_capture` to `seamless`, run DOSBox in a window
- launch DOS Navigator, Norton Commander, or other program having menus
- click outside of of the DOSBox window, so that it loses the focus
- click on the DOS navigator menu - even the first click, when DOSBox window has no focus yet, should be now passed to the guest software (before the PR the results were OS-dependent; on Linux with X11 and KDE the behavior was random, on Windows 11 the first mouse click was never propagated to guest)


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

