### PR TITLE
Fix two overflows caught when testing Frontier - First Encounters

### DIFF
--- a/src/cpu/core_full/string.h
+++ b/src/cpu/core_full/string.h
@@ -27,7 +27,14 @@
 	uint32_t si_index       = is_32bit_addr ? reg_esi : reg_si;
 	uint32_t di_index       = is_32bit_addr ? reg_edi : reg_di;
 
-	int32_t count = check_cast<int32_t>(is_32bit_addr ? reg_ecx : reg_cx);
+	// Count has to be large enough to both hold an unsigned 32-bit
+	// value and also be used as a signed counter. To test the
+	// maximum, press enter during Frontier First Encounter's intro
+	// sequence on an arm64 or PPC platform, in which case all bits
+	// of ECX will be set.
+	//
+	int64_t count = is_32bit_addr ? reg_ecx : reg_cx;
+
 	int32_t count_left = 0;
 
 	if (!(inst.prefix & PREFIX_REP)) {


### PR DESCRIPTION
# Description

A couple overflows were flagged when testing Frontier - First Encounters with a debug and UBSAN build.

This first is a type casting issue in the `DIMULD` operation, and a second is a counter not being of sufficient size.

Suggest reviewing commits separately.

## Related issues

When compiling a debug sanitizer build with the recompiling core, this allows Frontier - First Encounters to generate the same DOS page fault-related crash on x86-64 hosts as it currently does on arm64 and PPC hosts (finally; at least we have a common behaviour now).

# Manual testing


```shell
meson setup -Dbuildtype=debug -Db_sanitize=undefined \
            -Ddynamic_core=dynrec build
meson compile -C build
```

Tested the above debug + UBSAN build with the entire benchmark pack, including LINPACK and Frontier - First Encounters.

If the same build is run with Frontier - First Encounters, it will report a UBSAN overflow and terminate with out-of-bounds `check_cast` assertion.

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

