### PR TITLE
Fix for macOS runners

### DIFF
--- a/.github/meson/macos-arm64-to-x86_64-10.15-deployment-target.ini
+++ b/.github/meson/macos-arm64-to-x86_64-10.15-deployment-target.ini
@@ -19,5 +19,5 @@ c =   ['ccache', 'clang',   '-stdlib=libc++', '-mmacosx-version-min=10.15', '-ta
 cpp = ['ccache', 'clang++', '-stdlib=libc++', '-mmacosx-version-min=10.15', '-target', 'x86_64-apple-macos10.15']
 ld =  ['clang',             '-stdlib=libc++', '-mmacosx-version-min=10.15', '-target', 'x86_64-apple-macos10.15']
 
-cmake     = ['/usr/local/homebrew/bin/cmake']
-pkgconfig = ['/usr/local/homebrew/bin/pkg-config']
+cmake     = ['/usr/local/bin/cmake']
+pkgconfig = ['/usr/local/bin/pkg-config']

--- a/.github/meson/macos-arm64-to-x86_64-10.15-deployment-target.ini
+++ b/.github/meson/macos-arm64-to-x86_64-10.15-deployment-target.ini
@@ -15,9 +15,9 @@
 #   brew_x86 install $(cat packages/macos-latest-brew.txt)
 
 [binaries]
-c =   ['ccache', 'clang',   '-stdlib=libc++', '-mmacosx-version-min=10.15', '-target', 'x86_64-apple-macos10.15']
+c =   ['ccache', 'clang',   '-mmacosx-version-min=10.15', '-target', 'x86_64-apple-macos10.15']
 cpp = ['ccache', 'clang++', '-stdlib=libc++', '-mmacosx-version-min=10.15', '-target', 'x86_64-apple-macos10.15']
-ld =  ['clang',             '-stdlib=libc++', '-mmacosx-version-min=10.15', '-target', 'x86_64-apple-macos10.15']
+ld =  ['clang',             '-mmacosx-version-min=10.15', '-target', 'x86_64-apple-macos10.15']
 
 cmake     = ['/usr/local/bin/cmake']
 pkgconfig = ['/usr/local/bin/pkg-config']

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -148,7 +148,7 @@ jobs:
     strategy:
       matrix:
         runner:
-          - host: [self-hosted, macOS, arm64, release-builds]
+          - host: [self-hosted, macOS, X64, release-builds]
             arch: x86_64
             build_flags: -Db_lto=true -Db_lto_threads=4 --native-file=.github/meson/macos-arm64-to-x86_64-10.15-deployment-target.ini
             brew_path: /usr/local/homebrew

--- a/scripts/verify-macos-dylibs.py
+++ b/scripts/verify-macos-dylibs.py
@@ -25,6 +25,7 @@ if __name__ == "__main__":
         "/System/Library/Frameworks/AudioToolbox.framework/",
         "/System/Library/Frameworks/AudioUnit.framework/",
         "/System/Library/Frameworks/Carbon.framework/",
+        "/System/Library/Frameworks/Cocoa.framework/",
         "/System/Library/Frameworks/CoreAudio.framework/",
         "/System/Library/Frameworks/CoreFoundation.framework/",
         "/System/Library/Frameworks/CoreGraphics.framework/",
@@ -38,6 +39,7 @@ if __name__ == "__main__":
         "/System/Library/Frameworks/IOKit.framework/",
         "/System/Library/Frameworks/Metal.framework/",
         "/System/Library/Frameworks/OpenGL.framework/",
+        "/System/Library/Frameworks/QuartzCore.framework/",
         "/usr/lib/",
     ]
 


### PR DESCRIPTION
# Description

These fixes allow the macOS runner setup on my local Mac to build all the artifacts. I definitely consider this a temporary hack to get 0.82 out the door.

This setup requires a separate runner for each architecture, X64 and arm64; you must install the X64 runner for X64 builds.

# Manual testing

I have run the built Mac artifacts on my local system.

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

