### PR TITLE
Disable joystick emulation when "joystick = auto" is set and no joystick is found

### DIFF
--- a/contrib/resources/translations/en.lng
+++ b/contrib/resources/translations/en.lng
@@ -1487,6 +1487,7 @@ Override the frame rate code used during video playback:
 :CONFIG_JOYSTICKTYPE
 Type of joystick to emulate:
   auto:      Detect and use any joystick(s), if possible (default).
+             Joystick emulation is disabled if no joystick is found.
   2axis:     Support up to two joysticks, each with 2 axis.
   4axis:     Support the first joystick only, as a 4-axis type.
   4axis_2:   Support the second joystick only, as a 4-axis type.

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -1022,6 +1022,7 @@ void DOSBOX_Init()
 	pstring->Set_help(
 	        "Type of joystick to emulate:\n"
 	        "  auto:      Detect and use any joystick(s), if possible (default).\n"
+	        "             Joystick emulation is disabled if no joystick is found.\n"
 	        "  2axis:     Support up to two joysticks, each with 2 axis.\n"
 	        "  4axis:     Support the first joystick only, as a 4-axis type.\n"
 	        "  4axis_2:   Support the second joystick only, as a 4-axis type.\n"

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -2877,11 +2877,16 @@ static void QueryJoysticks()
 	if (SDL_WasInit(SDL_INIT_JOYSTICK) != SDL_INIT_JOYSTICK)
 		SDL_InitSubSystem(SDL_INIT_JOYSTICK);
 
+	const bool wants_auto_config = joytype & (JOY_AUTO | JOY_ONLY_FOR_MAPPING);
+
 	// Record how many joysticks are present and set our desired minimum axis
 	const auto num_joysticks = SDL_NumJoysticks();
 	if (num_joysticks < 0) {
 		LOG_WARNING("MAPPER: SDL_NumJoysticks() failed: %s", SDL_GetError());
 		LOG_WARNING("MAPPER: Skipping further joystick checks");
+		if (wants_auto_config) {
+			joytype = JOY_NONE_FOUND;
+		}
 		return;
 	}
 
@@ -2890,10 +2895,12 @@ static void QueryJoysticks()
 	mapper.sticks.num = static_cast<unsigned int>(num_joysticks);
 	if (num_joysticks == 0) {
 		LOG_MSG("MAPPER: No joysticks found");
+		if (wants_auto_config) {
+			joytype = JOY_NONE_FOUND;
+		}
 		return;
 	}
 
-	const bool wants_auto_config = joytype & (JOY_AUTO | JOY_ONLY_FOR_MAPPING);
 	if (!wants_auto_config)
 		return;
 


### PR DESCRIPTION
# Description

We support a "virtual" joystick by allowing the user to use `dosbox -startmapper` to map joystick keys to another device if they do not have a physical joystick.  On v0.80.1 ,this feature was broken.  On main, this "virtual" joystick is presented to DOS regardless of whether the user has any joystick keys actually mapped when `joystick = auto` is set (default setting).

This PR changes behavior to not emulate a joystick unless there is a physical joystick attached or the user explicitly enabled a joystick in the config (ex. by setting `joystick = 2axis`).  This matches the behavior of Dosbox 0.74.3.

Ideally, we may want "auto" to be a bit smarter and check if the user has joystick keys mapped but `sdl_mapper.cpp` makes me a bit nauseated every time I look at it so I think this quick fix is fine for v0.81.

My thinking is that mapping joystick keys is more of an advanced feature and those users can edit the config file.  This prevents certain games from being unplayable when a joystick is not present (see related issues).

## Related issues

#3320 (unable to reproduce)
#3326

# Manual testing

Tested with Hardball game on issue #3226

When `joystick = auto` is set, no joystick is detected unless there is one physically connected.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

