### PR TITLE
Fix Impossible Mission II transition effect

### DIFF
--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -2054,6 +2054,12 @@ ImageInfo setup_drawing()
 		return pcjr_or_tga();
 	};
 
+	// All Tandy modes have a height of 200.
+	// Some games (ex. Impossible Mission II) fiddle with vga.other.vdend
+	// The result of this should be rendering a short (by height) image in the horizonal center with black on the top/bottom.
+	// Use this hard-coded value when calculating pixel aspect ratio so this effect looks correct.
+	constexpr uint16_t CgaTandyAspectHeight = 200;
+
 	switch (vga.mode) {
 	case M_LIN4:
 	case M_LIN8:
@@ -2364,7 +2370,7 @@ ImageInfo setup_drawing()
 		render_height     = video_mode.height;
 
 		render_pixel_aspect_ratio = calc_pixel_aspect_from_dimensions(
-		        render_width, render_height, double_width, double_height);
+		        render_width, CgaTandyAspectHeight, double_width, double_height);
 		break;
 
 	case M_TANDY4:
@@ -2402,7 +2408,7 @@ ImageInfo setup_drawing()
 		render_height = video_mode.height;
 
 		render_pixel_aspect_ratio = calc_pixel_aspect_from_dimensions(
-		        render_width, render_height, double_width, double_height);
+		        render_width, CgaTandyAspectHeight, double_width, double_height);
 
 		// TODO this seems like overkill; could be probably simplified a
 		// lot
@@ -2452,7 +2458,7 @@ ImageInfo setup_drawing()
 		render_height = video_mode.height;
 
 		render_pixel_aspect_ratio = calc_pixel_aspect_from_dimensions(
-		        render_width, render_height, double_width, double_height);
+		        render_width, CgaTandyAspectHeight, double_width, double_height);
 
 		VGA_DrawLine = VGA_Draw_1BPP_Line;
 		break;
@@ -2563,7 +2569,7 @@ ImageInfo setup_drawing()
 		render_height = video_mode.height;
 
 		render_pixel_aspect_ratio = calc_pixel_aspect_from_dimensions(
-		        render_width, render_height, double_width, double_height);
+		        render_width, CgaTandyAspectHeight, double_width, double_height);
 
 		VGA_DrawLine = VGA_Draw_CGA4_Composite_Line;
 		break;
@@ -2584,7 +2590,7 @@ ImageInfo setup_drawing()
 		render_height = video_mode.height;
 
 		render_pixel_aspect_ratio = calc_pixel_aspect_from_dimensions(
-		        render_width, render_height, double_width, double_height);
+		        render_width, CgaTandyAspectHeight, double_width, double_height);
 
 		VGA_DrawLine = VGA_Draw_CGA2_Composite_Line;
 		break;

--- a/src/hardware/vga_other.cpp
+++ b/src/hardware/vga_other.cpp
@@ -92,8 +92,11 @@ static void write_crtc_data_other(io_port_t, io_val_t value, io_width_t)
 	case 0x06:		//Vertical rows
 		// Impossible Mission II sets this to zero briefly
 		// This leads to a divide by zero crash if VGA resize code is run
-		if ((val > 0) && (vga.other.vdend ^ val)) VGA_StartResize();
-		vga.other.vdend = val;
+		if (val > 0 && val != vga.other.vdend) {
+			vga.other.vdend = val;
+			// The default half-frame period delay leads to flickering in the level start zoom effect of Impossible Mission II on Tandy
+			VGA_StartResizeAfter(50);
+		}
 		break;
 	case 0x07:		//Vertical sync position
 		vga.other.vsyncp = val;


### PR DESCRIPTION
# Description

First commit addresses a regression caused by b68b66f07831c91f197acf0b06f847c28c9a7946.  It causes flickering when the video mode changes quickly during the transition effect.

Second commit addresses a regression caused by https://github.com/dosbox-staging/dosbox-staging/commit/dd8ae1423a9d496f78fdcf39798568aea6bbadca.  Previously, the aspect ratio for Tandy was hardcoded to 5/6.  We have since added some complexity where pixel-doubling and double-scanning need to be taken into account.  However, the width needs to be hard-coded to 200 so this effect renders correctly.


## Related issues

Fixes #3447


# Manual testing

With `machine = tandy` tested the following with both `glshader=crt-auto` (pixel doubling enabled) and `glshader=sharp` (pixel doubling disabled).

- Tested Impossible Mission II (160 x 200)
- Tested King's Quest 4 (320 x 200)
- Tested Space Quest 1 (TANDY 320 x 200 plus CGA text-mode 320x200)


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

