### PR TITLE
Manage sdlmain's DOS video mode as an `<optional>`

### DIFF
--- a/include/sdlmain.h
+++ b/include/sdlmain.h
@@ -195,7 +195,8 @@ struct SDL_Block {
 		bool height_was_doubled = false;
 	} draw = {};
 
-	VideoMode video_mode = {};
+	// The DOS video mode is populated after we set up the SDL window.
+	std::optional<VideoMode> maybe_video_mode = {};
 
 	struct {
 		struct {

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -593,17 +593,11 @@ bool RENDER_MaybeAutoSwitchShader([[maybe_unused]] const DosBox::Rect canvas_siz
                                   [[maybe_unused]] const VideoMode& video_mode,
                                   [[maybe_unused]] const bool reinit_render)
 {
-	if (GFX_GetRenderingBackend() != RenderingBackend::OpenGl) {
-		return false;
-	}
+	// We always expect a valid canvas and DOS video mode
+	assert(!canvas_size_px.IsEmpty());
+	assert(video_mode.width > 0 && video_mode.height > 0);
 
-	// Currently, the init sequence is slightly different on Windows, macOS,
-	// and Linux. The first call to this function on Windows receives an
-	// uninitialised VideoMode param with width and height set to 0 which
-	// results in a crash. The proper fix is to make the init sequence 100%
-	// identical on all platforms, but in the interim this workaround will do.
-	if (canvas_size_px.IsEmpty() || video_mode.width == 0 ||
-	    video_mode.height == 0) {
+	if (GFX_GetRenderingBackend() != RenderingBackend::OpenGl) {
 		return false;
 	}
 


### PR DESCRIPTION
# Description

The execution sequence starts by initializing SDL followed by starting the DOS normal loop, which eventually sets the DOS video mode.
    
This PR makes sdlmain's DOS video mode optional because (with respect to sdlmain), the DOS video mode doesn't exist (and may not exist) until the DOS side successfully sets the video mode through the emulated video card.
    
In terms of order of operations, Both the SDL and DOS side can drive mode changes that involve switching the GL Shader as well as logging the SDL window size or DOS display mode; this commit lets those play out as-is.

## Related issues

Fixes #3314 

# Manual testing

Tested debug and sanitizer builds on Linux and macOS starting up in windowed and fullscreen modes.

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

