### PR TITLE
Fix incomplete integration of Brazilian translation

### DIFF
--- a/contrib/resources/translations/meson.build
+++ b/contrib/resources/translations/meson.build
@@ -1,4 +1,5 @@
 resource_files = [
+    'br.lng',
     'de.lng',
     'en.lng',
     'es.lng',

--- a/contrib/resources/translations/update-sources.sh
+++ b/contrib/resources/translations/update-sources.sh
@@ -93,6 +93,7 @@ update en
 # any missing messages into them in English, so translators can easily
 # find and update those new messages.
 #
+update br
 update de
 update es
 update fr

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -471,8 +471,8 @@ void DOSBOX_Init()
 	secprop = control->AddSection_prop("dosbox", &DOSBOX_RealInit);
 	pstring = secprop->Add_string("language", always, "");
 	pstring->Set_help(
-	        "Select a language to use: 'de', 'en', 'es', 'fr', 'it', 'nl', 'pl', or 'ru'\n"
-	        "(unset by default; this defaults to English).\n"
+	        "Select a language to use: 'br', 'de', 'en', 'es', 'fr', 'it', 'nl', 'pl',\n"
+	        "or 'ru' (unset by default; this defaults to English).\n"
 	        "Notes:\n"
 	        "  - This setting will override the 'LANG' environment variable, if set.\n"
 	        "  - The bundled 'resources/translations' directory with the executable holds\n"


### PR DESCRIPTION
# Description

Few small pieces are missing in the recent Brazilian Portuguese translation integration:  https://github.com/dosbox-staging/dosbox-staging/pull/3432, this PR adds them.


# Manual testing

Set `language = br`, start emulator, make it display some internal message.


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

