### PR TITLE
Use GitHub runners for macOS builds

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -23,63 +23,19 @@ jobs:
             brew_path: /usr/local/homebrew
             max_warnings: 80
 
-#          - name: GCC 12
-#            host: macos-13
-#            arch: x86_64
-#            needs_deps: true
-#            packages: gcc@12
-#            build_flags: -Dbuildtype=debug -Dunit_tests=disabled --native-file=.github/meson/native-gcc-12.ini
-#            brew_path: /usr/local/homebrew
-#            max_warnings: 0
-
           - name: Clang
-            host: [self-hosted, macOS, arm64, debug-builds]
+            host: macos-14
             arch: arm64
-            needs_deps: false
-            packages: meson
+            needs_deps: true
             build_flags: -Dbuildtype=debug
             brew_path: /opt/homebrew
-            run_tests: true
-            max_warnings: 0
+            max_warnings: 60
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           submodules: false
-
-      # Let self-hosted runners, which don't need_deps, leverage their own ccache.
-      - name:  Add the ccache environment to GitHub-hosted runners
-        if:    matrix.conf.needs_deps
-        shell: bash
-        run: |
-          set -eu
-          echo 'CCACHE_DIR="${{ github.workspace }}/.ccache"' >> $GITHUB_ENV
-          echo 'CCACHE_MAXSIZE="64M"' >> $GITHUB_ENV
-          echo 'CCACHE_COMPRESS="true"' >> $GITHUB_ENV
-
-      - name:  Prepare brew and compiler caches
-        if:    matrix.conf.needs_deps
-        id:    prep-caches
-        shell: bash
-        run: |
-          set -eu
-          BREW_DIR="$(brew --cache)"
-          DISCARD_DIR="${{ github.workspace }}/discard"
-          mkdir -p "$DISCARD_DIR"
-          mv -f "$BREW_DIR"/* "$DISCARD_DIR" || true
-          mkdir -p "$CCACHE_DIR"
-          echo "brew_dir=$BREW_DIR"     >> $GITHUB_OUTPUT
-          echo "ccache_dir=$CCACHE_DIR" >> $GITHUB_OUTPUT
-          echo "today=$(date +%F)"      >> $GITHUB_OUTPUT
-          echo "name_hash=$(echo '${{ matrix.conf.name }} ${{ matrix.conf.arch }}' | shasum | cut -b-8)" >> $GITHUB_OUTPUT
-
-      - uses:  actions/cache@v3.3.2
-        if:    matrix.conf.needs_deps
-        with:
-          path: ${{ steps.prep-caches.outputs.brew_dir }}
-          key:  brew-cache-${{ matrix.conf.arch }}-${{ steps.prep-caches.outputs.today }}-2
-          restore-keys: brew-cache-${{ matrix.conf.arch }}-
 
       - name: Install C++ compiler and libraries
         if:   matrix.conf.needs_deps
@@ -91,15 +47,6 @@ jobs:
           arch -arch=${{ matrix.conf.arch }} brew install --overwrite \
             ${{ matrix.conf.packages }} \
             $(cat packages/macos-12-brew.txt) || true
-
-      - uses:  actions/cache@v3.3.2
-        if:    matrix.conf.needs_deps
-        with:
-          path: ${{ steps.prep-caches.outputs.ccache_dir }}
-          key:  ccache-macos-debug-${{ steps.prep-caches.outputs.name_hash }}-${{ steps.prep-caches.outputs.today }}-2
-          restore-keys: |
-            ccache-macos-debug-${{ steps.prep-caches.outputs.name_hash }}-
-            ccache-macos-debug-
 
       - name: Cache subprojects
         id:   cache-subprojects
@@ -148,19 +95,20 @@ jobs:
     strategy:
       matrix:
         runner:
-          - host: [self-hosted, macOS, X64, release-builds]
+          - host: macos-13
             arch: x86_64
-            build_flags: -Db_lto=true -Db_lto_threads=4
+            build_flags: -Db_lto=true
             brew_path: /usr/local/homebrew
             minimum_deployment: '10.15'
-            needs_deps: false
+            needs_deps: true
             needs_libintl_workaround: false
 
-          - host: [self-hosted, macOS, arm64, release-builds]
+          - host: macos-14
             arch: arm64
+            build_flags: -Db_lto=true
             brew_path: /opt/homebrew
             minimum_deployment: '11.0'
-            needs_deps: false
+            needs_deps: true
 
     steps:
       - name: Checkout repository
@@ -168,50 +116,11 @@ jobs:
         with:
           submodules: false
 
-      # Let self-hosted runners, which don't need_deps, leverage their own ccache.
-      - name:  Add the ccache environment to GitHub-hosted runners
-        if:    matrix.runner.needs_deps
-        shell: bash
-        run: |
-          set -eu
-          echo 'CCACHE_DIR="${{ github.workspace }}/.ccache"' >> $GITHUB_ENV
-          echo 'CCACHE_MAXSIZE="128M"' >> $GITHUB_ENV
-          echo 'CCACHE_COMPRESS="true"' >> $GITHUB_ENV
-          echo 'CCACHE_SLOPPINESS="pch_defines,time_macros"' >> $GITHUB_ENV
-
-      - name:  Prepare brew and compiler caches
-        if:    matrix.runner.needs_deps
-        id:    prep-caches
-        shell: bash
-        run: |
-          set -eu
-          BREW_DIR="$(brew --cache)"
-          DISCARD_DIR="${{ github.workspace }}/discard"
-          mkdir -p "$DISCARD_DIR"
-          mv -f "$BREW_DIR"/* "$DISCARD_DIR"
-          mkdir -p "$CCACHE_DIR"
-          echo "brew_dir=$BREW_DIR"     >> $GITHUB_OUTPUT
-          echo "ccache_dir=$CCACHE_DIR" >> $GITHUB_OUTPUT
-          echo "today=$(date +%F)"      >> $GITHUB_OUTPUT
-
-      - uses:  actions/cache@v3.3.2
-        if:    matrix.runner.needs_deps
-        with:
-          path: ${{ steps.prep-caches.outputs.brew_dir }}
-          key:  brew-cache-${{ matrix.runner.arch }}-${{ steps.prep-caches.outputs.today }}-2
-          restore-keys: brew-cache-${{ matrix.runner.arch }}-
-
       - name: Install C++ compiler and libraries
         if:   matrix.runner.needs_deps
-        run: >-
-          brew install --overwrite librsvg tree ccache libpng meson opusfile sdl2 sdl2_net speexdsp
-
-      - uses:  actions/cache@v3.3.2
-        if:    matrix.runner.needs_deps
-        with:
-          path: ${{ steps.prep-caches.outputs.ccache_dir }}
-          key:  ccache-macos-release-${{ matrix.runner.arch }}-${{ steps.prep-caches.outputs.today }}-2
-          restore-keys: ccache-macos-release-${{ matrix.runner.arch }}-
+        run: |
+          pip3 install meson setuptools
+          brew install librsvg tree libpng ninja opusfile speexdsp
 
       - name: Cache subprojects
         id: cache-subprojects
@@ -267,7 +176,7 @@ jobs:
   publish_universal_build:
     name: Publish universal build
     needs: build_macos_release
-    runs-on: macos-13
+    runs-on: macos-14
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -309,14 +218,6 @@ jobs:
               -srcfolder dist \
               -ov -format UDZO "dosbox-staging-macOS-${{ env.VERSION }}.dmg"
 
-      - name:  Clam AV scan
-        id:    prep-clamdb
-        shell: bash
-        run: |
-          brew install --overwrite clamav
-          export CLAMDB_DIR="/usr/local/Cellar/clamav"
-          clamscan --heuristic-scan-precedence=yes --recursive --infected dist || true
-
       - name: Upload disk image
         uses: actions/upload-artifact@v3
         # GitHub automatically zips the artifacts, and there's no option
@@ -332,7 +233,7 @@ jobs:
   publish_additional_artifacts:
     name: Publish additional artifacts
     needs: build_macos_release
-    runs-on: macos-13
+    runs-on: macos-14
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v4

--- a/packages/macos-12-brew.txt
+++ b/packages/macos-12-brew.txt
@@ -1,8 +1,6 @@
-ccache
 cmake
 curl
 fluid-synth
-git
 gnu-tar
 libpng
 libslirp
@@ -13,9 +11,6 @@ patchutils
 pcre 
 pkg-config
 readline
-sdl2
-sdl2_net
 speexdsp
 wget
 ffmpeg
-conan

--- a/packages/macos-latest-brew.txt
+++ b/packages/macos-latest-brew.txt
@@ -1,8 +1,6 @@
-ccache
 cmake
 curl
 fluid-synth
-git
 gnu-tar
 libpng
 libslirp
@@ -13,9 +11,6 @@ patchutils
 pcre 
 pkg-config
 readline
-sdl2
-sdl2_net
 speexdsp
 wget
 ffmpeg
-conan


### PR DESCRIPTION
# Description

With the new macOS M1 runners available, I updated the workflow to use them for both x64 and arm64.

I stripped out most of the caching logic but left subprojects in. Ccache makes performance worse than just leaving it out entirely. I also removed unnecessary homebrew packages to save time on installation.

LTO is now enabled for arm64 builds.

## Related issues

#3323 

# Manual testing

Downloaded the build artifacts and tested both architectures on my MacBook Pro M3.

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [s] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

