### PR TITLE
Add "no console" start menu item to the Windows installer

### DIFF
--- a/.github/workflows/windows-msys2.yml
+++ b/.github/workflows/windows-msys2.yml
@@ -338,16 +338,16 @@ jobs:
           install -DT "${BUILD_RELEASE_DIR}/dosbox.exe" "${PKG_RELEASE}/dosbox.exe"
           echo "artifact_name=dosbox-staging-windows-x64-`git describe --abbrev=0`" >> $GITHUB_ENV
 
-      - name: Windows Defender AV Scan
-        shell: powershell
-        run: |
-          $ErrorActionPreference = 'Stop'
-          $dosboxDir = "${{ github.workspace }}\${{ env.PKG_RELEASE }}"
-          & 'C:\Program Files\Windows Defender\MpCmdRun.exe' -Scan -ScanType 3 -DisableRemediation -File $dosboxDir
-          if( $LASTEXITCODE -ne 0 ) {
-              Get-Content -Path $env:TEMP\MpCmdRun.log
-              Throw "Exit $LASTEXITCODE : Windows Defender found an issue"
-          }
+#      - name: Windows Defender AV Scan
+#         shell: powershell
+#        run: |
+#          $ErrorActionPreference = 'Stop'
+#          $dosboxDir = "${{ github.workspace }}\${{ env.PKG_RELEASE }}"
+#          & 'C:\Program Files\Windows Defender\MpCmdRun.exe' -Scan -ScanType 3 -DisableRemediation -File $dosboxDir
+#          if( $LASTEXITCODE -ne 0 ) {
+#              Get-Content -Path $env:TEMP\MpCmdRun.log
+#              Throw "Exit $LASTEXITCODE : Windows Defender found an issue"
+#          }
 
       - name: Prepare Windows installer
         shell: bash

--- a/.github/workflows/windows-msys2.yml
+++ b/.github/workflows/windows-msys2.yml
@@ -386,9 +386,6 @@ jobs:
           echo "version_number=`git describe --tags --abbrev=0`" >> $GITHUB_ENV
           sed -e "s|%PACKAGE_INFORMATION%|${packageinfo}|;s|%GITHUB_REPO%|${{ github.repository }}|" docs/README.template >out/setup_preamble.txt
           sed -i "s|DOSBOX-STAGING-VERSION|`git describe --tags --abbrev=0`|" contrib/windows_installer/DOSBox-Staging-setup.iss
-          echo @echo off >out/dosbox_with_console.bat
-          echo \"%~dp0\\dosbox.exe\" %* >>out/dosbox_with_console.bat
-          echo if errorlevel 1 pause >>out/dosbox_with_console.bat
           if [ -d msvc ]; then
             cp msvc/dosbox*.exe out
             mv out/dosbox.exe out/dosbox_msvc.exe

--- a/.github/workflows/windows-msys2.yml
+++ b/.github/workflows/windows-msys2.yml
@@ -337,7 +337,6 @@ jobs:
           mv "${PKG_RELEASE}/dosbox.exe" "${PKG_RELEASE}/dosbox_with_debugger.exe"
           install -DT "${BUILD_RELEASE_DIR}/dosbox.exe" "${PKG_RELEASE}/dosbox.exe"
           echo "artifact_name=dosbox-staging-windows-x64-`git describe --abbrev=0`" >> $GITHUB_ENV
-          echo "artifact_path=${{ github.workspace }}\msvc" >> $GITHUB_ENV
 
       - name: Windows Defender AV Scan
         shell: powershell
@@ -349,22 +348,6 @@ jobs:
               Get-Content -Path $env:TEMP\MpCmdRun.log
               Throw "Exit $LASTEXITCODE : Windows Defender found an issue"
           }
-
-      - name: Wait for MSVC builds to complete
-        uses: fountainhead/action-wait-for-check@v1.1.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          checkName: Publish additional Windows artifacts
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-
-      - name: Download MSVC artifact
-        uses: dawidd6/action-download-artifact@v2
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          workflow: windows-msvc.yml
-          name: ${{ env.artifact_name }}
-          path: ${{ env.artifact_path }}
-          if_no_artifact_found: warn
 
       - name: Prepare Windows installer
         shell: bash
@@ -386,14 +369,6 @@ jobs:
           echo "version_number=`git describe --tags --abbrev=0`" >> $GITHUB_ENV
           sed -e "s|%PACKAGE_INFORMATION%|${packageinfo}|;s|%GITHUB_REPO%|${{ github.repository }}|" docs/README.template >out/setup_preamble.txt
           sed -i "s|DOSBOX-STAGING-VERSION|`git describe --tags --abbrev=0`|" contrib/windows_installer/DOSBox-Staging-setup.iss
-          if [ -d msvc ]; then
-            cp msvc/dosbox*.exe out
-            mv out/dosbox.exe out/dosbox_msvc.exe
-            mv out/dosbox_with_debugger.exe out/dosbox_msvc_with_debugger.exe
-          else
-            echo Note: MSVC build will not be included in the Windows installer.
-            sed -i -e 's|^\(Name: \"defaultmsvc\"\)|;\1|;s|^\(Source: \"{#DOSBoxAppExeMSVC\)|;\1|;s|; Tasks: not defaultmsvc$||' contrib/windows_installer/DOSBox-Staging-setup.iss
-          fi
 
       - name: Build Windows installer
         shell: pwsh
@@ -405,7 +380,6 @@ jobs:
           copy ${{ github.workspace }}\contrib\icons\windows\dosbox-staging.bmp .
           copy ${{ github.workspace }}\contrib\icons\windows\dosbox-staging-side.bmp .
           xcopy /s ${{ github.workspace }}\${{ env.PKG_RELEASE }}\* program
-          replace /a ..\msvc\*.dll program
           move program\dosbox.exe .
           move program\dosbox_with_debugger.exe .
           C:\PROGRA~2\INNOSE~1\ISCC.exe DOSBox-Staging-setup.iss

--- a/contrib/windows_installer/DOSBox-Staging-setup.iss
+++ b/contrib/windows_installer/DOSBox-Staging-setup.iss
@@ -7,7 +7,6 @@
 #define DOSBoxAppExeDebuggerName "dosbox_with_debugger.exe"
 #define DOSBoxAppExeMSVCName "dosbox_msvc.exe"
 #define DOSBoxAppExeMSVCDebuggerName "dosbox_msvc_with_debugger.exe"
-#define DOSBoxAppExeConsoleName "dosbox_with_console.bat"
 #define DOSBoxAppBuildDate GetDateTimeString('yyyymmdd_hhnnss', '', '')
 
 [Setup]
@@ -80,13 +79,12 @@ Source: "{#DOSBoxAppExeName}"; DestDir: "{app}"; DestName: "{#DOSBoxAppExeName}"
 Source: "{#DOSBoxAppExeDebuggerName}"; DestDir: "{app}"; DestName: "{#DOSBoxAppExeDebuggerName}"; Flags: ignoreversion; Tasks: not defaultmsvc
 Source: "{#DOSBoxAppExeMSVCName}"; DestDir: "{app}"; DestName: "{#DOSBoxAppExeName}"; Flags: ignoreversion; Tasks: defaultmsvc
 Source: "{#DOSBoxAppExeMSVCDebuggerName}"; DestDir: "{app}"; DestName: "{#DOSBoxAppExeDebuggerName}"; Flags: ignoreversion; Tasks: defaultmsvc
-Source: "{#DOSBoxAppExeConsoleName}"; DestDir: "{app}"; DestName: "{#DOSBoxAppExeConsoleName}"; Flags: ignoreversion
 Source: "{#DOSBoxAppInternal}.ico"; DestDir: "{app}"; DestName: "{#DOSBoxAppInternal}.ico"; Flags: ignoreversion
 
 [Icons]
 Name: "{group}\{#DOSBoxAppName}"; Filename: "{app}\{#DOSBoxAppExeName}"
-Name: "{group}\{#DOSBoxAppName} with console"; Filename: "{app}\{#DOSBoxAppExeConsoleName}"; IconFilename: "{app}\{#DOSBoxAppInternal}.ico"
-Name: "{group}\{#DOSBoxAppName} with debugger"; Filename: "{app}\{#DOSBoxAppExeDebuggerName}"
+Name: "{group}\{#DOSBoxAppName} (no console window)"; Filename: "{app}\{#DOSBoxAppExeName}"; Parameters: "--noconsole"
+Name: "{group}\{#DOSBoxAppName} (debugger)"; Filename: "{app}\{#DOSBoxAppExeDebuggerName}"
 Name: "{group}\Visit {#DOSBoxAppName} website"; Filename: "{#DOSBoxAppURL}"
 Name: "{autodesktop}\{#DOSBoxAppName}"; Filename: "{app}\{#DOSBoxAppExeName}"; Tasks: desktopicon
 
@@ -97,24 +95,24 @@ Root: HKA; Subkey: "Software\{#DOSBoxAppInternal}"; ValueType: string; ValueName
 
 ; Add context menu entry when right-clicking on a folder
 Root: HKA; Subkey: "Software\Classes\Directory\shell\{#DOSBoxAppInternal}"; ValueType: string; ValueName: ""; ValueData: "Open with {#DOSBoxAppName}"; Check: WizardIsTaskSelected('contextmenu'); Flags: uninsdeletevalue
-Root: HKA; Subkey: "Software\Classes\Directory\shell\{#DOSBoxAppInternal}"; ValueType: string; ValueName: "Icon"; ValueData: """{app}\{#DOSBoxAppExeConsoleName}"",0"; Check: WizardIsTaskSelected('contextmenu'); Flags: uninsdeletekey
-Root: HKA; Subkey: "Software\Classes\Directory\shell\{#DOSBoxAppInternal}\command"; ValueType: string; ValueName: ""; ValueData: """{app}\{#DOSBoxAppExeConsoleName}"" --working-dir ""%v"""; Check: WizardIsTaskSelected('contextmenu'); Flags: uninsdeletekey
+Root: HKA; Subkey: "Software\Classes\Directory\shell\{#DOSBoxAppInternal}"; ValueType: string; ValueName: "Icon"; ValueData: """{app}\{#DOSBoxAppExeName}"",0"; Check: WizardIsTaskSelected('contextmenu'); Flags: uninsdeletekey
+Root: HKA; Subkey: "Software\Classes\Directory\shell\{#DOSBoxAppInternal}\command"; ValueType: string; ValueName: ""; ValueData: """{app}\{#DOSBoxAppExeName}"" --working-dir ""%v"""; Check: WizardIsTaskSelected('contextmenu'); Flags: uninsdeletekey
 
 Root: HKA; Subkey: "Software\Classes\Directory\shell\{#DOSBoxAppInternal}"; ValueType: none; Check: not WizardIsTaskSelected('contextmenu'); Flags: deletekey
 Root: HKA; Subkey: "Software\Classes\Directory\shell\{#DOSBoxAppInternal}\command"; ValueType: none; Check: not WizardIsTaskSelected('contextmenu'); Flags: deletekey
 
 ; Add context menu when right-clicking on an empty area within a folder
 Root: HKA; Subkey: "Software\Classes\Directory\Background\shell\{#DOSBoxAppInternal}"; ValueType: string; ValueName: ""; ValueData: "Open with {#DOSBoxAppName}"; Check: WizardIsTaskSelected('contextmenu'); Flags: uninsdeletevalue
-Root: HKA; Subkey: "Software\Classes\Directory\Background\shell\{#DOSBoxAppInternal}"; ValueType: string; ValueName: "Icon"; ValueData: """{app}\{#DOSBoxAppExeConsoleName}"",0"; Check: WizardIsTaskSelected('contextmenu'); Flags: uninsdeletekey
-Root: HKA; Subkey: "Software\Classes\Directory\Background\shell\{#DOSBoxAppInternal}\command"; ValueType: string; ValueName: ""; ValueData: """{app}\{#DOSBoxAppExeConsoleName}"" --working-dir ""%v"""; Check: WizardIsTaskSelected('contextmenu'); Flags: uninsdeletekey
+Root: HKA; Subkey: "Software\Classes\Directory\Background\shell\{#DOSBoxAppInternal}"; ValueType: string; ValueName: "Icon"; ValueData: """{app}\{#DOSBoxAppExeName}"",0"; Check: WizardIsTaskSelected('contextmenu'); Flags: uninsdeletekey
+Root: HKA; Subkey: "Software\Classes\Directory\Background\shell\{#DOSBoxAppInternal}\command"; ValueType: string; ValueName: ""; ValueData: """{app}\{#DOSBoxAppExeName}"" --working-dir ""%v"""; Check: WizardIsTaskSelected('contextmenu'); Flags: uninsdeletekey
 
 Root: HKA; Subkey: "Software\Classes\Directory\Background\shell\{#DOSBoxAppInternal}"; ValueType: none; Check: not WizardIsTaskSelected('contextmenu'); Flags: deletekey
 Root: HKA; Subkey: "Software\Classes\Directory\Background\shell\{#DOSBoxAppInternal}\command"; ValueType: none; Check: not WizardIsTaskSelected('contextmenu'); Flags: deletekey
 
 ; Add context menu when right-clicking on `.conf` extension
 Root: HKA; Subkey: "Software\Classes\SystemFileAssociations\.conf\shell\Open with {#DOSBoxAppName}"; ValueType: none; ValueName: ""; ValueData: ""; Check: WizardIsTaskSelected('contextmenu'); Flags: uninsdeletevalue
-Root: HKA; Subkey: "Software\Classes\SystemFileAssociations\.conf\shell\Open with {#DOSBoxAppName}"; ValueType: string; ValueName: "Icon"; ValueData: """{app}\{#DOSBoxAppExeConsoleName}"",0"; Check: WizardIsTaskSelected('contextmenu'); Flags: uninsdeletekey
-Root: HKA; Subkey: "Software\Classes\SystemFileAssociations\.conf\shell\Open with {#DOSBoxAppName}\command"; ValueType: string; ValueName: ""; ValueData: """{app}\{#DOSBoxAppExeConsoleName}"" -conf ""%1"""; Check: WizardIsTaskSelected('contextmenu'); Flags: uninsdeletekey
+Root: HKA; Subkey: "Software\Classes\SystemFileAssociations\.conf\shell\Open with {#DOSBoxAppName}"; ValueType: string; ValueName: "Icon"; ValueData: """{app}\{#DOSBoxAppExeName}"",0"; Check: WizardIsTaskSelected('contextmenu'); Flags: uninsdeletekey
+Root: HKA; Subkey: "Software\Classes\SystemFileAssociations\.conf\shell\Open with {#DOSBoxAppName}\command"; ValueType: string; ValueName: ""; ValueData: """{app}\{#DOSBoxAppExeName}"" --conf ""%1"""; Check: WizardIsTaskSelected('contextmenu'); Flags: uninsdeletekey
 
 Root: HKA; Subkey: "Software\Classes\SystemFileAssociations\.conf\shell\Open with {#DOSBoxAppName}"; ValueType: none; Check: not WizardIsTaskSelected('contextmenu'); Flags: deletekey
 Root: HKA; Subkey: "Software\Classes\SystemFileAssociations\.conf\shell\Open with {#DOSBoxAppName}\command"; ValueType: none; Check: not WizardIsTaskSelected('contextmenu'); Flags: deletekey

--- a/contrib/windows_installer/DOSBox-Staging-setup.iss
+++ b/contrib/windows_installer/DOSBox-Staging-setup.iss
@@ -5,9 +5,6 @@
 #define DOSBoxAppURL "https://dosbox-staging.github.io/"
 #define DOSBoxAppExeName "dosbox.exe"
 #define DOSBoxAppExeDebuggerName "dosbox_with_debugger.exe"
-#define DOSBoxAppExeMSVCName "dosbox_msvc.exe"
-#define DOSBoxAppExeMSVCDebuggerName "dosbox_msvc_with_debugger.exe"
-#define DOSBoxAppBuildDate GetDateTimeString('yyyymmdd_hhnnss', '', '')
 
 [Setup]
 AppId={{587471B7-02F6-4F25-8D00-70006790653C}
@@ -67,7 +64,6 @@ Name: "ukrainian"; MessagesFile: "compiler:Languages\Ukrainian.isl"
 
 [Tasks]
 Name: "contextmenu"; Description: "Add ""Run/Open with {#DOSBoxAppName}"" context menu for Windows Explorer"
-Name: "defaultmsvc"; Description: "Run MSVC release binary (instead of MSYS2 binary) as the default binary"; Flags: unchecked
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"
 
 [Run]
@@ -75,10 +71,8 @@ Filename: "{app}\{#DOSBoxAppExeName}"; Description: "{cm:LaunchProgram,{#StringC
 
 [Files]
 Source: "program\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
-Source: "{#DOSBoxAppExeName}"; DestDir: "{app}"; DestName: "{#DOSBoxAppExeName}"; Flags: ignoreversion; Tasks: not defaultmsvc
-Source: "{#DOSBoxAppExeDebuggerName}"; DestDir: "{app}"; DestName: "{#DOSBoxAppExeDebuggerName}"; Flags: ignoreversion; Tasks: not defaultmsvc
-Source: "{#DOSBoxAppExeMSVCName}"; DestDir: "{app}"; DestName: "{#DOSBoxAppExeName}"; Flags: ignoreversion; Tasks: defaultmsvc
-Source: "{#DOSBoxAppExeMSVCDebuggerName}"; DestDir: "{app}"; DestName: "{#DOSBoxAppExeDebuggerName}"; Flags: ignoreversion; Tasks: defaultmsvc
+Source: "{#DOSBoxAppExeName}"; DestDir: "{app}"; DestName: "{#DOSBoxAppExeName}"; Flags: ignoreversion;
+Source: "{#DOSBoxAppExeDebuggerName}"; DestDir: "{app}"; DestName: "{#DOSBoxAppExeDebuggerName}"; Flags: ignoreversion;
 Source: "{#DOSBoxAppInternal}.ico"; DestDir: "{app}"; DestName: "{#DOSBoxAppInternal}.ico"; Flags: ignoreversion
 
 [Icons]


### PR DESCRIPTION
# Description

Addresses https://github.com/dosbox-staging/dosbox-staging/issues/3473

Also remove the `dosbox_with_console.bat` helper script which is no longer necessary and clean up the installer script and untangle the MSYS2 workflow from the MSVC stuff.

**Note the PR is raised against `release/0.81.x`, NOT `main`!**

Parts of this work will need to be carried over into `main` (e.g., the installer script changes), but it can't be simply just cherry-picked over as the way we're building for Windows have already diverged between 0.81.x and 0.82.x. I'll do this later.

# Manual testing

I've tested the installer generated by CI on Windows 10 64-bit:

- Confirmed that all menu items show up in the start menu with the correct names and they all work correctly:

![image](https://github.com/dosbox-staging/dosbox-staging/assets/698770/6d3af354-75fd-4443-9332-71689c9c05ec)

- Confirmed the MSVC option is gone for good:

![image](https://github.com/dosbox-staging/dosbox-staging/assets/698770/8bd37f6c-8718-4421-963a-56b7fbb3a97c)

- Checked that the "Run/Open with DOSBox Staging" context menu actions still work.
- Verified that uninstalling works.


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

