### PR TITLE
Cleanup a few warnings in cdrom_image.cpp

### DIFF
--- a/.github/workflows/pvs-studio.yml
+++ b/.github/workflows/pvs-studio.yml
@@ -112,7 +112,7 @@ jobs:
 
       - name: Summarize report
         env:
-          MAX_BUGS: 109
+          MAX_BUGS: 108
         run: |
           echo "Full report is included in build Artifacts"
           echo

--- a/src/dos/cdrom.h
+++ b/src/dos/cdrom.h
@@ -375,7 +375,7 @@ private:
 	} player;
 
 	// Private utility functions
-	bool  LoadIsoFile(char *filename);
+	bool  LoadIsoFile(const char *filename);
 	bool  CanReadPVD(TrackFile *file,
 	                 const uint16_t sectorSize,
 	                 const bool mode2);
@@ -383,7 +383,7 @@ private:
 	void CDAudioCallBack(uint16_t desired_frames);
 
 	// Private functions for cue sheet processing
-	bool  LoadCueSheet(char *cuefile);
+	bool  LoadCueSheet(const char *cuefile);
 	bool  GetRealFileName(std::string& filename, std::string& pathname);
 	bool  GetCueKeyword(std::string &keyword, std::istream &in);
 	bool  GetCueFrame(uint32_t &frames, std::istream &in);

--- a/src/dos/cdrom_image.cpp
+++ b/src/dos/cdrom_image.cpp
@@ -1445,7 +1445,7 @@ bool CDROM_Interface_Image::GetCueString(std::string& str, std::istream& in)
 	in >> str;
 	if (str[0] == '\"') {
 		if (str[str.size() - 1] == '\"') {
-			str.assign(str, 1, str.size() - 2);
+			str = str.substr(1, str.size() - 2);
 		} else {
 			in.seekg(pos, std::ios::beg);
 			char buffer[MAX_FILENAME_LENGTH];

--- a/src/dos/cdrom_image.cpp
+++ b/src/dos/cdrom_image.cpp
@@ -529,7 +529,7 @@ CDROM_Interface_Image::~CDROM_Interface_Image()
 
 bool CDROM_Interface_Image::SetDevice(const char* path, [[maybe_unused]] const int cd_number)
 {
-	const bool result = LoadCueSheet((char *)path) || LoadIsoFile((char *)path);
+	const bool result = LoadCueSheet(path) || LoadIsoFile(path);
 	if (!result) {
 		// print error message on dosbox console
 		char buf[MAX_LINE_LENGTH];
@@ -1062,7 +1062,7 @@ void CDROM_Interface_Image::CDAudioCallBack(uint16_t desired_track_frames)
 	}
 }
 
-bool CDROM_Interface_Image::LoadIsoFile(char* filename)
+bool CDROM_Interface_Image::LoadIsoFile(const char* filename)
 {
 	tracks.clear();
 
@@ -1153,7 +1153,7 @@ static std::string dirname(char* file)
 }
 #endif
 
-bool CDROM_Interface_Image::LoadCueSheet(char *cuefile)
+bool CDROM_Interface_Image::LoadCueSheet(const char *cuefile)
 {
 	tracks.clear();
 


### PR DESCRIPTION
# Description

This just fixes a few small warnings.  One by GCC in release build.  Apparently `str.assign()` uses `memcpy` and it is complaining about overlapping memory due to being assigned a substring of itself.

Also, fixed a PVS studio warning while I was in there (removing a couple of un-needed const casts).

## Related issues

Fixes #3430


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

