### PR TITLE
Fix sed creating backup files ending with "-e" in macOS bundle

### DIFF
--- a/scripts/create-package.sh
+++ b/scripts/create-package.sh
@@ -103,11 +103,21 @@ install_doc()
     else
         package_information="a development branch"
     fi
+
     if [ -n "$package_information" ]; then
-        sed -i -e "s|%PACKAGE_INFORMATION%|$package_information|" "$readme_tmpl"
+        if [ "$(uname)" = "Darwin" ]; then
+            sed -i '' -e "s|%PACKAGE_INFORMATION%|$package_information|" "$readme_tmpl"
+        else
+            sed -i -e "s|%PACKAGE_INFORMATION%|$package_information|" "$readme_tmpl"
+        fi
     fi
+
     if [ -n "$git_repo" ]; then
-        sed -i -e "s|%GITHUB_REPO%|$git_repo|"  "$readme_tmpl"
+        if [ "$(uname)" = "Darwin" ]; then
+            sed -i '' -e "s|%GITHUB_REPO%|$git_repo|" "$readme_tmpl"
+        else
+            sed -i -e "s|%GITHUB_REPO%|$git_repo|" "$readme_tmpl"
+        fi
     fi
 }
 
@@ -165,7 +175,7 @@ pkg_macos()
     install_file contrib/macos/PkgInfo                   "${macos_content_dir}/PkgInfo"
     install_file contrib/icons/macos/dosbox-staging.icns "${macos_content_dir}/Resources/"
 
-    sed -i -e "s|%VERSION%|${dbox_version}|"       "${macos_content_dir}/Info.plist"
+    sed -i '' -e "s|%VERSION%|${dbox_version}|"       "${macos_content_dir}/Info.plist"
 
 	# Install start commands
 	start_command="Start DOSBox Staging.command"


### PR DESCRIPTION
# Description

The `sed` command on macOS creates backup files by default when using the `-i` switch, which were ending up inside the packaged app bundle:

![CleanShot 2024-02-14 at 18 21 48@2x](https://github.com/dosbox-staging/dosbox-staging/assets/541026/c60b2ed0-ee15-46d7-b5f9-10893b956696)

 and causing notarization verification failures when using the `spctl` command:

```log
spctl -a -vvv -t install "/Volumes/DOSBox Staging/DOSBox Staging.app"
```

Before the fix:

```log
/Volumes/DOSBox Staging/DOSBox Staging.app: rejected
origin=Developer ID Application: Kirk Klobe (AQE3WD7H5H)
```

After:

```log
/Volumes/DOSBox Staging/DOSBox Staging.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Kirk Klobe (AQE3WD7H5H)
```
## Related issues

Hopefully this will allow passing the homebrew cask verification for #2426 

# Manual testing

Ran the `spctl` verification command listed above and manually verified the app bundle launches with no Gatekeeper warnings, and several apps run that require dynrec to ensure the `allow-jit` entitlement is working.

Also verified the artifacts from the build no longer have the offending files:

![CleanShot 2024-02-14 at 18 24 22@2x](https://github.com/dosbox-staging/dosbox-staging/assets/541026/51c4878a-a783-4f0e-8838-a9ccdf469806)

Checked the Linux build artifact to ensure the affected files still copied properly.
# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

