### PR TITLE
Use GitHub actions cache for vcpkg

### DIFF
--- a/.github/workflows/windows-msvc.yml
+++ b/.github/workflows/windows-msvc.yml
@@ -25,7 +25,7 @@ concurrency:
 
 env:
   VCPKG_ROOT: C:\vcpkg
-  VCPKG_BINARY_SOURCES: 'clear;nuget,GitHub,readwrite'
+  VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
 
 jobs:
   build_windows_vs:
@@ -45,25 +45,12 @@ jobs:
         with:
           submodules: false
 
-      - name:  Setup vcpkg and NuGet
-        shell: bash
-        run: |
-          set -euo pipefail
-          cd "${{ env.VCPKG_ROOT }}"
-          git checkout master -f
-          git pull
-          ./bootstrap-vcpkg.sh -disableMetrics
-          nuget=$(./vcpkg.exe fetch nuget | tail -n 1)
-          owner="${GITHUB_REPOSITORY%/*}"
-          source_url="https://nuget.pkg.github.com/$owner/index.json"
-          "$nuget" sources add \
-            -source "$source_url" \
-            -storepasswordincleartext \
-            -name "GitHub" \
-            -username "$owner" \
-            -password "${{ secrets.GITHUB_TOKEN }}"
-          "$nuget" setapikey "${{ secrets.GITHUB_TOKEN }}" \
-            -source "$source_url"
+      - name: Export GitHub Actions cache environment variables
+        uses: actions/github-script@v7
+        with:
+          script: |
+            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
       - name: Add MSBuild to PATH
         uses: microsoft/setup-msbuild@v2
@@ -124,25 +111,12 @@ jobs:
         with:
           submodules: false
 
-      - name:  Setup vcpkg and NuGet
-        shell: bash
-        run: |
-          set -euo pipefail
-          cd "${{ env.VCPKG_ROOT }}"
-          git checkout master -f
-          git pull
-          ./bootstrap-vcpkg.sh -disableMetrics
-          nuget=$(./vcpkg.exe fetch nuget | tail -n 1)
-          owner="${GITHUB_REPOSITORY%/*}"
-          source_url="https://nuget.pkg.github.com/$owner/index.json"
-          "$nuget" sources add \
-            -source "$source_url" \
-            -storepasswordincleartext \
-            -name "GitHub" \
-            -username "$owner" \
-            -password "${{ secrets.GITHUB_TOKEN }}"
-          "$nuget" setapikey "${{ secrets.GITHUB_TOKEN }}" \
-            -source "$source_url"
+      - name: Export GitHub Actions cache environment variables
+        uses: actions/github-script@v7
+        with:
+          script: |
+            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
       - name: Add MSBuild to PATH
         uses: microsoft/setup-msbuild@v2


### PR DESCRIPTION
# Description

Something in the NuGet machinery was causing the Windows MSVC workflow to fail. Using the GitHub actions cache is simpler and the [recommended](https://learn.microsoft.com/en-us/vcpkg/consume/binary-caching-github-actions-cache) setup anyways, so I migrated to it.

# Manual testing

Made follow-up pushes to test rebuild times and verify caching was working.

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

