### PR TITLE
Replace use of `stat` in imgmount

### DIFF
--- a/src/dos/program_imgmount.cpp
+++ b/src/dos/program_imgmount.cpp
@@ -291,12 +291,10 @@ void IMGMOUNT::Run(void)
 		}
 
 		// Test if input is file on virtual DOS drive.
-		constexpr int posix_success = 0;
-		struct stat test;
-		if (posix_success != stat(temp_line.c_str(), &test)) {
+		if (!path_exists(temp_line)) {
 			// See if it works if the ~ are written out
 			const auto home_dir = resolve_home(temp_line).string();
-			if (posix_success == stat(home_dir.c_str(), &test)) {
+			if (path_exists(home_dir)) {
 				temp_line = home_dir;
 			} else {
 				// convert dosbox filename to system filename
@@ -327,7 +325,7 @@ void IMGMOUNT::Run(void)
 				ldp->GetSystemFilename(tmp, fullname);
 				temp_line = tmp;
 
-				if (posix_success != stat(temp_line.c_str(), &test)) {
+				if (!path_exists(temp_line)) {
 					if (add_wildcard_paths(temp_line, paths)) {
 						continue;
 					} else {
@@ -342,7 +340,7 @@ void IMGMOUNT::Run(void)
 				        drive_letter(dummy));
 			}
 		}
-		if (S_ISDIR(test.st_mode)) {
+		if (is_directory(temp_line)) {
 			WriteOut(MSG_Get("PROGRAM_IMGMOUNT_MOUNT"));
 			return;
 		}


### PR DESCRIPTION
# Description

Replace use of `stat` in `imgmount` with `path_exists` and `is_directory`, which fixes mounting large disk image files with Visual Studio builds.

## Related issues
Fixes #3464 

# Manual testing

If you don't already have one, create a large `img` file (tested with 8GB image).

Start Dosbox-Staging, and enter the following imgmount command:
```
imgmount 2 "<path-to-disk-image>" -fs none -t hdd -size <size-for-disk-image>
```
Dosbox should show the message `Drive number 2 mounted as <image-path>`.

Also check the non existing file case:
```
imgmount 2 "<path-to-nonexisting-file>" -fs none -t hdd -size 512,63,255,1023
```
Dosbox should show an error message.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [ ] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

