### PR TITLE
Runtime SDL version checks

### DIFF
--- a/include/sdlmain.h
+++ b/include/sdlmain.h
@@ -337,4 +337,18 @@ struct SDL_Block {
 
 extern SDL_Block sdl;
 
+constexpr uint32_t sdl_version_to_uint32(const SDL_version version)
+{
+	return (version.major << 16) + (version.minor << 8) + version.patch;
+}
+
+bool is_runtime_sdl_version_at_least(const SDL_version min_version)
+{
+	SDL_version version = {};
+	SDL_GetVersion(&version);
+	const auto curr_version = sdl_version_to_uint32(version);
+
+	return curr_version >= sdl_version_to_uint32(min_version);
+}
+
 #endif

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -2302,11 +2302,17 @@ void GFX_CenterMouse()
 	int width  = 0;
 	int height = 0;
 
-#if defined(WIN32) && !SDL_VERSION_ATLEAST(2, 28, 1)
-	const auto canvas_size_px = get_canvas_size_in_pixels(sdl.rendering_backend);
+#if defined(WIN32)
+	if (is_runtime_sdl_version_at_least({2, 28, 1})) {
+		SDL_GetWindowSize(sdl.window, &width, &height);
 
-	width  = canvas_size_px.w;
-	height = canvas_size_px.h;
+	} else {
+		const auto canvas_size_px = get_canvas_size_in_pixels(
+		        sdl.rendering_backend);
+
+		width  = iroundf(canvas_size_px.w);
+		height = iroundf(canvas_size_px.h);
+	}
 #else
 	SDL_GetWindowSize(sdl.window, &width, &height);
 #endif
@@ -4900,7 +4906,7 @@ int sdl_main(int argc, char* argv[])
 		// Once initialised, ensure we clean up SDL for all exit conditions
 		atexit(QuitSDL);
 
-		SDL_version sdl_version;
+		SDL_version sdl_version = {};
 		SDL_GetVersion(&sdl_version);
 
 		LOG_MSG("SDL: version %d.%d.%d initialised (%s video and %s audio)",


### PR DESCRIPTION
# Description

It's preferable to do the SDL version check at runtime in certain scenarios (when the API is the same between two versions, but the behaviour is different, so we need runtime-version dependent workarounds).

## Related issues

https://github.com/dosbox-staging/dosbox-staging/pull/3373

# Manual testing

Quick general regression testing plus making sure the mouse pointer is centered to the window after uncapturing the mouse:

- [x] Tested on macOS
- [x] Tested on Windows
- [ ] Tested on Linux

On Windows, I downloaded the ZIP installer, confirmed SDL 2.28.5 gets logged, then tested that uncapturing the mouse centers the pointer to the window at 125% DPI scale factor.

Repeated the same steps after replacing `SDL2.dll` with 2.26.5 -- the mouse pointer still got centered at 125% DPI scale factor.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

