### PR TITLE
Fix crash on startup when `machine` is set to `cga_mono`

### DIFF
--- a/include/render.h
+++ b/include/render.h
@@ -196,6 +196,7 @@ DosBox::Rect RENDER_CalcRestrictedViewportSizeInPixels(const DosBox::Rect& canva
 
 const std::string RENDER_GetCgaColorsSetting();
 
+MonochromePalette RENDER_GetMonochromePalette();
 void RENDER_SyncMonochromePaletteSetting(const enum MonochromePalette palette);
 
 std::deque<std::string> RENDER_GenerateShaderInventoryMessage();

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -121,8 +121,6 @@ void XMS_Init(Section*);
 void AUTOEXEC_Init(Section*);
 void SHELL_Init();
 
-void INT10_Init(Section*);
-
 static LoopHandler * loop;
 
 static int64_t ticksRemain;

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -26,6 +26,7 @@
 #include <mutex>
 
 #include "../capture/capture.h"
+#include "../ints/int10.h"
 #include "control.h"
 #include "fraction.h"
 #include "mapper.h"
@@ -912,7 +913,6 @@ static std::optional<ViewportSettings> parse_relative_viewport_modes(const std::
 			return {};
 		}
 		if (!is_within_bounds(height_scale)) {
-			LOG_TRACE("****1");
 			const auto extra_info = format_string(
 			        "Vertical scale must be within the %g-%g%% range",
 			        MinRelativeScaleFactor * 100.0f,
@@ -1362,6 +1362,10 @@ void RENDER_Init(Section* sec)
 
 	render.pal.first = 256;
 	render.pal.last  = 0;
+
+	if (INT10_IsInitialised()) {
+		VGA_SetMonochromePalette(RENDER_GetMonochromePalette());
+	}
 
 	// Get aspect ratio correction mode & force square pixels if requested
 	aspect_ratio_correction_mode = get_aspect_ratio_correction_mode_setting();

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -1375,11 +1375,6 @@ void RENDER_Init(Section* sec)
 		set_default_viewport_setting();
 	}
 
-	// Set monochrome palette
-	const auto mono_palette = to_monochrome_palette_enum(
-	        section->Get_string("monochrome_palette").c_str());
-	VGA_SetMonochromePalette(mono_palette);
-
 	// Only use the default 1x rendering scaler
 	render.scale.size = 1;
 

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -1296,6 +1296,12 @@ void RENDER_AddConfigSection(const config_ptr_t& conf)
 	init_render_settings(*sec);
 }
 
+MonochromePalette RENDER_GetMonochromePalette()
+{
+	return to_monochrome_palette_enum(
+	        get_render_section()->Get_string("monochrome_palette").c_str());
+}
+
 void RENDER_SyncMonochromePaletteSetting(const enum MonochromePalette palette)
 {
 	const auto string_prop = get_render_section()->GetStringProp(

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -701,9 +701,9 @@ static MonochromePalette to_monochrome_palette_enum(const char* setting)
 	return {};
 }
 
-static const char* to_string(const enum MonochromePalette palette)
+static const char* to_string(const enum MonochromePalette mono_palette)
 {
-	switch (palette) {
+	switch (mono_palette) {
 	case MonochromePalette::Amber: return MonochromePaletteAmber;
 	case MonochromePalette::Green: return MonochromePaletteGreen;
 	case MonochromePalette::White: return MonochromePaletteWhite;
@@ -1302,11 +1302,11 @@ MonochromePalette RENDER_GetMonochromePalette()
 	        get_render_section()->Get_string("monochrome_palette").c_str());
 }
 
-void RENDER_SyncMonochromePaletteSetting(const enum MonochromePalette palette)
+void RENDER_SyncMonochromePaletteSetting(const enum MonochromePalette mono_palette)
 {
 	const auto string_prop = get_render_section()->GetStringProp(
 	        "monochrome_palette");
-	string_prop->SetValue(to_string(palette));
+	string_prop->SetValue(to_string(mono_palette));
 }
 
 static bool handle_shader_changes()

--- a/src/ints/int10.cpp
+++ b/src/ints/int10.cpp
@@ -17,14 +17,14 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-
 #include "dosbox.h"
-#include "mem.h"
-#include "callback.h"
-#include "regs.h"
-#include "inout.h"
+
 #include "int10.h"
+#include "callback.h"
+#include "inout.h"
+#include "mem.h"
 #include "mouse.h"
+#include "regs.h"
 #include "setup.h"
 
 Int10Data int10;
@@ -731,6 +731,9 @@ static void SetupTandyBios(void) {
 	}
 }
 
+// forward declaration
+MonochromePalette RENDER_GetMonochromePalette();
+
 void INT10_Init(Section*)
 {
 	CurMode = std::prev(ModeList_VGA.end());
@@ -747,8 +750,11 @@ void INT10_Init(Section*)
 	CALLBACK_Setup(call_10, &INT10_Handler, CB_IRET, "Int 10 video");
 	RealSetVec(0x10, CALLBACK_RealPointer(call_10));
 
-	// Init the 0x40 segment and init the data structures in the video ROM area
+	// Init the 0x40 segment and the data structures in the video ROM area
 	INT10_SetupRomMemory();
 	INT10_Seg40Init();
 	INT10_SetVideoMode(0x3);
+
+	// Init monochrome palette from the config for Hercules and CGA mono
+	VGA_SetMonochromePalette(RENDER_GetMonochromePalette());
 }

--- a/src/ints/int10.cpp
+++ b/src/ints/int10.cpp
@@ -731,6 +731,13 @@ static void SetupTandyBios(void) {
 	}
 }
 
+static bool is_module_initialised = false;
+
+bool INT10_IsInitialised()
+{
+	return is_module_initialised;
+}
+
 // forward declaration
 MonochromePalette RENDER_GetMonochromePalette();
 
@@ -757,4 +764,6 @@ void INT10_Init(Section*)
 
 	// Init monochrome palette from the config for Hercules and CGA mono
 	VGA_SetMonochromePalette(RENDER_GetMonochromePalette());
+
+	is_module_initialised = true;
 }

--- a/src/ints/int10.cpp
+++ b/src/ints/int10.cpp
@@ -731,16 +731,23 @@ static void SetupTandyBios(void) {
 	}
 }
 
-void INT10_Init(Section* /*sec*/) {
+void INT10_Init(Section*)
+{
 	CurMode = std::prev(ModeList_VGA.end());
+
 	INT10_SetupPalette();
 	INT10_InitVGA();
-	if (IS_TANDY_ARCH) SetupTandyBios();
-	/* Setup the INT 10 vector */
-	call_10=CALLBACK_Allocate();	
-	CALLBACK_Setup(call_10,&INT10_Handler,CB_IRET,"Int 10 video");
-	RealSetVec(0x10,CALLBACK_RealPointer(call_10));
-	//Init the 0x40 segment and init the datastructures in the video rom area
+
+	if (IS_TANDY_ARCH) {
+		SetupTandyBios();
+	}
+
+	// Set up the INT 10h vector
+	call_10 = CALLBACK_Allocate();
+	CALLBACK_Setup(call_10, &INT10_Handler, CB_IRET, "Int 10 video");
+	RealSetVec(0x10, CALLBACK_RealPointer(call_10));
+
+	// Init the 0x40 segment and init the data structures in the video ROM area
 	INT10_SetupRomMemory();
 	INT10_Seg40Init();
 	INT10_SetVideoMode(0x3);

--- a/src/ints/int10.h
+++ b/src/ints/int10.h
@@ -224,6 +224,9 @@ inline uint8_t CURSOR_POS_ROW(const uint8_t page)
 	return real_readb(BIOSMEM_SEG, BIOSMEM_CURSOR_POS + cursor_offset);
 }
 
+void INT10_Init(Section*);
+bool INT10_IsInitialised();
+
 void INT10_SetupPalette();
 
 bool INT10_SetVideoMode(uint16_t mode);


### PR DESCRIPTION
# Description

Okay, the `CurMode` iterator issue keeps giving... 😅 This is part 2 after the Hercules fix. I forgot to test `cga_mono` as well, mea culpa...

I'm doing a more extensive refactoring/cleanup/modularisation as part of this fix.

Recommend to review by commit.

## Related issues

https://github.com/dosbox-staging/dosbox-staging/pull/3386

# Manual testing

### `machine = cga_mono`

Tested **Zak McKracken and the Alien Mindbenders (v1)** with the following base config:

```ini
[dosbox]
machine = cga_mono

[render]
monochrome_palette = green
```

Tested that:

- All valid values set from the config: `amber`, `green`, `white`, and `paperwhite`.
- An invalid value will default to `amber` and a warning gets logged.
- Changing `monochrome_palette` at runtime works as expected (as per the previous two tests).
- Changing the palette at runtime with the **Mono CGA Pal** hotkey works.

### `machine = hercules`

Repeated the same tests

### Other tests

Random regression testing with `svga_s3`, `tandy`, `ega`, `cga`, etc.


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

