### PR TITLE
Create basic macOS notarization script

### DIFF
--- a/contrib/macos/Entitlements.plist
+++ b/contrib/macos/Entitlements.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.cs.allow-jit</key>
+	<true/>
+</dict>
+</plist>

--- a/scripts/notarize-macos-dmg.sh
+++ b/scripts/notarize-macos-dmg.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Copyright (C) 2024-2024	The DOSBox Staging Team
+
+# This script notarizes a macOS DMG produced from the CI builds by
+# extracting the DMG, signing the app bundle, using the rest of the files
+# and the newly-signed app bundle to create a new DMG, then signing and 
+# notarizing the entire new DMG. Xcode must be installed.
+
+# Ensure developer identity and keychain profile name are set as environment variables
+# For example:
+# export DEVELOPER_IDENTITY="Developer ID Application: Valued Developer (xxxxxxxxxxx)"
+# export KEYCHAIN_PROFILE="Valued Developer Personal"
+#
+# Apple's notarization documentation: 
+# https://developer.apple.com/documentation/security/notarizing_macos_software_before_distribution
+
+if [[ -z "$DEVELOPER_IDENTITY" || -z "$KEYCHAIN_PROFILE" ]]; then
+    echo "Error: DEVELOPER_IDENTITY and KEYCHAIN_PROFILE environment variables must be set."
+    exit 1
+fi
+
+if [ "$#" -ne 2 ]; then
+    echo "Usage: $0 INPUT_DMG OUTPUT_DMG"
+    exit 1
+fi
+
+SCRIPT_DIR=$(pwd)
+INPUT_DMG="$1"
+OUTPUT_DMG="$2"
+TEMP_DIR=$(mktemp -d)
+
+ATTACHED_VOLUME_PATH=$(hdiutil attach "$INPUT_DMG" | grep "Volumes" | awk 'BEGIN {FS="\t"}; {print $NF}')
+ATTACHED_VOLUME_NAME=$(basename "$ATTACHED_VOLUME_PATH")
+
+if [ -z "$ATTACHED_VOLUME_NAME" ]; then
+    echo "Error attaching DMG."
+    exit 1
+fi
+
+SRC_DIR="$TEMP_DIR/$ATTACHED_VOLUME_NAME"
+
+cp -a "$ATTACHED_VOLUME_PATH" "$TEMP_DIR"
+
+cd "$TEMP_DIR/$ATTACHED_VOLUME_NAME" || { echo "Failed to change to $TEMP_DIR/$ATTACHED_VOLUME_NAME"; exit 1; }
+
+codesign -s "$DEVELOPER_IDENTITY" -fv "DOSBox Staging.app" --entitlements "${SCRIPT_DIR}/contrib/macos/Entitlements.plist" --options runtime
+
+hdiutil create -volname "$ATTACHED_VOLUME_NAME" -srcfolder "$SRC_DIR" -ov -format UDZO "$OUTPUT_DMG"
+
+codesign -s "$DEVELOPER_IDENTITY" -fv "$OUTPUT_DMG"
+
+xcrun notarytool submit "$OUTPUT_DMG" --keychain-profile "$KEYCHAIN_PROFILE" --wait
+xcrun stapler staple "$OUTPUT_DMG"
+
+hdiutil detach "$ATTACHED_VOLUME_PATH"
+rm -rf "$TEMP_DIR"


### PR DESCRIPTION
# Description

This is a rough script to take a macOS DMG artifact and repackage it after notarizing it with Apple. It is out-of-band, not intended to be run as part of the CI process since it requires a golden Developer ID signing certificate; it can be run on any of our DMGs after the fact.

# Related issues

#1901 

# Manual testing

I verified the UI elements are in the target disk image:

![CleanShot 2024-02-09 at 17 52 29@2x](https://github.com/dosbox-staging/dosbox-staging/assets/541026/8a643265-d89c-4e0d-ba0e-d079a67baa4d)

I uploaded the notarized DMG and re-downloaded it to trigger Gatekeeper, and ran the app to verify:

![CleanShot 2024-02-09 at 17 51 52@2x](https://github.com/dosbox-staging/dosbox-staging/assets/541026/d14eb547-552f-422d-a3c3-04418fdb268a)

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

