### PR TITLE
Fix shell history creation regression

### DIFF
--- a/src/shell/shell_history.cpp
+++ b/src/shell/shell_history.cpp
@@ -29,7 +29,7 @@
 CHECK_NARROWING();
 
 static constexpr int HistoryMaxLineLength = 256;
-static constexpr int HistoryMaxNumLines = 500;
+static constexpr int HistoryMaxNumLines   = 500;
 
 static std_fs::path get_shell_history_path();
 static bool command_is_exit(std::string_view command);
@@ -41,9 +41,9 @@ void ShellHistory::Append(std::string command, uint16_t code_page)
 		dos_to_utf8(dos_str, utf8_str, code_page);
 		return utf8_str;
 	};
-	
+
 	trim(command);
-	
+
 	auto utf8_command = to_utf8_str(command);
 
 	if (!command_is_exit(command) && !command.empty() &&
@@ -81,7 +81,11 @@ ShellHistory::ShellHistory() : path(get_shell_history_path())
 	}
 	auto history_file = std::ifstream(path);
 	if (!history_file) {
-		path.clear();
+		if (std::filesystem::exists(path)) {
+			LOG_WARNING("SHELL: Unable to read history file: '%s'",
+		            path.string().c_str());
+			path.clear();
+		}
 		return;
 	}
 


### PR DESCRIPTION
# Description

When moving the shell history to its own class, I opted to have the path cleared if the ifstream failed to open. This was because if the file couldn't be read but could still be written to (ie. strange file permissions), it would delete whatever was in the history file.

Seems that I failed to consider the obvious case where the file doesn't exist in the first place.

This fix includes a check to ensure that the file exists before clearing the path when the ifstream fails. 

## Related issues

Should resolve #3482

# Manual testing

Added a manual test to ensure a shell history file is created if none exists.

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [ ] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

