### PR TITLE
Cleanup of using namespace

### DIFF
--- a/src/debug/debug.cpp
+++ b/src/debug/debug.cpp
@@ -29,7 +29,6 @@
 #include <sstream>
 #include <string>
 #include <vector>
-using namespace std;
 
 #include "debug.h"
 #include "cross.h" //snprintf
@@ -101,7 +100,7 @@ bool	exitLoop	= false;
 
 // Heavy Debugging Vars for logging
 #if C_HEAVY_DEBUG
-static ofstream 	cpuLogFile;
+static std::ofstream 	cpuLogFile;
 static bool		cpuLog			= false;
 static int		cpuLogCounter	= 0;
 static int		cpuLogType		= 1;	// log detail
@@ -172,7 +171,7 @@ static void ClearInputLine(void) {
 
 // History stuff
 #define MAX_HIST_BUFFER 50
-static list<string> histBuff = {};
+static std::list<std::string> histBuff = {};
 static auto histBuffPos = histBuff.end();
 
 /***********/
@@ -1083,12 +1082,14 @@ bool ParseCommand(char* str) {
 		*idx = toupper(*idx);
 
 	found = trim(found);
-	string s_found(found);
-	istringstream stream(s_found);
-	string command;
+	std::string s_found(found);
+	std::istringstream stream(s_found);
+	std::string command;
 	stream >> command;
-	string::size_type next = s_found.find_first_not_of(' ',command.size());
-	if(next == string::npos) next = command.size();
+	std::string::size_type next = s_found.find_first_not_of(' ', command.size());
+	if (next == std::string::npos) {
+		next = command.size();
+	}
 	(s_found.erase)(0,next);
 	found = const_cast<char*>(s_found.c_str());
 
@@ -1317,7 +1318,8 @@ bool ParseCommand(char* str) {
 		DEBUG_ShowMsg("DEBUG: Logfile '%s' created.\n",
 		              std_fs::absolute(log_cpu_txt).string().c_str());
 		//Initialize log object
-		cpuLogFile << hex << noshowbase << setfill('0') << uppercase;
+		cpuLogFile << std::hex << std::noshowbase << std::setfill('0')
+		           << std::uppercase;
 		cpuLog = true;
 		cpuLogCounter = GetHexValue(found,found);
 
@@ -2218,12 +2220,13 @@ static void LogCPUInfo(void) {
 }
 
 #if C_HEAVY_DEBUG
-static void LogInstruction(uint16_t segValue, uint32_t eipValue, ofstream &out)
+static void LogInstruction(uint16_t segValue, uint32_t eipValue, std::ofstream &out)
 {
 	static char empty[23] = { 32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,0 };
 
+	using std::setw;
 	if (cpuLogType == 3) { //Log only cs:ip.
-		out << setw(4) << SegValue(cs) << ":" << setw(8) << reg_eip << endl;
+		out << setw(4) << SegValue(cs) << ":" << setw(8) << reg_eip << std::endl;
 		return;
 	}
 
@@ -2281,7 +2284,7 @@ static void LogInstruction(uint16_t segValue, uint32_t eipValue, ofstream &out)
 		out << " TF:" << GETFLAGBOOL(TF) << " VM:" << GETFLAGBOOL(VM) <<" FLG:" << setw(8) << reg_flags
 		    << " CR0:" << setw(8) << cpu.cr0;
 	}
-	out << endl;
+	out << std::endl;
 }
 #endif
 
@@ -2698,16 +2701,17 @@ void DEBUG_HeavyWriteLogInstruction()
 
 	DEBUG_ShowMsg("DEBUG: Creating cpu log LOGCPU_INT_CD.TXT\n");
 
-	ofstream out("LOGCPU_INT_CD.TXT");
+	std::ofstream out("LOGCPU_INT_CD.TXT");
 	if (!out.is_open()) {
 		DEBUG_ShowMsg("DEBUG: Failed.\n");
 		return;
 	}
-	out << hex << noshowbase << setfill('0') << uppercase;
+	out << std::hex << std::noshowbase << std::setfill('0') << std::uppercase;
 	uint32_t startLog = logCount;
 	do {
 		// Write Instructions
 		TLogInst & inst = logInst[startLog];
+		using std::setw;
 		out << setw(4) << inst.s_cs << ":" << setw(8) << inst.eip << "  "
 		    << inst.dline << "  " << inst.res << " EAX:" << setw(8)<< inst.eax
 		    << " EBX:" << setw(8) << inst.ebx << " ECX:" << setw(8) << inst.ecx
@@ -2718,7 +2722,7 @@ void DEBUG_HeavyWriteLogInstruction()
 		    << " GS:"  << setw(4) << inst.s_gs<< " SS:"  << setw(4) << inst.s_ss
 		    << " CF:"  << inst.c  << " ZF:"   << inst.z  << " SF:"  << inst.s
 		    << " OF:"  << inst.o  << " AF:"   << inst.a  << " PF:"  << inst.p
-		    << " IF:"  << inst.i  << endl;
+		    << " IF:"  << inst.i  << std::endl;
 
 /*		fprintf(f,"%04X:%08X   %s  %s  EAX:%08X EBX:%08X ECX:%08X EDX:%08X ESI:%08X EDI:%08X EBP:%08X ESP:%08X DS:%04X ES:%04X FS:%04X GS:%04X SS:%04X CF:%01X ZF:%01X SF:%01X OF:%01X AF:%01X PF:%01X IF:%01X\n",
 			logInst[startLog].s_cs,logInst[startLog].eip,logInst[startLog].dline,logInst[startLog].res,logInst[startLog].eax,logInst[startLog].ebx,logInst[startLog].ecx,logInst[startLog].edx,logInst[startLog].esi,logInst[startLog].edi,logInst[startLog].ebp,logInst[startLog].esp,

--- a/src/debug/debug_gui.cpp
+++ b/src/debug/debug_gui.cpp
@@ -44,11 +44,10 @@ struct _LogGroup {
 };
 #include <list>
 #include <string>
-using namespace std;
 
 #define MAX_LOG_BUFFER 500
-static list<string> logBuff = {};
-static list<string>::iterator logBuffPos = logBuff.end();
+static std::list<std::string> logBuff    = {};
+static std::list<std::string>::iterator logBuffPos = logBuff.end();
 
 static _LogGroup loggrp[LOG_MAX]={{"",true},{nullptr,false}};
 static FILE *debuglog = nullptr;
@@ -102,7 +101,7 @@ void DEBUG_RefreshPage(int scroll) {
 	else if (scroll == 1 && logBuffPos != logBuff.end())
 		++logBuffPos;
 
-	list<string>::iterator i = logBuffPos;
+	std::list<std::string>::iterator i = logBuffPos;
 	int maxy, maxx; getmaxyx(dbg.win_out,maxy,maxx);
 	int rem_lines = maxy;
 	if(rem_lines == -1) return;
@@ -111,8 +110,11 @@ void DEBUG_RefreshPage(int scroll) {
 
 	while (rem_lines > 0 && i!=logBuff.begin()) {
 		--i;
-		for (string::size_type posf=0, posl; (posl=(*i).find('\n',posf)) != string::npos ;posf=posl+1)
-			rem_lines -= (int) ((posl-posf) / maxx) + 1; // len=(posl+1)-posf-1
+		for (std::string::size_type posf = 0, posl;
+		     (posl = (*i).find('\n', posf)) != std::string::npos;
+		     posf = posl + 1) {
+			rem_lines -= (int)((posl - posf) / maxx) + 1; // len=(posl+1)-posf-1
+		}
 		/* Const cast is needed for pdcurses which has no const char in mvwprintw (bug maybe) */
 		mvwprintw(dbg.win_out,rem_lines-1, 0, const_cast<char*>((*i).c_str()));
 	}

--- a/src/dos/drive_overlay.cpp
+++ b/src/dos/drive_overlay.cpp
@@ -38,7 +38,6 @@
 
 #define OVERLAY_DIR 1
 bool logoverlay = false;
-using namespace std;
 
 #if defined (WIN32)
 #define CROSS_DOSFILENAME(blah)
@@ -715,11 +714,14 @@ void Overlay_Drive::update_cache(bool read_directory_contents) {
 				    strncmp(dir_name,
 				            special_prefix.c_str(),
 				            prefix_lengh) == 0) {
-					specials.emplace_back(string(dirpush) + dir_name);
+					specials.emplace_back(
+					        std::string(dirpush) + dir_name);
 				} else if (is_directory) {
-					dirnames.emplace_back(string(dirpush) + dir_name);
+					dirnames.emplace_back(
+					        std::string(dirpush) + dir_name);
 				} else {
-					filenames.emplace_back(string(dirpush) + dir_name);
+					filenames.emplace_back(
+					        std::string(dirpush) + dir_name);
 				}
 			};
 			// Read complete directory

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -1921,6 +1921,8 @@ static std::string humanize_key_name(const CBindList &binds, const std::string &
 
 static void update_active_bind_ui()
 {
+	using namespace std::string_literals;
+
 	if (mapper.abind == nullptr) {
 		bind_but.bind_title->Enable(false);
 		bind_but.del->Enable(false);
@@ -1953,8 +1955,6 @@ static void update_active_bind_ui()
 	// Correlate mod event bindlists to button labels and prepare
 	// human-readable mod key names.
 	for (auto &event : events) {
-		using namespace std::string_literals;
-
 		assert(event);
 		const auto bindlist = event->bindlist;
 

--- a/src/hardware/gameblaster.cpp
+++ b/src/hardware/gameblaster.cpp
@@ -30,6 +30,8 @@
 void GameBlaster::Open(const int port_choice, const std::string &card_choice,
                        const std::string &filter_choice)
 {
+	using namespace std::placeholders;
+
 	Close();
 	assert(!is_open);
 
@@ -54,7 +56,6 @@ void GameBlaster::Open(const int port_choice, const std::string &card_choice,
 	// compatibility, and the Sound Blaster 2.0 had sockets for them as
 	// optional add-ons. Therefore, we always set up these handlers, even if
 	// the card type isn't a Game Blaster.
-	using namespace std::placeholders;
 	const auto data_to_left = std::bind(&GameBlaster::WriteDataToLeftDevice, this, _1, _2, _3);
 	const auto control_to_left = std::bind(&GameBlaster::WriteControlToLeftDevice, this, _1, _2, _3);
 	const auto data_to_right = std::bind(&GameBlaster::WriteDataToRightDevice, this, _1, _2, _3);

--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -335,8 +335,6 @@ private:
 	bool should_change_irq_dma      = false;
 };
 
-using namespace std::placeholders;
-
 // External Tie-in for OPL FM-audio
 uint8_t adlib_commandreg = ADLIB_CMD_DEFAULT;
 
@@ -1249,6 +1247,8 @@ uint16_t Gus::ReadFromRegister()
 
 void Gus::RegisterIoHandlers()
 {
+	using namespace std::placeholders;
+	
 	// Register the IO read addresses
 	assert(read_handlers.size() > 7);
 	const auto read_from = std::bind(&Gus::ReadFromPort, this, _1, _2);
@@ -1320,6 +1320,8 @@ static void gus_destroy(Section*);
 
 void Gus::UpdateDmaAddress(const uint8_t new_address)
 {
+	using namespace std::placeholders;
+
 	// Has it changed?
 	if (new_address == dma1) {
 		return;

--- a/src/hardware/imfc.cpp
+++ b/src/hardware/imfc.cpp
@@ -5722,6 +5722,8 @@ private:
 	// and 0xE5 (reboot command). This value will be sent to the system.
 	void softReboot(uint8_t commandThatRequestedTheSoftReboot)
 	{
+		using namespace std::chrono_literals;
+
 		disableInterrupts();
 		// reset the stack pointer :)
 		m_cardMode = MUSIC_MODE;
@@ -5759,7 +5761,6 @@ private:
 			// reenable
 			MUSIC_MODE_LOOP_read_System_And_Dispatch();
 			logSuccess();
-			using namespace std::chrono_literals;
 			std::this_thread::sleep_for(1ms);
 		}
 	}
@@ -12926,6 +12927,8 @@ public:
 	          m_bufferFromSystemState("bufferFromSystemState", 0x2000),
 	          m_bufferToSystemState("bufferToSystemState", 256)
 	{
+		using namespace std::chrono_literals;
+
 		// now wire everything up (see Figure "2-1 Music Card Interrupt
 		// System" in the Techniucal Reference Manual)
 
@@ -13035,7 +13038,6 @@ public:
 		// wait until we're ready to receive data... it's a workaround
 		// for now, but well....
 		while (!m_finishedBootupSequence) {
-			using namespace std::chrono_literals;
 			std::this_thread::sleep_for(1ms);
 		}
 
@@ -13229,6 +13231,8 @@ public:
 
 	~MusicFeatureCard()
 	{
+		using namespace std::chrono_literals;
+
 		LOG_MSG("IMFC: Shutting down");
 
 		keepRunning = false;
@@ -13240,7 +13244,6 @@ public:
 			wh.Uninstall();
 
 		// Give the threads a small bit of time to gracefully complete
-		using namespace std::chrono_literals;
 		std::this_thread::sleep_for(20ms);
 
 		SDL_WaitThread(m_mainThread, nullptr);
@@ -13250,6 +13253,8 @@ public:
 
 void MusicFeatureCard::RegisterIoHandlers(const io_port_t port)
 {
+	using namespace std::placeholders;
+
 	const io_port_t port_piu0  = port + 0x0;
 	const io_port_t port_piu1  = port + 0x1;
 	const io_port_t port_piu2  = port + 0x2;
@@ -13264,7 +13269,6 @@ void MusicFeatureCard::RegisterIoHandlers(const io_port_t port)
 	// Consistency check
 	assert(readHandlers.size() == NumIoHandlers);
 	assert(writeHandlers.size() == NumIoHandlers);
-	using namespace std::placeholders;
 
 	auto read_piu0 = std::bind(&MusicFeatureCard::readPortPIU0, this, _1, _2);
 	readHandlers.at(0).Install(port_piu0, read_piu0, io_width_t::byte);

--- a/src/hardware/innovation.cpp
+++ b/src/hardware/innovation.cpp
@@ -35,6 +35,8 @@ void Innovation::Open(const std::string_view model_choice,
                       const int filter_strength_8580, const int port_choice,
                       const std::string_view channel_filter_choice)
 {
+	using namespace std::placeholders;
+
 	Close();
 
 	// Sentinel
@@ -79,7 +81,6 @@ void Innovation::Open(const std::string_view model_choice,
 	ms_per_clock = millis_in_second / chip_clock;
 
 	// Setup the mixer and get it's sampling rate
-	using namespace std::placeholders;
 	const auto mixer_callback = std::bind(&Innovation::AudioCallback, this, _1);
 
 	auto mixer_channel = MIXER_AddChannel(mixer_callback,

--- a/src/hardware/input/intel8042.cpp
+++ b/src/hardware/input/intel8042.cpp
@@ -30,8 +30,6 @@
 #include "mem.h"
 #include "pic.h"
 
-using namespace bit::literals;
-
 CHECK_NARROWING();
 
 // Emulates the Intel 8042 keyboard/mouse controller.
@@ -895,6 +893,7 @@ static void execute_command(const Command command, const uint8_t param)
 	// LOG_INFO("I8042: Command 0x%02x, parameter 0x%02x",
 	//          static_cast<int>(command), param);
 
+	using namespace bit::literals;
 	switch (command) {
 	case Command::WriteByteConfig: // 0x60
 		// Writes the keyboard controller configuration byte

--- a/src/hardware/input/intel8255.cpp
+++ b/src/hardware/input/intel8255.cpp
@@ -28,8 +28,6 @@
 #include "mixer.h"
 #include "timer.h"
 
-using namespace bit::literals;
-
 CHECK_NARROWING();
 
 // ***************************************************************************
@@ -137,6 +135,8 @@ static uint8_t read_p61(io_port_t, io_width_t)
 
 static uint8_t read_p62(io_port_t, io_width_t)
 {
+	using namespace bit::literals;
+
 	auto ret = bit::all<uint8_t>();
 
 	if (!TIMER_GetOutput2()) {

--- a/src/hardware/input/keyboard.cpp
+++ b/src/hardware/input/keyboard.cpp
@@ -34,8 +34,6 @@
 #include "support.h"
 #include "timer.h"
 
-using namespace bit::literals;
-
 CHECK_NARROWING();
 
 // Emulates the PS/2 keybaord, as seen by the Intel 8042 microcontroller.
@@ -631,6 +629,8 @@ void KEYBOARD_WaitForSecureMode()
 
 void KEYBOARD_PortWrite(const uint8_t byte)
 {
+	using namespace bit::literals;
+
 	// Highest bit set usuaally means a command
 	const bool is_command = bit::is(byte, b7) &&
 	                        current_command != Command::Set3KeyTypematic &&

--- a/src/hardware/input/mouseif_dos_driver.cpp
+++ b/src/hardware/input/mouseif_dos_driver.cpp
@@ -37,8 +37,6 @@
 
 #include "../../ints/int10.h"
 
-using namespace bit::literals;
-
 CHECK_NARROWING();
 
 // This file implements the DOS mouse driver interface,
@@ -1340,6 +1338,8 @@ void MOUSEDOS_NotifyWheel(const int16_t w_rel)
 
 static Bitu int33_handler()
 {
+	using namespace bit::literals;
+
 	switch (reg_ax) {
 	case 0x00: // MS MOUSE - reset driver and read status
 		reset_hardware();

--- a/src/hardware/input/mouseif_ps2_bios.cpp
+++ b/src/hardware/input/mouseif_ps2_bios.cpp
@@ -37,8 +37,6 @@
 
 #include "../../ints/int10.h"
 
-using namespace bit::literals;
-
 CHECK_NARROWING();
 
 // This file implements both BIOS interface and PS/2 direct mouse access.
@@ -261,6 +259,8 @@ static void reset_counters()
 
 static void build_protocol_frame(const bool is_polling = false)
 {
+	using namespace bit::literals;
+
 	union {
 		uint8_t _data = 0x08;
 
@@ -327,6 +327,7 @@ static void build_protocol_frame(const bool is_polling = false)
 	} else if (protocol == MouseModelPS2::Explorer) {
 		frame.resize(4);
 		frame[3] = get_reset_wheel_4bit();
+
 		if (buttons.extra_1) {
 			bit::set(frame[3], b4);
 		}
@@ -805,6 +806,8 @@ static bool bios_disable()
 
 static bool bios_is_aux_byte_waiting()
 {
+	using namespace bit::literals;
+
 	const auto byte = IO_ReadB(0x64);
 	return bit::is(byte, b0) && bit::is(byte, b5);
 }

--- a/src/hardware/lpt_dac.cpp
+++ b/src/hardware/lpt_dac.cpp
@@ -35,8 +35,9 @@ LptDac::LptDac(const std::string_view name, const uint16_t channel_rate_hz,
                std::set<ChannelFeature> extra_features)
         : dac_name(name)
 {
-	assert(!dac_name.empty());
 	using namespace std::placeholders;
+
+	assert(!dac_name.empty());
 	const auto audio_callback = std::bind(&LptDac::AudioCallback, this, _1);
 
 	std::set<ChannelFeature> features = {ChannelFeature::Sleep,

--- a/src/hardware/opl.cpp
+++ b/src/hardware/opl.cpp
@@ -914,6 +914,8 @@ static std::string opl_mode_to_string(const Mode mode)
 
 OPL::OPL(Section *configuration, const OplMode oplmode)
 {
+	using namespace std::placeholders;
+
 	assert(oplmode != OplMode::Cms);
 	assert(oplmode != OplMode::None);
 
@@ -971,8 +973,6 @@ OPL::OPL(Section *configuration, const OplMode oplmode)
 	}
 
 	Init(check_cast<uint16_t>(channel->GetSampleRate()));
-
-	using namespace std::placeholders;
 
 	const auto read_from = std::bind(&OPL::PortRead, this, _1, _2);
 	const auto write_to  = std::bind(&OPL::PortWrite, this, _1, _2, _3);

--- a/src/hardware/ps1audio.cpp
+++ b/src/hardware/ps1audio.cpp
@@ -42,8 +42,6 @@
 
 #include "residfp/resample/TwoPassSincResampler.h"
 
-using namespace std::placeholders;
-
 struct Ps1Registers {
 	uint8_t status = 0;     // Read via port 0x202 control status
 	uint8_t command = 0;    // Written via port 0x202 for control, read via 0x200 for DAC
@@ -124,6 +122,8 @@ static void setup_filter(mixer_channel_t &channel)
 
 Ps1Dac::Ps1Dac(const std::string_view filter_choice)
 {
+	using namespace std::placeholders;
+
 	const auto callback = std::bind(&Ps1Dac::Update, this, _1);
 
 	channel = MIXER_AddChannel(callback,
@@ -413,6 +413,8 @@ private:
 Ps1Synth::Ps1Synth(const std::string_view filter_choice)
         : device(nullptr, nullptr, ps1_psg_clock_hz)
 {
+	using namespace std::placeholders;
+
 	const auto callback = std::bind(&Ps1Synth::AudioCallback, this, _1);
 
 	channel = MIXER_AddChannel(callback,

--- a/src/hardware/ston1_dac.cpp
+++ b/src/hardware/ston1_dac.cpp
@@ -26,6 +26,7 @@ CHECK_NARROWING();
 void StereoOn1::BindToPort(const io_port_t lpt_port)
 {
 	using namespace std::placeholders;
+
 	const auto write_data = std::bind(&StereoOn1::WriteData, this, _1, _2, _3);
 	const auto read_status = std::bind(&StereoOn1::ReadStatus, this, _1, _2);
 	const auto write_control = std::bind(&StereoOn1::WriteControl, this, _1, _2, _3);

--- a/src/hardware/tandy_sound.cpp
+++ b/src/hardware/tandy_sound.cpp
@@ -64,8 +64,6 @@
 
 #include "residfp/resample/TwoPassSincResampler.h"
 
-using namespace std::placeholders;
-
 // Constants used by the DAC and PSG
 constexpr uint16_t card_base_offset = 288;
 constexpr auto tandy_psg_clock_hz   = 14318180 / 4;
@@ -187,6 +185,8 @@ static void setup_filters(mixer_channel_t &channel) {
 TandyDAC::TandyDAC(const ConfigProfile config_profile,
                    const std::string_view filter_choice)
 {
+	using namespace std::placeholders;
+
 	assert(config_profile != ConfigProfile::SoundCardRemoved);
 
 	// Run the audio channel at the mixer's native rate
@@ -281,6 +281,8 @@ void TandyDAC::DmaCallback([[maybe_unused]] const DmaChannel*, DMAEvent event)
 
 void TandyDAC::ChangeMode()
 {
+	using namespace std::placeholders;
+
 	// Typical sample rates are 1.7. 5.5, 11, and rarely 22 KHz. Although
 	// several games (one being OutRun) set instantaneous rates above
 	// 100,000 Hz, we throw these out as they can cause garbage high
@@ -312,9 +314,8 @@ void TandyDAC::ChangeMode()
 				dma.is_done = false;
 				dma.channel = DMA_GetChannel(io.dma);
 				if (dma.channel) {
-					const auto callback =
-					        std::bind(&TandyDAC::DmaCallback,
-					                  this, _1, _2);
+					const auto callback = std::bind(
+					        &TandyDAC::DmaCallback, this, _1, _2);
 					dma.channel->RegisterCallback(callback);
 					channel->Enable(true);
 					// LOG_MSG("TANDYDAC: playback started with freqency %f, volume %f", sample_rate, vol);
@@ -427,6 +428,8 @@ TandyPSG::TandyPSG(const ConfigProfile config_profile, const bool is_dac_enabled
                    const std::string_view fadeout_choice,
                    const std::string_view filter_choice)
 {
+	using namespace std::placeholders;
+
 	assert(config_profile != ConfigProfile::SoundCardRemoved);
 
 	// Instantiate the MAME PSG device

--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -491,6 +491,8 @@ enum CursorOp : uint8_t {
 
 static uint8_t* draw_unwrapped_line_from_dac_palette_with_hwcursor(Bitu vidstart, Bitu /*line*/)
 {
+	using namespace bit::literals;
+
 	// Draw the underlying line without the cursor
 	const auto line_addr = reinterpret_cast<uint32_t*>(
 	        draw_unwrapped_line_from_dac_palette(vidstart));
@@ -519,12 +521,11 @@ static uint8_t* draw_unwrapped_line_from_dac_palette_with_hwcursor(Bitu vidstart
 		return reinterpret_cast<uint8_t*>(line_addr);
 	}
 
-	using namespace bit;
 	// the index of the bit inside the cursor bitmap we start at:
 	const auto source_start_bit = ((line_at_y - cursor.originy) + cursor.posy) *
 	                                      bitmap_width_bits + cursor.posx;
 	const auto cursor_start_bit = source_start_bit & 0x7;
-	uint8_t cursor_bit = literals::b7 >> cursor_start_bit;
+	uint8_t cursor_bit          = b7 >> cursor_start_bit;
 
 	// Convert to video memory addr and bit index
 	// start adjusted to the pattern structure (thus shift address by 2
@@ -554,19 +555,21 @@ static uint8_t* draw_unwrapped_line_from_dac_palette_with_hwcursor(Bitu vidstart
 
 		while (cursor_bit != 0) {
 			uint8_t op = {};
-			set_to(op, literals::b0, is(bits_a, cursor_bit));
-			set_to(op, literals::b1, is(bits_b, cursor_bit));
+			bit::set_to(op, b0, bit::is(bits_a, cursor_bit));
+			bit::set_to(op, b1, bit::is(bits_b, cursor_bit));
 
 			switch (static_cast<CursorOp>(op)) {
 			case CursorOp::Foreground: *cursor_addr = fg_colour; break;
 			case CursorOp::Background: *cursor_addr = bg_colour; break;
-			case CursorOp::Invert: flip_all(*cursor_addr); break;
+			case CursorOp::Invert:
+				bit::flip_all(*cursor_addr);
+				break;
 			case CursorOp::Transparent: break;
 			};
 			cursor_addr++;
 			cursor_bit >>= 1;
 		}
-		cursor_bit = literals::b7;
+		cursor_bit = b7;
 	}
 	return reinterpret_cast<uint8_t*>(line_addr);
 }

--- a/src/hardware/voodoo.cpp
+++ b/src/hardware/voodoo.cpp
@@ -6754,6 +6754,8 @@ static int32_t texture_w(uint32_t offset, uint32_t data) {
  *************************************/
 static uint32_t register_r(const uint32_t offset)
 {
+	using namespace bit::literals;
+
 	const auto regnum = static_cast<uint8_t>((offset) & 0xff);
 
 	//LOG(LOG_VOODOO,LOG_WARN)("Voodoo:read chip %x reg %x (%s)", chips, regnum<<2, voodoo_reg_name[regnum]);
@@ -6786,7 +6788,6 @@ static uint32_t register_r(const uint32_t offset)
 				// bit 7 is FBI graphics engine busy
 				// bit 8 is TREX busy
 				// bit 9 is overall busy
-				using namespace bit::literals;
 				result |= (b7 | b8 | b9);
 			}
 

--- a/src/ints/int10_modes.cpp
+++ b/src/ints/int10_modes.cpp
@@ -41,9 +41,6 @@
 #define GFX_REGS 0x09
 #define ATT_REGS 0x15
 
-using namespace bit;
-using namespace bit::literals;
-
 // clang-format off
 std::vector<VideoModeBlock> ModeList_VGA = {
   //     mode     type     sw    sh    tw  th  cw ch  pt pstart    plength htot  vtot  hde  vde    special flags
@@ -1033,11 +1030,13 @@ static void write_palette_dac_data(const std::vector<Rgb666>& colors)
 
 bool INT10_SetVideoMode(uint16_t mode)
 {
+	using namespace bit::literals;
+
 	bool clearmem = true;
 	Bitu i;
 
-	const auto UseLinearFramebuffer    = is(mode, b14);
-	const auto DoNotClearDisplayMemory = is(mode, b15);
+	const auto UseLinearFramebuffer    = bit::is(mode, b14);
+	const auto DoNotClearDisplayMemory = bit::is(mode, b15);
 
 	if (mode >= MinVesaBiosModeNumber) {
 		if (UseLinearFramebuffer && int10.vesa_nolfb) {

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -42,8 +42,6 @@ _CRTIMP extern char** _environ;
 extern char** environ;
 #endif
 
-using namespace std;
-
 // Commonly accessed global that holds configuration records
 std::unique_ptr<Config> control = {};
 
@@ -137,8 +135,8 @@ bool Value::SetValue(const std::string& in, const Etype _type)
 
 bool Value::SetHex(const std::string& in)
 {
-	istringstream input(in);
-	input.flags(ios::hex);
+	std::istringstream input(in);
+	input.flags(std::ios::hex);
 	int result = INT_MIN;
 	input >> result;
 	if (result == INT_MIN) {
@@ -150,7 +148,7 @@ bool Value::SetHex(const std::string& in)
 
 bool Value::SetInt(const std::string& in)
 {
-	istringstream input(in);
+	std::istringstream input(in);
 	int result = INT_MIN;
 	input >> result;
 	if (result == INT_MIN) {
@@ -162,7 +160,7 @@ bool Value::SetInt(const std::string& in)
 
 bool Value::SetDouble(const std::string& in)
 {
-	istringstream input(in);
+	std::istringstream input(in);
 	double result = std::numeric_limits<double>::infinity();
 	input >> result;
 	if (result == std::numeric_limits<double>::infinity()) {
@@ -188,20 +186,20 @@ void Value::SetString(const std::string& in)
 	_string = in;
 }
 
-string Value::ToString() const
+std::string Value::ToString() const
 {
-	ostringstream oss;
+	std::ostringstream oss;
 	switch (type) {
 	case V_HEX:
-		oss.flags(ios::hex);
+		oss.flags(std::ios::hex);
 		oss << _hex;
 		break;
 	case V_INT: oss << _int; break;
-	case V_BOOL: oss << boolalpha << _bool; break;
+	case V_BOOL: oss << std::boolalpha << _bool; break;
 	case V_STRING: oss << _string; break;
 	case V_DOUBLE:
 		oss.precision(2);
-		oss << fixed << _double;
+		oss << std::fixed << _double;
 		break;
 	case V_NONE:
 	case V_CURRENT:
@@ -271,7 +269,7 @@ bool Property::ValidateValue(const Value& in)
 
 void Property::Set_help(const std::string& in)
 {
-	string result = string("CONFIG_") + propname;
+	std::string result = std::string("CONFIG_") + propname;
 	upcase(result);
 	MSG_Add(result.c_str(), in.c_str());
 }
@@ -529,20 +527,20 @@ bool PropMultiValRemain::SetValue(const std::string& input)
 		number_of_properties++;
 	}
 
-	string::size_type loc = string::npos;
+	std::string::size_type loc = std::string::npos;
 
 	while ((p = section->Get_prop(i++))) {
 		// trim leading separators
 		loc = local.find_first_not_of(separator);
-		if (loc != string::npos) {
+		if (loc != std::string::npos) {
 			local.erase(0, loc);
 		}
-		loc       = local.find_first_of(separator);
-		string in = "";
+		loc            = local.find_first_of(separator);
+		std::string in = "";
 
 		// When i == number_of_properties add the total line. (makes
 		// more then one string argument possible for parameters of cpu)
-		if (loc != string::npos && i < number_of_properties) {
+		if (loc != std::string::npos && i < number_of_properties) {
 			// Separator found
 			in = local.substr(0, loc);
 			local.erase(0, loc + 1);
@@ -577,21 +575,21 @@ bool PropMultiVal::SetValue(const std::string& input)
 	}
 
 	Value::Etype prevtype = Value::V_NONE;
-	string prevargument   = "";
+	std::string prevargument = "";
 
-	string::size_type loc = string::npos;
+	std::string::size_type loc = std::string::npos;
 	while ((p = section->Get_prop(i++))) {
 		// Trim leading separators
 		loc = local.find_first_not_of(separator);
-		if (loc != string::npos) {
+		if (loc != std::string::npos) {
 			local.erase(0, loc);
 		}
 
 		loc = local.find_first_of(separator);
 
-		string in = "";
+		std::string in = "";
 
-		if (loc != string::npos) {
+		if (loc != std::string::npos) {
 			// Separator found
 			in = local.substr(0, loc);
 			local.erase(0, loc + 1);
@@ -912,18 +910,18 @@ Hex Section_prop::Get_hex(const std::string& _propname) const
 
 bool Section_prop::HandleInputline(const std::string& line)
 {
-	string::size_type loc = line.find('=');
+	std::string::size_type loc = line.find('=');
 
-	if (loc == string::npos) {
+	if (loc == std::string::npos) {
 		return false;
 	}
 
-	string name = line.substr(0, loc);
-	string val  = line.substr(loc + 1);
+	std::string name = line.substr(0, loc);
+	std::string val  = line.substr(loc + 1);
 
 	// Strip quotes around the value
 	trim(val);
-	string::size_type length = val.length();
+	std::string::size_type length = val.length();
 	if (length > 1 && ((val[0] == '\"' && val[length - 1] == '\"') ||
 	                   (val[0] == '\'' && val[length - 1] == '\''))) {
 		val = val.substr(1, length - 2);
@@ -975,7 +973,7 @@ void Section_prop::PrintData(FILE* outfile) const
 	}
 }
 
-string Section_prop::GetPropValue(const std::string& _property) const
+std::string Section_prop::GetPropValue(const std::string& _property) const
 {
 	for (const_it tel = properties.begin(); tel != properties.end(); ++tel) {
 		if (!strcasecmp((*tel)->propname.c_str(), _property.c_str())) {
@@ -1336,7 +1334,7 @@ bool Config::ParseConfigFile(const std::string& type,
 		return true;
 	}
 
-	ifstream in(canonical_path);
+	std::ifstream in(canonical_path);
 	if (!in) {
 		return false;
 	}
@@ -1409,7 +1407,7 @@ bool Config::ParseConfigFile(const std::string& type,
 		if (is_section_start(line)) {
 			// New section
 			const auto bracket_pos = line.find(']');
-			if (bracket_pos == string::npos) {
+			if (bracket_pos == std::string::npos) {
 				continue;
 			}
 			line.erase(bracket_pos);
@@ -1450,7 +1448,7 @@ parse_environ_result_t parse_environ(const char* const* envp) noexcept
 
 		const std::string rest       = (env_var + 7);
 		const auto section_delimiter = rest.find('_');
-		if (section_delimiter == string::npos) {
+		if (section_delimiter == std::string::npos) {
 			continue;
 		}
 

--- a/src/misc/support.cpp
+++ b/src/misc/support.cpp
@@ -525,13 +525,14 @@ bool is_readonly(const std_fs::path &p)
 
 bool make_writable(const std_fs::path &p)
 {
+	using namespace std_fs;
+
 	// Check
 	if (is_writable(p))
 		return true;
 
 	// Apply
 	std::error_code ec;
-	using namespace std_fs;
 	permissions(p, perms::owner_write, perm_options::add, ec);
 
 	// Result and verification
@@ -546,12 +547,13 @@ bool make_writable(const std_fs::path &p)
 
 bool make_readonly(const std_fs::path &p)
 {
+	using namespace std_fs;
+
 	// Check
 	if (is_readonly(p))
 		return true;
 
 	// Apply
-	using namespace std_fs;
 	constexpr auto write_perms = (perms::owner_write |
 	                              perms::group_write |
 	                              perms::others_write);

--- a/tests/bitops_tests.cpp
+++ b/tests/bitops_tests.cpp
@@ -24,10 +24,10 @@
 
 namespace {
 
-using namespace bit::literals;
-
 TEST(bitops, enum_vals)
 {
+	using namespace bit::literals;
+
 	// check against bit-shifts
 	EXPECT_FALSE(b0 == 0 << 0);
 	EXPECT_TRUE(b0 == 1 << 0); // this is why
@@ -71,6 +71,8 @@ TEST(bitops, enum_vals)
 
 TEST(bitops, nominal_byte)
 {
+	using namespace bit::literals;
+
 	const auto even_bits = (b0 | b2 | b4 | b6);
 	const auto odd_bits = (b1 | b3 | b5 | b7);
 
@@ -140,6 +142,8 @@ TEST(bitops, nominal_byte)
 
 TEST(bitops, nominal_word)
 {
+	using namespace bit::literals;
+
 	const auto even_bits = (b8 | b10 | b12 | b14);
 	const auto odd_bits = (b9 | b11 | b13 | b15);
 
@@ -190,6 +194,8 @@ TEST(bitops, nominal_word)
 
 TEST(bitops, nominal_dword)
 {
+	using namespace bit::literals;
+
 	constexpr uint32_t even_bits = {b16 | b18 | b20 | b22 | b24 | b26 | b28 | b30};
 	constexpr uint32_t odd_bits = {b17 | b19 | b21 | b23 | b25 | b27 | b29 | b31};
 
@@ -240,6 +246,8 @@ TEST(bitops, nominal_dword)
 
 TEST(bitops, bits_too_wide_for_byte)
 {
+	using namespace bit::literals;
+
 	uint8_t reg = 0;
 	bit::set(reg, b7);
 	EXPECT_TRUE(bit::is(reg, b7));
@@ -258,6 +266,8 @@ TEST(bitops, bits_too_wide_for_byte)
 
 TEST(bitops, bits_too_wide_for_word)
 {
+	using namespace bit::literals;
+
 	uint16_t reg = 0;
 	bit::set(reg, b8);
 	EXPECT_TRUE(bit::is(reg, b8));
@@ -276,6 +286,8 @@ TEST(bitops, bits_too_wide_for_word)
 
 TEST(bitops, bits_not_too_wide_for_dword)
 {
+	using namespace bit::literals;
+
 	uint32_t reg = 0;
 	bit::set(reg, b8);
 	bit::set(reg, b24);
@@ -296,6 +308,8 @@ TEST(bitops, bits_not_too_wide_for_dword)
 // Retain operations
 TEST(bitops, retain)
 {
+	using namespace bit::literals;
+
 	// Retain a positive bit, with surrounding other bits
 	uint8_t reg = (b0 | b1 | b2);
 	bit::retain(reg, b1);
@@ -310,17 +324,17 @@ TEST(bitops, retain)
 // Masking operations
 TEST(bitops, masking)
 {
-	using namespace bit;
+	using namespace bit::literals;
 
 	// Prepopulated register with bit 4 cleared:
 	constexpr uint8_t reg = (b0 | b1 | b2 | b3 /*| b4*/ | b5 | b6 | b7);
 
-	EXPECT_TRUE(is(mask_on(reg, b4), b4));
-	EXPECT_TRUE(cleared(mask_off(reg, b4), b4));
-	EXPECT_TRUE(any(mask_to(reg, b4, true), b4));
-	EXPECT_TRUE(cleared(mask_to(reg, b4, false), b4));
-	EXPECT_TRUE(any(mask_flip(reg, b4), b4));
-	EXPECT_TRUE(is(mask_flip_all(reg), b4));
+	EXPECT_TRUE(bit::is(bit::mask_on(reg, b4), b4));
+	EXPECT_TRUE(bit::cleared(bit::mask_off(reg, b4), b4));
+	EXPECT_TRUE(bit::any(bit::mask_to(reg, b4, true), b4));
+	EXPECT_TRUE(bit::cleared(bit::mask_to(reg, b4, false), b4));
+	EXPECT_TRUE(bit::any(bit::mask_flip(reg, b4), b4));
+	EXPECT_TRUE(bit::is(bit::mask_flip_all(reg), b4));
 }
 
 } // namespace


### PR DESCRIPTION
# Description

Replace all top-level uses of "using namespace ..." with more local uses, or prefix with the namespace if necessary.

# Manual testing

DOSBox still starts.

Since this change does not involve any functional code changes, no failures are expected (famous last words).

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [ ] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

