### PR TITLE
MIDI capture: close file on fseek error

### DIFF
--- a/src/capture/capture_midi.cpp
+++ b/src/capture/capture_midi.cpp
@@ -132,6 +132,8 @@ void capture_midi_finalise()
 	if (fseek(midi.handle, midi_header_size_offset, SEEK_SET) != 0) {
 		LOG_WARNING("CAPTURE: Failed to seek in captured MIDI file '%s'",
 		            safe_strerror(errno).c_str());
+		fclose(midi.handle);
+		midi = {};
 		return;
 	}
 


### PR DESCRIPTION
# Description

In the unlikely event that fseek() fails before writing the header, the file was not closed.


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [ ] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

