### PR TITLE
De-officialise MSVC Windows builds

### DIFF
--- a/website/docs/releases/development-builds.md
+++ b/website/docs/releases/development-builds.md
@@ -112,8 +112,7 @@ function set_ci_status(workflow_file, os_name, description) {
 document.addEventListener("DOMContentLoaded", () => {
     set_ci_status("linux.yml", "linux", "Linux x86-64");
     set_ci_status("macos.yml", "macos", "macOS ¹");
-    set_ci_status("windows-msys2.yml", "msys2", "Windows MSYS2 builds ²");
-    set_ci_status("windows-msvc.yml", "windows", "Windows MSVC builds ³");
+    set_ci_status("windows-msys2.yml", "windows", "Windows builds ²");
 });
 
 </script>
@@ -156,17 +155,6 @@ document.addEventListener("DOMContentLoaded", () => {
     </td>
   </tr>
   <tr>
-    <td id="msys2-build-link">
-      <img style="margin:auto;margin-left:0.1em;" src="../images/dots.svg">
-    </td>
-    <td id="msys2-build-version">
-      <img style="margin:auto;margin-left:0.1em;" src="../images/dots.svg">
-    </td>
-    <td id="msys2-build-date">
-      <img style="margin:auto;margin-left:0.1em;" src="../images/dots.svg">
-    </td>
-  </tr>
-  <tr>
     <td id="windows-build-link">
       <img style="margin:auto;margin-left:0.1em;" src="../images/dots.svg">
     </td>
@@ -182,10 +170,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
 ¹ macOS builds include Intel, Apple silicon, and universal binaries.
 
-² Windows MSYS2 builds include 64-bit ZIP and Installer with both 64-bit MSYS2
-(default) and 64-bit MSVC (optional).
-
-³ Windows MSVC builds include 32-bit ZIP and 64-bit ZIP.
+² Windows builds are 64-bit and include portable ZIP and installer variants.
 
 
 ## Installation notes

--- a/website/docs/releases/windows.md
+++ b/website/docs/releases/windows.md
@@ -37,6 +37,9 @@ the changes and improvements introduced in this release.
 
 ### Windows 7
 
+The official distribution packages only support Windows 7 up to version
+0.80.1.
+
 For 64-bit Windows 7, use the 64-bit MSVC build. It can be optionally selected
 in the [installer][0_80_1_x64_INSTALLER] and is also available as a [portable
 ZIP archive][0_80_1_x64_ZIP].


### PR DESCRIPTION
# Description

We made an executive decision with @kcgen in December that due to various problems with it, we'll simply stop shipping Windows MSVC builds in our releases going forward. The MSVC builds have already been dropped from the 0.81.0 release candidates.

Ideally, we want to keep the MSVC workflow running in CI for hardening, plus Windows devs might prefer MSCV to MSYS2 for development. But as we're not officially shipping these builds, they should be removed from the public dev builds page on our website. Having them listed there would just confuse users, they'd download the wrong build by mistake, etc.

This will mean we no longer support Windows 7 in our new releases. My understanding is MSYS2 builds need Windows 10, but people could still use our MSVC builds on Windows 7.

Before people bring out the pitchforks, here's an announcement from Steam:

> As of January 1 2024, Steam will officially stop supporting the Windows 7, Windows 8 and Windows 8.1 operating systems. After that date, existing Steam Client installations on these operating systems will no longer receive updates of any kind including security updates. Steam Support will be unable to offer users technical support for issues related to the old operating systems, and Steam will be unable to guarantee continued functionality of Steam on the unsupported operating system versions.

---

@kcgen disabled the MSVC workflow because and shared a screenshot how to re-enable it. As mentioned, we'll need to fix the problem after re-enabling it, now it's broken:

![image](https://github.com/dosbox-staging/dosbox-staging/assets/698770/c630acbb-4505-4c6f-a73e-408a8b91934e)

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

