### PR TITLE
Load front-page images from `static/images` instead of archive.org

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -64,9 +64,11 @@ jobs:
               FILES=$(find . \
                   -not -path '*/\.*'        `# ignore hidden files` \
                   -not -path "."            `# ignore current dir` \
+                  -not -path "./static"     `# ignore manually managed 'static' dir` \
+                  -not -path "./static/*"   `# ignore manually managed 'static' dir contents` \
                   -not -path "./preview"    `# ignore 'preview' dir` \
                   -not -path "./preview/*"  `# ignore 'preview' dir contents` \
-                  -not -name "index.md"     `# ignore 'index.md' files` \
+                  -not -name "README.md"    `# ignore 'README.md'` \
                   -not -name "CNAME"        `# ignore CNAME`
               )
               echo $FILES | xargs git rm -rf --

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -2,13 +2,24 @@
 
 ## Overview
 
-The website and documentation at the
-[https://dosbox-staging.github.io/][website] project website are generated
+The website and documentation at
+[https://dosbox-staging.github.io/][website] are generated
 from the [MkDocs][mkdocs] sources in the [`website`](/website) directory of
 this repository. We use a customised version of the [Material for
 MkDocs]([mkdocs-material]) theme.
 
-Both the website and documentation sources live in this single MkDocs source tree.
+The [Deploy website][deploy-website] GitHub workflow publishes the
+generated website to our organisation-level GitHub Pages repository at
+[https://github.com/dosbox-staging/dosbox-staging.github.io/][dosbox-github-pages].
+
+The website and documentation sources live in a single MkDocs source tree,
+including a minimal amount of small image files. Large binary files (e.g.,
+images, audio and video files) are checked in directly to the
+[static](https://github.com/dosbox-staging/dosbox-staging.github.io/tree/master/static)
+directory of the [GitHub Pages repo][dosbox-github-pages]. This is necessary
+to keep the size of the [main DOSBox Staging repo][dosbox-staging] to a
+minimum. The [Deploy website workflow][deploy-website] leaves the `static`
+directory alone; its contents are managed entirely manually.
 
 If you're unfamiliar with MkDocs, here are a few pointers to get you started:
 
@@ -20,8 +31,13 @@ If you're unfamiliar with MkDocs, here are a few pointers to get you started:
 > or documentation—*do not* attempt to push any manual changes to our
 > organisation-level GitHub Pages repo directly at
 > [https://github.com/dosbox-staging/dosbox-staging.github.io/][dosbox-github-pages].
-> If you do so, your manual changes will be overwritten by the next proper
-> website deployment action.
+> If you do so, your manual changes will be overwritten by the next run of the
+> deploy website workflow.
+>
+> As noted above, the only exception to this is managing large binary
+> files in the
+> [static](https://github.com/dosbox-staging/dosbox-staging.github.io/tree/master/static)
+> directory.
 
 
 ## Branching strategy
@@ -90,7 +106,7 @@ There are two common scenarios when making website/documentation changes:
 ## Deploying the website & documentation
 
 The website and documentation are deployed via the  [Deploy
-website][deploy-website] GitHub Action. This will generate the website from
+website][deploy-website] GitHub workflow. This will generate the website from
 the MkDocs sources and push the generated content into our [organisation-level
 GitHub Pages repo][dosbox-github-pages]. The changes should automatically
 appear on the [https://dosbox-staging.github.io/][website] project website
@@ -120,9 +136,8 @@ management tool to install MkDocs and its dependencies. Please refer to
 [pip installation instructions](https://pip.pypa.io/en/stable/installation/)
 for details.
 
-Our [Deploy website][deploy-website] GitHub Action that builds and deploys the
-documentation uses the [Ubuntu
-22.04](https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md)
+Our [Deploy website][deploy-website] GitHub workflow that builds and deploys the
+documentation uses the [Ubuntu 22.04](https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md)
 image, which comes with Python 3.10.6 and pip3 22.0.2, so these are the
 recommended minimum versions.
 
@@ -196,7 +211,8 @@ then check in both the `.css` and the `.scss` files.
 
 - We generally recommend following Google's
   [developer documentation style guide](https://developers.google.com/style).
-  At the very least, familiarise yourself with the [key points](https://developers.google.com/style/highlights);
+  At the very least, familiarise yourself with the
+  [key points](https://developers.google.com/style/highlights);
   it will greatly improve your style and consistency.
 
 - We use International English as opposed to American English in our
@@ -225,8 +241,8 @@ then check in both the `.css` and the `.scss` files.
   writer! Just as you would not publish your very first working draft of a
   piece of code without cleaning it up first (at least we *really* hope you
   wouldn't! 😎), very few people are able to churn out perfect prose without
-  iteratively revising it a few times. Even the greatest literary authors
-  need a team of editors, or self-edit and refine their work themselves over long
+  iteratively revising it a few times. Even the greatest literary authors need
+  a team of editors, or self-edit and refine their work themselves over long
   periods of time!
 
 
@@ -248,36 +264,52 @@ then check in both the `.css` and the `.scss` files.
 [mkdocs-material]: https://squidfunk.github.io/mkdocs-material/
 
 [website]: https://dosbox-staging.github.io/
+[dosbox-staging]: https://github.com/dosbox-staging/dosbox-staging/
 [dosbox-github-pages]: https://github.com/dosbox-staging/dosbox-staging.github.io/
 [deploy-website]: https://github.com/dosbox-staging/dosbox-staging/actions/workflows/deploy-website.yml
 [main-branch]: https://github.com/dosbox-staging/dosbox-staging/tree/main
 
 ## Deploy website action
 
-The [Deploy website][deploy-website] GitHub Action needs to push the generated files to our [organisation-level GitHub Pages repo](dosbox-github-pages). Such cross-repository access is a bit tricky; the deploy action achieves it via a personal access token. We use tokens with an expiry for security reasons, so at some point the "Commit & publish new release" step of the deploy action will start to fail. You'll need to generate a new token when this happens as described below.
+The [Deploy website][deploy-website] GitHub workflow needs to push the
+generated files to our [organisation-level GitHub Pages
+repo](dosbox-github-pages). Such cross-repository access is a bit tricky; the
+deploy action achieves it via a personal access token. We use tokens with an
+expiry for security reasons, so at some point the "Commit & publish new
+release" step of the deploy action will start to fail. You'll need to generate
+a new token when this happens as described below.
 
 ### Generate a new classic personal access token
 
-1. When logged in to GitHub as the administrator of the DOSBox Staging organisation, click on your user profile picture in the top right corner, then on the **Settings** menu (cog icon).
+1. When logged in to GitHub as the administrator of the DOSBox Staging
+   organisation, click on your user profile picture in the top right corner,
+   then on the **Settings** menu (cog icon).
 
 2. Go to the **Developer settings** page (bottom-most item in the left menu pane).
 
 3. Go to the **Personalised access tokens / Tokens (classic)** page.
 
-4. Click on the **Generate new token** button, then select **Generate new token (classic)**.
+4. Click on the **Generate new token** button, then select **Generate new
+   token (classic)**.
 
-5. Give your new token a name and an expiry date (say a year from now), then enable all repo privileges by checking the **repo** item.
+5. Give your new token a name and an expiry date (say a year from now), then
+   enable all repo privileges by checking the **repo** item.
  
-6. Press **Generate token** at the bottom of the page, then copy the generated token (you won't be able to retrieve it later; you'll need to generate a new one if you lose it).
+6. Press **Generate token** at the bottom of the page, then copy the generated
+   token (you won't be able to retrieve it later; you'll need to generate a
+   new one if you lose it).
 
 ### Set up the secret access token
 
-1. Go to the **Settings** page of the [dosbox-staging](https://github.com/dosbox-staging/dosbox-staging/settings) repo.
+1. Go to the [Settings page](https://github.com/dosbox-staging/dosbox-staging/settings) of the
+   [dosbox-staging][dosbox-staging]  repo.
 
-2. Open the **Secrets and variables** menu in the left pane, then select **Actions**.
+2. Open the **Secrets and variables** menu in the left pane, then select
+   **Actions**.
 
-3. Edit the `ACCESS_TOKEN_REPO` item in **Repository secrets** (or add it if it doesn't exist), paste in the new token, then click the **Update secret** button.
+3. Edit the `ACCESS_TOKEN_REPO` item in **Repository secrets** (or add it if
+   it doesn't exist), paste in the new token, then click the **Update secret**
+   button.
 
 After these steps, the deploy website action should run without errors.
-
 

--- a/website/.gitignore
+++ b/website/.gitignore
@@ -1,1 +1,2 @@
 site
+*.css.map

--- a/website/overrides/home.html
+++ b/website/overrides/home.html
@@ -56,8 +56,8 @@
       <div class="image-grid">
         <figure>
           <p>
-            <a class="glightbox" href="https://archive.org/download/dosbox-staging-v0.81.0-the-legend-of-kyrandia/legend-of-kyrandia.jpg">
-              <img alt="The Legend of Kyrandia — 320&times;200 VGA" class="skip-lightbox" src="https://archive.org/download/dosbox-staging-v0.81.0-the-legend-of-kyrandia/legend-of-kyrandia-small.jpg">
+            <a class="glightbox" href="https://dosbox-staging.github.io/static/images/front-page/legend-of-kyrandia.jpg">
+              <img alt="The Legend of Kyrandia — 320&times;200 VGA" class="skip-lightbox" src="https://dosbox-staging.github.io/static/images/front-page/legend-of-kyrandia-small.jpg">
             </a>
           </p>
           <figcaption>
@@ -67,8 +67,8 @@
 
         <figure>
           <p>
-            <a class="glightbox" href="https://archive.org/download/dosbox-staging-v0.81.0-heroes-of-might-and-magic/heroes-of-might-and-magic.jpg">
-              <img alt="Heroes of Might and Magic — 640&times;480 SVGA" class="skip-lightbox" src="https://archive.org/download/dosbox-staging-v0.81.0-heroes-of-might-and-magic/heroes-of-might-and-magic-small.jpg">
+            <a class="glightbox" href="https://dosbox-staging.github.io/static/images/front-page/heroes-of-might-and-magic.jpg">
+              <img alt="Heroes of Might and Magic — 640&times;480 SVGA" class="skip-lightbox" src="https://dosbox-staging.github.io/static/images/front-page/heroes-of-might-and-magic-small.jpg">
             </a>
           </p>
           <figcaption>
@@ -78,8 +78,8 @@
 
         <figure>
           <p>
-            <a class="glightbox" href="https://archive.org/download/dosbox-staging-v0.81.0-dark-seed/dark-seed.jpg">
-              <img alt="Dark Seed — 640&times;350 EGA" class="skip-lightbox" src="https://archive.org/download/dosbox-staging-v0.81.0-dark-seed/dark-seed-small.jpg">
+            <a class="glightbox" href="https://dosbox-staging.github.io/static/images/front-page/dark-seed.jpg">
+              <img alt="Dark Seed — 640&times;350 EGA" class="skip-lightbox" src="https://dosbox-staging.github.io/static/images/front-page/dark-seed-small.jpg">
             </a>
           </p>
           <figcaption>
@@ -89,8 +89,8 @@
 
         <figure>
           <p>
-            <a class="glightbox" href="https://archive.org/download/dosbox-staging-v0.81.0-space-quest-iii/space-quest-iii.jpg">
-              <img alt="Space Quest III — 320&times;200 EGA" class="skip-lightbox" src="https://archive.org/download/dosbox-staging-v0.81.0-space-quest-iii/space-quest-iii-small.jpg">
+            <a class="glightbox" href="https://dosbox-staging.github.io/static/images/front-page/space-quest-iii.jpg">
+              <img alt="Space Quest III — 320&times;200 EGA" class="skip-lightbox" src="https://dosbox-staging.github.io/static/images/front-page/space-quest-iii-small.jpg">
             </a>
           </p>
           <figcaption>
@@ -100,8 +100,8 @@
 
         <figure>
           <p>
-            <a class="glightbox" href="https://archive.org/download/dosbox-staging-v0.81.0-wizardry/wizardry.jpg">
-              <img alt="Wizardry — 320&times;200 CGA" class="skip-lightbox" src="https://archive.org/download/dosbox-staging-v0.81.0-wizardry/wizardry-small.jpg">
+            <a class="glightbox" href="https://dosbox-staging.github.io/static/images/front-page/wizardry.jpg">
+              <img alt="Wizardry — 320&times;200 CGA" class="skip-lightbox" src="https://dosbox-staging.github.io/static/images/front-page/wizardry-small.jpg">
             </a>
           </p>
           <figcaption>
@@ -111,8 +111,8 @@
 
         <figure>
           <p>
-            <a class="glightbox" href="https://archive.org/download/dosbox-staging-v0.81.0-starblade/starblade.jpg">
-              <img alt="Starblade — 720&times;348 Hercules" class="skip-lightbox" src="https://archive.org/download/dosbox-staging-v0.81.0-starblade/starblade-small.jpg">
+            <a class="glightbox" href="https://dosbox-staging.github.io/static/images/front-page/starblade.jpg">
+              <img alt="Starblade — 720&times;348 Hercules" class="skip-lightbox" src="https://dosbox-staging.github.io/static/images/front-page/starblade-small.jpg">
             </a>
           </p>
           <figcaption>
@@ -274,8 +274,8 @@
         <div class="image-grid">
           <figure>
             <p>
-              <a class="glightbox" href="https://archive.org/download/dosbox-staging-v0.81.0-death-gate/death-gate.jpg">
-                <img alt="Death Gate — 640&times;480 SVGA" class="skip-lightbox" loading="lazy" src="https://archive.org/download/dosbox-staging-v0.81.0-death-gate/death-gate-small.jpg">
+              <a class="glightbox" href="https://dosbox-staging.github.io/static/images/front-page/death-gate.jpg">
+                <img alt="Death Gate — 640&times;480 SVGA" class="skip-lightbox" loading="lazy" src="https://dosbox-staging.github.io/static/images/front-page/death-gate-small.jpg">
               </a>
             </p>
             <figcaption>
@@ -285,8 +285,8 @@
 
           <figure>
             <p>
-              <a class="glightbox" href="https://archive.org/download/dosbox-staging-v0.81.0-populous-ii/populous-ii-hires.jpg">
-                <img alt="Populous II — 640&times;480 VGA" class="skip-lightbox" loading="lazy" src="https://archive.org/download/dosbox-staging-v0.81.0-populous-ii/populous-ii-hires-small.jpg">
+              <a class="glightbox" href="https://dosbox-staging.github.io/static/images/front-page/populous-ii-hires.jpg">
+                <img alt="Populous II — 640&times;480 VGA" class="skip-lightbox" loading="lazy" src="https://dosbox-staging.github.io/static/images/front-page/populous-ii-hires-small.jpg">
               </a>
             </p>
             <figcaption>
@@ -296,8 +296,8 @@
 
           <figure>
             <p>
-              <a class="glightbox" href="https://archive.org/download/dosbox-staging-v0.81.0-celtic-tales/celtic-tales.jpg">
-                <img alt="Celtic Tales — 640&times;480 VGA" class="skip-lightbox" loading="lazy" src="https://archive.org/download/dosbox-staging-v0.81.0-celtic-tales/celtic-tales-small.jpg">
+              <a class="glightbox" href="https://dosbox-staging.github.io/static/images/front-page/celtic-tales.jpg">
+                <img alt="Celtic Tales — 640&times;480 VGA" class="skip-lightbox" loading="lazy" src="https://dosbox-staging.github.io/static/images/front-page/celtic-tales-small.jpg">
               </a>
             </p>
             <figcaption>
@@ -307,8 +307,8 @@
 
           <figure>
             <p>
-              <a class="glightbox" href="https://archive.org/download/dosbox-staging-v0.81.0-wing-commander/wing-commander.jpg">
-                <img alt="Wing Commander — 320&times;200 VGA" class="skip-lightbox" loading="lazy" src="https://archive.org/download/dosbox-staging-v0.81.0-wing-commander/wing-commander-small.jpg">
+              <a class="glightbox" href="https://dosbox-staging.github.io/static/images/front-page/wing-commander.jpg">
+                <img alt="Wing Commander — 320&times;200 VGA" class="skip-lightbox" loading="lazy" src="https://dosbox-staging.github.io/static/images/front-page/wing-commander-small.jpg">
               </a>
             </p>
             <figcaption>
@@ -318,8 +318,8 @@
 
           <figure>
             <p>
-              <a class="glightbox" href="https://archive.org/download/dosbox-staging-v0.81.0-indiana-jones-and-the-fate-of-atlantis/indy4.jpg">
-                <img alt="Indiana Jones and the Fate of Atlantis — 320&times;200 VGA" class="skip-lightbox" loading="lazy" src="https://archive.org/download/dosbox-staging-v0.81.0-indiana-jones-and-the-fate-of-atlantis/indy4-small.jpg">
+              <a class="glightbox" href="https://dosbox-staging.github.io/static/images/front-page/indy4.jpg">
+                <img alt="Indiana Jones and the Fate of Atlantis — 320&times;200 VGA" class="skip-lightbox" loading="lazy" src="https://dosbox-staging.github.io/static/images/front-page/indy4-small.jpg">
               </a>
             </p>
             <figcaption>
@@ -329,8 +329,8 @@
 
           <figure>
             <p>
-              <a class="glightbox" href="https://archive.org/download/dosbox-staging-v0.81.0-ultima-iv/ultima-vi.jpg">
-                <img alt="Ultima VI — 320&times;200 VGA" class="skip-lightbox" loading="lazy" src="https://archive.org/download/dosbox-staging-v0.81.0-ultima-iv/ultima-vi-small.jpg">
+              <a class="glightbox" href="https://dosbox-staging.github.io/static/images/front-page/ultima-vi.jpg">
+                <img alt="Ultima VI — 320&times;200 VGA" class="skip-lightbox" loading="lazy" src="https://dosbox-staging.github.io/static/images/front-page/ultima-vi-small.jpg">
               </a>
             </p>
             <figcaption>
@@ -349,8 +349,8 @@
         <div class="image-grid">
           <figure>
             <p>
-              <a class="glightbox" href="https://archive.org/download/dosbox-staging-v0.81.0-spellcasting-201/spellcasting-201.jpg">
-                <img alt="Spellcasting 201 — 640&times;350 EGA" class="skip-lightbox" loading="lazy" src="https://archive.org/download/dosbox-staging-v0.81.0-spellcasting-201/spellcasting-201-small.jpg">
+              <a class="glightbox" href="https://dosbox-staging.github.io/static/images/front-page/spellcasting-201.jpg">
+                <img alt="Spellcasting 201 — 640&times;350 EGA" class="skip-lightbox" loading="lazy" src="https://dosbox-staging.github.io/static/images/front-page/spellcasting-201-small.jpg">
               </a>
             </p>
             <figcaption>
@@ -360,8 +360,8 @@
 
           <figure>
             <p>
-              <a class="glightbox" href="https://archive.org/download/dosbox-staging-v0.81.0-ghengis-khan/ghengis-khan.jpg">
-                <img alt="Ghengis Khan — 640&times;200 EGA" class="skip-lightbox" loading="lazy" src="https://archive.org/download/dosbox-staging-v0.81.0-ghengis-khan/ghengis-khan-small.jpg">
+              <a class="glightbox" href="https://dosbox-staging.github.io/static/images/front-page/ghengis-khan.jpg">
+                <img alt="Ghengis Khan — 640&times;200 EGA" class="skip-lightbox" loading="lazy" src="https://dosbox-staging.github.io/static/images/front-page/ghengis-khan-small.jpg">
               </a>
             </p>
             <figcaption>
@@ -371,8 +371,8 @@
 
           <figure>
             <p>
-              <a class="glightbox" href="https://archive.org/download/dosbox-staging-v0.81.0-quest-for-glory-i/quest-for-glory-ega.jpg">
-                <img alt="Quest for Glory I — 320&times;200 EGA" class="skip-lightbox" loading="lazy" src="https://archive.org/download/dosbox-staging-v0.81.0-quest-for-glory-i/quest-for-glory-ega-small.jpg">
+              <a class="glightbox" href="https://dosbox-staging.github.io/static/images/front-page/quest-for-glory-ega.jpg">
+                <img alt="Quest for Glory I — 320&times;200 EGA" class="skip-lightbox" loading="lazy" src="https://dosbox-staging.github.io/static/images/front-page/quest-for-glory-ega-small.jpg">
               </a>
             </p>
             <figcaption>
@@ -382,8 +382,8 @@
 
           <figure>
             <p>
-              <a class="glightbox" href="https://archive.org/download/dosbox-staging-v0.81.0-windwalker/windwalker-ega.jpg">
-                <img alt="Windwalker — 320&times;200 EGA" class="skip-lightbox" loading="lazy" src="https://archive.org/download/dosbox-staging-v0.81.0-windwalker/windwalker-ega-small.jpg">
+              <a class="glightbox" href="https://dosbox-staging.github.io/static/images/front-page/windwalker-ega.jpg">
+                <img alt="Windwalker — 320&times;200 EGA" class="skip-lightbox" loading="lazy" src="https://dosbox-staging.github.io/static/images/front-page/windwalker-ega-small.jpg">
               </a>
             </p>
             <figcaption>
@@ -393,8 +393,8 @@
 
           <figure>
             <p>
-              <a class="glightbox" href="https://archive.org/download/dosbox-staging-v0.81.0-monkey-island/monkey-island.jpg">
-                <img alt="The Secret of Monkey Island -- 320&times;200 EGA" class="skip-lightbox" loading="lazy" src="https://archive.org/download/dosbox-staging-v0.81.0-monkey-island/monkey-island-small.jpg">
+              <a class="glightbox" href="https://dosbox-staging.github.io/static/images/front-page/monkey-island.jpg">
+                <img alt="The Secret of Monkey Island -- 320&times;200 EGA" class="skip-lightbox" loading="lazy" src="https://dosbox-staging.github.io/static/images/front-page/monkey-island-small.jpg">
               </a>
             </p>
             <figcaption>
@@ -404,8 +404,8 @@
 
           <figure>
             <p>
-              <a class="glightbox" href="https://archive.org/download/dosbox-staging-v0.81.0-loom/loom-ingame-ega.jpg">
-                <img alt="Loom — 320&times;200 EGA" class="skip-lightbox" loading="lazy" src="https://archive.org/download/dosbox-staging-v0.81.0-loom/loom-ingame-ega-small.jpg">
+              <a class="glightbox" href="https://dosbox-staging.github.io/static/images/front-page/loom-ingame-ega.jpg">
+                <img alt="Loom — 320&times;200 EGA" class="skip-lightbox" loading="lazy" src="https://dosbox-staging.github.io/static/images/front-page/loom-ingame-ega-small.jpg">
               </a>
             </p>
             <figcaption>
@@ -424,8 +424,8 @@
         <div class="image-grid">
           <figure>
             <p>
-              <a class="glightbox" href="https://archive.org/download/dosbox-staging-v0.81.0-captain-blood/captain-blood-ega.jpg">
-                <img alt="Captain Blood — 320&times;200 CGA" class="skip-lightbox" loading="lazy" src="https://archive.org/download/dosbox-staging-v0.81.0-captain-blood/captain-blood-ega-small.jpg">
+              <a class="glightbox" href="https://dosbox-staging.github.io/static/images/front-page/captain-blood-ega.jpg">
+                <img alt="Captain Blood — 320&times;200 CGA" class="skip-lightbox" loading="lazy" src="https://dosbox-staging.github.io/static/images/front-page/captain-blood-ega-small.jpg">
               </a>
             </p>
             <figcaption>
@@ -435,8 +435,8 @@
 
           <figure>
             <p>
-              <a class="glightbox" href="https://archive.org/download/dosbox-staging-v0.81.0-rogue/rogue.jpg">
-                <img alt="Rogue — 320&times;200 CGA" class="skip-lightbox" loading="lazy" src="https://archive.org/download/dosbox-staging-v0.81.0-rogue/rogue-small.jpg">
+              <a class="glightbox" href="https://dosbox-staging.github.io/static/images/front-page/rogue.jpg">
+                <img alt="Rogue — 320&times;200 CGA" class="skip-lightbox" loading="lazy" src="https://dosbox-staging.github.io/static/images/front-page/rogue-small.jpg">
               </a>
             </p>
             <figcaption>
@@ -446,8 +446,8 @@
 
           <figure>
             <p>
-              <a class="glightbox" href="https://archive.org/download/dosbox-staging-v0.81.0-targhan/targhan-cga.jpg">
-                <img alt="Targhan — 320&times;200 CGA" class="skip-lightbox" loading="lazy" src="https://archive.org/download/dosbox-staging-v0.81.0-targhan/targhan-cga-small.jpg">
+              <a class="glightbox" href="https://dosbox-staging.github.io/static/images/front-page/targhan-cga.jpg">
+                <img alt="Targhan — 320&times;200 CGA" class="skip-lightbox" loading="lazy" src="https://dosbox-staging.github.io/static/images/front-page/targhan-cga-small.jpg">
               </a>
             </p>
             <figcaption>
@@ -457,8 +457,8 @@
 
           <figure>
             <p>
-              <a class="glightbox" href="https://archive.org/download/dosbox-staging-v0.81.0-rockford/rockford-cga-mono-amber.jpg">
-                <img alt="Rockford — 320&times;200 Monochrome CGA" class="skip-lightbox" loading="lazy" src="https://archive.org/download/dosbox-staging-v0.81.0-rockford/rockford-cga-mono-amber-small.jpg">
+              <a class="glightbox" href="https://dosbox-staging.github.io/static/images/front-page/rockford-cga-mono-amber.jpg">
+                <img alt="Rockford — 320&times;200 Monochrome CGA" class="skip-lightbox" loading="lazy" src="https://dosbox-staging.github.io/static/images/front-page/rockford-cga-mono-amber-small.jpg">
               </a>
             </p>
             <figcaption>
@@ -468,8 +468,8 @@
 
           <figure>
             <p>
-              <a class="glightbox" href="https://archive.org/download/dosbox-staging-v0.81.0-california-games/california-games-cga-composite.jpg">
-                <img alt="California Games — 640&times;200 Composite CGA" class="skip-lightbox" loading="lazy" src="https://archive.org/download/dosbox-staging-v0.81.0-california-games/california-games-cga-composite-small.jpg">
+              <a class="glightbox" href="https://dosbox-staging.github.io/static/images/front-page/california-games-cga-composite.jpg">
+                <img alt="California Games — 640&times;200 Composite CGA" class="skip-lightbox" loading="lazy" src="https://dosbox-staging.github.io/static/images/front-page/california-games-cga-composite-small.jpg">
               </a>
             </p>
             <figcaption>
@@ -479,8 +479,8 @@
 
           <figure>
             <p>
-              <a class="glightbox" href="https://archive.org/download/dosbox-staging-v0.81.0-zak-mckracken/zak.jpg">
-                <img alt="Zak McKracken and the Alien Mindbenders — 320&times;200 Composite CGA (Tandy)" class="skip-lightbox" loading="lazy" src="https://archive.org/download/dosbox-staging-v0.81.0-zak-mckracken/zak-small.jpg">
+              <a class="glightbox" href="https://dosbox-staging.github.io/static/images/front-page/zak.jpg">
+                <img alt="Zak McKracken and the Alien Mindbenders — 320&times;200 Composite CGA (Tandy)" class="skip-lightbox" loading="lazy" src="https://dosbox-staging.github.io/static/images/front-page/zak-small.jpg">
               </a>
             </p>
             <figcaption>
@@ -499,8 +499,8 @@
         <div class="image-grid">
           <figure>
             <p>
-              <a class="glightbox" href="https://archive.org/download/dosbox-staging-v0.81.0-total-eclipse/total-eclipse-hercules-custom-stretch.png">
-                <img alt="Total Eclipse — 720&times;348 Hercules (with custom viewport stretch)" class="skip-lightbox" loading="lazy" src="https://archive.org/download/dosbox-staging-v0.81.0-total-eclipse/total-eclipse-hercules-custom-stretch.png">
+              <a class="glightbox" href="https://dosbox-staging.github.io/static/images/front-page/total-eclipse-hercules-custom-stretch.png">
+                <img alt="Total Eclipse — 720&times;348 Hercules (with custom viewport stretch)" class="skip-lightbox" loading="lazy" src="https://dosbox-staging.github.io/static/images/front-page/total-eclipse-hercules-custom-stretch.png">
               </a>
             </p>
             <figcaption>
@@ -510,8 +510,8 @@
 
           <figure>
             <p>
-              <a class="glightbox" href="https://archive.org/download/dosbox-staging-v0.81.0-blockout/blockout-hercules-custom-stretch.png">
-                <img alt="Blockout — 720&times;348 Hercules" class="skip-lightbox" loading="lazy" src="https://archive.org/download/dosbox-staging-v0.81.0-blockout/blockout-hercules-custom-stretch.png">
+              <a class="glightbox" href="https://dosbox-staging.github.io/static/images/front-page/blockout-hercules-custom-stretch.png">
+                <img alt="Blockout — 720&times;348 Hercules" class="skip-lightbox" loading="lazy" src="https://dosbox-staging.github.io/static/images/front-page/blockout-hercules-custom-stretch.png">
               </a>
             </p>
             <figcaption>
@@ -521,8 +521,8 @@
 
           <figure>
             <p>
-              <a class="glightbox" href="https://archive.org/download/dosbox-staging-v0.81.0-prince-of-persia/pop-hercules-aspect-corrected.jpg">
-                <img alt="Prince of Persia — 720&times;348 Hercules (with custom viewport stretch)" class="skip-lightbox" loading="lazy" src="https://archive.org/download/dosbox-staging-v0.81.0-prince-of-persia/pop-hercules-aspect-corrected.jpg">
+              <a class="glightbox" href="https://dosbox-staging.github.io/static/images/front-page/pop-hercules-aspect-corrected.jpg">
+                <img alt="Prince of Persia — 720&times;348 Hercules (with custom viewport stretch)" class="skip-lightbox" loading="lazy" src="https://dosbox-staging.github.io/static/images/front-page/pop-hercules-aspect-corrected.jpg">
               </a>
             </p>
             <figcaption>
@@ -541,8 +541,8 @@
         <div class="image-grid">
           <figure>
             <p>
-              <a class="glightbox" href="https://archive.org/download/dosbox-staging-v0.81.0-gods/gods-arcade.jpg">
-                <img alt="Gods — 320&times;200 VGA" class="skip-lightbox" loading="lazy" src="https://archive.org/download/dosbox-staging-v0.81.0-gods/gods-arcade-small.jpg">
+              <a class="glightbox" href="https://dosbox-staging.github.io/static/images/front-page/gods-arcade.jpg">
+                <img alt="Gods — 320&times;200 VGA" class="skip-lightbox" loading="lazy" src="https://dosbox-staging.github.io/static/images/front-page/gods-arcade-small.jpg">
               </a>
             </p>
             <figcaption>
@@ -552,8 +552,8 @@
 
           <figure>
             <p>
-              <a class="glightbox" href="https://archive.org/download/dosbox-staging-v0.81.0-elvira/elvira-arcade.jpg">
-                <img alt="Elvira — 320&times;200 VGA" class="skip-lightbox" loading="lazy" src="https://archive.org/download/dosbox-staging-v0.81.0-elvira/elvira-arcade-small.jpg">
+              <a class="glightbox" href="https://dosbox-staging.github.io/static/images/front-page/elvira-arcade.jpg">
+                <img alt="Elvira — 320&times;200 VGA" class="skip-lightbox" loading="lazy" src="https://dosbox-staging.github.io/static/images/front-page/elvira-arcade-small.jpg">
               </a>
             </p>
             <figcaption>
@@ -563,8 +563,8 @@
 
           <figure>
             <p>
-              <a class="glightbox" href="https://archive.org/download/dosbox-staging-v0.81.0-friend/friend-arcade.jpg">
-                <img alt="Friend — Growth of a Legend by Critkill — 320&times;256 Amiga OCS" class="skip-lightbox" loading="lazy" src="https://archive.org/download/dosbox-staging-v0.81.0-friend/friend-arcade-small.jpg">
+              <a class="glightbox" href="https://dosbox-staging.github.io/static/images/front-page/friend-arcade.jpg">
+                <img alt="Friend — Growth of a Legend by Critkill — 320&times;256 Amiga OCS" class="skip-lightbox" loading="lazy" src="https://dosbox-staging.github.io/static/images/front-page/friend-arcade-small.jpg">
               </a>
             </p>
             <figcaption>


### PR DESCRIPTION
# Description

As discussed, I'm experimenting with hosting the front page images in our GitHub Pages site instead of archive.org. I think it's definitely faster this way.

I copied the images into the `static/images` dir of our org level GitHub Pages repo:
https://github.com/dosbox-staging/dosbox-staging.github.io/tree/master/_images

This is where the website gets published, so I've extended the workflow to ignore the `static` dir on deploys. The idea is that if this works well, I will move all files over, then we could have `static/files`, `static/audio`, `static/video`, etc. 

# Manual testing

Deployed this as the preview website to https://dosbox-staging.github.io/preview/dev/

Verified that there are no links to archive.org on the front page. The screenshots now all live in GitHub pages, e.g.:

```
https://dosbox-staging.github.io/static/images/front-page/legend-of-kyrandia.jpg
```

It feels faster to me. Let me know what you think.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [x] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

