### PR TITLE
Fix invalid iterator crash in debug build

### DIFF
--- a/src/ints/int10.cpp
+++ b/src/ints/int10.cpp
@@ -732,6 +732,7 @@ static void SetupTandyBios(void) {
 }
 
 void INT10_Init(Section* /*sec*/) {
+	CurMode = std::prev(ModeList_VGA.end());
 	INT10_SetupPalette();
 	INT10_InitVGA();
 	if (IS_TANDY_ARCH) SetupTandyBios();

--- a/src/ints/int10_modes.cpp
+++ b/src/ints/int10_modes.cpp
@@ -587,7 +587,7 @@ static void init_all_palettes(const cga_colors_t& cga_colors)
 	// clang-format on
 }
 
-video_mode_block_iterator_t CurMode = std::prev(ModeList_VGA.end());
+video_mode_block_iterator_t CurMode = {};
 
 static void log_invalid_video_mode_error(const uint16_t mode) {
 	LOG_ERR("INT10H: Trying to set invalid video mode: %02Xh", mode);
@@ -2322,4 +2322,3 @@ void INT10_SetupPalette()
 	auto cga_colors = configure_cga_colors();
 	init_all_palettes(cga_colors);
 }
-


### PR DESCRIPTION
# Description

Regression from https://github.com/dosbox-staging/dosbox-staging/commit/1bba63c6da9ff3dc77c77ff3a8d4e8172121173b although the root problem was around before this commit.

The CurMode iterator was being initalized in a global. This leads to undefined behavior as to when the constructor gets run. On Windows and Linux, this leads to a crash in VGA init code.

The iterator got invalidated here:

https://github.com/dosbox-staging/dosbox-staging/blob/5bec21b908e9aac3524a3e1b90332a27bcd18fbb/src/hardware/vga_s3.cpp#L767-L769

Then the Crash happened on this line:

https://github.com/dosbox-staging/dosbox-staging/blob/5bec21b908e9aac3524a3e1b90332a27bcd18fbb/src/hardware/vga_dac.cpp#L83

The fix is to init the iterator in INT10_Init after the vector has been modified.  This way the iterator stays valid.  It would also crash in a predictable way if someone tries to use it early but this does not happen in testing.

# Manual testing

- Stepped through with debugger to figure out wtf was going on.
- Modified code
- No more crash at startup :)


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

