### PR TITLE
website: Add NixOS install instructions

### DIFF
--- a/website/docs/releases/linux.md
+++ b/website/docs/releases/linux.md
@@ -83,6 +83,24 @@ Available via [Personal Package Archive](https://launchpad.net/~feignint/+archiv
 
 Available via [Arch User Repository](https://aur.archlinux.org/packages/dosbox-staging).
 
+### NixOS repository package
+
+Available via NixOS or Home Manager. Add the following to your `configuration.nix` file:
+
+For NixOS:
+
+    environment.systemPackages = with pkgs; [
+      dosbox-staging
+    ];
+
+For Home Manager:
+
+    home.packages = with pkgs; [
+      dosbox-staging
+    ];
+
+Then rebuild your system with: `nixos-rebuild switch`
+
 ### Other repository packages
 
 [![Packaging status](https://repology.org/badge/vertical-allrepos/dosbox-staging.svg){ width=230 }][other-repos]


### PR DESCRIPTION
# Description

Adds install instructions for Nix/NixOS users to the Linux release page.

Leaving out instructions for the fancy nix stuff like `nix run` & `nix shell`. And also mac/darwin; I haven't looked into the differences between nix on mac & linux.

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [x] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

