### PR TITLE
Fix macOS CI workflow

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -33,7 +33,7 @@ jobs:
       matrix:
         conf:
           - name: Clang
-            host: macos-13
+            host: macos-12
             arch: x86_64
             needs_deps: true
             build_flags: -Denable_debugger=normal
@@ -67,7 +67,7 @@ jobs:
 
       - name: Cache subprojects
         id:   cache-subprojects
-        uses: actions/cache@v4.0.1
+        uses: actions/cache@v4
         with:
           path: subprojects.tar
           key: subprojects-${{ hashFiles('subprojects/*.wrap') }}-1
@@ -112,7 +112,7 @@ jobs:
     strategy:
       matrix:
         runner:
-          - host: macos-13
+          - host: macos-12
             arch: x86_64
             build_flags: -Db_lto=true
             brew_path: /usr/local/homebrew
@@ -136,12 +136,11 @@ jobs:
       - name: Install C++ compiler and libraries
         if:   matrix.runner.needs_deps
         run: |
-          pip3 install meson setuptools
-          brew install librsvg tree libpng ninja opusfile speexdsp
+          brew install librsvg tree libpng ninja opusfile speexdsp meson python-setuptools
 
       - name: Cache subprojects
         id: cache-subprojects
-        uses: actions/cache@v4.0.1
+        uses: actions/cache@v4
         with:
           path: subprojects.tar
           key:  subprojects-${{ hashFiles('subprojects/*.wrap') }}-1
@@ -179,14 +178,14 @@ jobs:
           meson compile -C build
 
       - name: Upload binary
-        uses: actions/upload-artifact@v4.3.1
+        uses: actions/upload-artifact@v4
         with:
           name: dosbox-${{ matrix.runner.arch }}
           path: build/dosbox
           overwrite: true
 
       - name: Upload resources
-        uses: actions/upload-artifact@v4.3.1
+        uses: actions/upload-artifact@v4
         with:
           name: Resources
           path: Resources
@@ -214,7 +213,7 @@ jobs:
         run: HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 brew install --overwrite librsvg
 
       - name: Download binaries
-        uses: actions/download-artifact@v4.1.3
+        uses: actions/download-artifact@v4
 
       - name: Package
         run: |
@@ -238,7 +237,7 @@ jobs:
               -ov -format UDZO "dosbox-staging-macOS-${{ env.VERSION }}.dmg"
 
       - name: Upload disk image
-        uses: actions/upload-artifact@v4.3.1
+        uses: actions/upload-artifact@v4
         # GitHub automatically zips the artifacts, and there's no option
         # to skip it or upload a file only.
         with:
@@ -270,7 +269,7 @@ jobs:
           NEWEST_TAG=$(git describe --abbrev=0)
           git log "$NEWEST_TAG..HEAD" > changelog-$VERSION.txt
 
-      - uses: actions/upload-artifact@v4.3.1
+      - uses: actions/upload-artifact@v4
         with:
           # Keep exactly this artifact name; it's being used to propagate
           # version info via GitHub REST API


### PR DESCRIPTION
# Description

The macOS workflow was failing due to conflicts between the macos-13 x64 runner's system-installed Python and homebrew. Downgrading to the macos-12 image allows it to build. The macos-14 free runner only supports arm64 right now; x64 requires macos-14-large, which isn't available for free yet. The long-term solution is to move away from homebrew, but this should hold us for now.

This puts us back to Xcode 14.2, so our C++20 support will be a bit limited.

# Manual testing

Downloaded and ran the x64 (via Rosetta) and arm64 variants.

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

