### PR TITLE
Make PCjr application memory contiguous

### DIFF
--- a/include/dos_memory.h
+++ b/include/dos_memory.h
@@ -1,0 +1,27 @@
+/*
+ *  Copyright (C) 2024-2024  The DOSBox Staging Team
+ *  Copyright (C) 2002-2021  The DOSBox Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#ifndef DOS_MEMORY_H
+#define DOS_MEMORY_H
+
+constexpr auto ConventionalMemorySizeKb = 640;
+constexpr auto PcjrVideoMemorySizeKb    = 32;
+constexpr auto PcjrStandardMemorySizeKb = 128;
+
+#endif

--- a/src/dos/dos_memory.cpp
+++ b/src/dos/dos_memory.cpp
@@ -18,7 +18,9 @@
 
 #include "dosbox.h"
 
+#include "control.h"
 #include "dos_inc.h"
+#include "dos_memory.h"
 #include "mem.h"
 #include "support.h"
 
@@ -468,6 +470,12 @@ bool DOS_LinkUMBsToMemChain(uint16_t linkstate) {
 	return true;
 }
 
+static constexpr uint16_t kilobytes_to_segment(size_t address_kb)
+{
+	constexpr auto bytes_per_segment = 16;
+	constexpr auto bytes_per_kilobyte = 1024;
+	return (address_kb * bytes_per_kilobyte) / bytes_per_segment;
+}
 
 void DOS_SetupMemory(void) {
 	/* Let dos claim a few bios interrupts. Makes DOSBox more compatible with 
@@ -504,33 +512,65 @@ void DOS_SetupMemory(void) {
 	mcb_sizes+=17;
 	tempmcb2.SetType(middle_mcb_type);
 
-	DOS_MCB mcb((uint16_t)DOS_MEM_START+mcb_sizes);
-	mcb.SetPSPSeg(MCB_FREE);						//Free
-	mcb.SetType(ending_mcb_type); // Last Block
 	if (machine==MCH_TANDY) {
 		/* memory up to 608k available, the rest (to 640k) is used by
 			the tandy graphics system's variable mapping of 0xb800 */
-		mcb.SetSize(0x9BFF - DOS_MEM_START - mcb_sizes);
+		DOS_MCB free_block((uint16_t)DOS_MEM_START+mcb_sizes);
+		free_block.SetPSPSeg(MCB_FREE);
+		free_block.SetType(ending_mcb_type);
+		free_block.SetSize(0x9BFF - DOS_MEM_START - mcb_sizes);
 	} else if (machine==MCH_PCJR) {
-		/* memory from 128k to 640k is available */
-		mcb_devicedummy.SetPt((uint16_t)0x2000);
-		mcb_devicedummy.SetPSPSeg(MCB_FREE);
-		mcb_devicedummy.SetSize(umb_start_seg - 0x2000);
-		mcb_devicedummy.SetType(ending_mcb_type);
+		const auto pcjr_start = DOS_MEM_START + mcb_sizes;
+		constexpr auto mcb_entry_size = 1;
 
-		/* exclude PCJr graphics region */
-		mcb_devicedummy.SetPt((uint16_t)0x17ff);
-		mcb_devicedummy.SetPSPSeg(MCB_DOS);
-		mcb_devicedummy.SetSize(0x800);
-		mcb_devicedummy.SetType(middle_mcb_type);
+		// PCjr video memory uses 32KB shared RAM
+		constexpr auto video_memory_start =
+			kilobytes_to_segment(PcjrStandardMemorySizeKb - PcjrVideoMemorySizeKb);
 
-		/* memory below 96k */
-		mcb.SetSize(0x1800 - DOS_MEM_START - (2+mcb_sizes));
-		mcb.SetType(middle_mcb_type);
+		const Section_prop* section = static_cast<Section_prop*>(control->GetSection("dos"));
+		assert(section);
+		const std::string pcjr_memory_config = section->Get_string("pcjr_memory_config");
+		if (pcjr_memory_config == "expanded") {
+			// With expanded memory, reserve the lower memory up to video memory.
+			// This makes application memory contiguous in order to prevent crashes.
+			// This is needed to prevent Sierra AGI games from crashing.
+			// Further details:
+			// https://www.atarimagazines.com/compute/issue58/pcjr_memory.html
+
+			// Space Quest version 1.0x is a special case.
+			// It requires an additional 16 KB above the 32KB video memory to be reserved.
+			constexpr auto application_segment =
+				video_memory_start + kilobytes_to_segment(PcjrVideoMemorySizeKb + 16);
+
+			// The size from the MCB entry itself must be subtracted from the total size.
+			const auto reserved_size = application_segment - pcjr_start - mcb_entry_size;
+			constexpr auto application_size = umb_start_seg - application_segment - mcb_entry_size;
+
+			DOS_MCB reserved(pcjr_start);
+			reserved.SetPSPSeg(MCB_DOS);
+			reserved.SetSize(reserved_size);
+			reserved.SetType(middle_mcb_type);
+
+			DOS_MCB free_block(application_segment);
+			free_block.SetPSPSeg(MCB_FREE);
+			free_block.SetSize(application_size);
+			free_block.SetType(ending_mcb_type);
+		} else {
+			// No expanded memory means the lower 96KB is usable for applications
+			assert(pcjr_memory_config == "standard");
+
+			DOS_MCB free_block(pcjr_start);
+			free_block.SetPSPSeg(MCB_FREE);
+			free_block.SetSize(video_memory_start - pcjr_start - mcb_entry_size);
+			free_block.SetType(ending_mcb_type);
+		}
 	} else {
 		/* complete memory up to 640k available */
 		/* last paragraph used to add UMB chain to low-memory MCB chain */
-		mcb.SetSize(0x9FFE - DOS_MEM_START - mcb_sizes);
+		DOS_MCB free_block((uint16_t)DOS_MEM_START+mcb_sizes);
+		free_block.SetPSPSeg(MCB_FREE);
+		free_block.SetType(ending_mcb_type);
+		free_block.SetSize(0x9FFE - DOS_MEM_START - mcb_sizes);
 	}
 
 	dos.firstMCB=DOS_MEM_START;

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -1229,6 +1229,17 @@ void DOSBOX_Init()
 	        "tab-separated format, used by SETVER.EXE as a persistent storage\n"
 	        "(empty by default).");
 
+	const char* pcjr_memory_configurations[] = {"expanded", "standard", nullptr};
+	pstring = secprop->Add_string("pcjr_memory_config", only_at_start, "expanded");
+	pstring->Set_values(pcjr_memory_configurations);
+	pstring->Set_help(
+		"PCjr memory layout ('expanded' by default).\n"
+		"  expanded:  640 KB total memory with applications residing above 128 KB.\n"
+		"             Compatible with most games.\n"
+		"  standard:  128 KB total memory with applications residing below 96 KB.\n"
+		"             Required for some older games (e.g., Jumpman, Troll)."
+	);
+
 	// Mscdex
 	secprop->AddInitFunction(&MSCDEX_Init);
 	secprop->AddInitFunction(&DRIVES_Init);


### PR DESCRIPTION
# Description

I spent a lot of time researching this.  This comment was very accurate:  https://github.com/dosbox-staging/dosbox-staging/issues/2851#issuecomment-1712875708

## Failed attempt to relocate video memory

I originally tried what he suggested by relocating the video memory from it's default location at 96KB linear memory to 16KB, similar to what a real PCjr memory manager would do.  This worked fine for some games.  Others like Thexder seemingly have the video memory address hard-coded and displayed garbage.

Additionally, this method requires changing a BIOS INT10 function to change the memory page the video card uses.  This would then need a somewhat hacky workaround to revert that change for stand-alone bootable games (that use `boot a:` to launch outside of DOS).  I am kind of curious how the real PCjr memory managers intercepted this BIOS interrupts but that's out of the scope of this PR.

## Successful work-around

What ended up working best from a bunch of testing is simply reserving the entire block up to 144KB.  This leaves the video memory at its standard location while also leaving a large chunk of high memory for application use.

This isn't exactly what real pcjr memory managers do but it's closer than what we had before.  Previously, we had a small free block under the video memory and then a large free block above it.  On real early DOS that pcjr's shipped with, the high memory (above the video memory ending at 128KB) would be invisible since early DOS required contiguous memory.

## Related issues

Fixes #2851

# Manual testing

Tested the following games and they work fine with this PR:

- Space Quest 1.0x (hangs at startup on main)
- Space Quest 2.2 (hangs the entire emulator on main)
- King's Quest 1986 pcjr DOS version (hangs the entire emulator on main)
- King's Quest 1984 pcjr bootable version (works on main)
- Thexder (works on main)
- Impossible Mission 2 (no pcjr support but a test for CGA compatibility) - works on main

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

