### PR TITLE
Don't use SDL wraps as fallback

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -680,6 +680,7 @@ else
         'sdl2',
         version: ['>= 2.0.5', '< 3'],
         static: ('sdl2' in static_libs_list),
+        fallback: [],
         include_type: 'system',
     )
 endif
@@ -936,6 +937,7 @@ if get_option('use_sdl2_net')
             'SDL2_net',
             version: ['>= 2.0.0', '< 3'],
             static: ('sdl2_net' in static_libs_list),
+            fallback: [],
             not_found_message: msg.format('use_sdl2_net'),
             include_type: 'system',
         )


### PR DESCRIPTION
# Description

Adding the SDL wraps in #3332 and #3335 broke the linux builds. This change disallows falling back to the wraps on non-macOS systems.

## Related issues

Fixes #3338 

# Manual testing

@weirddan455 tested the Linux build and I tested macOS.

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

