### PR TITLE
Ignore meson.build in VS tests project

### DIFF
--- a/tests/vs/tests.vcxproj
+++ b/tests/vs/tests.vcxproj
@@ -357,9 +357,6 @@ $(TargetPath)</Command>
     <ClCompile Include="..\stubs.cpp" />
     <ClCompile Include="..\support_tests.cpp" />
   </ItemGroup>
-  <ItemGroup>
-    <None Include="..\meson.build" />
-  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/tests/vs/tests.vcxproj.filters
+++ b/tests/vs/tests.vcxproj.filters
@@ -29,7 +29,4 @@
     <ClCompile Include="..\support_tests.cpp" />
     <ClCompile Include="..\..\src\misc\messages_stubs.cpp" />
   </ItemGroup>
-  <ItemGroup>
-    <None Include="..\meson.build" />
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
# Description

Fixes errors in solution-wide analysis. `meson.build` doesn't need to be in the solution anyways.

Before:
![Screenshot 2024-02-19 085402](https://github.com/dosbox-staging/dosbox-staging/assets/541026/ddc4480c-0323-44d6-946a-cbc7a5fb1449)
After:
![image](https://github.com/dosbox-staging/dosbox-staging/assets/541026/888d50fc-2e3c-4887-a9a7-a6988f74c158)

# Manual testing

Rebuilt the solution and ran the `dosbox` project.

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

