### PR TITLE
Raise window to foreground after creation

### DIFF
--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -4565,7 +4565,7 @@ void restart_program(std::vector<std::string> & parameters) {
 	// nullptr for default
 	const LPSECURITY_ATTRIBUTES thread_attributes = nullptr;
 
-	const WINBOOL inherit_handles = FALSE;
+	const BOOL inherit_handles = FALSE;
 
 	// CREATE_NEW_CONSOLE fixes a bug where the parent process exiting kills the child process.
 	// This can manifest when you use the "restart" hotkey action to restart DOSBox.

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1439,6 +1439,8 @@ finish:
 	if (sdl.draw.callback)
 		sdl.draw.callback(GFX_CallBackRedraw);
 
+	SDL_RaiseWindow(sdl.window);
+
 	// Ensure the time to change window modes isn't counted against
 	// our paced timing. This is a rare event that depends on host
 	// latency (and not the rendering pipeline).


### PR DESCRIPTION
# Description

On restart, the DOSBox window would be unfocused and sometimes hidden behind the console.  This was reproducible for me on Windows 10 after installing [Windows Terminal](https://apps.microsoft.com/detail/9N0DX20HK701?hl=en-US&gl=US) and setting it to be the default over the build-in command prompt.

This makes sure we raise the window to the foreground after we've created a new one.  Also snuck in an MSVC build fix.  MSVC still builds fine.  I accidentally broke it in my last PR.  Apparently `WINBOOL` is a MinGW'ism.

## Related issues

Fixes #3346 (hopefully for good this time!)

# Manual testing

- Set Windows Terminal to be default.
- Ctrl + Alt + Home to restart DOSBox
- Tested in MSVC plus MSYS2 Clang

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

