### PR TITLE
Fix console color after restart

### DIFF
--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -4567,8 +4567,10 @@ void restart_program(std::vector<std::string> & parameters) {
 
 	const WINBOOL inherit_handles = FALSE;
 
-	// DETACHED_PROCESS fixes https://github.com/dosbox-staging/dosbox-staging/issues/3346
-	const DWORD creation_flags = DETACHED_PROCESS;
+	// CREATE_NEW_CONSOLE fixes a bug where the parent process exiting kills the child process.
+	// This can manifest when you use the "restart" hotkey action to restart DOSBox.
+	// https://github.com/dosbox-staging/dosbox-staging/issues/3346
+	const DWORD creation_flags = CREATE_NEW_CONSOLE;
 
 	// nullptr to use parent's environment
 	const LPVOID environment_variables = nullptr;


### PR DESCRIPTION
# Description

Regression from PR #3349 I was under the incorrect assumption that the Windows console was being created via an `AllocConsole` call here:

https://github.com/dosbox-staging/dosbox-staging/blob/0d3c555cb16028face41c0546326503b0a409229/src/gui/sdlmain.cpp#L4841-L4864

It turns out this is not the case.  Staging is being built as a console app meaning Windows creates a console for us before we even get to main.  This means on first run, the `AllocConsole` call fails because we already have a console.  After restart, we were successfully creating a console here but it was probably not using the correct mode for handling color escape codes (https://learn.microsoft.com/en-us/windows/console/setconsolemode).  There's also the issue that we're creating this console after Loguru initializes so the beginning of the logs are never visible.

We probably want to re-visit the above code in the future but the simple fix is to just use the `CREATE_NEW_CONSOLE` flag instead of `DETACHED_PROCESS`.  This both does not inherit the old console and creates a new one for the child process to use.

## Related issues

Fixes #3346

# Manual testing

Used Ctrl + Alt + Home to restart and verified the console has color afterwards.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

