### PR TITLE
Only raise window when it is newly created

### DIFF
--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1394,6 +1394,8 @@ static SDL_Window* SetWindowMode(const RenderingBackend rendering_backend,
 
 		GFX_RefreshTitle();
 
+		SDL_RaiseWindow(sdl.window);
+
 		if (!fullscreen) {
 			goto finish;
 		}
@@ -1437,8 +1439,6 @@ finish:
 	// Force redraw after changing the window
 	if (sdl.draw.callback)
 		sdl.draw.callback(GFX_CallBackRedraw);
-
-	SDL_RaiseWindow(sdl.window);
 
 	// Ensure the time to change window modes isn't counted against
 	// our paced timing. This is a rare event that depends on host


### PR DESCRIPTION
# Description

Regression from commit a07c416

`SDL_RaiseWindow` call was in the wrong place.  This needs to only happen if a window is newly created.

## Related issues

#3433
#3346

# Manual testing

- Confirmed fixed on Windows 10
- Confirmed the issue described in #3346 does not return on Windows 10

Issue persists on Linux with X11 backend (but not Wayland).  This is due to SDL also raising the window on `SDL_SetWindowMinimumSize` on X11.  Will file bug report/PR with SDL (should be a single line removal in SDL code).

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

