### PR TITLE
Add a simple DC bias remover for the OPL output

### DIFF
--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -821,6 +821,14 @@ void DOSBOX_Init()
 	        "                300 200 (Wait 300ms before fading out over a 200ms period)\n"
 	        "                1000 3000 (Wait 1s before fading out over a 3s period)");
 
+	pbool = secprop->Add_bool("opl_remove_dc_bias", when_idle, false);
+	pbool->Set_help(
+	        "Remove DC bias from the OPL output. This should only be used as a last resort\n"
+	        "to fix popping in games that play PCM audio using the OPL synthesiser on a\n"
+	        "Sound Blaster or AdLib card, such as in: Golden Eagle (1991), Wizardry 6\n"
+	        "(1990), and Wizardry 7 (1992). Please open an issue ticket if you find other\n"
+	        "affected games.");
+
 	pstring = secprop->Add_string("oplemu", deprecated, "");
 	pstring->Set_help("Only 'nuked' OPL emulation is supported now.");
 

--- a/src/hardware/opl.h
+++ b/src/hardware/opl.h
@@ -130,6 +130,7 @@ private:
 
 		bool active = false;
 		bool mixer  = false;
+		bool wants_dc_bias_removed = false;
 	} ctrl = {};
 
 	void Init(const uint16_t sample_rate);


### PR DESCRIPTION
# Description

Some games like Golden Eagle (1991) play PCM music and effects using the Adlib OPL channels by rapidly changing the volume in very crude steps, similar to Disney or the Covox LPT DACs.

In this case, the game uses a large DC bias which produces a heavy pop around the effect sequences:

![2024-01-07_20-05](https://github.com/dosbox-staging/dosbox-staging/assets/1557255/8fee89fd-0cb4-490c-a724-8347d07dbf13)

https://github.com/dosbox-staging/dosbox-staging/assets/1557255/f86999c8-e4db-4b9f-aca0-304b844cd6f5

---

This PR adds an opt-in feature that eliminates the OPL DC bias, which eliminates the pops:

![2024-01-07_20-05_1](https://github.com/dosbox-staging/dosbox-staging/assets/1557255/6a8869cf-9eee-4fa9-93fd-2613954568ef)

https://github.com/dosbox-staging/dosbox-staging/assets/1557255/31b1317d-206e-4ff8-8d86-723ba2f1874a

We could parameterize the settings if more games can be served by this, and if they benefit from other settings. For now, let's not over-engineer it until we need to.

Vogons has a thread that lists some (all?) of these games:

https://www.vogons.org/viewtopic.php?f=7&t=50525

_Describe a summary of your changes clearly and concisely, including motivation and context._
_Breaking changes need extra explanation on backward compatibility considerations._

_Feel free to include additional details, but please respect the reviewer's time and keep it brief._

## Related issues

Fixes #3306.

Fixes #963.

Recommended settings for Wizardry 6:

![2024-01-08_17-43](https://github.com/dosbox-staging/dosbox-staging/assets/1557255/4614cffb-e906-4775-933c-e0e275fff6f4)



```ini
[dosbox]
machine = ega

[cpu]
cycles = 1000

[sblaster]
sbtype = none
oplmode = opl2
opl_remove_dc_bias = true
opl_filter = lpf 2 5500

[speaker]
pcspeaker=off

[autoexec]
@mount c ..
c:
cd bane
mixer opl 500
```



# Manual testing

This is a default-off (opt-in) feature, and it works as expected in this one games.  Did a couple regression tests to confirm it's not active with default settings.

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

