### PR TITLE
Use Meson wrap for SDL_net

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -669,12 +669,20 @@ opus_dep = dependency(
     include_type: 'system',
 )
 
-sdl2_dep = dependency(
-    'sdl2',
-    version: ['>= 2.0.5', '< 3'],
-    static: ('sdl2' in static_libs_list),
-    include_type: 'system',
-)
+if host_machine.system() == 'darwin'
+    # use SDL2 wrap so we can control MACOSX_DEPLOYMENT_TARGET during the build
+    sdl2_dep = subproject(
+        'sdl2',
+        default_options: default_wrap_options,
+    ).get_variable('sdl2_dep')
+else
+    sdl2_dep = dependency(
+        'sdl2',
+        version: ['>= 2.0.5', '< 3'],
+        static: ('sdl2' in static_libs_list),
+        include_type: 'system',
+    )
+endif
 
 # zlib
 # ~~~~
@@ -917,13 +925,21 @@ have_fd_zero = (
 sdl2_net_dep = optional_dep
 sdl2_net_summary_msg = 'Disabled'
 if get_option('use_sdl2_net')
-    sdl2_net_dep = dependency(
-        'SDL2_net',
-        version: ['>= 2.0.0', '< 3'],
-        static: ('sdl2_net' in static_libs_list),
-        not_found_message: msg.format('use_sdl2_net'),
-        include_type: 'system',
-    )
+    if host_machine.system() == 'darwin'
+        # use wrap so we can control MACOSX_DEPLOYMENT_TARGET during the build
+        sdl2_net_dep = subproject(
+            'sdl2_net',
+            default_options: default_wrap_options,
+        ).get_variable('sdl2_net_dep')
+    else
+        sdl2_net_dep = dependency(
+            'SDL2_net',
+            version: ['>= 2.0.0', '< 3'],
+            static: ('sdl2_net' in static_libs_list),
+            not_found_message: msg.format('use_sdl2_net'),
+            include_type: 'system',
+        )
+    endif
     sdl2_net_summary_msg = sdl2_net_dep.found()
 
     if sdl2_net_dep.found() and not have_fd_zero
@@ -1028,12 +1044,6 @@ if host_machine.system() == 'darwin'
     if cxx.has_argument('-lobjc')
         add_project_arguments('-lobjc', language: 'cpp')
     endif
-
-    # use SDL2 wrap so we can control MACOSX_DEPLOYMENT_TARGET during the build
-    sdl2_dep = subproject(
-        'sdl2',
-        default_options: default_wrap_options,
-    ).get_variable('sdl2_dep')
 
     # Core Audio
     coreaudio_dep = dependency(

--- a/src/hardware/vga_other.cpp
+++ b/src/hardware/vga_other.cpp
@@ -487,7 +487,7 @@ static void update_cga16_color_pcjr()
 
 			auto to_linear_rgb = [=](const float v) -> uint8_t {
 				// Only operate on reasonably positive v-values
-				if (!isnormal(v) || v <= 0.0f)
+				if (!std::isnormal(v) || v <= 0.0f)
 					return 0;
 				// switch to linear RGB space and scale to the 8-bit range
 				constexpr int max_8bit = UINT8_MAX;

--- a/subprojects/.gitignore
+++ b/subprojects/.gitignore
@@ -13,6 +13,7 @@ pcre*
 proxy-libintl*
 SDL2-*
 SDL2_image-*
+SDL2_net-*
 speexdsp-*
 tracy-*
 zlib*

--- a/subprojects/sdl2_net.wrap
+++ b/subprojects/sdl2_net.wrap
@@ -1,0 +1,12 @@
+[wrap-file]
+directory = SDL2_net-2.2.0
+source_url = https://www.libsdl.org/projects/SDL_net/release/SDL2_net-2.2.0.tar.gz
+source_filename = SDL2_net-2.2.0.tar.gz
+source_hash = 4e4a891988316271974ff4e9585ed1ef729a123d22c08bd473129179dc857feb
+patch_filename = sdl2_net_2.2.0-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/sdl2_net_2.2.0-1/get_patch
+patch_hash = f63aea40e83c2b4d97d63d97d94c76e73fdaf5923b71a319938cbebea21d7834
+wrapdb_version = 2.2.0-1
+
+[provide]
+sdl2_net = sdl2_net_dep


### PR DESCRIPTION
# Description

The build was pulling in homebrew's SDL2_net, which then pulled in homebrew's SDL2, which caused duplicate symbol warnings in the dev builds such as

```log
objc[88982]: Class SDLApplication is implemented in both /opt/homebrew/Cellar/sdl2/2.28.5/lib/libSDL2-2.0.0.dylib (0x1075388e0) and /Users/kklobe/src/dosbox-staging/build/release-arm64/dosbox (0x104617678). One of the two will be used. Which one is undefined.
objc[88982]: Class SDLAppDelegate is implemented in both /opt/homebrew/Cellar/sdl2/2.28.5/lib/libSDL2-2.0.0.dylib (0x107538930) and /Users/kklobe/src/dosbox-staging/build/release-arm64/dosbox (0x1046176c8). One of the two will be used. Which one is undefined.
```

So this forces all SDL libraries to come from the wraps.

## Related issues

Same logic and justification as #3332 

# Manual testing

Ran the build artifacts locally.

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

