### PR TITLE
Throw error if user attempts to change an unchangeable setting

### DIFF
--- a/include/setup.h
+++ b/include/setup.h
@@ -397,6 +397,7 @@ public:
 	                                      const std::string& sep);
 
 	Property* Get_prop(int index);
+	Property* Get_prop(const std::string& propname);
 
 	int Get_int(const std::string& _propname) const;
 

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -798,7 +798,20 @@ void CONFIG::Run(void)
 			if (strlen(result)) {
 				WriteOut(result);
 			} else {
-				Section* tsec = control->GetSection(pvars[0]);
+				auto* tsec = dynamic_cast<Section_prop *>(control->GetSection(pvars[0]));
+				if (!tsec) {
+					WriteOut(MSG_Get("PROGRAM_CONFIG_PROPERTY_ERROR"), pvars[0].c_str());
+					return;
+				}
+				const auto* property = tsec->Get_prop(pvars[1]);
+				if (!property) {
+					WriteOut(MSG_Get("PROGRAM_CONFIG_PROPERTY_ERROR"), pvars[1].c_str());
+					return;
+				}
+				if (property->GetChange() == Property::Changeable::OnlyAtStart) {
+					WriteOut(MSG_Get("PROGRAM_CONFIG_NOT_CHANGEABLE"), pvars[1].c_str());
+					return;
+				}
 				// Input has been parsed (pvar[0]=section,
 				// [1]=property, [2]=value) now execute
 				std::string value(pvars[2]);
@@ -1002,4 +1015,6 @@ void PROGRAMS_Init(Section* sec)
 	MSG_Add("PROGRAM_EXECUTABLE_MISSING", "Executable file not found: '%s'\n");
 
 	MSG_Add("CONJUNCTION_AND", "and");
+
+	MSG_Add("PROGRAM_CONFIG_NOT_CHANGEABLE", "Property '%s' is not changeable at runtime.");
 }

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -867,6 +867,16 @@ Property* Section_prop::Get_prop(int index)
 	return nullptr;
 }
 
+Property* Section_prop::Get_prop(const std::string& propname)
+{
+	for (Property* property : properties) {
+		if (property->propname == propname) {
+			return property;
+		}
+	}
+	return nullptr;
+}
+
 std::string Section_prop::Get_string(const std::string& _propname) const
 {
 	for (const_it tel = properties.begin(); tel != properties.end(); ++tel) {


### PR DESCRIPTION
# Description

The changeable when value on config settings was not actually being enforced anywhere.  This is a simple change to the `config -set` DOS program to check that value and throw an error if the setting is not meant to be changed at runtime.

## Related issues

Fixes #3080
Fixes #1027

# Manual testing

`pause_when_inactive=true` no longer changes the value or runs destroy + init functions.  It instead simply throws an error stating the setting is not allowed to be changed.

Tested with several other config settings as well.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

