### PR TITLE
Fix IPX ping value display

### DIFF
--- a/src/hardware/ipx.cpp
+++ b/src/hardware/ipx.cpp
@@ -1053,7 +1053,7 @@ public:
 					CALLBACK_Idle();
 					if(pingCheck(&pingHead)) {
 						WriteOut(
-						        "Response from %d.%d.%d.%d, port %d time=ms\n",
+						        "Response from %d.%d.%d.%d, port %d time=%lldms\n",
 						        CONVIP(pingHead.src.addr.byIP.host),
 						        SDLNet_Read16(&pingHead.src.addr.byIP.port),
 						        GetTicksSince(ticks));

--- a/src/hardware/ipxserver.cpp
+++ b/src/hardware/ipxserver.cpp
@@ -230,11 +230,11 @@ bool IPX_StartServer(uint16_t portnum)
 		if (!socket_set) {
 			socket_set = SDLNet_AllocSocketSet(1);
 			if (!socket_set) {
-				LOG_ERR("IPXServer: %s", SDLNet_GetError());
+				LOG_ERR("IPXSERVER: %s", SDLNet_GetError());
 				return false;
 			}
 			if (SDLNet_UDP_AddSocket(socket_set, ipxServerSocket) == -1) {
-				LOG_ERR("IPXServer: %s", SDLNet_GetError());
+				LOG_ERR("IPXSERVER: %s", SDLNet_GetError());
 				return false;
 			}
 		}
@@ -246,7 +246,7 @@ bool IPX_StartServer(uint16_t portnum)
                                         const int num_ready = SDLNet_CheckSockets(
                                                 socket_set, 100);
                                         if (num_ready == -1) {
-                                                LOG_ERR("IPXServer: %s",
+                                                LOG_ERR("IPXSERVER: %s",
                                                         SDLNet_GetError());
                                                 continue;
                                         }


### PR DESCRIPTION
# Description

The IPX ping command wasn't displaying the ping time.

![CleanShot 2024-02-18 at 15 35 10@2x](https://github.com/dosbox-staging/dosbox-staging/assets/541026/12ebc7f9-1efb-4f31-b475-832c3fd4422f)

# Manual testing

Ran `ipxnet ping` to verify proper display.

![CleanShot 2024-02-18 at 15 33 35@2x](https://github.com/dosbox-staging/dosbox-staging/assets/541026/4f951ce9-1169-4c55-b56d-f98059b150e1)

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

