### PR TITLE
Update SDL2 wrap

### DIFF
--- a/subprojects/sdl2.wrap
+++ b/subprojects/sdl2.wrap
@@ -3,11 +3,11 @@ directory = SDL2-2.28.5
 source_url = https://github.com/libsdl-org/SDL/releases/download/release-2.28.5/SDL2-2.28.5.tar.gz
 source_filename = SDL2-2.28.5.tar.gz
 source_hash = 332cb37d0be20cb9541739c61f79bae5a477427d79ae85e352089afdaf6666e4
-patch_filename = sdl2_2.28.5-1_patch.zip
-patch_url = https://wrapdb.mesonbuild.com/v2/sdl2_2.28.5-1/get_patch
-patch_hash = 5d5f23359a841111e9b72060686a3ad8c4bf1eb4b338a36bdcdd4d37129d596c
-source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/sdl2_2.28.5-1/SDL2-2.28.5.tar.gz
-wrapdb_version = 2.28.5-1
+patch_filename = sdl2_2.28.5-2_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/sdl2_2.28.5-2/get_patch
+patch_hash = 8a5d7e7cd58932e0231963d42aa79776c2af1aceea6506a06be25a56935121eb
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/sdl2_2.28.5-2/SDL2-2.28.5.tar.gz
+wrapdb_version = 2.28.5-2
 
 [provide]
 sdl2 = sdl2_dep


### PR DESCRIPTION
# Description

Fixes a linking issue (https://github.com/mesonbuild/wrapdb/pull/1368). The wrap was pulling in libusb if present via e.g. homebrew as a dep for the HIDAPI functionality in SDL2, causing a runtime dep on the libusb.dylib for macOS builds.

# Manual testing

Ran the macOS build artifact

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

