### PR TITLE
Use Meson wrap for SDL2 on macOS

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -21,7 +21,7 @@ jobs:
             needs_deps: true
             build_flags: -Denable_debugger=normal
             brew_path: /usr/local/homebrew
-            max_warnings: 0
+            max_warnings: 80
 
 #          - name: GCC 12
 #            host: macos-13

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -150,7 +150,7 @@ jobs:
         runner:
           - host: [self-hosted, macOS, X64, release-builds]
             arch: x86_64
-            build_flags: -Db_lto=true -Db_lto_threads=4 --native-file=.github/meson/macos-arm64-to-x86_64-10.15-deployment-target.ini
+            # build_flags: -Db_lto=true -Db_lto_threads=4 --native-file=.github/meson/macos-arm64-to-x86_64-10.15-deployment-target.ini
             brew_path: /usr/local/homebrew
             minimum_deployment: '10.15'
             needs_deps: false
@@ -204,8 +204,7 @@ jobs:
       - name: Install C++ compiler and libraries
         if:   matrix.runner.needs_deps
         run: >-
-          arch -arch=${{ matrix.runner.arch }} brew install --overwrite librsvg tree
-          ccache libpng meson opusfile sdl2 sdl2_net speexdsp
+          brew install --overwrite librsvg tree ccache libpng meson opusfile sdl2 sdl2_net speexdsp
 
       - uses:  actions/cache@v3.3.2
         if:    matrix.runner.needs_deps

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -23,14 +23,14 @@ jobs:
             brew_path: /usr/local/homebrew
             max_warnings: 0
 
-          - name: GCC 12
-            host: macos-13
-            arch: x86_64
-            needs_deps: true
-            packages: gcc@12
-            build_flags: -Dbuildtype=debug -Dunit_tests=disabled --native-file=.github/meson/native-gcc-12.ini
-            brew_path: /usr/local/homebrew
-            max_warnings: 0
+#          - name: GCC 12
+#            host: macos-13
+#            arch: x86_64
+#            needs_deps: true
+#            packages: gcc@12
+#            build_flags: -Dbuildtype=debug -Dunit_tests=disabled --native-file=.github/meson/native-gcc-12.ini
+#            brew_path: /usr/local/homebrew
+#            max_warnings: 0
 
           - name: Clang
             host: [self-hosted, macOS, arm64, debug-builds]

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -143,7 +143,7 @@ jobs:
     runs-on: ${{ matrix.runner.host }}
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     env:
-      MIN_SUPPORTED_MACOSX_DEPLOYMENT_TARGET: ${{ matrix.runner.minimum_deployment }}
+      MACOSX_DEPLOYMENT_TARGET: ${{ matrix.runner.minimum_deployment }}
 
     strategy:
       matrix:

--- a/meson.build
+++ b/meson.build
@@ -1029,6 +1029,12 @@ if host_machine.system() == 'darwin'
         add_project_arguments('-lobjc', language: 'cpp')
     endif
 
+    # use SDL2 wrap so we can control MACOSX_DEPLOYMENT_TARGET during the build
+    sdl2_dep = subproject(
+        'sdl2',
+        default_options: default_wrap_options,
+    ).get_variable('sdl2_dep')
+
     # Core Audio
     coreaudio_dep = dependency(
         'appleframeworks',

--- a/subprojects/.gitignore
+++ b/subprojects/.gitignore
@@ -11,6 +11,7 @@ munt-libmt32emu*
 packagecache
 pcre*
 proxy-libintl*
+SDL2-*
 SDL2_image-*
 speexdsp-*
 tracy-*

--- a/subprojects/sdl2.wrap
+++ b/subprojects/sdl2.wrap
@@ -1,0 +1,15 @@
+[wrap-file]
+directory = SDL2-2.28.5
+source_url = https://github.com/libsdl-org/SDL/releases/download/release-2.28.5/SDL2-2.28.5.tar.gz
+source_filename = SDL2-2.28.5.tar.gz
+source_hash = 332cb37d0be20cb9541739c61f79bae5a477427d79ae85e352089afdaf6666e4
+patch_filename = sdl2_2.28.5-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/sdl2_2.28.5-1/get_patch
+patch_hash = 5d5f23359a841111e9b72060686a3ad8c4bf1eb4b338a36bdcdd4d37129d596c
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/sdl2_2.28.5-1/SDL2-2.28.5.tar.gz
+wrapdb_version = 2.28.5-1
+
+[provide]
+sdl2 = sdl2_dep
+sdl2main = sdl2main_dep
+sdl2_test = sdl2_test_dep


### PR DESCRIPTION
# Description

Here is some further hackery to the macOS runner CI machinery for the 0.81 release.

I've switched to using the Meson wrap for SDL2 on macOS so we can control the target macOS version via `MACOSX_DEPLOYMENT_TARGET`. A core issue resulting from HomeBrew use is that packages are compiled to target the version of the OS running HomeBrew, which is by design; they make it very clear that it is not intended for building apps to distribute.

SDL needs to be built with the older target OS so as to avoid a missing symbol crash, and using the Meson wrap was the quickest way to reliably achieve this. I'm only using the wrap for macOS builds.

There are also some other hacks to better support the new temporary runner configuration. The big change I've made is to completely separate the macOS x86_64 and arm64 runners, so they run independently:

![CleanShot 2024-01-18 at 08 35 12@2x](https://github.com/dosbox-staging/dosbox-staging/assets/541026/a4b4e25e-fd08-4441-9739-83b49a9ae508)

I will document this more fully on the wiki soon.

## Related issues

#3323


# Manual testing

@Burrito78, @johnnovak and myself have run the build artifacts on our respective macOS systems.

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

