### PR TITLE
Don't sign extend 16-bit immediates to 32-bit in ppc dynrec, fixes 

### DIFF
--- a/src/cpu/core_dynrec/risc_ppc.h
+++ b/src/cpu/core_dynrec/risc_ppc.h
@@ -149,7 +149,12 @@ static void gen_mov_regs(HostReg reg_dst,HostReg reg_src)
 // the upper 16bit of the destination register may be destroyed
 static void gen_mov_word_to_reg_imm(HostReg dest_reg,uint16_t imm)
 {
-	IMM_OP(14, dest_reg, 0, imm); // li dest,imm
+	if (imm & 0x8000) {                 // watch out for sign extension
+		IMM_OP(14, dest_reg, 0, 0); // li dest,0
+		IMM_OP(24, dest_reg, dest_reg, imm); // ori dest,dest,imm
+	} else {
+		IMM_OP(14, dest_reg, 0, imm); // li dest,imm
+	}
 }
 
 DRC_PTR_SIZE_IM block_ptr;


### PR DESCRIPTION
# Description

Apply @classilla's same sign extend check to the 32-bit PPC dynrec, as he did for the 64-bit PPC LE.

This was confirmed working by @casey-ac (note - by 'revert' I belive he means this change):

> I verified the same text rendering issue occurs with big endian PowerPC and applying the revert to risc_ppc.h fixes the issue.

# Manual testing

None. I don't have my PPC laptop setup. Going by @casey-ac's comment and the fact that this makes sense.

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

