### PR TITLE
Don't execute compile workflows on documentation and script changes

### DIFF
--- a/.github/workflows/clang-analysis.yml
+++ b/.github/workflows/clang-analysis.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   build_clang_static_analyser:
     name: Clang static analyzer
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: run_linters
     steps:
       - name: Checkout repository
@@ -28,7 +28,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get install clang-tools python3-bs4 $(cat packages/ubuntu-20.04-apt.txt)
+          sudo apt-get install clang-tools python3-bs4 $(cat packages/ubuntu-22.04-apt.txt)
           sudo pip3 install --upgrade meson ninja
 
       - name:  Prepare compiler cache
@@ -56,8 +56,8 @@ jobs:
           key: subprojects-${{ hashFiles('subprojects/*.wrap') }}-1
           enableCrossOsArchive: true
 
-      - if:   steps.cache-subprojects.outputs.cache-hit != 'true'
-        name: Generate subprojects cache
+      - name: Generate subprojects cache
+        if:   steps.cache-subprojects.outputs.cache-hit != 'true'
         run:  scripts/fetch-and-tar-subprojects.sh
 
       - name: Extract subprojects cache

--- a/.github/workflows/clang-analysis.yml
+++ b/.github/workflows/clang-analysis.yml
@@ -1,4 +1,4 @@
-name: Code analysis
+name: Clang analysis
 
 on: [push, pull_request]
 
@@ -13,37 +13,6 @@ env:
   CCACHE_SLOPPINESS: "pch_defines,time_macros"
 
 jobs:
-  run_linters:
-    name: Script linters
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          submodules: false
-
-      - run:  sudo apt-get update
-      - name: Run shellcheck
-        run:  ./scripts/verify-bash.sh
-      - name: Install pylint
-        run: |
-          sudo apt-get install python3-setuptools
-          sudo pip3 install pylint beautifulsoup4 html5lib
-      - name: Run pylint
-        run:  ./scripts/verify-python.sh
-      - name: Install markdownlint
-        run: |
-          sudo apt-get install ruby-full
-          ruby --version
-          sudo gem install mdl
-      - name: Run markdownlint
-        run:  ./scripts/verify-markdown.sh
-      - name: Install appstream-util
-        run:  sudo apt-get install appstream-util
-      - name: Verify metainfo.xml
-        run:  appstream-util validate-relax --nonet contrib/linux/dosbox-staging.metainfo.xml
-
   build_clang_static_analyser:
     name: Clang static analyzer
     runs-on: ubuntu-20.04
@@ -54,7 +23,8 @@ jobs:
         with:
           submodules: false
 
-      - run:  sudo apt-get update
+      - name: Update packages
+        run:  sudo apt-get update
 
       - name: Install dependencies
         run: |
@@ -96,7 +66,8 @@ jobs:
       - name: Log environment
         run:  ./scripts/log-env.sh
 
-      - run: |
+      - name: Meson setup
+        run: |
           meson setup \
           -Dbuildtype=debug \
           -Duse_alsa=false \
@@ -126,6 +97,7 @@ jobs:
           MAX_BUGS: 3
         run: |
           # summary
-          echo "Full report is included in build Artifacts"
+          echo "Full report is included in build artifacts"
           echo
           ./scripts/count-clang-bugs.py report/*/index.html
+

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -1,4 +1,4 @@
-name: Coverity Scan analysis
+name: Coverity analysis
 
 on:
   push:
@@ -31,7 +31,8 @@ jobs:
         with:
           submodules: false
 
-      - run:  sudo apt-get update
+      - name: Update packages
+        run:  sudo apt-get update
 
       - name: Log and setup environment
         run: |
@@ -64,6 +65,7 @@ jobs:
         with:
           path: ${{ env.PACKAGE_DIR }}
           key: coverity-${{ env.PACKAGE_VERSION }}
+
       - name:  Fetch the Coverity package
         if:    steps.cache-coverity.outputs.cache-hit != 'true'
         run:   curl -L "${TARBALL_URL}" > "${PACKAGE}"
@@ -106,3 +108,4 @@ jobs:
           --form version="${GITHUB_REF}" \
           --form description="${GITHUB_REPOSITORY}" \
           "https://scan.coverity.com/builds?project=dosbox-staging"
+

--- a/.github/workflows/debian-docker-build.yml
+++ b/.github/workflows/debian-docker-build.yml
@@ -1,4 +1,4 @@
-name: Debian docker image builder
+name: Debian Docker image builder
 
 on:
   push:

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -14,7 +14,11 @@ on:
         type: string
 
 jobs:
+  linting:
+    uses: ./.github/workflows/linting.yml
+
   build_and_deploy_website:
+    needs: linting
     runs-on: ubuntu-latest
     steps:
       - name: Check out MkDocs sources

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   build_and_deploy_website:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check out MkDocs sources
         uses: actions/checkout@v4

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,0 +1,47 @@
+name: Lint scripts & Markdown
+
+on: [push, pull_request, workflow_call]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  run_linters:
+    name: Run scripts & Markdown linters
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: false
+
+      - name: Update packages
+        run:  sudo apt-get update
+
+      - name: Run shellcheck
+        run:  ./scripts/verify-bash.sh
+
+      - name: Install pylint
+        run: |
+          sudo apt-get install python3-setuptools
+          sudo pip3 install pylint beautifulsoup4 html5lib
+
+      - name: Run pylint
+        run:  ./scripts/verify-python.sh
+
+      - name: Install markdownlint
+        run: |
+          sudo apt-get install ruby-full
+          ruby --version
+          sudo gem install mdl
+
+      - name: Run markdownlint
+        run:  ./scripts/verify-markdown.sh
+
+      - name: Install appstream-util
+        run:  sudo apt-get install appstream-util
+
+      - name: Verify metainfo.xml
+        run:  appstream-util validate-relax --nonet contrib/linux/dosbox-staging.metainfo.xml

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,6 +1,23 @@
 name: Linux builds
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - '.clang-format'
+      - '.mdl-styles'
+      - '*.md'
+      - 'docs/**'
+      - 'licenses/**'
+      - 'website/**'
+
+  pull_request:
+    paths-ignore:
+      - '.clang-format'
+      - '.mdl-styles'
+      - '*.md'
+      - 'docs/**'
+      - 'licenses/**'
+      - 'website/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,6 +1,23 @@
 name: macOS builds
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - '.clang-format'
+      - '.mdl-styles'
+      - '*.md'
+      - 'docs/**'
+      - 'licenses/**'
+      - 'website/**'
+
+  pull_request:
+    paths-ignore:
+      - '.clang-format'
+      - '.mdl-styles'
+      - '*.md'
+      - 'docs/**'
+      - 'licenses/**'
+      - 'website/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/pvs-studio.yml
+++ b/.github/workflows/pvs-studio.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   pvs_studio_analyzer:
     name: PVS-Studio static analyzer
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       debfile: pvs-studio-7.29.79138.387-amd64.deb
     steps:
@@ -50,7 +50,7 @@ jobs:
       - name: Install dependencies
         run: |
           set -xeu
-          sudo apt-get install -y strace $(cat packages/ubuntu-20.04-apt.txt)
+          sudo apt-get install -y strace $(cat packages/ubuntu-22.04-apt.txt)
           sudo pip3 install --upgrade meson ninja
           sudo dpkg -i "pvs-package/pvs.deb"
           pvs-studio-analyzer credentials "${{ secrets.PvsStudioName }}" "${{ secrets.PvsStudioKey }}"

--- a/.github/workflows/pvs-studio.yml
+++ b/.github/workflows/pvs-studio.yml
@@ -12,7 +12,15 @@ on:
       - 'docs/**'
       - 'licenses/**'
       - 'website/**'
-      - 'scripts/**'
+
+  pull_request:
+    paths-ignore:
+      - '.clang-format'
+      - '.mdl-styles'
+      - '*.md'
+      - 'docs/**'
+      - 'licenses/**'
+      - 'website/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/pvs-studio.yml
+++ b/.github/workflows/pvs-studio.yml
@@ -3,7 +3,16 @@ name: PVS-Studio analysis
 # If the CI job fails with 404-not-found, then PVS studio has updated the release.
 # Get the new DEB version from: https://pvs-studio.com/en/pvs-studio/download-all/
 
-on: push
+on:
+  push:
+    paths-ignore:
+      - '.clang-format'
+      - '.mdl-styles'
+      - '*.md'
+      - 'docs/**'
+      - 'licenses/**'
+      - 'website/**'
+      - 'scripts/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/windows-msvc.yml
+++ b/.github/workflows/windows-msvc.yml
@@ -1,6 +1,23 @@
 name: Windows MSVC builds
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - '.clang-format'
+      - '.mdl-styles'
+      - '*.md'
+      - 'docs/**'
+      - 'licenses/**'
+      - 'website/**'
+
+  pull_request:
+    paths-ignore:
+      - '.clang-format'
+      - '.mdl-styles'
+      - '*.md'
+      - 'docs/**'
+      - 'licenses/**'
+      - 'website/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/windows-msys2.yml
+++ b/.github/workflows/windows-msys2.yml
@@ -1,6 +1,23 @@
 name: Windows MSYS2 builds
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - '.clang-format'
+      - '.mdl-styles'
+      - '*.md'
+      - 'docs/**'
+      - 'licenses/**'
+      - 'website/**'
+
+  pull_request:
+    paths-ignore:
+      - '.clang-format'
+      - '.mdl-styles'
+      - '*.md'
+      - 'docs/**'
+      - 'licenses/**'
+      - 'website/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
# Description

It makes no sense to rebuild the binaries when _only_ changing documentation-related stuff in a PR or push. So with this change, I'm excluding those build workflows from firing on doco-only changes.

Additionally, I'm splitting the previous "analyse" workflow into "Clang analysis" and "Lint scripts & Markdown", and I'm running the script linter workflow as a prerequisite when deploy the website.

It would be nice if we didn't have to provide the whole list of patterns in each `paths-ignore` block, but unforunately that's not possible currently.

A few people have suggested how this could be improved, but no movement so far:

https://github.com/orgs/community/discussions/18608

https://github.com/orgs/community/discussions/70584

# Manual testing

1. Made a test website related commit to make sure only the `linters` workflow gets triggered.

2. Ran the `deploy-website` workflow off this branch and verified that it runs the `linters` workflow as a dependency:

<img width="1123" alt="image" src="https://github.com/dosbox-staging/dosbox-staging/assets/698770/065317d0-3bc8-467a-b7dd-8fc94a0d13ea">


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

