### PR TITLE
Allow SDL wraps to be bypassed on macOS

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -669,7 +669,7 @@ opus_dep = dependency(
     include_type: 'system',
 )
 
-if host_machine.system() == 'darwin'
+if host_machine.system() == 'darwin' and not wraps_disabled
     # use SDL2 wrap so we can control MACOSX_DEPLOYMENT_TARGET during the build
     sdl2_dep = subproject(
         'sdl2',
@@ -926,7 +926,7 @@ have_fd_zero = (
 sdl2_net_dep = optional_dep
 sdl2_net_summary_msg = 'Disabled'
 if get_option('use_sdl2_net')
-    if host_machine.system() == 'darwin'
+    if host_machine.system() == 'darwin' and not wraps_disabled
         # use wrap so we can control MACOSX_DEPLOYMENT_TARGET during the build
         sdl2_net_dep = subproject(
             'sdl2_net',


### PR DESCRIPTION
# Description
During the release of 0.81, we forced SDL and SDL_net to use wraps in order to control the macOS deployment version, so we could make builds that ran on 10.15 and 11.0. Homebrew doesn't allow these bundled dependencies, so I added a test for the `wraps_disabled` option that was originally added for `zlib-ng`.

Enable this with `wrap_mode=nofallback`. For example, the brew formula could be updated with:

```ruby
def install
    args = %w[-Ddefault_library=shared -Db_lto=true -Dwrap_mode=nofallback -Dtracy=false]
```

## Related issues
#3443 
# Manual testing

Created builds using

`meson setup -Dwrap_mode=nofallback build/release-nowraps`

and

`meson setup build/release`

and verified they were built without and with the wraps.


# Checklist

 have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

