### PR TITLE
Re-create CurMode iterator after backing array has been changed

### DIFF
--- a/src/hardware/vga_s3.cpp
+++ b/src/hardware/vga_s3.cpp
@@ -767,6 +767,7 @@ void filter_s3_modes_to_oem_only()
 	ModeList_VGA.erase(std::remove_if(ModeList_VGA.begin(),
 	                                  ModeList_VGA.end(), mode_not_allowed),
 	                   ModeList_VGA.end());
+	CurMode = std::prev(ModeList_VGA.end());
 }
 
 void SVGA_Setup_S3Trio(void)

--- a/src/ints/int10.cpp
+++ b/src/ints/int10.cpp
@@ -732,7 +732,6 @@ static void SetupTandyBios(void) {
 }
 
 void INT10_Init(Section* /*sec*/) {
-	CurMode = std::prev(ModeList_VGA.end());
 	INT10_SetupPalette();
 	INT10_InitVGA();
 	if (IS_TANDY_ARCH) SetupTandyBios();

--- a/src/ints/int10_modes.cpp
+++ b/src/ints/int10_modes.cpp
@@ -587,7 +587,7 @@ static void init_all_palettes(const cga_colors_t& cga_colors)
 	// clang-format on
 }
 
-video_mode_block_iterator_t CurMode = {};
+video_mode_block_iterator_t CurMode = std::prev(ModeList_VGA.end());
 
 static void log_invalid_video_mode_error(const uint16_t mode) {
 	LOG_ERR("INT10H: Trying to set invalid video mode: %02Xh", mode);
@@ -2322,3 +2322,4 @@ void INT10_SetupPalette()
 	auto cga_colors = configure_cga_colors();
 	init_all_palettes(cga_colors);
 }
+


### PR DESCRIPTION
# Description

I think my #3374 PR was just bad after @johnnovak submitted 2 PRs fixing crashes caused by it.  I've reverted that and the previous workaround.

Rather than trying to pick a place (somewhat arbitrarily in `INT10_Init`) to initialize this thing, leave the global init  just re-create it when it gets invalidated.  This happens exactly once in the code in SVGA_S3 init.

The real problem here was the edge case when the iterator gets invalidated.  So just fix the edge case rather than trying to dive into this init mess so close to the 0.81 release.

## Related issues

#3374
#3386
#3387

# Manual testing

Tested with all machine types to confirm no more crashes.


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

