### PR TITLE
Add suffix to MSVC debugger CI build artifact name

### DIFF
--- a/.github/workflows/windows-msvc.yml
+++ b/.github/workflows/windows-msvc.yml
@@ -224,7 +224,7 @@ jobs:
         if:   ${{ matrix.conf.debugger }}
         uses: actions/upload-artifact@v4.3.1
         with:
-          name: ${{ steps.set_pkg_dir.outputs.pkg_dir }}
+          name: ${{ steps.set_pkg_dir.outputs.pkg_dir }}-with-debugger
           path: ${{ steps.set_pkg_dir.outputs.pkg_dir }}/dosbox_with_debugger.exe
           overwrite: true
 


### PR DESCRIPTION
# Description

The Windows CI build was using the same artifact name for the Release debugger and non-debugger builds, resulting in errors or just one of the sets being uploaded. I added a "-with-debugger" suffix to the debugger build name.
 
# Manual testing

Downloaded and ran all four CI artifacts.

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

