### PR TITLE
Fix "unorthodox" scanline repeats on VGA

### DIFF
--- a/include/vga.h
+++ b/include/vga.h
@@ -1167,7 +1167,6 @@ void VGA_SetOverride(const bool vga_override, const double override_refresh_hz =
 void VGA_LogInitialization(const char* adapter_name, const char* ram_type,
                            const size_t num_modes);
 
-void VGA_ForceSquarePixels(const bool enabled);
 void VGA_AllowVgaScanDoubling(const bool allow);
 void VGA_AllowPixelDoubling(const bool allow);
 

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -585,8 +585,8 @@ static void setup_scan_and_pixel_doubling()
 	default: assertm(false, "Invalid RenderindBackend value");
 	}
 
-	VGA_EnableVgaDoubleScanning(!force_vga_single_scan);
-	VGA_EnablePixelDoubling(!force_no_pixel_doubling);
+	VGA_AllowVgaScanDoubling(!force_vga_single_scan);
+	VGA_AllowPixelDoubling(!force_no_pixel_doubling);
 }
 
 bool RENDER_MaybeAutoSwitchShader([[maybe_unused]] const DosBox::Rect canvas_size_px,

--- a/src/hardware/vga.cpp
+++ b/src/hardware/vga.cpp
@@ -365,29 +365,29 @@ void VGA_SetCGA4Table(uint8_t val0,uint8_t val1,uint8_t val2,uint8_t val3) {
 	}	
 }
 
-void VGA_EnableVgaDoubleScanning(const bool enable)
+void VGA_AllowVgaScanDoubling(const bool allow)
 {
 	if (machine != MCH_VGA) {
 		return;
 	}
-	if (enable && !vga.draw.double_scanning_enabled) {
+	if (allow && !vga.draw.scan_doubling_allowed) {
 		LOG_MSG("VGA: Double scanning VGA video modes enabled");
 	}
-	if (!enable && vga.draw.double_scanning_enabled) {
+	if (!allow && vga.draw.scan_doubling_allowed) {
 		LOG_MSG("VGA: Forcing single scanning of double-scanned VGA video modes");
 	}
-	vga.draw.double_scanning_enabled = enable;
+	vga.draw.scan_doubling_allowed = allow;
 }
 
-void VGA_EnablePixelDoubling(const bool enable)
+void VGA_AllowPixelDoubling(const bool allow)
 {
-	if (enable && !vga.draw.pixel_doubling_enabled) {
+	if (allow && !vga.draw.pixel_doubling_allowed) {
 		LOG_MSG("VGA: Pixel doubling enabled");
 	}
-	if (!enable && vga.draw.pixel_doubling_enabled) {
+	if (!allow && vga.draw.pixel_doubling_allowed) {
 		LOG_MSG("VGA: Forcing no pixel doubling");
 	}
-	vga.draw.pixel_doubling_enabled = enable;
+	vga.draw.pixel_doubling_allowed = allow;
 }
 
 void VGA_Init(Section* sec)

--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -2103,7 +2103,7 @@ ImageInfo setup_drawing()
 		default: assert(false);
 		}
 
-		double_width = is_pixel_doubling && vga.draw.pixel_doubling_enabled;
+		double_width = is_pixel_doubling && vga.draw.pixel_doubling_allowed;
 
 		// No need to actually render double-scanned for VGA modes other
 		// than 13h (and its tweak-mode variants; we'll just fake it with
@@ -2115,8 +2115,8 @@ ImageInfo setup_drawing()
 			vga.draw.address_line_total /= 2;
 
 			video_mode.height  = vert_end / 2;
-			double_height      = vga.draw.double_scanning_enabled;
-			forced_single_scan = !vga.draw.double_scanning_enabled;
+			double_height      = vga.draw.scan_doubling_allowed;
+			forced_single_scan = !vga.draw.scan_doubling_allowed;
 		} else {
 			video_mode.height = vert_end;
 		}
@@ -2183,7 +2183,7 @@ ImageInfo setup_drawing()
 			// scan mode to yield correct results.
 			const auto is_odd_address_line_total = vga.draw.address_line_total & 1;
 
-			if (vga.draw.double_scanning_enabled || is_odd_address_line_total) {
+			if (vga.draw.scan_doubling_allowed || is_odd_address_line_total) {
 				vga.draw.is_double_scanning = true;
 				render_height        = video_mode.height * 2;
 				rendered_double_scan = true;
@@ -2209,7 +2209,7 @@ ImageInfo setup_drawing()
 		// More information here:
 		// https://github.com/joncampbell123/dosbox-x/issues/951
 		//
-		if (vga.draw.pixel_doubling_enabled) {
+		if (vga.draw.pixel_doubling_allowed) {
 			double_width = true;
 		} else {
 			render_pixel_aspect_ratio *= 2;
@@ -2265,7 +2265,7 @@ ImageInfo setup_drawing()
 		render_width     = video_mode.width;
 
 		double_width = vga.seq.clocking_mode.is_pixel_doubling &&
-		               vga.draw.pixel_doubling_enabled;
+		               vga.draw.pixel_doubling_allowed;
 
 		if (IS_VGA_ARCH) {
 			render_pixel_aspect_ratio = calc_pixel_aspect_from_timings(
@@ -2279,9 +2279,9 @@ ImageInfo setup_drawing()
 			if (is_vga_scan_doubling()) {
 				video_mode.is_double_scanned_mode = true;
 				video_mode.height = vert_end / 2;
-				forced_single_scan = !vga.draw.double_scanning_enabled;
+				forced_single_scan = !vga.draw.scan_doubling_allowed;
 
-				if (vga.draw.double_scanning_enabled) {
+				if (vga.draw.scan_doubling_allowed) {
 					vga.draw.is_double_scanning = true;
 					render_height = video_mode.height * 2;
 					rendered_double_scan = true;
@@ -2296,7 +2296,7 @@ ImageInfo setup_drawing()
 			}
 
 			if (vga.seq.clocking_mode.is_pixel_doubling &&
-			    !vga.draw.pixel_doubling_enabled) {
+			    !vga.draw.pixel_doubling_allowed) {
 				render_pixel_aspect_ratio *= 2;
 			}
 
@@ -2334,14 +2334,14 @@ ImageInfo setup_drawing()
 				video_mode.width = horiz_end * 8;
 				render_width     = video_mode.width;
 			} else {
-				double_width = vga.draw.pixel_doubling_enabled;
+				double_width = vga.draw.pixel_doubling_allowed;
 				video_mode.width = horiz_end * 4;
 				render_width     = video_mode.width;
 			}
 			VGA_DrawLine = VGA_Draw_4BPP_Line;
 
 		} else { // low-bandwidth
-			double_width     = vga.draw.pixel_doubling_enabled;
+			double_width     = vga.draw.pixel_doubling_allowed;
 			video_mode.width = horiz_end * 4;
 			render_width     = video_mode.width * 2;
 			rendered_pixel_doubling = true;
@@ -2385,7 +2385,7 @@ ImageInfo setup_drawing()
 		*/
 
 		double_width = (video_mode.width < 640) &&
-		               vga.draw.pixel_doubling_enabled;
+		               vga.draw.pixel_doubling_allowed;
 
 		render_width  = video_mode.width;
 		render_height = video_mode.height;
@@ -2423,7 +2423,7 @@ ImageInfo setup_drawing()
 			video_mode.width = vga.draw.blocks * 2;
 
 			double_width = !vga.tandy.mode_control.is_pcjr_640x200_2_color_graphics &&
-			               vga.draw.pixel_doubling_enabled;
+			               vga.draw.pixel_doubling_allowed;
 
 		} else { // Tandy
 			vga.draw.blocks = horiz_end * (vga.tandy.mode.is_tandy_640_dot_graphics
@@ -2432,7 +2432,7 @@ ImageInfo setup_drawing()
 			video_mode.width = vga.draw.blocks * 8;
 
 			double_width = !vga.tandy.mode.is_tandy_640_dot_graphics &&
-			               vga.draw.pixel_doubling_enabled;
+			               vga.draw.pixel_doubling_allowed;
 		}
 
 		video_mode.height = vert_end;
@@ -2471,7 +2471,7 @@ ImageInfo setup_drawing()
 		render_width     = video_mode.width;
 
 		double_width = vga.seq.clocking_mode.is_pixel_doubling &&
-		               vga.draw.pixel_doubling_enabled;
+		               vga.draw.pixel_doubling_allowed;
 
 		if (IS_VGA_ARCH) {
 			video_mode.is_double_scanned_mode = true;
@@ -2479,7 +2479,7 @@ ImageInfo setup_drawing()
 			video_mode.height = vert_end / 2;
 			render_height     = video_mode.height;
 
-			double_height = vga.draw.double_scanning_enabled;
+			double_height = vga.draw.scan_doubling_allowed;
 
 			// We never render true double-scanned CGA modes; we
 			// always fake it even if double scanning is requested
@@ -2488,11 +2488,11 @@ ImageInfo setup_drawing()
 			render_pixel_aspect_ratio = calc_pixel_aspect_from_timings(
 			        vga_timings);
 
-			if (!vga.draw.double_scanning_enabled) {
+			if (!vga.draw.scan_doubling_allowed) {
 				render_pixel_aspect_ratio /= 2;
 			}
 			if (vga.seq.clocking_mode.is_pixel_doubling &&
-			    !vga.draw.pixel_doubling_enabled) {
+			    !vga.draw.pixel_doubling_allowed) {
 				render_pixel_aspect_ratio *= 2;
 			}
 
@@ -2523,7 +2523,7 @@ ImageInfo setup_drawing()
 		video_mode.width  = horiz_end * 8;
 		video_mode.height = vert_end;
 
-		double_width = vga.draw.pixel_doubling_enabled;
+		double_width = vga.draw.pixel_doubling_allowed;
 
 		// Composite emulation is rendered at 2x the horizontal resolution
 		render_width  = video_mode.width * 2;
@@ -2645,7 +2645,7 @@ ImageInfo setup_drawing()
 		render_height = video_mode.height;
 
 		double_width = vga.seq.clocking_mode.is_pixel_doubling &&
-		               vga.draw.pixel_doubling_enabled;
+		               vga.draw.pixel_doubling_allowed;
 
 		if (IS_VGA_ARCH) {
 			render_pixel_aspect_ratio = calc_pixel_aspect_from_timings(
@@ -2676,7 +2676,7 @@ ImageInfo setup_drawing()
 		render_height = video_mode.height;
 
 		double_width = !vga.tandy.mode.is_high_bandwidth &&
-		               vga.draw.pixel_doubling_enabled;
+		               vga.draw.pixel_doubling_allowed;
 
 		render_pixel_aspect_ratio = calc_pixel_aspect_from_dimensions(
 		        render_width, render_height, double_width, double_height);

--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -1819,7 +1819,7 @@ static UpdatedTimings update_vga_timings(const VgaTimings& timings)
 	return {horiz_display_end, vert_display_end, vblank_skip};
 }
 
-static bool is_vga_scan_doubling()
+static bool is_scan_doubling_bit_set()
 {
 	// Scan doubling on VGA is generally achieved in one of two ways,
 	// depending on the video mode:
@@ -1919,7 +1919,8 @@ ImageInfo setup_drawing()
 
 	const auto vga_timings = calculate_vga_timings();
 
-	if (is_vga_scan_doubling() && !(vga.mode == M_CGA2 || vga.mode == M_CGA4)) {
+	if (is_scan_doubling_bit_set() &&
+	    !(vga.mode == M_CGA2 || vga.mode == M_CGA4)) {
 		vga.draw.address_line_total *= 2;
 	}
 
@@ -2108,7 +2109,7 @@ ImageInfo setup_drawing()
 		// No need to actually render double-scanned for VGA modes other
 		// than 13h (and its tweak-mode variants; we'll just fake it with
 		// `double_height`.
-		if (is_vga_scan_doubling()) {
+		if (is_scan_doubling_bit_set()) {
 			video_mode.is_double_scanned_mode = true;
 
 			vga.draw.is_double_scanning = true;
@@ -2154,10 +2155,8 @@ ImageInfo setup_drawing()
 		video_mode.graphics_standard = GraphicsStandard::Vga;
 		video_mode.color_depth       = ColorDepth::IndexedColor256;
 
-		const auto is_double_scanning =
+		video_mode.is_double_scanned_mode =
 		        (vga.crtc.maximum_scan_line.maximum_scan_line > 0);
-
-		video_mode.is_double_scanned_mode = is_double_scanning;
 
 		render_pixel_aspect_ratio = calc_pixel_aspect_from_timings(vga_timings);
 
@@ -2170,7 +2169,7 @@ ImageInfo setup_drawing()
 		// "fake double-scan" on VGA (render single-scanned, then double
 		// the image vertically with a scaler).
 		//
-		if (is_double_scanning) {
+		if (video_mode.is_double_scanned_mode) {
 			video_mode.height  = vert_end / 2;
 
 			// Some rare demos set up odd Maximum Scan Line CRTC register
@@ -2276,7 +2275,7 @@ ImageInfo setup_drawing()
 			// on emulated VGA adapters only; for everything else, we "fake
 			// double-scan" on VGA (render single-scanned, then double the
 			// image vertically with a scaler).
-			if (is_vga_scan_doubling()) {
+			if (is_scan_doubling_bit_set()) {
 				video_mode.is_double_scanned_mode = true;
 				video_mode.height = vert_end / 2;
 				forced_single_scan = !vga.draw.scan_doubling_allowed;


### PR DESCRIPTION
# Description

Fixes https://github.com/dosbox-staging/dosbox-staging/issues/3434

The original DOSBox code contained a special case for handling "unorthodox scan doublings" that we lost during the removal of the `vgaonly` refactors.

Some rare demos set up odd Maximum Scan Line CRTC register values; for example, Show by Majic 12 uses the value 4 during the zoom-rotator part in the intro to set up "scanline quintupling". That's right, every scanline is repeated 4 times, resulting in a total number of 5 scanlines per "logical pixel"!

This change fixes the forced single scan case (the authentic double-scanned VGA emulation path was fine). Effectively, scanline repeating is forced when encountering odd Maximum Scan Line values, even in forced single scan mode.

**Note the bug _only_ manifested with forced single scanning. To force single scanning, you need to use `glshader = sharp`, `glshader = crt-auto-arcade`, or `output = texturenb`.**

This is where the original code performed this special casing (it's not so easy to see as I've refactoring the code substantially since then... How did I find this out? By comparing trace logs between the old and the new VGA code for a few hours...)
https://github.com/dosbox-staging/dosbox-staging/blob/release/0.80.x/src/hardware/vga_draw.cpp#L1803-L1811

### Show by Majic 12, zoom rotator part

<img width="1376" alt="image" src="https://github.com/dosbox-staging/dosbox-staging/assets/698770/154917bb-dae2-4c02-bf6e-5b58a71a8226">

### Zoomed-in view

Count the scanlines — there are five per each "logical pixel"!

![image](https://github.com/dosbox-staging/dosbox-staging/assets/698770/8e8aeaf2-67fb-4e43-8c14-be5159a1c633)

# Manual testing

Tested the following:

- Copper demo
- Show by Majic 12
- Second Reality by Future Crew
- Catacomb 3D
- Gods
- The Legend of Kyrandia: Book One
- Ravenloft - Strahd's Possession
- Pinball Fantasies
- Pinball Illusions

With these `glshader` settings:

- `crt-auto` (double scanning)
- `crt-auto-arcade` (forces single scanning)
- `sharp` (forces single scanning)

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

