### PR TITLE
Fix double-scanning behavior for SVGA/VESA games

### DIFF
--- a/src/hardware/vga_crtc.cpp
+++ b/src/hardware/vga_crtc.cpp
@@ -189,31 +189,14 @@ void vga_write_p3d5(io_port_t, io_val_t value, io_width_t)
 
 		vga.crtc.maximum_scan_line.data = new_val.data;
 
-		if (vga.draw.is_double_scanning) {
-			auto flipped = new_val;
-			flipped.start_vertical_blanking_bit9.flip();
-
-			// Only true if only `start_vertical_blanking_bit9` has
-			// been changed and all other bits are unchanged.
-			if (old_val.data == flipped.data) {
-				VGA_StartResize();
-			}
-
-			vga.draw.address_line_total = new_val.maximum_scan_line + 1;
-
-			if (new_val.is_scan_doubling_enabled) {
-				vga.draw.address_line_total *= 2;
-			}
-		} else {
-			// Start resize if any bit except `line_compare_bit9` has been
-			// changed.
-			if ((old_val.maximum_scan_line != new_val.maximum_scan_line) ||
-			    (old_val.start_vertical_blanking_bit9 !=
-			     new_val.start_vertical_blanking_bit9) ||
-			    (old_val.is_scan_doubling_enabled !=
-			     new_val.is_scan_doubling_enabled)) {
-				VGA_StartResize();
-			}
+		// Start resize if any bit except `line_compare_bit9` has been
+		// changed.
+		if ((old_val.maximum_scan_line != new_val.maximum_scan_line) ||
+		    (old_val.start_vertical_blanking_bit9 !=
+		     new_val.start_vertical_blanking_bit9) ||
+		    (old_val.is_scan_doubling_enabled !=
+		     new_val.is_scan_doubling_enabled)) {
+			VGA_StartResize();
 		}
 	} break;
 


### PR DESCRIPTION
# Description

The branch which sometimes skips VGA re-sizing for double-scan modes does not work at SVGA/VESA resolutions.  Those modes have a "faked" double-scan that gets calculated here:

https://github.com/dosbox-staging/dosbox-staging/blob/0c8e8cec90cdbda8821492e1b3094b58d11746cd/src/hardware/vga_draw.cpp#L2108-L2119

Simply doubling `vga.draw.address_line_total` is not enough.

## Related issues

Fixes #3416

# Manual testing

Confirmed this fixes Wing Commander 3.  That game switches into double-scanning (640X240) while playing videos and then back out again (640X480) when the video finishes playing.  These transitions were not being handled properly before.

Regression Testing:

- Watched **Second Reality** demo.  Looks fine.
- **Catacomb 3D** works
- **Legend of Kyrandia** scrolling bug is not present
- **Threat** works

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

