### PR TITLE
Add missing `#version` pragma to some shaders

### DIFF
--- a/contrib/resources/glshaders/crt/arcade-1080p.glsl
+++ b/contrib/resources/glshaders/crt/arcade-1080p.glsl
@@ -3,6 +3,8 @@
 /*
    Hyllian's CRT Shader
 
+   Copyright (C) 2020-2024  The DOSBox Staging Team
+
    Copyright (C) 2011-2020 Hyllian - sergiogdb@gmail.com
 
    Copyright (C) 2020, this file ported from Libretro's GLSL

--- a/contrib/resources/glshaders/crt/arcade-1440p.glsl
+++ b/contrib/resources/glshaders/crt/arcade-1440p.glsl
@@ -3,6 +3,8 @@
 /*
    Hyllian's CRT Shader
 
+   Copyright (C) 2020-2024  The DOSBox Staging Team
+
    Copyright (C) 2011-2020 Hyllian - sergiogdb@gmail.com
 
    Copyright (C) 2020, this file ported from Libretro's GLSL

--- a/contrib/resources/glshaders/crt/arcade-4k.glsl
+++ b/contrib/resources/glshaders/crt/arcade-4k.glsl
@@ -3,6 +3,8 @@
 /*
    Hyllian's CRT Shader
 
+   Copyright (C) 2020-2024  The DOSBox Staging Team
+
    Copyright (C) 2011-2020 Hyllian - sergiogdb@gmail.com
 
    Copyright (C) 2020, this file ported from Libretro's GLSL

--- a/contrib/resources/glshaders/crt/arcade-sharp-1080p.glsl
+++ b/contrib/resources/glshaders/crt/arcade-sharp-1080p.glsl
@@ -3,6 +3,8 @@
 /*
    Hyllian's CRT Shader
 
+   Copyright (C) 2020-2024  The DOSBox Staging Team
+
    Copyright (C) 2011-2020 Hyllian - sergiogdb@gmail.com
 
    Copyright (C) 2020, this file ported from Libretro's GLSL

--- a/contrib/resources/glshaders/crt/arcade-sharp-1440p.glsl
+++ b/contrib/resources/glshaders/crt/arcade-sharp-1440p.glsl
@@ -3,6 +3,8 @@
 /*
    Hyllian's CRT Shader
 
+   Copyright (C) 2020-2024  The DOSBox Staging Team
+
    Copyright (C) 2011-2020 Hyllian - sergiogdb@gmail.com
 
    Copyright (C) 2020, this file ported from Libretro's GLSL

--- a/contrib/resources/glshaders/crt/arcade-sharp-4k.glsl
+++ b/contrib/resources/glshaders/crt/arcade-sharp-4k.glsl
@@ -3,6 +3,8 @@
 /*
    Hyllian's CRT Shader
 
+   Copyright (C) 2020-2024  The DOSBox Staging Team
+
    Copyright (C) 2011-2020 Hyllian - sergiogdb@gmail.com
 
    Copyright (C) 2020, this file ported from Libretro's GLSL

--- a/contrib/resources/glshaders/crt/cga-1080p.glsl
+++ b/contrib/resources/glshaders/crt/cga-1080p.glsl
@@ -3,6 +3,8 @@
 /*
    Hyllian's CRT Shader
 
+   Copyright (C) 2020-2024  The DOSBox Staging Team
+
    Copyright (C) 2011-2020 Hyllian - sergiogdb@gmail.com
 
    Copyright (C) 2020, this file ported from Libretro's GLSL

--- a/contrib/resources/glshaders/crt/cga-1440p.glsl
+++ b/contrib/resources/glshaders/crt/cga-1440p.glsl
@@ -3,6 +3,8 @@
 /*
    Hyllian's CRT Shader
 
+   Copyright (C) 2020-2024  The DOSBox Staging Team
+
    Copyright (C) 2011-2020 Hyllian - sergiogdb@gmail.com
 
    Copyright (C) 2020, this file ported from Libretro's GLSL

--- a/contrib/resources/glshaders/crt/cga-4k.glsl
+++ b/contrib/resources/glshaders/crt/cga-4k.glsl
@@ -3,6 +3,8 @@
 /*
    Hyllian's CRT Shader
 
+   Copyright (C) 2020-2024  The DOSBox Staging Team
+
    Copyright (C) 2011-2020 Hyllian - sergiogdb@gmail.com
 
    Copyright (C) 2020, this file ported from Libretro's GLSL

--- a/contrib/resources/glshaders/crt/cga-720p.glsl
+++ b/contrib/resources/glshaders/crt/cga-720p.glsl
@@ -3,6 +3,8 @@
 /*
    Hyllian's CRT Shader
 
+   Copyright (C) 2020-2024  The DOSBox Staging Team
+
    Copyright (C) 2011-2020 Hyllian - sergiogdb@gmail.com
 
    Copyright (C) 2020, this file ported from Libretro's GLSL

--- a/contrib/resources/glshaders/crt/composite-1080p.glsl
+++ b/contrib/resources/glshaders/crt/composite-1080p.glsl
@@ -3,6 +3,8 @@
 /*
    Hyllian's CRT Shader
 
+   Copyright (C) 2020-2024  The DOSBox Staging Team
+
    Copyright (C) 2011-2020 Hyllian - sergiogdb@gmail.com
 
    Copyright (C) 2020, this file ported from Libretro's GLSL

--- a/contrib/resources/glshaders/crt/composite-1440p.glsl
+++ b/contrib/resources/glshaders/crt/composite-1440p.glsl
@@ -3,6 +3,8 @@
 /*
    Hyllian's CRT Shader
 
+   Copyright (C) 2020-2024  The DOSBox Staging Team
+
    Copyright (C) 2011-2020 Hyllian - sergiogdb@gmail.com
 
    Copyright (C) 2020, this file ported from Libretro's GLSL

--- a/contrib/resources/glshaders/crt/composite-4k.glsl
+++ b/contrib/resources/glshaders/crt/composite-4k.glsl
@@ -3,6 +3,8 @@
 /*
    Hyllian's CRT Shader
 
+   Copyright (C) 2020-2024  The DOSBox Staging Team
+
    Copyright (C) 2011-2020 Hyllian - sergiogdb@gmail.com
 
    Copyright (C) 2020, this file ported from Libretro's GLSL

--- a/contrib/resources/glshaders/crt/ega-1080p.glsl
+++ b/contrib/resources/glshaders/crt/ega-1080p.glsl
@@ -3,6 +3,8 @@
 /*
    Hyllian's CRT Shader
 
+   Copyright (C) 2020-2024  The DOSBox Staging Team
+
    Copyright (C) 2011-2020 Hyllian - sergiogdb@gmail.com
 
    Copyright (C) 2020, this file ported from Libretro's GLSL

--- a/contrib/resources/glshaders/crt/ega-1440p.glsl
+++ b/contrib/resources/glshaders/crt/ega-1440p.glsl
@@ -3,6 +3,8 @@
 /*
    Hyllian's CRT Shader
 
+   Copyright (C) 2020-2024  The DOSBox Staging Team
+
    Copyright (C) 2011-2020 Hyllian - sergiogdb@gmail.com
 
    Copyright (C) 2020, this file ported from Libretro's GLSL

--- a/contrib/resources/glshaders/crt/ega-4k.glsl
+++ b/contrib/resources/glshaders/crt/ega-4k.glsl
@@ -3,6 +3,8 @@
 /*
    Hyllian's CRT Shader
 
+   Copyright (C) 2020-2024  The DOSBox Staging Team
+
    Copyright (C) 2011-2020 Hyllian - sergiogdb@gmail.com
 
    Copyright (C) 2020, this file ported from Libretro's GLSL

--- a/contrib/resources/glshaders/crt/ega-720p.glsl
+++ b/contrib/resources/glshaders/crt/ega-720p.glsl
@@ -3,6 +3,8 @@
 /*
    Hyllian's CRT Shader
 
+   Copyright (C) 2020-2024  The DOSBox Staging Team
+
    Copyright (C) 2011-2020 Hyllian - sergiogdb@gmail.com
 
    Copyright (C) 2020, this file ported from Libretro's GLSL

--- a/contrib/resources/glshaders/crt/hercules.glsl
+++ b/contrib/resources/glshaders/crt/hercules.glsl
@@ -3,6 +3,8 @@
 /*
    Hyllian's CRT Shader
 
+   Copyright (C) 2020-2024  The DOSBox Staging Team
+
    Copyright (C) 2011-2020 Hyllian - sergiogdb@gmail.com
 
    Copyright (C) 2020, this file ported from Libretro's GLSL

--- a/contrib/resources/glshaders/crt/monochrome-hires.glsl
+++ b/contrib/resources/glshaders/crt/monochrome-hires.glsl
@@ -3,6 +3,8 @@
 /*
    Hyllian's CRT Shader
 
+   Copyright (C) 2020-2024  The DOSBox Staging Team
+
    Copyright (C) 2011-2020 Hyllian - sergiogdb@gmail.com
 
    Copyright (C) 2020, this file ported from Libretro's GLSL

--- a/contrib/resources/glshaders/crt/monochrome-lowres.glsl
+++ b/contrib/resources/glshaders/crt/monochrome-lowres.glsl
@@ -3,6 +3,8 @@
 /*
    Hyllian's CRT Shader
 
+   Copyright (C) 2020-2024  The DOSBox Staging Team
+
    Copyright (C) 2011-2020 Hyllian - sergiogdb@gmail.com
 
    Copyright (C) 2020, this file ported from Libretro's GLSL

--- a/contrib/resources/glshaders/crt/vga-1080p-fake-double-scan.glsl
+++ b/contrib/resources/glshaders/crt/vga-1080p-fake-double-scan.glsl
@@ -1,5 +1,28 @@
 #version 120
 
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2020-2024  The DOSBox Staging Team
+ *
+ *  Based on parts of the Caligari shader plus bits and pieces from Hyllian,
+ *  Easymode, and probably a few others.
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
 #pragma use_npot_texture
 #pragma force_single_scan
 

--- a/contrib/resources/glshaders/crt/vga-1080p.glsl
+++ b/contrib/resources/glshaders/crt/vga-1080p.glsl
@@ -1,5 +1,28 @@
 #version 120
 
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2020-2024  The DOSBox Staging Team
+ *
+ *  Based on parts of the Caligari shader plus bits and pieces from Hyllian,
+ *  Easymode, and probably a few others.
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
 #pragma use_npot_texture
 
 #define SPOT_WIDTH             0.85
@@ -50,9 +73,9 @@ uniform sampler2D rubyTexture;
 
 // Macro for weights computing
 #define WEIGHT(w) \
-    if (w > 1.0) w = 1.0; \
-  w = 1.0 - w * w; \
-  w = w * w;
+   if (w > 1.0) w = 1.0; \
+   w = 1.0 - w * w; \
+   w = w * w;
 
 
 vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout){

--- a/contrib/resources/glshaders/crt/vga-1440p.glsl
+++ b/contrib/resources/glshaders/crt/vga-1440p.glsl
@@ -3,6 +3,8 @@
 /*
    Hyllian's CRT Shader
 
+   Copyright (C) 2020-2024  The DOSBox Staging Team
+
    Copyright (C) 2011-2020 Hyllian - sergiogdb@gmail.com
 
    Copyright (C) 2020, this file ported from Libretro's GLSL

--- a/contrib/resources/glshaders/crt/vga-4k.glsl
+++ b/contrib/resources/glshaders/crt/vga-4k.glsl
@@ -3,6 +3,8 @@
 /*
    Hyllian's CRT Shader
 
+   Copyright (C) 2020-2024  The DOSBox Staging Team
+
    Copyright (C) 2011-2020 Hyllian - sergiogdb@gmail.com
 
    Copyright (C) 2020, this file ported from Libretro's GLSL

--- a/contrib/resources/glshaders/interpolation/catmull-rom.glsl
+++ b/contrib/resources/glshaders/interpolation/catmull-rom.glsl
@@ -1,14 +1,39 @@
 #version 120
 
 /*
-	Ported from https://gist.github.com/TheRealMJP/c83b8c0f46b63f3a88a5986f4fa982b1
-	Based on Tyrell Sassen's template from https://github.com/tyrells/dosbox-svn-shaders
+ *	SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *	Copyright (C) 2020-2024  The DOSBox Staging Team
+ *
+ *	This program is free software; you can redistribute it and/or modify
+ *	it under the terms of the GNU General Public License as published by
+ *	the Free Software Foundation; either version 2 of the License, or
+ *	(at your option) any later version.
+ *
+ *	This program is distributed in the hope that it will be useful,
+ *	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *	GNU General Public License for more details.
+ *
+ *	You should have received a copy of the GNU General Public License along
+ *	with this program; if not, write to the Free Software Foundation, Inc.,
+ *	51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
 
-	The following code is licensed under the MIT license: https://gist.github.com/TheRealMJP/bc503b0b87b643d3505d41eab8b332ae
-
-	Samples a texture with Catmull-Rom filtering, using 9 texture fetches instead of 16.
-	See http://vec3.ca/bicubic-filtering-in-fewer-taps/ for more details
-*/
+/*
+ *	Ported from:
+ *	https://gist.github.com/TheRealMJP/c83b8c0f46b63f3a88a5986f4fa982b1
+ *
+ *	Based on Tyrell Sassen's template from
+ *	https://github.com/tyrells/dosbox-svn-shaders
+ *
+ *	The following code is licensed under the MIT license:
+ *	https://gist.github.com/TheRealMJP/bc503b0b87b643d3505d41eab8b332ae
+ *
+ *	Samples a texture with Catmull-Rom filtering, using 9 texture fetches
+ *	instead of 16. See http://vec3.ca/bicubic-filtering-in-fewer-taps/ for
+ *	more details
+ */
 
 #pragma use_npot_texture
 #pragma use_srgb_texture

--- a/contrib/resources/glshaders/interpolation/sharp.glsl
+++ b/contrib/resources/glshaders/interpolation/sharp.glsl
@@ -1,3 +1,5 @@
+#version 120
+
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *

--- a/contrib/resources/glshaders/interpolation/sharp.glsl
+++ b/contrib/resources/glshaders/interpolation/sharp.glsl
@@ -3,9 +3,10 @@
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *
+ *  Copyright (C) 2020-2024  The DOSBox Staging Team
  *  Copyright (C) 2020  The DOSBox Team
  *
- * Contributors:
+ *  Contributors:
  *   - 2020, jmarsh <jmarsh@vogons.org>: authored.
  *           https://svn.code.sf.net/p/dosbox/code-0/dosbox/trunk@4319
  *

--- a/contrib/resources/glshaders/misc/fixvideo-scanlines.glsl
+++ b/contrib/resources/glshaders/misc/fixvideo-scanlines.glsl
@@ -7,7 +7,7 @@
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *
- *  Copyright (C) 2020-2023  The DOSBox Staging Team
+ *  Copyright (C) 2020-2024  The DOSBox Staging Team
  *  Copyright (C) 2015 Ove Kaaven
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/contrib/resources/glshaders/misc/fixvideo.glsl
+++ b/contrib/resources/glshaders/misc/fixvideo.glsl
@@ -7,7 +7,7 @@
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *
- *  Copyright (C) 2020-2023  The DOSBox Staging Team
+ *  Copyright (C) 2020-2024  The DOSBox Staging Team
  *  Copyright (C) 2015 Ove Kaaven
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/contrib/resources/glshaders/none.glsl
+++ b/contrib/resources/glshaders/none.glsl
@@ -3,7 +3,7 @@
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *
- *  Copyright (C) 2020-2023  The DOSBox Staging Team
+ *  Copyright (C) 2020-2024  The DOSBox Staging Team
  *  Copyright (C) 2020  The DOSBox Team
  *
  *  Contributors:

--- a/contrib/resources/glshaders/scaler/advinterp2x.glsl
+++ b/contrib/resources/glshaders/scaler/advinterp2x.glsl
@@ -1,3 +1,5 @@
+#version 120
+
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *

--- a/contrib/resources/glshaders/scaler/advinterp2x.glsl
+++ b/contrib/resources/glshaders/scaler/advinterp2x.glsl
@@ -3,9 +3,10 @@
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *
+ *  Copyright (C) 2020-2024  The DOSBox Staging Team
  *  Copyright (C) 2004-2020  The DOSBox Team
  *
- * Contributors:
+ *  Contributors:
  *   - 2004, Sjoerd van der Berg <harekiet@users.sourceforge.net>: authored
  *           https://svn.code.sf.net/p/dosbox/code-0/dosbox/trunk@1817
  *

--- a/contrib/resources/glshaders/scaler/advinterp3x.glsl
+++ b/contrib/resources/glshaders/scaler/advinterp3x.glsl
@@ -1,3 +1,5 @@
+#version 120
+
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *

--- a/contrib/resources/glshaders/scaler/advinterp3x.glsl
+++ b/contrib/resources/glshaders/scaler/advinterp3x.glsl
@@ -3,6 +3,7 @@
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *
+ *  Copyright (C) 2020-2024  The DOSBox Staging Team
  *  Copyright (C) 2006-2020  The DOSBox Team
  *
  * Contributors:

--- a/contrib/resources/glshaders/scaler/advmame2x.glsl
+++ b/contrib/resources/glshaders/scaler/advmame2x.glsl
@@ -1,3 +1,5 @@
+#version 120
+
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *

--- a/contrib/resources/glshaders/scaler/advmame2x.glsl
+++ b/contrib/resources/glshaders/scaler/advmame2x.glsl
@@ -3,9 +3,10 @@
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *
+ *  Copyright (C) 2020-2024  The DOSBox Staging Team
  *  Copyright (C) 2003-2020  The DOSBox Team
  *
- * Contributors:
+ *  Contributors:
  *   - 2003, Sjoerd van der Berg <harekiet@users.sourceforge.net>: authored
  *           https://svn.code.sf.net/p/dosbox/code-0/dosbox/trunk@1320
  *

--- a/contrib/resources/glshaders/scaler/advmame3x.glsl
+++ b/contrib/resources/glshaders/scaler/advmame3x.glsl
@@ -1,3 +1,5 @@
+#version 120
+
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *

--- a/contrib/resources/glshaders/scaler/advmame3x.glsl
+++ b/contrib/resources/glshaders/scaler/advmame3x.glsl
@@ -3,9 +3,10 @@
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *
+ *  Copyright (C) 2020-2024  The DOSBox Staging Team
  *  Copyright (C) 2004-2020  The DOSBox Team
  *
- * Contributors:
+ *  Contributors:
  *   - 2004, Sjoerd van der Berg <harekiet@users.sourceforge.net>: authored
  *           https://svn.code.sf.net/p/dosbox/code-0/dosbox/trunk@1817
  *

--- a/contrib/resources/glshaders/scaler/rgb2x.glsl
+++ b/contrib/resources/glshaders/scaler/rgb2x.glsl
@@ -1,3 +1,5 @@
+#version 120
+
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *

--- a/contrib/resources/glshaders/scaler/rgb2x.glsl
+++ b/contrib/resources/glshaders/scaler/rgb2x.glsl
@@ -3,9 +3,10 @@
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *
+ *  Copyright (C) 2020-2024  The DOSBox Staging Team
  *  Copyright (C) 2006-2020  The DOSBox Team
  *
- * Contributors:
+ *  Contributors:
  *   - 2006, Sjoerd van der Berg <harekiet@users.sourceforge.net>: authored
  *           https://svn.code.sf.net/p/dosbox/code-0/dosbox/trunk@2444
  *

--- a/contrib/resources/glshaders/scaler/rgb3x.glsl
+++ b/contrib/resources/glshaders/scaler/rgb3x.glsl
@@ -1,3 +1,5 @@
+#version 120
+
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *

--- a/contrib/resources/glshaders/scaler/rgb3x.glsl
+++ b/contrib/resources/glshaders/scaler/rgb3x.glsl
@@ -3,9 +3,10 @@
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *
+ *  Copyright (C) 2020-2024  The DOSBox Staging Team
  *  Copyright (C) 2006-2020  The DOSBox Team
  *
- * Contributors:
+ *  Contributors:
  *   - 2006, Sjoerd van der Berg <harekiet@users.sourceforge.net>: authored
  *           https://svn.code.sf.net/p/dosbox/code-0/dosbox/trunk@2444
  *

--- a/contrib/resources/glshaders/scaler/scan2x.glsl
+++ b/contrib/resources/glshaders/scaler/scan2x.glsl
@@ -1,3 +1,5 @@
+#version 120
+
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *

--- a/contrib/resources/glshaders/scaler/scan2x.glsl
+++ b/contrib/resources/glshaders/scaler/scan2x.glsl
@@ -3,9 +3,10 @@
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *
+ *  Copyright (C) 2020-2024  The DOSBox Staging Team
  *  Copyright (C) 2006-2020  The DOSBox Team
  *
- * Contributors:
+ *  Contributors:
  *   - 2006, Sjoerd van der Berg <harekiet@users.sourceforge.net>: authored
  *           https://svn.code.sf.net/p/dosbox/code-0/dosbox/trunk@2444
  *

--- a/contrib/resources/glshaders/scaler/scan3x.glsl
+++ b/contrib/resources/glshaders/scaler/scan3x.glsl
@@ -1,3 +1,5 @@
+#version 120
+
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *

--- a/contrib/resources/glshaders/scaler/scan3x.glsl
+++ b/contrib/resources/glshaders/scaler/scan3x.glsl
@@ -3,9 +3,10 @@
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *
+ *  Copyright (C) 2020-2024  The DOSBox Staging Team
  *  Copyright (C) 2006-2020  The DOSBox Team
  *
- * Contributors:
+ *  Contributors:
  *   - 2006, Sjoerd van der Berg <harekiet@users.sourceforge.net>: authored
  *           https://svn.code.sf.net/p/dosbox/code-0/dosbox/trunk@2444
  *

--- a/contrib/resources/glshaders/scaler/tv2x.glsl
+++ b/contrib/resources/glshaders/scaler/tv2x.glsl
@@ -1,3 +1,5 @@
+#version 120
+
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *

--- a/contrib/resources/glshaders/scaler/tv2x.glsl
+++ b/contrib/resources/glshaders/scaler/tv2x.glsl
@@ -3,9 +3,10 @@
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *
+ *  Copyright (C) 2020-2024  The DOSBox Staging Team
  *  Copyright (C) 2004-2020  The DOSBox Team
  *
- * Contributors:
+ *  Contributors:
  *   - 2004, Sjoerd van der Berg <harekiet@users.sourceforge.net>: authored
  *           https://svn.code.sf.net/p/dosbox/code-0/dosbox/trunk@1817
  *

--- a/contrib/resources/glshaders/scaler/tv3x.glsl
+++ b/contrib/resources/glshaders/scaler/tv3x.glsl
@@ -1,3 +1,5 @@
+#version 120
+
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *

--- a/contrib/resources/glshaders/scaler/tv3x.glsl
+++ b/contrib/resources/glshaders/scaler/tv3x.glsl
@@ -3,9 +3,10 @@
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *
+ *  Copyright (C) 2020-2024  The DOSBox Staging Team
  *  Copyright (C) 2006-2020  The DOSBox Team
  *
- * Contributors:
+ *  Contributors:
  *   - 2006, Sjoerd van der Berg <harekiet@users.sourceforge.net>: authored
  *           https://svn.code.sf.net/p/dosbox/code-0/dosbox/trunk@2444
  *


### PR DESCRIPTION
# Description

Apparently, some GPUs don't like it if the `#version` pragma is not specified in a GLSL shader. So this PR adds the missing `#version` pragma to some shaders that don't have it.

Fixes https://github.com/dosbox-staging/dosbox-staging/issues/3308.

## Related issues

https://github.com/dosbox-staging/dosbox-staging/issues/3308

# Manual testing

@MonkeyPilot has verified adding the version pragma fixes the issue, plus I've regression tested the shaders.


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

