### PR TITLE
Fix crash on startup when `machine` is set to `hercules`

### DIFF
--- a/src/hardware/vga_dac.cpp
+++ b/src/hardware/vga_dac.cpp
@@ -76,12 +76,6 @@ static void vga_dac_send_color(const uint8_t palette_idx, const uint8_t color_id
 {
 	const auto rgb666 = vga.dac.rgb[color_idx];
 
-	// We might be in the middle of a mode change, so we can't use
-	// VGA_GetCurrentVideoMode() here. That's because the INT 10H mode
-	// change BIOS routine needs to set up the Palette and Color Registers
-	// which will trigger this function.
-	const auto bios_mode_number = CurMode->mode;
-
 	// In the automatic "video mode specific" CRT emulation mode, we want
 	// "true EGA" games (EGA modes with the default EGA palette on VGA) to
 	// use the single-scanline EGA shader. But VGA games that just happen to
@@ -95,38 +89,46 @@ static void vga_dac_send_color(const uint8_t palette_idx, const uint8_t color_id
 	// Note that custom CGA colours (via the `cga_colors` setting) are
 	// handled correctly as well.
 	//
-	if (machine == MCH_VGA && !vga.ega_mode_with_vga_colors &&
-	    bios_mode_number <= MaxEgaBiosModeNumber) {
-		bool non_ega_color = false;
+	if (machine == MCH_VGA && !vga.ega_mode_with_vga_colors) {
+		// We might be in the middle of a mode change, so we can't use
+		// VGA_GetCurrentVideoMode() here. That's because the INT 10H
+		// mode change BIOS routine needs to set up the Palette and
+		// Color Registers which will trigger this function.
+		const auto bios_mode_number = CurMode->mode;
 
-		const auto is_640x350_16color_mode = (bios_mode_number == 0x10);
+		if (bios_mode_number <= MaxEgaBiosModeNumber) {
+			bool non_ega_color = false;
 
-		if (is_640x350_16color_mode) {
-			// The 640x350 16-colour EGA mode (mode 10h) is special:
-			// the 16 colors can be freely chosen from a gamut of 64
-			// colours (6-bit RGB).
-			non_ega_color = !is_ega_color(rgb666);
-		} else {
-			// In all other EGA modes, the fixed "canonical
-			// 16-element CGA palette" (as emulated by VGA cards) is
-			// used.
-			non_ega_color = !is_cga_color(rgb666);
-		}
+			const auto is_640x350_16color_mode = (bios_mode_number == 0x10);
 
-		if (non_ega_color) {
-			vga.ega_mode_with_vga_colors = true;
+			if (is_640x350_16color_mode) {
+				// The 640x350 16-colour EGA mode (mode 10h) is
+				// special: the 16 colors can be freely chosen
+				// from a gamut of 64 colours (6-bit RGB).
+				non_ega_color = !is_ega_color(rgb666);
+			} else {
+				// In all other EGA modes, the fixed "canonical
+				// 16-element CGA palette" (as emulated by VGA
+				// cards) is used.
+				non_ega_color = !is_cga_color(rgb666);
+			}
 
-			// If we're inside a mode change, the
-			// `ega_mode_with_vga_color` will be taken into account
-			// in VGA_GetCurrentVideoMode() which concludes the mode
-			// change process.
-			//
-			// But if a palette entry was set to a non-EGA colour
-			// after the mode change was completed, we need to
-			// notify the renderer so it can re-init itself and
-			// potentially switch the current shader.
-			if (!vga.mode_change_in_progress) {
-				RENDER_NotifyEgaModeWithVgaPalette();
+			if (non_ega_color) {
+				vga.ega_mode_with_vga_colors = true;
+
+				// If we're inside a mode change, the
+				// `ega_mode_with_vga_color` will be taken into
+				// account in VGA_GetCurrentVideoMode() which
+				// concludes the mode change process.
+				//
+				// But if a palette entry was set to a non-EGA
+				// colour after the mode change was completed,
+				// we need to notify the renderer so it can
+				// re-init itself and potentially switch the
+				// current shader.
+				if (!vga.mode_change_in_progress) {
+					RENDER_NotifyEgaModeWithVgaPalette();
+				}
 			}
 		}
 	}


### PR DESCRIPTION
# Description

@weirddan455's previous fix (https://github.com/dosbox-staging/dosbox-staging/commit/512efbd9aebc49b280e9903dc9d51b8f781f7e10) caused DOSBox crash right away with `machine = hercules`:

```
Loguru caught a signal: SIGSEGV
Stack trace:
10         0x18cfb10e0 start + 2360
9          0x100dded00 main + 36
8          0x10133926c sdl_main(int, char**) + 5844
7          0x100e8c7c4 Config::Init() const + 116
6          0x100e8ca38 Section::ExecuteInit(bool) + 244
5          0x1012f621c RENDER_Init(Section*) + 640
4          0x101504bec VGA_SetMonochromePalette(MonochromePalette) + 60
3          0x101504d78 VGA_SetHerculesPalette() + 308
2          0x1014f1904 VGA_DAC_CombineColor(unsigned char, unsigned char) + 92
1          0x1014f19a4 vga_dac_send_color(unsigned char, unsigned char) + 144
0          0x18d361a24 _sigtramp + 56
2024-02-08 18:21:32.222 | Signal: SIGSEGV
```

None of the other `machine` modes was affected 🤦🏻 Lesson learned: always test with all `machine` types after any video-related changes 😅 

The root cause of the problem is that we have all sorts of global initialisation going on, plus we have the section initialisers that are called in registration order. That's a bit shit; we should have a cycle-free dependency graph instead and no globals to ensure that every dependency gets created and initialised before the stuff that depends on on it (easier said than done, though, with this spaghetti mess... 🍝) So there's a real risk in fixing global initialisation because depending on where you move the init stuff within the chain of initialisers that "grew organically" and hang together like a house of cards, things might just blow up... A bit sad, really.

I could also "fix" this by moving `RENDER_AddConfigSection(control);` after `secprop->AddInitFunction(&INT10_Init);` in `dosbox.cpp`, but that's way too risky. Who knows what other bugs we might introduce by changing the init order of those sections... So, this more surgical approach seems more appropriate.

# Manual testing

Start with `machine = hercules` in the config — no crash.

Regression tested with all `machine` types (`svga_s3` is enough for VGA). Tested CGA composite as well.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

