### PR TITLE
Update README, add missing special keys

### DIFF
--- a/README
+++ b/README
@@ -1201,9 +1201,11 @@ Alt+Pause     Pause/Unpause emulator.*
 Ctrl+F1       Start the keymapper*.
 Ctrl+F4       Change between mounted floppy/CD images. Update directory cache
               for all drives*.
-Ctrl+F5       Save a screenshot*. (PNG format)
+Alt+F5        Save a screenshot of the rendered image*. (PNG format)
+Ctrl+F5       Save a screenshot of the pre-rendered image*. (PNG format)
 Ctrl+F6       Start/Stop recording sound output to a wave file*.
 Ctrl+F7       Start/Stop recording video output to a zmbv file*.
+Ctrl+F8       Mute/Unmute the audio*.
 Ctrl+F9       Shutdown emulator*.
 Ctrl+F10      Capture/Release the mouse*.
 Ctrl+F11      Slow down emulation (Decrease DOSBox Cycles)*.


### PR DESCRIPTION
Ctrl+F8 and Alt+F5 are mentioned in-app help (intro special) but not in README. Description of Ctrl+F5 does not match with the in-app help.

# Description

_Describe a summary of your changes clearly and concisely, including motivation and context._
_Breaking changes need extra explanation on backward compatibility considerations._

_Feel free to include additional details, but please respect the reviewer's time and keep it brief._


## Related issues

_Related issues can be listed here (remove the section if not applicable.)_


# Manual testing

_Please describe the tests that you ran to verify your changes._

_Provide clear instructions so the reviewers can reproduce and verify your results._

_Include relevant details for your test configuration, operating system, etc._

_Ideally, you would also test your changes with a [sanitizer build](https://github.com/dosbox-staging/dosbox-staging/blob/main/BUILD.md#make-a-sanitizer-build) and confirm no issues were found._


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [ ] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [ ] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

