### PR TITLE
Fix video regression in Catacomb 3D

### DIFF
--- a/src/hardware/vga_crtc.cpp
+++ b/src/hardware/vga_crtc.cpp
@@ -198,6 +198,12 @@ void vga_write_p3d5(io_port_t, io_val_t value, io_width_t)
 			if (old_val.data == flipped.data) {
 				VGA_StartResize();
 			}
+
+			vga.draw.address_line_total = new_val.maximum_scan_line + 1;
+
+			if (new_val.is_scan_doubling_enabled) {
+				vga.draw.address_line_total *= 2;
+			}
 		} else {
 			auto flipped = new_val;
 			flipped.maximum_scan_line = new_val.maximum_scan_line ^ 1;
@@ -219,12 +225,6 @@ void vga_write_p3d5(io_port_t, io_val_t value, io_width_t)
 			if (old_val.data == flipped.data) {
 				VGA_StartResize();
 			}
-		}
-
-		vga.draw.address_line_total = new_val.maximum_scan_line + 1;
-
-		if (new_val.is_scan_doubling_enabled) {
-			vga.draw.address_line_total *= 2;
 		}
 	} break;
 


### PR DESCRIPTION
# Description

[This earlier VGA CRTC fix](https://github.com/dosbox-staging/dosbox-staging/pull/3279) of mine corrected the scrolling problem in the **Legend of Kyrandia 1** intro, but it broke **Catacomb 3D**. After the fix, the two in-game split screens in the game became vertically doubled (note that the intro screens are unaffected as those don't use this split-screen trick).

Comparing the fix to the old code prior to all the double-scanning refactors it's obvious I made a mistake, so this should be the final bug-free revision.

<img width="1215" alt="image" src="https://github.com/dosbox-staging/dosbox-staging/assets/698770/eae38196-bbf3-41c3-8c45-fc17ab8083a6">

## Related issues

https://github.com/dosbox-staging/dosbox-staging/pull/3279

https://github.com/dosbox-staging/dosbox-staging/issues/3268

https://github.com/dosbox-staging/dosbox-staging/commit/e7c596b26982e87f85cf3db8f4b4f392da3ac8e9

# Manual testing

- Regression tested the following games that use the custom 320x400 VGA mode:
  - **Ravenloft – Stone Prophet**
  - **Ravenloft – Strahd's Posession**
  - **The Summoning**
  - **Threat**

- Confirmed that the scrolling in the **Legend of Kyrandia 1** intro is still fine.

- Confirmed that the in-game split screen stuff in **Catacomb 3D** has been fixed:

<img width="1215" alt="image" src="https://github.com/dosbox-staging/dosbox-staging/assets/698770/6aae06c1-54c5-4694-84c4-600e15756288">


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

