### PR TITLE
Fix PVS-Studio workflow on branched PRs & forks

### DIFF
--- a/.github/workflows/pvs-studio.yml
+++ b/.github/workflows/pvs-studio.yml
@@ -14,12 +14,12 @@ on:
       - 'website/**'
 
   # Same as 'pull_request', except for forked PRs where it uses the last
-  # commit of the workflow from the *target branch*, plus gives read/write
-  # token permissions and access to secrets.
-  # 
+  # commit of the *target branch*, plus gives read/write token permissions and
+  # access to secrets.
+  #
   # Access to secrets is the important bit here; with regular 'pull_request',
   # forked PRs could not access the PVS-Studio license stored as a secret and
-  # this workflow would just fail.
+  # this workflow would fail.
   pull_request_target:
     paths-ignore:
       - '.clang-format'
@@ -39,13 +39,30 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       debfile: pvs-studio-7.29.79138.387-amd64.deb
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          submodules: false
 
-      - run:  sudo apt-get update
+    steps:
+      - name: Checkout PR branch and all PR commits
+        uses: actions/checkout@v3
+        with:
+          # `pull_request_target` checks out the target branch by default due
+          # to security reasons. We explicitly override that here to check out
+          # the code from the PR instead. This way, we can run the code from
+          # the PR while still having access to the secrets (the PVS-Studio
+          # license is stored as a secret).
+          #
+          # This is potentially dangerous, as any random contributor could
+          # modify any of the referenced scripts in the PVS workflow to dump
+          # the secrets into the logs or upload them somewhere. Therefore, we
+          # enforce in the repository settings that workflow runs must always
+          # be manually approved on all forked PRs from external contributors.
+          #
+          # The important bit is ALWAYS REVIEW PRs from unknowns external
+          # contributors first and look out for malicious code before
+          # approving the workflow runs!
+          #
+          #
+          ref: ${{  github.event.pull_request.head.sha }}
+          submodules: false
 
       - name: Log and setup environment
         run: |


### PR DESCRIPTION
# Description

The goal here is to allow the PVS-Studio workflow run in forked PRs. If we don't do that, any number of PVS warnings can slip through, then the next PVS run on `main` would fail. This is a pain.

The complication is that PVS-Studio needs a license key, and that's stored as a GitHub Actions secret. Forked PRs don't have access to secrets by default. We can however give access to the secrets and full read/write access in forked PRs as well with `pull_request_target`, but that checks out the target branch (original base branch) by default due to security reasons.

With this change, we explicitly override that to check out the code from the PR instead. This way, we can run the code from the PR while still having access to the secrets (the PVS-Studio license is stored as a secret).

This is potentially dangerous, as any random contributor could modify any of the referenced scripts in the PVS workflow to dump the secrets into the logs or upload them somewhere. Therefore, we enforce in the repository settings that workflow runs must always be manually approved on all forked PRs from external contributors.

The important bit is **_ALWAYS REVIEW PRs from unknown external contributors_** first and look out for malicious code before approving the workflow runs!

Naturally, we trust team members and people on the collaborator list, otherwise no one would be able to get any work done here... 😅 

I've tightened our security so we **_always_** must approve workflow runs in PRs from external contributors (not just first time contributors):

![image](https://github.com/dosbox-staging/dosbox-staging/assets/698770/6a86ecac-e339-4b87-9355-07917e335705)


## Related issues

https://github.com/dosbox-staging/dosbox-staging/pull/3494

# Manual testing

TBD

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

