### PR TITLE
Rework "EGA mode with VGA palette" CRT shader auto-switching

### DIFF
--- a/include/vga.h
+++ b/include/vga.h
@@ -1059,6 +1059,9 @@ struct VgaType {
 	// that, we stop checking palette changes until the next screen mode
 	// change.
 	bool ega_mode_with_vga_colors = false;
+
+	// Flag to signal that we're in the middle of a mode change.
+	bool mode_change_in_progress = false;
 };
 
 // Hercules & CGA monochrome palette

--- a/src/capture/image/image_decoder.cpp
+++ b/src/capture/image/image_decoder.cpp
@@ -24,31 +24,31 @@
 
 CHECK_NARROWING();
 
-void ImageDecoder::Init(const RenderedImage& image, const uint8_t row_skip_count,
-                        const uint8_t pixel_skip_count)
+void ImageDecoder::Init(const RenderedImage& _image, const uint8_t _row_skip_count,
+                        const uint8_t _pixel_skip_count)
 {
-	assert(image.params.width > 0);
-	assert(image.params.height > 0);
+	assert(_image.params.width > 0);
+	assert(_image.params.height > 0);
 
-	assert(image.pitch >= image.params.width);
-	assert(image.params.pixel_aspect_ratio.ToDouble() >= 0.0);
-	assert(image.image_data);
+	assert(_image.pitch >= _image.params.width);
+	assert(_image.params.pixel_aspect_ratio.ToDouble() >= 0.0);
+	assert(_image.image_data);
 
-	if (image.is_paletted()) {
-		assert(image.palette_data);
+	if (_image.is_paletted()) {
+		assert(_image.palette_data);
 	}
 
-	if (image.is_flipped_vertically) {
-		curr_row_start = image.image_data +
-		                 (image.params.height - 1) * image.pitch;
+	if (_image.is_flipped_vertically) {
+		curr_row_start = _image.image_data +
+		                 (_image.params.height - 1) * _image.pitch;
 	} else {
-		curr_row_start = image.image_data;
+		curr_row_start = _image.image_data;
 	}
 	pos = curr_row_start;
 
-	this->image            = image;
-	this->row_skip_count   = row_skip_count;
-	this->pixel_skip_count = pixel_skip_count;
+	image            = _image;
+	row_skip_count   = _row_skip_count;
+	pixel_skip_count = _pixel_skip_count;
 }
 
 void ImageDecoder::AdvanceRow()

--- a/src/dos/program_more_output.cpp
+++ b/src/dos/program_more_output.cpp
@@ -806,9 +806,9 @@ void MoreOutputFiles::DisplayInputFiles()
 		// If input from a device, CTRL+C shall quit
 		should_end_on_ctrl_c = input_file.is_device;
 
-		const auto decision = DisplaySingleStream();
+		const auto d = DisplaySingleStream();
 		DOS_CloseFile(input_handle);
-		if (decision == UserDecision::Cancel) {
+		if (d == UserDecision::Cancel) {
 			break;
 		}
 	}

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -634,7 +634,6 @@ void RENDER_NotifyEgaModeWithVgaPalette()
 	assert(machine == MCH_VGA);
 
 	auto video_mode = VGA_GetCurrentVideoMode();
-	assert(video_mode.graphics_standard == GraphicsStandard::Ega);
 
 	if (!video_mode.has_vga_colors) {
 		video_mode.has_vga_colors = true;

--- a/src/gui/shader_manager.cpp
+++ b/src/gui/shader_manager.cpp
@@ -79,8 +79,8 @@ void ShaderManager::NotifyGlshaderSettingChanged(const std::string& shader_name)
 	MaybeAutoSwitchShader();
 }
 
-void ShaderManager::NotifyRenderParametersChanged(const DosBox::Rect canvas_size_px,
-                                                  const VideoMode& video_mode)
+void ShaderManager::NotifyRenderParametersChanged(const DosBox::Rect new_canvas_size_px,
+                                                  const VideoMode& new_video_mode)
 {
 	// We need to calculate the scale factors for two eventualities: 1)
 	// potentially double-scanned, and 2) forced single-scanned output. Then
@@ -99,25 +99,30 @@ void ShaderManager::NotifyRenderParametersChanged(const DosBox::Rect canvas_size
 	// (i.e., always double scanning on VGA).
 	//
 	pixels_per_scanline = [&] {
-		const auto double_scan = video_mode.is_double_scanned_mode ? 2 : 1;
+		const auto double_scan = new_video_mode.is_double_scanned_mode ? 2 : 1;
 
-		const DosBox::Rect render_size_px = {video_mode.width * double_scan,
-		                                     video_mode.height * double_scan};
+		const DosBox::Rect render_size_px = {new_video_mode.width * double_scan,
+		                                     new_video_mode.height *
+		                                             double_scan};
 
 		const auto draw_rect_px = GFX_CalcDrawRectInPixels(
-		        canvas_size_px, render_size_px, video_mode.pixel_aspect_ratio);
+		        new_canvas_size_px,
+		        render_size_px,
+		        new_video_mode.pixel_aspect_ratio);
 
 		return iroundf(draw_rect_px.h) / iroundf(render_size_px.h);
 	}();
 
 	// 2) Calculate vertical scale factor for forced single scanning on VGA
 	// for double-scanned modes.
-	if (video_mode.is_double_scanned_mode) {
-		const DosBox::Rect render_size_px = {video_mode.width,
-		                                     video_mode.height};
+	if (new_video_mode.is_double_scanned_mode) {
+		const DosBox::Rect render_size_px = {new_video_mode.width,
+		                                     new_video_mode.height};
 
 		const auto draw_rect_px = GFX_CalcDrawRectInPixels(
-		        canvas_size_px, render_size_px, video_mode.pixel_aspect_ratio);
+		        new_canvas_size_px,
+		        render_size_px,
+		        new_video_mode.pixel_aspect_ratio);
 
 		pixels_per_scanline_force_single_scan = iroundf(draw_rect_px.h) /
 		                                        iroundf(render_size_px.h);
@@ -125,7 +130,7 @@ void ShaderManager::NotifyRenderParametersChanged(const DosBox::Rect canvas_size
 		pixels_per_scanline_force_single_scan = pixels_per_scanline;
 	}
 
-	this->video_mode = video_mode;
+	video_mode = new_video_mode;
 
 	MaybeAutoSwitchShader();
 }

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -2283,19 +2283,21 @@ static void mix_samples(const int frames_requested)
 	}
 
 	// Apply high-pass filter to the master output
-	auto pos = start_pos;
+	{
+		auto pos = start_pos;
 
-	for (work_index_t i = 0; i < frames_added; ++i) {
-		for (size_t ch = 0; ch < 2; ++ch) {
-			mixer.work[pos][ch] = mixer.highpass_filter[ch].filter(
-			        mixer.work[pos][ch]);
+		for (work_index_t i = 0; i < frames_added; ++i) {
+			for (size_t ch = 0; ch < 2; ++ch) {
+				mixer.work[pos][ch] = mixer.highpass_filter[ch].filter(
+						mixer.work[pos][ch]);
+			}
+			pos = (pos + 1) & MixerBufferMask;
 		}
-		pos = (pos + 1) & MixerBufferMask;
 	}
 
 	if (mixer.do_compressor) {
 		// Apply compressor to the master output as the very last step
-		pos = start_pos;
+		auto pos = start_pos;
 
 		for (work_index_t i = 0; i < frames_added; ++i) {
 			AudioFrame frame = {mixer.work[pos][0], mixer.work[pos][1]};

--- a/src/hardware/reelmagic/video_mixer.cpp
+++ b/src/hardware/reelmagic/video_mixer.cpp
@@ -227,19 +227,21 @@ static uint32_t _renderHeight        = 0;
 //      also, as i'm carrying around an alpha channel, i should probably put that to good use...
 //
 template <typename VGAPixelT, typename MPEGPixelT>
-static inline void MixPixel(RenderOutputPixel& out, const VGAPixelT& vga, const MPEGPixelT& mpeg)
+static inline void MixPixel(RenderOutputPixel& out, const VGAPixelT& vga_pixel,
+                            const MPEGPixelT& mpeg)
 {
-	if (vga.IsTransparent())
+	if (vga_pixel.IsTransparent()) {
 		mpeg.CopyRGBTo(out);
-	else
-		vga.CopyRGBTo(out);
+	} else {
+		vga_pixel.CopyRGBTo(out);
+	}
 	out.alpha = 0;
 }
 
 template <typename VGAPixelT>
-static inline void MixPixel(RenderOutputPixel& out, const VGAPixelT& vga)
+static inline void MixPixel(RenderOutputPixel& out, const VGAPixelT& vga_pixel)
 {
-	vga.CopyRGBTo(out);
+	vga_pixel.CopyRGBTo(out);
 	out.alpha = 0;
 }
 

--- a/src/hardware/vga.cpp
+++ b/src/hardware/vga.cpp
@@ -480,7 +480,12 @@ void SVGA_Setup_Driver(void) {
 	}
 }
 
-const VideoMode& VGA_GetCurrentVideoMode() {
+const VideoMode& VGA_GetCurrentVideoMode()
+{
+	// This function would most likely return the previous video mode if
+	// called in the middle of a mode change.
+	assert(!vga.mode_change_in_progress);
+
 	return vga.draw.image_info.video_mode;
 }
 

--- a/src/hardware/vga_attr.cpp
+++ b/src/hardware/vga_attr.cpp
@@ -147,7 +147,7 @@ static void write_p3c0(io_port_t, io_val_t value, io_width_t)
 		case 0x0f:
 			// Index into the 256 color DAC table.
 			// May be modified by 3C0h index 10h and 14h.
-			if (vga.attr.disabled & 0x1) {
+			if (vga.attr.disabled) {
 				const auto index = vga.attr.index;
 				VGA_ATTR_SetPalette(index, PaletteRegister{val});
 			}

--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -1887,7 +1887,6 @@ constexpr auto pixel_aspect_1280x1024 = Fraction(4, 3) / Fraction(1280, 1024);
 //   vga.draw.uses_vga_palette
 //   vga.draw.vblank_skip
 //   vga.draw.vret_triggered
-//   vga.ega_mode_with_vga_colors
 //
 ImageInfo setup_drawing()
 {
@@ -2942,11 +2941,6 @@ void VGA_SetupDrawing(uint32_t /*val*/)
 		}
 
 		previous_video_mode = image_info.video_mode;
-
-		// We always assume a "true EGA mode" first when switching to a
-		// new video mode, then set this flag to true once the first
-		// non-EGA palette colour has been set.
-		vga.ega_mode_with_vga_colors = false;
 	}
 
 	finalise_mode_change();

--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -2841,20 +2841,20 @@ ImageInfo setup_drawing()
 	          vga.draw.delay.vrend);
 #endif
 
-	ImageInfo render = {};
+	ImageInfo img_info = {};
 
-	render.width                   = render_width;
-	render.height                  = render_height;
-	render.double_width            = double_width;
-	render.double_height           = double_height;
-	render.forced_single_scan      = forced_single_scan;
-	render.rendered_double_scan    = rendered_double_scan;
-	render.rendered_pixel_doubling = rendered_pixel_doubling;
-	render.pixel_aspect_ratio      = render_pixel_aspect_ratio;
-	render.pixel_format            = pixel_format;
-	render.video_mode              = video_mode;
+	img_info.width                   = render_width;
+	img_info.height                  = render_height;
+	img_info.double_width            = double_width;
+	img_info.double_height           = double_height;
+	img_info.forced_single_scan      = forced_single_scan;
+	img_info.rendered_double_scan    = rendered_double_scan;
+	img_info.rendered_pixel_doubling = rendered_pixel_doubling;
+	img_info.pixel_aspect_ratio      = render_pixel_aspect_ratio;
+	img_info.pixel_format            = pixel_format;
+	img_info.video_mode              = video_mode;
 
-	return render;
+	return img_info;
 }
 
 void VGA_SetupDrawing(uint32_t /*val*/)

--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -2857,12 +2857,23 @@ ImageInfo setup_drawing()
 	return img_info;
 }
 
+static void finalise_mode_change()
+{
+	// The assumption is that all mode changes eventually call
+	// VGA_SetupDrawing() which concludes the mode change process.
+	// If this assumption turns out to be false, we'll need to
+	// revisit the logic that resets this flag.
+	vga.mode_change_in_progress = false;
+}
+
 void VGA_SetupDrawing(uint32_t /*val*/)
 {
 	if (vga.mode == M_ERROR) {
 		PIC_RemoveEvents(VGA_VerticalTimer);
 		PIC_RemoveEvents(VGA_PanningLatch);
 		PIC_RemoveEvents(VGA_DisplayStartLatch);
+
+		finalise_mode_change();
 		return;
 	}
 
@@ -2937,6 +2948,8 @@ void VGA_SetupDrawing(uint32_t /*val*/)
 		// non-EGA palette colour has been set.
 		vga.ega_mode_with_vga_colors = false;
 	}
+
+	finalise_mode_change();
 }
 
 void VGA_KillDrawing(void) {

--- a/src/hardware/vga_other.cpp
+++ b/src/hardware/vga_other.cpp
@@ -1141,21 +1141,21 @@ static void write_pcjr(io_port_t port, io_val_t value, io_width_t)
 	}
 }
 
-void VGA_SetMonochromePalette(const enum MonochromePalette palette)
+void VGA_SetMonochromePalette(const enum MonochromePalette _palette)
 {
 	if (machine == MCH_HERC) {
-		hercules_palette = palette;
+		hercules_palette = _palette;
 		VGA_SetHerculesPalette();
 
 	} else if (machine == MCH_CGA && mono_cga) {
-		mono_cga_palette = palette;
+		mono_cga_palette = _palette;
 		VGA_SetMonochromeCgaPalette();
 	}
 }
 
-static MonochromePalette cycle_forward(const MonochromePalette palette)
+static MonochromePalette cycle_forward(const MonochromePalette _palette)
 {
-	auto value = (enum_val(palette) + 1) % NumMonochromePalettes;
+	auto value = (enum_val(_palette) + 1) % NumMonochromePalettes;
 	return static_cast<MonochromePalette>(value);
 }
 

--- a/src/hardware/vga_xga.cpp
+++ b/src/hardware/vga_xga.cpp
@@ -624,12 +624,15 @@ static void DrawWaitSub(uint32_t mixmode, Bitu srcval)
 
 void XGA_DrawWait(uint32_t val, io_width_t width)
 {
-	if (!xga.waitcmd.wait)
+	if (!xga.waitcmd.wait) {
 		return;
+	}
+
 	uint32_t mixmode = (xga.pix_cntl >> 6) & 0x3;
+
 	Bitu srcval;
 	Bitu chunksize = 0;
-	Bitu chunks = 0;
+	Bitu chunks    = 0;
 
 	const uint8_t len = (width == io_width_t::dword  ? 4
 	                     : width == io_width_t::word ? 2
@@ -752,9 +755,9 @@ void XGA_DrawWait(uint32_t val, io_width_t width)
 					                     1) + chunksize * k;
 					const auto mask = static_cast<uint64_t>(1) << lshift;
 
-					const uint32_t mixmode = (val & mask)
-					                                 ? xga.foremix
-					                                 : xga.backmix;
+					mixmode = (val & mask) ? xga.foremix
+					                       : xga.backmix;
+
 					switch ((mixmode >> 5) & 0x03) {
 					case 0x00: // Src is background color
 						srcval = xga.backcolor;

--- a/src/ints/int10.h
+++ b/src/ints/int10.h
@@ -51,6 +51,8 @@ class Rgb666;
 #define BIOSMEM_CRTCPU_PAGE   0x8A
 #define BIOSMEM_VS_POINTER    0xA8
 
+constexpr uint16_t MaxEgaBiosModeNumber = 0x10;
+
 constexpr uint16_t MinVesaBiosModeNumber = 0x100;
 constexpr uint16_t MaxVesaBiosModeNumber = 0x7ff;
 

--- a/src/ints/int10_modes.cpp
+++ b/src/ints/int10_modes.cpp
@@ -608,6 +608,12 @@ static bool SetCurMode(const std::vector<VideoModeBlock>& modeblock, uint16_t mo
 				// at the end of the mode change process.
 				vga.mode_change_in_progress = true;
 
+				// Clear flag when setting up a new mode. This
+				// will only be set to true when the first
+				// non-EGA DAC palette colour is set in an EGA
+				// mode on a VGA adapter.
+				vga.ega_mode_with_vga_colors = false;
+
 				return true;
 			}
 			return false;

--- a/src/ints/int10_modes.cpp
+++ b/src/ints/int10_modes.cpp
@@ -2126,18 +2126,18 @@ std::optional<Rgb888> parse_color_token(const std::string& token,
 		}
 
 		if (is_hex3_token) {
-			auto r4 = static_cast<uint8_t>(value >> 8 & 0xf);
-			auto g4 = static_cast<uint8_t>(value >> 4 & 0xf);
-			auto b4 = static_cast<uint8_t>(value      & 0xf);
+			auto red4   = static_cast<uint8_t>(value >> 8 & 0xf);
+			auto green4 = static_cast<uint8_t>(value >> 4 & 0xf);
+			auto blue4  = static_cast<uint8_t>(value      & 0xf);
 
-			return Rgb888::FromRgb444(r4, g4, b4);
+			return Rgb888::FromRgb444(red4, green4, blue4);
 
 		} else { // hex6 token
-			const auto r8 = static_cast<uint8_t>(value >> 16 & 0xff);
-			const auto g8 = static_cast<uint8_t>(value >>  8 & 0xff);
-			const auto b8 = static_cast<uint8_t>(value       & 0xff);
+			const auto red8   = static_cast<uint8_t>(value >> 16 & 0xff);
+			const auto green8 = static_cast<uint8_t>(value >>  8 & 0xff);
+			const auto blue8  = static_cast<uint8_t>(value       & 0xff);
 
-			return Rgb888(r8, g8, b8);
+			return Rgb888(red8, green8, blue8);
 		}
 	}
 	case '(': {
@@ -2175,14 +2175,14 @@ std::optional<Rgb888> parse_color_token(const std::string& token,
 			return value;
 		};
 
-		const auto r8 = parse_component(r_string);
-		const auto g8 = parse_component(g_string);
-		const auto b8 = parse_component(b_string);
+		const auto red8   = parse_component(r_string);
+		const auto green8 = parse_component(g_string);
+		const auto blue8  = parse_component(b_string);
 
-		if (r8 && g8 && b8) {
-			return Rgb888(static_cast<uint8_t>(*r8),
-			              static_cast<uint8_t>(*g8),
-			              static_cast<uint8_t>(*b8));
+		if (red8 && green8 && blue8) {
+			return Rgb888(static_cast<uint8_t>(*red8),
+			              static_cast<uint8_t>(*green8),
+			              static_cast<uint8_t>(*blue8));
 		} else {
 			return {};
 		}

--- a/src/ints/int10_modes.cpp
+++ b/src/ints/int10_modes.cpp
@@ -1673,16 +1673,11 @@ att_text16:
 		break;
 	}
 	IO_Read(mono_mode ? 0x3ba : 0x3da);
+
 	if ((modeset_ctl & 8)==0) {
-		for (uint8_t ct=0;ct<ATT_REGS;ct++) {
-			IO_Write(0x3c0,ct);
-			IO_Write(0x3c0,att_data[ct]);
-		}
-		vga.config.pel_panning = 0;
-		IO_Write(0x3c0,0x20); IO_Write(0x3c0,0x00); //Disable palette access
-		IO_Write(0x3c6,0xff); //Reset Pelmask
-		//  Setup the DAC
-		IO_Write(0x3c8,0);
+		// Set up Color Registers (DAC colours)
+		IO_Write(0x3c8, 0);
+
 		switch (CurMode->type) {
 		case M_EGA:
 			if (CurMode->mode > 0xf)
@@ -1740,6 +1735,22 @@ dac_text16:
 			assert(false);
 			break;
 		}
+
+		// Set up Palette Registers
+		for (uint8_t ct = 0; ct < ATT_REGS; ct++) {
+			IO_Write(0x3c0, ct);
+			IO_Write(0x3c0, att_data[ct]);
+		}
+
+		vga.config.pel_panning = 0;
+
+		// Disable palette access
+		IO_Write(0x3c0, 0x20);
+		IO_Write(0x3c0, 0x00);
+
+		// Reset PEL mask
+		IO_Write(0x3c6, 0xff);
+
 		if (IS_VGA_ARCH) {
 			//  check if gray scale summing is enabled
 			if (real_readb(BIOSMEM_SEG,BIOSMEM_MODESET_CTL) & 2) {
@@ -1884,13 +1895,17 @@ dac_text16:
 
 	//  Set vga attrib register into defined state
 	IO_Read(mono_mode ? 0x3ba : 0x3da);
-	IO_Write(0x3c0,0x20);
+
+	// Disable palette access
+	IO_Write(0x3c0, 0x20);
+
 	IO_Read(mono_mode ? 0x3ba : 0x3da); // Kukoo2 demo
 
 	//  Load text mode font
 	if (CurMode->type==M_TEXT) {
 		INT10_ReloadFont();
 	}
+
 	return true;
 }
 

--- a/src/ints/int10_modes.cpp
+++ b/src/ints/int10_modes.cpp
@@ -603,6 +603,11 @@ static bool SetCurMode(const std::vector<VideoModeBlock>& modeblock, uint16_t mo
 			if (!int10.vesa_oldvbe ||
 			    ModeList_VGA[i].mode < vesa_2_0_modes_start) {
 				CurMode = modeblock.begin() + i;
+
+				// The flag will be reset by VGA_SetupDrawing()
+				// at the end of the mode change process.
+				vga.mode_change_in_progress = true;
+
 				return true;
 			}
 			return false;

--- a/src/midi/midi_coreaudio.h
+++ b/src/midi/midi_coreaudio.h
@@ -32,8 +32,8 @@
 // A macro to simplify error handling a bit.
 #define RequireNoErr(error)                                         \
 do {                                                                \
-	err = error;                                                    \
-	if (err != noErr)                                               \
+	status = error;                                                 \
+	if (status != noErr)                                            \
 		goto bail;                                                  \
 } while (false)
 
@@ -88,7 +88,7 @@ public:
 
 	bool Open(const char *conf) override
 	{
-		OSStatus err = 0;
+		OSStatus status = 0;
 
 		if (m_auGraph)
 			return false;

--- a/src/midi/midi_fluidsynth.h
+++ b/src/midi/midi_fluidsynth.h
@@ -73,7 +73,7 @@ private:
 	fluid_settings_ptr_t settings{nullptr, &delete_fluid_settings};
 	fsynth_ptr_t synth{nullptr, &delete_fluid_synth};
 
-	mixer_channel_t channel = nullptr;
+	mixer_channel_t mixer_channel = nullptr;
 	RWQueue<AudioFrame> audio_frame_fifo{1};
 	RWQueue<MidiWork> work_fifo{1};
 	std::thread renderer = {};

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -308,19 +308,25 @@ void DOS_Shell::CMD_DELETE(char * args) {
 	}
 	//end can't be 0, but if it is we'll get a nice crash, who cares :)
 	char * end=strrchr(full,'\\')+1;*end=0;
-	DOS_DTA::Result search_result       = {};
+
+	DOS_DTA::Result search_result = {};
 
 	DOS_DTA dta(dos.dta());
+
 	while (res) {
-		DOS_DTA::Result search_result = {};
+		search_result = {};
 		dta.GetResult(search_result);
 		strcpy(end, search_result.name.c_str());
+
 		if (search_result.IsReadOnly()) {
 			WriteOut(MSG_Get("SHELL_ACCESS_DENIED"), full);
+
 		} else if (!search_result.IsDirectory()) {
-			if (!DOS_UnlinkFile(full)) WriteOut(MSG_Get("SHELL_CMD_DEL_ERROR"),full);
+			if (!DOS_UnlinkFile(full)) {
+				WriteOut(MSG_Get("SHELL_CMD_DEL_ERROR"), full);
+			}
 		}
-		res=DOS_FindNext();
+		res = DOS_FindNext();
 	}
 	dos.dta(save_dta);
 }


### PR DESCRIPTION
# Description

The auto-switching to VGA shaders for EGA modes with custom VGA palettes on emulated VGA adapters worked when launching games, but kinda by fluke. It was only reliable on text mode to EGA graphics mode transitions, but only by sheer luck... Things then started falling apart when using an image viewer such as QPV.

Definitely review commit by commit; the first commit is just about removing warnings and is very noisy.

It's a bit hard to explain succinctly why the implementation needs to be done in this particular way. I've spent about 5-6 hours just tracing through the code to figure out how the Rube Goldberg mode-switching machinery works... I understand it now, but I don't want to write 10 pages to explain which no one would bother to read anyway... 😝  Please read the comments and the commit messages if you want to understand it deeper what's really going on.

The high-level overview is that I tried to be a bit too clever previously when detecting non-EGA colours; now it just checks the new colour against all possible EGA colours whenever the program changes a VGA DAC palette entry.

I don't _really_ expect anybody to go through my manual testing steps in detail, but it forces me to do a thorough job, and it will be useful for regression testing later if needed.

Could this all be done in a simpler and more straightforward way? Sure. After spending 5k+ hours refactoring the whole VGA code, everything VGA-related should be simpler. See you in 2050 😎 🤘🏻 

## Related issues

Original PR:

**crt-auto should auto-switch to VGA shaders in EGA modes with 18-bit VGA palettes**
https://github.com/dosbox-staging/dosbox-staging/pull/2819

# Manual testing

## General testing

Used the following specially prepared test pics in QPV: [test-pics.zip](https://github.com/dosbox-staging/dosbox-staging/files/14071021/test-pics.zip)

[Grafx2](http://grafx2.chez.com/) is great for such manipulations of paletted/bitplane-based graphics.

### MONKEY1.IFF
320x200, 16-colour, EGA palette in canonical EGA colour order.
<img width="436" alt="image" src="https://github.com/dosbox-staging/dosbox-staging/assets/698770/1fe6b753-f582-40fd-8fda-53705989e116">

<img width="941" alt="image" src="https://github.com/dosbox-staging/dosbox-staging/assets/698770/c168ce72-df71-4bdc-b88f-0444463f10c1">


### MONKEY2.IFF

320x200, 16-colour, EGA palette, but with bright cyan missing.
<img width="438" alt="image" src="https://github.com/dosbox-staging/dosbox-staging/assets/698770/00a82f0d-dc0b-4243-80a5-2e64683a12d8">

<img width="947" alt="image" src="https://github.com/dosbox-staging/dosbox-staging/assets/698770/8d53cb84-599e-4e07-bad3-d5f94c744db3">


### SQ3.IFF

320x200, 16-colour, EGA palette, but with brown missing and a completely different colour ordering.
<img width="438" alt="image" src="https://github.com/dosbox-staging/dosbox-staging/assets/698770/fb3085ea-be49-4640-9385-622c0fe3eeb6">

<img width="947" alt="image" src="https://github.com/dosbox-staging/dosbox-staging/assets/698770/6d996bd2-c002-4bdb-8566-625708fdd457">

### MAGICWLD.IFF

320x200, 16-colour, non-EGA palette. 
<img width="438" alt="image" src="https://github.com/dosbox-staging/dosbox-staging/assets/698770/b458e2d0-4882-4a15-b171-638afde6f8a8">

<img width="819" alt="image" src="https://github.com/dosbox-staging/dosbox-staging/assets/698770/17e85f97-9c4a-491e-89c3-68d118560976">


### SCOOPEX.IFF

320x200, 16-colour, non-EGA palette. 
<img width="436" alt="image" src="https://github.com/dosbox-staging/dosbox-staging/assets/698770/0b0a456c-c755-42b5-a04b-fff01c3228ef">

<img width="776" alt="image" src="https://github.com/dosbox-staging/dosbox-staging/assets/698770/006c7b14-dd23-4b70-b03f-7d99884b8ad7">


 ---

Make sure QPV is configured for EGA modes. You should have something like this in `QPV.CFG`:

```
# 16-colour EGA/VGA modes
 320  200   16     40 $0d 0
 640  200   16     80 $0e 0
 640  350   16     80 $10 0
 640  480   16     80 $12 0
```
Turn off auto resolution (`#` key) and select the 320x200 16-colour mode (with the `+` and `-` keys).

### Test 1

With the default config:

- Press enter on `MONKEY1.IFF` — EGA shader gets picked.
- Press Esc to return to the 640x480 interface screen.
- Press enter on `MONKEY2.IFF` — EGA shader gets picked.
- Press Esc.
- Press enter on `SQ3.IFF` — EGA shader gets picked.
- Press Esc.
- Press enter on `MAGICWLD.IFF` — VGA shader gets picked.
- Press Esc.
- Press enter on `SCOOPEX.IFF` — VGA shader gets picked.

### Test 2

With the default config:

- Press enter on `MONKEY1.IFF` — EGA shader gets picked
- Press enter to advance to `MONKEY2.IFF` — This involves no scree mode change, but as the image still contains EGA colours only, the EGA shader remains active.
- Press enter to advance to `SCOOPEX.IFF` — This contains VGA colours, so the VGA shader gets selected.
- Press enter to advance to `SQ3.IFF` — This has EGA colours, but no screen mode change is involved, so we're stuck with the VGA shader.
- Press Esc and then Enter to display `SQ3.IFF` but trigger a screen mode change — EGA shader gets picked.

### Test 3

Repeated the above tests with different `glshader` and `machine` settings:

- `glshader = none` & `sharp` — Works as expected.
- `glshader = crt-auto-arcade` & `crt-auto-arcade-sharp` — The single-scanned arcade shaders get always picked.
- `glshader = crt-auto-machine` & `machine = vga` — Always the VGA shader gets picked.

### Test 4

- Use the default config, then start Deluxe Paint in EGA 640x350 16 colors mode (option "e").
- EGA shader gets picked.
- Open the palette editor with the P key, then start dragging the RGB sliders around.
- DPaint snaps the colours to the 64-colour EGA palette, so no shader switching will take place.
- Repeat the test in the VGA 640x350 16 colour mode (option "j"). This mode allows setting VGA colours for this EGA screen mode.
- The EGA shader gets picked initially, but once you start dragging the RGB sliders, the shader auto-switches to VGA.
- Repeat the steps in the 320x200 16 colour mode on EGA vs VGA.

### Test 4

Tried a few games with the default config plus `cga_color = colodore`:

- **Dark Seed** — VGA shader gets picked
- **Gods** — VGA shader gets picked
- **Space Quest 3** — EGA shader gets picked & the custom colours are displayed correctly.
- **Spellcasting 201** — EGA shader gets picked & the custom colours are displayed correctly.

### Test 5

Regression tested **Total Eclipse** in Hercules, CGA, CGA Mono, and Tandy modes with the appropriate machine settings.

## "True EGA"

Confirmed that the below "true EGA" games pick the EGA shader with `crt-auto` on a VGA adapter:

- **Command Keen: Keen Dreams**
- **Drakkhen**
- **Space Quest II**
- **Wasteland**
- **Spellcasting 201** — Picks an EGA shader as the game uses the 640x350 16-colour EGA mode (out of a total palette of 64 possible colours).
- Plus a good selection of the test cases [from here](https://github.com/dosbox-staging/dosbox-staging/pull/2819#issuecomment-1704002909)

## EGA modes with VGA palette

Confirmed that the below games that use EGA modes with custom VGA palettes pick the VGA shader with `crt-auto`:

- **Gods** — 320x200 16-colour EGA mode but with a VGA palette. The game switches to an EGA mode at startup, then loads the VGA palette only a few seconds later (the shader switching happens then).
- **Dark Seed** – The game uses 640x350 but with a custom 16-colour VGA palette. Before this PR, an EGA shader was picked incorrectly for this game (the difference is very subtle, but still not quite correct).
- Plus a good selection of the test cases [from here](https://github.com/dosbox-staging/dosbox-staging/pull/2819#issuecomment-1704002909)

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

