### PR TITLE
Check the validity of leading path when checking device name

### DIFF
--- a/src/dos/dos_devices.cpp
+++ b/src/dos/dos_devices.cpp
@@ -389,8 +389,9 @@ uint8_t DOS_FindDevice(const char* name)
 	if(name_part) {
 		*name_part++ = 0;
 		// Check validity of leading directory.
-		//  if(!Drives.at(drive)->TestDir(fullname))
-		//      return DOS_DEVICES; //can be invalid
+		if(!Drives.at(drive)->TestDir(fullname)) {
+			return DOS_DEVICES;
+		}
 	} else
 		name_part = fullname;
 


### PR DESCRIPTION
# Description

Fixes a bug with the Alpha Storm batch file installer which depends on checks like: `IF EXIST %1\NUL`

This is a revert of r4475 from DOSBox SVN
Partial revert of the merge commit c5f2bfe233edf71be0874f113c796bf01d1bf3c7

https://sourceforge.net/p/dosbox/code-0/4475/tree//dosbox/trunk/src/dos/dos_devices.cpp?diff=5049d97e71b75b3379a0122d:4474

## Related issues

Fixes #3517

# Manual testing

It fixes the Alpha Storm installer.  The commit claims to fix World Series of Poker installer.  That's a Windows 3.1 game though and I don't have that setup.  Possible regression there but do we even support Windows games?

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

