### PR TITLE
Set BIOS_Destroy not changeable at runtime

### DIFF
--- a/src/ints/bios.cpp
+++ b/src/ints/bios.cpp
@@ -1463,6 +1463,6 @@ void BIOS_Init(Section* sec)
 
 	test = new BIOS(sec);
 
-	constexpr auto changeable_at_runtime = true;
+	constexpr auto changeable_at_runtime = false;
 	sec->AddDestroyFunction(&BIOS_Destroy, changeable_at_runtime);
 }


### PR DESCRIPTION
# Description

This fixes a bug where BIOS_Destroy gets run but not BIOS_Init when a config change happens under the joystick section.

I may have put the cart before the horse with my big refactor PR.  This bug can also be fixed in the short term by changing a single 1 to a 0 :smile: 

This is a regression from v0.80.1 introduced by 32b916937601c0e7f3b1a8a8f7e93a9ec32d0e75

We may want to backport this if we release a v0.81.1.

## Related issues

Fixes #3411


# Manual testing

- Ran FreeDOS's MEM.EXE and verified memory looks normal
- Ran various joystick config changes like `timed=true` and `deadzone=20`
-  Verified memory still looks normal

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

