### PR TITLE
Allow the PVS-Studio workflow run in forked PRs

### DIFF
--- a/.github/workflows/pvs-studio.yml
+++ b/.github/workflows/pvs-studio.yml
@@ -13,7 +13,14 @@ on:
       - 'licenses/**'
       - 'website/**'
 
-  pull_request:
+  # Same as 'pull_request', except for forked PRs where it uses the last
+  # commit of the workflow from the *target branch*, plus gives read/write
+  # token permissions and access to secrets.
+  # 
+  # Access to secrets is the important bit here; with regular 'pull_request',
+  # forked PRs could not access the PVS-Studio license stored as a secret and
+  # this workflow would just fail.
+  pull_request_target:
     paths-ignore:
       - '.clang-format'
       - '.mdl-styles'


### PR DESCRIPTION
# Description

This solves the problem where the PVS-Studio workflow cannot run on forked PRs because it does not have access to the secret that holds the license key.

# Manual testing

Raised a PR with this change, and the PVS-Studio workflow still works.

We'll see how it works in actual practice with forked PRs.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [ ] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

