### PR TITLE
Cleanup some missed C++ header conversions

### DIFF
--- a/include/bios_disk.h
+++ b/include/bios_disk.h
@@ -21,9 +21,9 @@
 
 #include "dosbox.h"
 
-#include <memory>
-#include <stdio.h>
+#include <cstdio>
 #include <array>
+#include <memory>
 
 #include "bios.h"
 #include "dos_inc.h"

--- a/include/hardware.h
+++ b/include/hardware.h
@@ -24,7 +24,7 @@
 
 #include "dosbox.h"
 
-#include <stdio.h>
+#include <cstdio>
 #include <string>
 
 class Section;

--- a/include/sdlmain.h
+++ b/include/sdlmain.h
@@ -22,8 +22,9 @@
 #define DOSBOX_SDLMAIN_H
 
 #include "SDL.h"
+
+#include <cstring>
 #include <optional>
-#include <string.h>
 #include <string>
 #include <string_view>
 


### PR DESCRIPTION
# Description

Missed a few legacy include headers in #3284 

# Manual testing

Ran the build artifacts for Windows and macOS.

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

