### PR TITLE
Improve 'keyboardlayout' option description

### DIFF
--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -1188,7 +1188,8 @@ void DOSBOX_Init()
 	secprop->AddInitFunction(&DOS_KeyboardLayout_Init, changeable_at_runtime);
 	pstring = secprop->Add_string("keyboardlayout", when_idle, "auto");
 	pstring->Set_help(
-	        "Language code of the keyboard layout, or 'auto' ('auto' by default).");
+	        "Keyboard layout code ('auto' by default), i.e. 'us' for US English layout.\n"
+	        "Other possible values are the same as accepted by FreeDOS.");
 
 	// COMMAND.COM settings
 


### PR DESCRIPTION
# Description

Slightly improve description of the `keyboardlayout` option, hopefully users won't be confused anymore, like in the related issue.

## Related issues

https://github.com/dosbox-staging/dosbox-staging/issues/3401

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

