### PR TITLE
Add `vga_render_per_scanline` option

### DIFF
--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -584,6 +584,12 @@ void DOSBOX_Init()
 	pbool = secprop->Add_bool("vga_8dot_font", only_at_start, false);
 	pbool->Set_help("Use 8-pixel-wide fonts on VGA adapters (disabled by default).");
 
+	pbool = secprop->Add_bool("vga_render_per_scanline", only_at_start, true);
+	pbool->Set_help(
+	        "Emulate accurate per-scanline VGA rendering (enabled by default).\n"
+	        "Currently, you need to disable this for a few games, otherwise they will crash\n"
+	        "at startup (e.g., Deus, Ishar 3, Robinson's Requiem, Time Warriors).");
+
 	pbool = secprop->Add_bool("speed_mods", only_at_start, true);
 	pbool->Set_help(
 	        "Permit changes known to improve performance (enabled by default).\n"

--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -1452,7 +1452,20 @@ PixelFormat VGA_ActivateHardwareCursor()
 // A single point to set total drawn lines and update affected delay values
 static void setup_line_drawing_delays(const uint32_t total_lines)
 {
-	vga.draw.parts_total = total_lines;
+	const auto conf    = control->GetSection("dosbox");
+	const auto section = static_cast<Section_prop*>(conf);
+	assert(section);
+
+	if (vga.draw.mode == PART && !section->Get_bool("vga_render_per_scanline")) {
+		// Render the screen in 4 parts; this was the legacy DOSBox behaviour.
+		// A few games needs this (e.g., Deus, Ishar 3, Robinson's Requiem,
+		// Time Travelers) and would crash at startup with per-scanline
+		// rendering enabled. This is most likely due to some VGA emulation
+		// deficiency.
+		vga.draw.parts_total = 4;
+	} else {
+		vga.draw.parts_total = total_lines;
+	}
 
 	vga.draw.delay.parts = vga.draw.delay.vdend / vga.draw.parts_total;
 


### PR DESCRIPTION
# Description

Partially fixes https://github.com/dosbox-staging/dosbox-staging/issues/3501

This flag fixes the crash-at-startup regressions with the following games:

- Deus (1996)
- Ishar 3 (1994)
- Robinson's Requiem (1994)
- Time Warriors (1997)

This is enabled by default to render the VGA image by scanline, which is the new accurate VGA emulation behaviour.

However, a few games (e.g., Deus, Ishar 3, Robinson's Requiem, Time Travelers) would crash at startup with per-scanline rendering enabled. This is most likely due to some VGA emulation deficiency.

Disabling `vga_render_per_scanline` restores the the legacy DOSBox behaviour of rendering the VGA image in 4 parts instead of per-scanline.

Of course, this is a workaround, but finding the root cause for this in the VGA code could take ages... I'm not up for that job right now. We just want to get a patch out to get the games working again. If someone improves the accuracy of the VGA code later, this flag could become a no-op or we can just deprecate/remove it.

# Manual testing

Tested that the games run fine with the following configs. `vga_render_per_scanline = off` is required for all of them and the `cycles` settings needs to be in a certain range for each game (outside of this range, you'll get the crash again).

Tested on both macOS (ARM) and Windows 10 (x86).

### Deus (1996)

```ini
[dosbox]
vga_render_per_scanline = off

[cpu]
# going higher results in a crash at startup
cycles = 40000

[autoexec]
imgmount d cd/Deus.cue -t iso
d:
start
```

### Ishar 3 (1994)

```ini
[dosbox]
vga_render_per_scanline = off

[cpu]
cycles = 20000

[autoexec]
imgmount d cd/Ishar_3.cue -t iso
d:
start
```

### Robinson's Requiem (1994)

```ini
[dosbox]
vga_render_per_scanline = off

[cpu]
# going higher results in a crash at startup
cycles = 22000

[autoexec]
imgmount d cd/robin.cue -t iso
d:
start
```

### Time Warriors (1997)

```ini
[dosbox]
vga_render_per_scanline = off

[cpu]
# going higher results in a crash at startup
cycles = 60000

[autoexec]
imgmount d cd/Timewar.cue -t iso
d:
start
```

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

