### PR TITLE
Improve VGA double scanning criteria

### DIFF
--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -2158,8 +2158,10 @@ ImageInfo setup_drawing()
 		video_mode.graphics_standard = GraphicsStandard::Vga;
 		video_mode.color_depth       = ColorDepth::IndexedColor256;
 
-		video_mode.is_double_scanned_mode =
-		        (vga.crtc.maximum_scan_line.maximum_scan_line > 0);
+		const bool num_scanline_repeats = vga.crtc.maximum_scan_line.maximum_scan_line;
+
+		video_mode.is_double_scanned_mode = (num_scanline_repeats > 0 ||
+		                                     is_scan_doubling_bit_set());
 
 		render_pixel_aspect_ratio = calc_pixel_aspect_from_timings(vga_timings);
 
@@ -2278,8 +2280,15 @@ ImageInfo setup_drawing()
 			// on emulated VGA adapters only; for everything else, we "fake
 			// double-scan" on VGA (render single-scanned, then double the
 			// image vertically with a scaler).
-			if (is_scan_doubling_bit_set()) {
-				video_mode.is_double_scanned_mode = true;
+			//
+			const bool num_scanline_repeats =
+			        vga.crtc.maximum_scan_line.maximum_scan_line;
+
+			video_mode.is_double_scanned_mode =
+			        (num_scanline_repeats > 0 ||
+			         is_scan_doubling_bit_set());
+
+			if (video_mode.is_double_scanned_mode) {
 				video_mode.height = vert_end / 2;
 				forced_single_scan = !vga.draw.scan_doubling_allowed;
 


### PR DESCRIPTION
# Description

Some 320x200, 320x240 and similar tweaked double-scanned VGA modes were identified as 320x400, 320x480, etc., which was not quite correct, it was confusing in the logs, and most importantly, single scanning could not be forced on them.

Examples:

- **Pinball Fantasies:** 320x240 intro pictures before the "true 640x480" Pinball Fantasies logo.

- **Show by Majic 12:** many of the parts use the 16-colour 320x200 EGA mode with VGA palettes (e.g., copper majic, greetings, etc.); these were treated as a weird "320x400 EGA mode" before.

- **Copper demo:** now the demo stays in 320x200 until the end.

# Manual testing

I've tested the following:

- Catacomb 3D
- Copper demo
- Gods
- Pinball Fantasies
- Pinball Illusions
- Quake
- Ravenloft - Strahd's Possession
- Show by Majic 12
- The Legend of Kyrandia: Book One

With these `glshader` settings:

- `crt-auto-arcade`
- `crt-auto`
- `sharp`


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

