### PR TITLE
Improve Sound Blaster DSP write buffer status IO (02x0Ch) logic

### DIFF
--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -1980,31 +1980,32 @@ static uint8_t read_sb(io_port_t port, io_width_t)
 	case MIXER_DATA: return CTMIXER_Read();
 	case DSP_READ_DATA: return DSP_ReadData();
 	case DSP_READ_STATUS:
-		//TODO See for high speed dma :)
-		if (sb.irq.pending_8bit)  {
-			sb.irq.pending_8bit=false;
+		// TODO See for high speed dma :)
+		if (sb.irq.pending_8bit) {
+			sb.irq.pending_8bit = false;
 			PIC_DeActivateIRQ(sb.hw.irq);
 		}
-		if (sb.dsp.out.used) return 0xff;
-		else return 0x7f;
-	case DSP_ACK_16BIT:
-		sb.irq.pending_16bit=false;
-		break;
+		if (sb.dsp.out.used) {
+			return 0xff;
+		} else {
+			return 0x7f;
+		}
+	case DSP_ACK_16BIT: sb.irq.pending_16bit = false; break;
 	case DSP_WRITE_STATUS:
 		switch (sb.dsp.state) {
 		case DSP_S_NORMAL:
 			sb.dsp.write_busy++;
-			if (sb.dsp.write_busy & 8) return 0xff;
+			if (sb.dsp.write_busy & 8) {
+				return 0xff;
+			}
 			return 0x7f;
 		case DSP_S_RESET:
-		case DSP_S_RESET_WAIT:
-			return 0xff;
+		case DSP_S_RESET_WAIT: return 0xff;
 		}
 		return 0xff;
-	case DSP_RESET:
-		return 0xff;
+	case DSP_RESET: return 0xff;
 	default:
-		LOG(LOG_SB,LOG_NORMAL)("Unhandled read from SB Port %4X",port);
+		LOG(LOG_SB, LOG_NORMAL)("Unhandled read from SB Port %4X", port);
 		break;
 	}
 	return 0xff;


### PR DESCRIPTION
# Description

The Sound Blaster's 02x0Ch read IO call checks to see if the DSP can support more data writes.

In the baseline code, repeated reads from 02x0Ch use a counter that flip-flops in batches of eight between _"we're full, we can't accept data"_ and _"yes, we can accept data"_.

This behaviour causes SimLife and Scali's modified the Crystal Dream demo to eventually give up on setting up their DMA transfers.

This PR split this eight on/off logic:
1. The `off` part is kept; we now report available room every 8th call.
2. The `on` part is replaced with an actual check of the DMA buffer state.

So this replaces the _"we're busy, we're busy, we're busy, [x8]"_ with
an actual check of the DMA status.. and if DMA isn't running or
at the minimum (about to run dry), then we say _"we're available"_.

Suggest reviewing commit-by-commit. I've taken care to make sure each type of change is isolated one by one, so we can bisect to the specific issue.

## Related issues

Fixes #3212 

https://github.com/dosbox-staging/dosbox-staging/assets/1557255/bd6f2db2-c2c3-4bf0-993e-f8b91932e3c0

# Manual testing

Regression tested:
- Alone in the Dark
- Albion
- Crystal Dream (Scali's DMA-improved version)
- DOOM
- DOOM II
- Duke Nukem 2
- Freddy Pharkas
- HoMM I
- Impulse Tracker
- Jet Pack
- Mortal Kombat 2
- OCP Player
- Overdrive
- Pinball Dreams
- Scream Tracker 3
- Sim City 2000
- SimLife
- Tale of Peter Rabbit
- Terminal Velocity
- The Rocketeer
- Prehistorik 2
- Blue Brothers 2

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

