### PR TITLE
Enable all features on MSVC build

### DIFF
--- a/.github/workflows/windows-msvc.yml
+++ b/.github/workflows/windows-msvc.yml
@@ -20,7 +20,7 @@ jobs:
         conf:
           - name: MSVC 32-bit
             arch: x86
-            max_warnings: 17
+            max_warnings: 24
           - name: MSVC 64-bit
             arch: x64
             max_warnings: 687

--- a/src/fpu/fpu_instructions_x86.h
+++ b/src/fpu/fpu_instructions_x86.h
@@ -23,8 +23,7 @@
 // #define WEAK_EXCEPTIONS
 
 
-#if defined (_MSC_VER)
-
+#if defined(_MSC_VER) && defined(_M_IX86)
 #ifdef WEAK_EXCEPTIONS
 #define clx
 #else
@@ -503,7 +502,9 @@
 #else
 
 // !defined _MSC_VER
-
+#if defined(_MSC_VER) && !defined(__clang__)
+#error "Requires Clang under Visual Studio"
+#endif
 #ifdef WEAK_EXCEPTIONS
 #define clx
 #else

--- a/src/libs/zmbv/zmbv.vcxproj
+++ b/src/libs/zmbv/zmbv.vcxproj
@@ -34,7 +34,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>ClangCL</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Tracy|Win32'" Label="Configuration">
@@ -44,7 +44,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>ClangCL</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Tracy|x64'" Label="Configuration">
@@ -54,12 +54,12 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>ClangCL</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>ClangCL</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
@@ -134,6 +134,7 @@
   </PropertyGroup>
   <PropertyGroup Label="Vcpkg">
     <VcpkgEnableManifest>true</VcpkgEnableManifest>
+    <VcpkgAutoLink>false</VcpkgAutoLink>
   </PropertyGroup>
   <PropertyGroup Label="Vcpkg" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <VcpkgConfiguration>Debug</VcpkgConfiguration>
@@ -163,7 +164,7 @@
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>winmm.lib;odbc32.lib;odbccp32.lib;zlibd.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>winmm.lib;odbc32.lib;odbccp32.lib;zlib-ngd.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)zmbv.dll</OutputFile>
       <ModuleDefinitionFile>zmbv.def</ModuleDefinitionFile>
       <ProgramDatabaseFile>$(OutDir)zmbv.pdb</ProgramDatabaseFile>
@@ -195,7 +196,7 @@
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>winmm.lib;odbc32.lib;odbccp32.lib;zlibd.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>winmm.lib;odbc32.lib;odbccp32.lib;zlib-ngd.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)zmbv.dll</OutputFile>
       <ModuleDefinitionFile>zmbv.def</ModuleDefinitionFile>
       <ProgramDatabaseFile>$(OutDir)zmbv.pdb</ProgramDatabaseFile>
@@ -227,7 +228,7 @@
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>winmm.lib;odbc32.lib;odbccp32.lib;zlib.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>winmm.lib;odbc32.lib;odbccp32.lib;zlib-ng.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)zmbv.dll</OutputFile>
       <ModuleDefinitionFile>zmbv.def</ModuleDefinitionFile>
       <MapExports>true</MapExports>
@@ -298,7 +299,7 @@
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>winmm.lib;odbc32.lib;odbccp32.lib;zlib.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>winmm.lib;odbc32.lib;odbccp32.lib;zlib-ng.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)zmbv.dll</OutputFile>
       <ModuleDefinitionFile>zmbv.def</ModuleDefinitionFile>
       <MapExports>true</MapExports>

--- a/src/misc/ethernet_slirp.cpp
+++ b/src/misc/ethernet_slirp.cpp
@@ -40,7 +40,7 @@
  * object. The user data is provided inside the 'opaque' pointer.
  */
 
-ssize_t slirp_receive_packet(const void *buf, size_t len, void *opaque)
+db_ssize_t slirp_receive_packet(const void *buf, size_t len, void *opaque)
 {
 	// sentinels
 	if (!len)

--- a/src/misc/ethernet_slirp.h
+++ b/src/misc/ethernet_slirp.h
@@ -28,7 +28,15 @@
 #include <map>
 #include <deque>
 #include <vector>
+
+// Specific unreleased slirp to work with MSVC
+#if _MSC_VER >= 1920
+#include <slirp/libslirp.h>
+#define db_ssize_t slirp_ssize_t
+#else
 #include <libslirp.h>
+#define db_ssize_t ssize_t
+#endif
 
 #include "config.h"
 #include "ethernet.h"

--- a/src/platform/visualc/config.h
+++ b/src/platform/visualc/config.h
@@ -40,6 +40,9 @@
 /* Define to 1 to enable slirp networking support, requires libslirp */
 #define C_SLIRP 1
 
+/* Define to 1 when zlib-ng support is provided by the system */
+#define C_SYSTEM_ZLIB_NG 1
+
 /* Enable some heavy debugging options */
 #define C_HEAVY_DEBUG 0
 

--- a/src/platform/visualc/config.h
+++ b/src/platform/visualc/config.h
@@ -34,6 +34,12 @@
 /* Define to 1 to enable IPX networking support, requires SDL_net */
 #define C_IPX 1
 
+/* Define to 1 to enable NE2000 emulation */
+#define C_NE2000 1
+
+/* Define to 1 to enable slirp networking support, requires libslirp */
+#define C_SLIRP 1
+
 /* Enable some heavy debugging options */
 #define C_HEAVY_DEBUG 0
 
@@ -68,14 +74,8 @@
 /* Enable the FPU module, still only for beta testing */
 #define C_FPU 1
 
-/* Define to 1 to use a x86 assembly fpu core */
-#ifdef _M_X64
-//No support for inline asm with visual studio in x64 bit mode.
-//This means that non-dynamic cores can't use the better fpu emulation.
-#define C_FPU_X86 0
-#else // _M_IX86
+/* Define to 1 to use x86 assembly fpu core. Requires Clang toolchain for x64 */
 #define C_FPU_X86 1
-#endif
 
 /* Define to 1 to use a unaligned memory access */
 #define C_UNALIGNED_MEMORY 1

--- a/tests/vs/tests.vcxproj
+++ b/tests/vs/tests.vcxproj
@@ -37,13 +37,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>ClangCL</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>ClangCL</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Tracy|Win32'" Label="Configuration">
@@ -55,13 +55,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>ClangCL</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>ClangCL</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Tracy|x64'" Label="Configuration">
@@ -142,6 +142,7 @@
   </PropertyGroup>
   <PropertyGroup Label="Vcpkg">
     <VcpkgEnableManifest>true</VcpkgEnableManifest>
+    <VcpkgAutoLink>false</VcpkgAutoLink>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>

--- a/tests/vs/tests.vcxproj.filters
+++ b/tests/vs/tests.vcxproj.filters
@@ -27,6 +27,7 @@
     <ClCompile Include="..\string_utils_tests.cpp" />
     <ClCompile Include="..\stubs.cpp" />
     <ClCompile Include="..\support_tests.cpp" />
+    <ClCompile Include="..\..\src\misc\messages_stubs.cpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\meson.build" />

--- a/vcpkg-overlay/libslirp/portfile.cmake
+++ b/vcpkg-overlay/libslirp/portfile.cmake
@@ -1,0 +1,27 @@
+vcpkg_from_gitlab(
+    GITLAB_URL https://gitlab.freedesktop.org
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO slirp/libslirp
+    REF 129077f9870426d1b7b3a8239d8b5a50bee017b4
+    SHA512 8223352cf09154a857960b852c9b1a8a01ab0c86c3cc873fc37da337174c59b68b50939cffc018c91f320000da09ce833acf966a3492de1453bc7196d14c1198
+    HEAD_REF master
+)
+
+if(VCPKG_HOST_IS_WINDOWS)
+    vcpkg_acquire_msys(MSYS_ROOT)
+    vcpkg_add_to_path("${MSYS_ROOT}/usr/bin")
+endif()
+
+vcpkg_configure_meson(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${OPTIONS}
+)
+
+vcpkg_install_meson(ADD_BIN_TO_PATH)
+
+vcpkg_fixup_pkgconfig()
+
+vcpkg_copy_pdbs()
+
+file(INSTALL "${SOURCE_PATH}/COPYRIGHT" DESTINATION "${CURRENT_PACKAGES_DIR}/share/libslirp" RENAME copyright)

--- a/vcpkg-overlay/libslirp/vcpkg.json
+++ b/vcpkg-overlay/libslirp/vcpkg.json
@@ -1,0 +1,15 @@
+{
+  "name": "libslirp",
+  "version-date": "2023-08-13",
+  "description": "libslirp is a user-mode networking library used by virtual machines, containers or various tools.",
+  "homepage": "https://gitlab.freedesktop.org/slirp/libslirp",
+  "license": "BSD-3-Clause",
+  "supports": "windows | mingw",
+  "dependencies": [
+    "glib",
+    {
+      "name": "vcpkg-tool-meson",
+      "host": true
+    }
+  ]
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,20 +1,31 @@
 {
-    "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
-    "name": "dosbox-staging",
-    "description": "DOSBox Staging is a modern continuation of DOSBox with advanced features and current development practices.",
-    "version": "0.82.0-alpha",
-    "dependencies": [
-        "fluidsynth",
-        "gtest",
-        "iir1",
-        "libmt32emu",
-        "libpng",
-        "opusfile",
-        "sdl2",
-        "sdl2-image",
-        "sdl2-net",
-        "speexdsp",
-        "tracy",
-        "zlib"
-    ]
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
+  "name": "dosbox-staging",
+  "description": "DOSBox Staging is a modern continuation of DOSBox with advanced features and current development practices.",
+  "version": "0.81.0-alpha",
+  "dependencies": [
+    "fluidsynth",
+    "gtest",
+    "iir1",
+    "libmt32emu",
+    "libpng",
+    "libslirp",
+    "opusfile",
+    "sdl2",
+    "sdl2-image",
+    "sdl2-net",
+    "speexdsp",
+    "tracy",
+    "zlib"
+  ],
+  "vcpkg-configuration": {
+    "overlay-ports": ["./vcpkg-overlay"]
+  },
+  "builtin-baseline": "80403036a665cb8fcc1a1b3e17593d20b03b2489",
+  "overrides": [
+    { 
+        "name": "sdl2", 
+        "version": "2.26.5"
+    }
+  ]  
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
   "name": "dosbox-staging",
   "description": "DOSBox Staging is a modern continuation of DOSBox with advanced features and current development practices.",
-  "version": "0.81.0-alpha",
+  "version": "0.82-rc",
   "dependencies": [
     "fluidsynth",
     "gtest",
@@ -16,7 +16,7 @@
     "sdl2-net",
     "speexdsp",
     "tracy",
-    "zlib"
+    "zlib-ng"
   ],
   "vcpkg-configuration": {
     "overlay-ports": ["./vcpkg-overlay"]

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
   "name": "dosbox-staging",
   "description": "DOSBox Staging is a modern continuation of DOSBox with advanced features and current development practices.",
-  "version": "0.82-rc",
+  "version": "0.81.0",
   "dependencies": [
     "fluidsynth",
     "gtest",

--- a/vs/dosbox.vcxproj
+++ b/vs/dosbox.vcxproj
@@ -175,7 +175,7 @@
       <ObjectFileName>$(IntDir)\$(ProjectName)\$(ConfigurationName)\%(RelativeDir)</ObjectFileName>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>slirp.lib;zlibd.lib;iir.lib;fluidsynth.lib;opengl32.lib;SDL2_netd.lib;winmm.lib;libpng16d.lib;SDL2maind.lib;SDL2d.lib;odbc32.lib;odbccp32.lib;ws2_32.lib;mt32emu.lib;opusfile.lib;opus.lib;ogg.lib;speexdsp.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>slirp.lib;zlib-ngd.lib;iir.lib;fluidsynth.lib;opengl32.lib;SDL2_netd.lib;winmm.lib;libpng16d.lib;SDL2maind.lib;SDL2d.lib;odbc32.lib;odbccp32.lib;ws2_32.lib;mt32emu.lib;opusfile.lib;opus.lib;ogg.lib;speexdsp.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)\dosbox.exe</OutputFile>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
@@ -219,7 +219,7 @@ IF %ERRORLEVEL% LSS 8 SET ERRORLEVEL = 0</Command>
       <ObjectFileName>$(IntDir)\$(ProjectName)\$(ConfigurationName)\%(RelativeDir)</ObjectFileName>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>slirp.lib;zlibd.lib;iir.lib;fluidsynth.lib;opengl32.lib;SDL2_netd.lib;winmm.lib;libpng16d.lib;SDL2maind.lib;SDL2d.lib;odbc32.lib;odbccp32.lib;ws2_32.lib;mt32emu.lib;opusfile.lib;opus.lib;ogg.lib;speexdsp.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>slirp.lib;zlib-ngd.lib;iir.lib;fluidsynth.lib;opengl32.lib;SDL2_netd.lib;winmm.lib;libpng16d.lib;SDL2maind.lib;SDL2d.lib;odbc32.lib;odbccp32.lib;ws2_32.lib;mt32emu.lib;opusfile.lib;opus.lib;ogg.lib;speexdsp.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)\dosbox.exe</OutputFile>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
@@ -265,7 +265,7 @@ IF %ERRORLEVEL% LSS 8 SET ERRORLEVEL = 0</Command>
       <ObjectFileName>$(IntDir)\$(ProjectName)\$(ConfigurationName)\%(RelativeDir)</ObjectFileName>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>slirp.lib;zlib.lib;iir.lib;opengl32.lib;winmm.lib;libpng16.lib;SDL2_net.lib;SDL2.lib;SDL2main.lib;odbc32.lib;odbccp32.lib;ws2_32.lib;mt32emu.lib;opusfile.lib;opus.lib;ogg.lib;fluidsynth.lib;speexdsp.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>slirp.lib;zlib-ng.lib;iir.lib;opengl32.lib;winmm.lib;libpng16.lib;SDL2_net.lib;SDL2.lib;SDL2main.lib;odbc32.lib;odbccp32.lib;ws2_32.lib;mt32emu.lib;opusfile.lib;opus.lib;ogg.lib;fluidsynth.lib;speexdsp.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)\dosbox.exe</OutputFile>
       <GenerateDebugInformation>false</GenerateDebugInformation>
       <ProgramDatabaseFile />
@@ -377,7 +377,7 @@ IF %ERRORLEVEL% LSS 8 SET ERRORLEVEL = 0</Command>
       <ObjectFileName>$(IntDir)\$(ProjectName)\$(ConfigurationName)\%(RelativeDir)</ObjectFileName>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>slirp.lib;fluidsynth.lib;zlib.lib;iir.lib;opengl32.lib;winmm.lib;libpng16.lib;SDL2_net.lib;SDL2.lib;SDL2main.lib;odbc32.lib;odbccp32.lib;ws2_32.lib;mt32emu.lib;opusfile.lib;opus.lib;ogg.lib;speexdsp.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>slirp.lib;fluidsynth.lib;zlib-ng.lib;iir.lib;opengl32.lib;winmm.lib;libpng16.lib;SDL2_net.lib;SDL2.lib;SDL2main.lib;odbc32.lib;odbccp32.lib;ws2_32.lib;mt32emu.lib;opusfile.lib;opus.lib;ogg.lib;speexdsp.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)\dosbox.exe</OutputFile>
       <GenerateDebugInformation>false</GenerateDebugInformation>
       <ProgramDatabaseFile>

--- a/vs/dosbox.vcxproj
+++ b/vs/dosbox.vcxproj
@@ -38,6 +38,7 @@
     <PlatformToolset>v143</PlatformToolset>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Tracy|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
@@ -47,7 +48,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>ClangCL</PlatformToolset>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
@@ -67,7 +68,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>ClangCL</PlatformToolset>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
@@ -148,6 +149,7 @@
   </PropertyGroup>
   <PropertyGroup Label="Vcpkg">
     <VcpkgEnableManifest>true</VcpkgEnableManifest>
+    <VcpkgAutoLink>false</VcpkgAutoLink>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
@@ -163,7 +165,6 @@
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
-      <FloatingPointExceptions>true</FloatingPointExceptions>
       <LanguageStandard_C>stdc11</LanguageStandard_C>
       <EnableFiberSafeOptimizations>true</EnableFiberSafeOptimizations>
       <MinimalRebuild>false</MinimalRebuild>
@@ -174,7 +175,7 @@
       <ObjectFileName>$(IntDir)\$(ProjectName)\$(ConfigurationName)\%(RelativeDir)</ObjectFileName>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>opengl32.lib;SDL2_netd.lib;winmm.lib;libpng16d.lib;SDL2maind.lib;SDL2d.lib;odbc32.lib;odbccp32.lib;ws2_32.lib;mt32emu.lib;opusfile.lib;opus.lib;ogg.lib;fluidsynth.lib;speexdsp.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>slirp.lib;zlibd.lib;iir.lib;fluidsynth.lib;opengl32.lib;SDL2_netd.lib;winmm.lib;libpng16d.lib;SDL2maind.lib;SDL2d.lib;odbc32.lib;odbccp32.lib;ws2_32.lib;mt32emu.lib;opusfile.lib;opus.lib;ogg.lib;speexdsp.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)\dosbox.exe</OutputFile>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
@@ -208,7 +209,6 @@ IF %ERRORLEVEL% LSS 8 SET ERRORLEVEL = 0</Command>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <OmitFramePointers>false</OmitFramePointers>
-      <FloatingPointExceptions>true</FloatingPointExceptions>
       <MinimalRebuild>false</MinimalRebuild>
       <LanguageStandard_C>stdc11</LanguageStandard_C>
       <EnableFiberSafeOptimizations>true</EnableFiberSafeOptimizations>
@@ -219,7 +219,7 @@ IF %ERRORLEVEL% LSS 8 SET ERRORLEVEL = 0</Command>
       <ObjectFileName>$(IntDir)\$(ProjectName)\$(ConfigurationName)\%(RelativeDir)</ObjectFileName>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>opengl32.lib;SDL2_netd.lib;winmm.lib;libpng16d.lib;SDL2maind.lib;SDL2d.lib;odbc32.lib;odbccp32.lib;ws2_32.lib;mt32emu.lib;opusfile.lib;opus.lib;ogg.lib;speexdsp.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>slirp.lib;zlibd.lib;iir.lib;fluidsynth.lib;opengl32.lib;SDL2_netd.lib;winmm.lib;libpng16d.lib;SDL2maind.lib;SDL2d.lib;odbc32.lib;odbccp32.lib;ws2_32.lib;mt32emu.lib;opusfile.lib;opus.lib;ogg.lib;speexdsp.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)\dosbox.exe</OutputFile>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
@@ -257,8 +257,6 @@ IF %ERRORLEVEL% LSS 8 SET ERRORLEVEL = 0</Command>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <WholeProgramOptimization>true</WholeProgramOptimization>
       <EnableFiberSafeOptimizations>true</EnableFiberSafeOptimizations>
-      <FloatingPointModel>Fast</FloatingPointModel>
-      <FloatingPointExceptions>false</FloatingPointExceptions>
       <LanguageStandard_C>stdc11</LanguageStandard_C>
       <AssemblerOutput>NoListing</AssemblerOutput>
       <BufferSecurityCheck>false</BufferSecurityCheck>
@@ -267,7 +265,7 @@ IF %ERRORLEVEL% LSS 8 SET ERRORLEVEL = 0</Command>
       <ObjectFileName>$(IntDir)\$(ProjectName)\$(ConfigurationName)\%(RelativeDir)</ObjectFileName>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>opengl32.lib;winmm.lib;libpng16.lib;SDL2_net.lib;SDL2.lib;SDL2main.lib;odbc32.lib;odbccp32.lib;ws2_32.lib;mt32emu.lib;opusfile.lib;opus.lib;ogg.lib;fluidsynth.lib;speexdsp.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>slirp.lib;zlib.lib;iir.lib;opengl32.lib;winmm.lib;libpng16.lib;SDL2_net.lib;SDL2.lib;SDL2main.lib;odbc32.lib;odbccp32.lib;ws2_32.lib;mt32emu.lib;opusfile.lib;opus.lib;ogg.lib;fluidsynth.lib;speexdsp.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)\dosbox.exe</OutputFile>
       <GenerateDebugInformation>false</GenerateDebugInformation>
       <ProgramDatabaseFile />
@@ -371,8 +369,6 @@ IF %ERRORLEVEL% LSS 8 SET ERRORLEVEL = 0</Command>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <WholeProgramOptimization>true</WholeProgramOptimization>
       <EnableFiberSafeOptimizations>true</EnableFiberSafeOptimizations>
-      <FloatingPointModel>Fast</FloatingPointModel>
-      <FloatingPointExceptions>false</FloatingPointExceptions>
       <LanguageStandard_C>stdc11</LanguageStandard_C>
       <AssemblerOutput>NoListing</AssemblerOutput>
       <BufferSecurityCheck>false</BufferSecurityCheck>
@@ -381,7 +377,7 @@ IF %ERRORLEVEL% LSS 8 SET ERRORLEVEL = 0</Command>
       <ObjectFileName>$(IntDir)\$(ProjectName)\$(ConfigurationName)\%(RelativeDir)</ObjectFileName>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>opengl32.lib;winmm.lib;libpng16.lib;SDL2_net.lib;SDL2.lib;SDL2main.lib;odbc32.lib;odbccp32.lib;ws2_32.lib;mt32emu.lib;opusfile.lib;opus.lib;ogg.lib;speexdsp.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>slirp.lib;fluidsynth.lib;zlib.lib;iir.lib;opengl32.lib;winmm.lib;libpng16.lib;SDL2_net.lib;SDL2.lib;SDL2main.lib;odbc32.lib;odbccp32.lib;ws2_32.lib;mt32emu.lib;opusfile.lib;opus.lib;ogg.lib;speexdsp.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)\dosbox.exe</OutputFile>
       <GenerateDebugInformation>false</GenerateDebugInformation>
       <ProgramDatabaseFile>

--- a/vs/dosbox.vcxproj.filters
+++ b/vs/dosbox.vcxproj.filters
@@ -181,9 +181,6 @@
     <ClCompile Include="..\src\hardware\gus.cpp">
       <Filter>src\hardware</Filter>
     </ClCompile>
-    <ClCompile Include="..\src\hardware\hardware.cpp">
-      <Filter>src\hardware</Filter>
-    </ClCompile>
     <ClCompile Include="..\src\hardware\ide.cpp">
       <Filter>src\hardware</Filter>
     </ClCompile>
@@ -471,9 +468,6 @@
     </ClCompile>
     <ClCompile Include="..\src\libs\nuked\opl3.c">
       <Filter>src\libs\nuked</Filter>
-    </ClCompile>
-    <ClCompile Include="..\src\libs\ppscale\ppscale.c">
-      <Filter>src\libs\ppscale</Filter>
     </ClCompile>
     <ClCompile Include="..\src\misc\cross.cpp">
       <Filter>src\misc</Filter>
@@ -867,9 +861,6 @@
     <ClInclude Include="..\include\audio_frame.h">
       <Filter>include</Filter>
     </ClInclude>
-    <ClCompile Include="..\include\autoexec.h">
-      <Filter>src\shell</Filter>
-    </ClCompile>
     <ClInclude Include="..\include\bios.h">
       <Filter>include</Filter>
     </ClInclude>
@@ -1032,12 +1023,6 @@
     <ClInclude Include="..\src\capture\image\image_decoder.h">
       <Filter>src\capture\image</Filter>
     </ClInclude>
-    <ClCompile Include="..\src\capture\image\image_saver.h">
-      <Filter>src\capture\image</Filter>
-    </ClCompile>
-    <ClCompile Include="..\src\capture\image\image_scaler.h">
-      <Filter>src\capture\image</Filter>
-    </ClCompile>
     <ClInclude Include="..\src\capture\image\png_writer.h">
       <Filter>src\capture\image</Filter>
     </ClInclude>
@@ -1170,39 +1155,15 @@
     <ClInclude Include="..\src\hardware\adlib_gold.h">
       <Filter>src\hardware</Filter>
     </ClInclude>
-    <ClCompile Include="..\src\hardware\compressor.h">
-      <Filter>src\hardware</Filter>
-    </ClCompile>
-    <ClCompile Include="..\src\hardware\covox.h">
-      <Filter>src\hardware</Filter>
-    </ClCompile>
-    <ClCompile Include="..\src\hardware\disney.h">
-      <Filter>src\hardware</Filter>
-    </ClCompile>
     <ClInclude Include="..\src\hardware\gameblaster.h">
       <Filter>src\hardware</Filter>
     </ClInclude>
     <ClInclude Include="..\src\hardware\innovation.h">
       <Filter>src\hardware</Filter>
     </ClInclude>
-    <ClCompile Include="..\src\hardware\lpt_dac.h">
-      <Filter>src\hardware</Filter>
-    </ClCompile>
     <ClInclude Include="..\src\hardware\opl.h">
       <Filter>src\hardware</Filter>
     </ClInclude>
-    <ClCompile Include="..\src\hardware\pcspeaker.h">
-      <Filter>src\hardware</Filter>
-    </ClCompile>
-    <ClCompile Include="..\src\hardware\pcspeaker_discrete.h">
-      <Filter>src\hardware</Filter>
-    </ClCompile>
-    <ClCompile Include="..\src\hardware\pcspeaker_impulse.h">
-      <Filter>src\hardware</Filter>
-    </ClCompile>
-    <ClCompile Include="..\src\hardware\ston1_dac.h">
-      <Filter>src\hardware</Filter>
-    </ClCompile>
     <ClInclude Include="..\src\hardware\input\intel8042.h">
       <Filter>src\hardware\input</Filter>
     </ClInclude>
@@ -1295,9 +1256,6 @@
     </ClInclude>
     <ClInclude Include="..\src\libs\nuked\opl3.h">
       <Filter>src\libs\nuked</Filter>
-    </ClInclude>
-    <ClInclude Include="..\src\libs\ppscale\ppscale.h">
-      <Filter>src\libs\ppscale</Filter>
     </ClInclude>
     <ClInclude Include="..\src\platform\visualc\config.h">
       <Filter>src\platform\visualc</Filter>
@@ -1428,9 +1386,6 @@
     <ClInclude Include="..\src\dos\program_serial.h">
       <Filter>src\dos</Filter>
     </ClInclude>
-    <ClInclude Include="..\src\dos\program_tree.h">
-      <Filter>src\dos</Filter>
-    </ClInclude>
     <ClInclude Include="..\src\libs\loguru\loguru.hpp">
       <Filter>src\libs\loguru</Filter>
     </ClInclude>
@@ -1453,6 +1408,18 @@
     <ClInclude Include="..\src\libs\zmbv\zmbv.h">
       <Filter>src\libs\zmbv</Filter>
     </ClInclude>
+    <ClInclude Include="..\include\autoexec.h" />
+    <ClInclude Include="..\src\capture\image\image_saver.h" />
+    <ClInclude Include="..\src\capture\image\image_scaler.h" />
+    <ClInclude Include="..\src\dos\dos_locale.h" />
+    <ClInclude Include="..\src\hardware\compressor.h" />
+    <ClInclude Include="..\src\hardware\covox.h" />
+    <ClInclude Include="..\src\hardware\disney.h" />
+    <ClInclude Include="..\src\hardware\lpt_dac.h" />
+    <ClInclude Include="..\src\hardware\pcspeaker.h" />
+    <ClInclude Include="..\src\hardware\pcspeaker_discrete.h" />
+    <ClInclude Include="..\src\hardware\pcspeaker_impulse.h" />
+    <ClInclude Include="..\src\hardware\ston1_dac.h" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\src\winres.rc">


### PR DESCRIPTION
# Description

This PR updates the MSVC build to enable feature parity with other x64 builds:

- enable libslirp
- use x87 floating point asm

By using the Clang toolchain in Visual Studio, the x87 floating point code in `fpu_instructions_x86.h` now works.

It also incorporates @shermp's libslirp integration [fix](https://github.com/dosbox-staging/dosbox-staging/tree/sp/msvc-slirp-1).

I've also pinned the vcpkg repository to a baseline, so new versions of packages won't get slipstreamed over time, and specifically pinned SDL2 to 2.26.5.

This should allow us to use Visual Studio as the official Windows toolchain.

# Related issues

MSVC limitations mentioned in #3091 

# Manual testing

**QTD**:

![image](https://github.com/dosbox-staging/dosbox-staging/assets/541026/bb6e39f6-eaa4-4ac9-8ee6-8852ad1f49f5)

**SLIRP**:

```log
2024-02-04 08:36:56.759 | SLIRP: Slirp version: 4.7.0
2024-02-04 08:36:56.759 | SLIRP: Successfully initialized
2024-02-04 08:36:56.759 | NE2000: Initialised on port 300h and IRQ 3
```
![image](https://github.com/dosbox-staging/dosbox-staging/assets/541026/a2967009-247e-47cc-8286-efe81b79ed98)

**Pinned SDL**:

```log
2024-02-04 08:36:56.425 | SDL: version 2.26.5 initialised (windows video and wasapi audio)
```

**MCPDIAG**:

![image](https://github.com/dosbox-staging/dosbox-staging/assets/541026/7ba80494-0f07-46ca-b331-67cebc2186b4)

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

