### PR TITLE
Keep file handle instead of entry in FileReader

### DIFF
--- a/include/shell.h
+++ b/include/shell.h
@@ -43,7 +43,7 @@ extern DOS_Shell* first_shell;
 class LineReader {
 public:
 	virtual void Reset()       = 0;
-	virtual std::string Read() = 0;
+	virtual std::optional<std::string> Read() = 0;
 
 	virtual ~LineReader() = default;
 };
@@ -67,7 +67,7 @@ public:
 
 private:
 	[[nodiscard]] std::string ExpandedBatchLine(std::string_view line) const;
-	[[nodiscard]] std::string GetLine();
+	[[nodiscard]] std::optional<std::string> GetLine();
 
 	const Environment& shell;
 	CommandLine cmd;

--- a/include/shell.h
+++ b/include/shell.h
@@ -40,22 +40,17 @@ extern callback_number_t call_shellstop;
  * by "external" programs. (config) */
 extern DOS_Shell* first_shell;
 
-class ByteReader {
+class LineReader {
 public:
-	virtual void Reset()                  = 0;
-	virtual std::optional<uint8_t> Read() = 0;
+	virtual void Reset()       = 0;
+	virtual std::string Read() = 0;
 
-	ByteReader()                             = default;
-	ByteReader(const ByteReader&)            = delete;
-	ByteReader& operator=(const ByteReader&) = delete;
-	ByteReader(ByteReader&&)                 = delete;
-	ByteReader& operator=(ByteReader&&)      = delete;
-	virtual ~ByteReader()                    = default;
+	virtual ~LineReader() = default;
 };
 
 class BatchFile {
 public:
-	BatchFile(const Environment& host, std::unique_ptr<ByteReader> input_reader,
+	BatchFile(const Environment& host, std::unique_ptr<LineReader> input_reader,
 	          std::string_view entered_name, std::string_view cmd_line,
 	          bool echo_on);
 	BatchFile(const BatchFile&)            = delete;
@@ -76,7 +71,7 @@ private:
 
 	const Environment& shell;
 	CommandLine cmd;
-	std::unique_ptr<ByteReader> reader;
+	std::unique_ptr<LineReader> reader;
 	bool echo;
 };
 

--- a/src/dos/program_mount.h
+++ b/src/dos/program_mount.h
@@ -34,7 +34,6 @@ class MOUNT final : public Program {
 		                   HELP_CmdType::Program,
 		                   "MOUNT"};
 	    }
-	    void Move_Z(char new_z);
 	    void ListMounts();
 	    void Run() override;
     private:

--- a/src/shell/file_reader.cpp
+++ b/src/shell/file_reader.cpp
@@ -23,7 +23,7 @@
 std::optional<FileReader> FileReader::GetFileReader(const std::string& filename)
 {
 	auto fullname = DOS_Canonicalize(filename.c_str());
-	
+
 	std::uint16_t handle = {};
 	if (!DOS_OpenFile(fullname.c_str(), (DOS_NOT_INHERIT | OPEN_READ), &handle)) {
 		return {};
@@ -36,11 +36,11 @@ FileReader::FileReader(std::string filename)
           cursor(0)
 {}
 
-std::string FileReader::Read()
+std::optional<std::string> FileReader::Read()
 {
 	uint16_t entry = {};
 	if (!DOS_OpenFile(filename.c_str(), (DOS_NOT_INHERIT | OPEN_READ), &entry)) {
-		return "";
+		return {};
 	}
 	DOS_SeekFile(entry, &cursor, DOS_SEEK_SET);
 
@@ -59,6 +59,10 @@ std::string FileReader::Read()
 	cursor = 0;
 	DOS_SeekFile(entry, &cursor, DOS_SEEK_CUR);
 	DOS_CloseFile(entry);
+
+	if (line.empty()) {
+		return {};
+	}
 
 	return line;
 }

--- a/src/shell/file_reader.h
+++ b/src/shell/file_reader.h
@@ -26,24 +26,24 @@
 
 #include "shell.h"
 
-class FileReader final : public ByteReader {
+class FileReader final : public LineReader {
 public:
 	static std::optional<FileReader> GetFileReader(const std::string& file);
 
 	void Reset() final;
-	std::optional<uint8_t> Read() final;
-
-	~FileReader() final;
+	std::string Read() final;
 
 	FileReader(const FileReader&)            = delete;
 	FileReader& operator=(const FileReader&) = delete;
-
-	FileReader(FileReader&& other) noexcept;
-	FileReader& operator=(FileReader&& other) noexcept;
+	FileReader(FileReader&&)                 = default;
+	FileReader& operator=(FileReader&&)      = default;
+	~FileReader() final                      = default;
 
 private:
-	explicit FileReader(uint16_t file_handle);
-	std::optional<uint16_t> handle;
+	explicit FileReader(std::string filename);
+
+	std::string filename;
+	uint32_t cursor;
 };
 
 #endif

--- a/src/shell/file_reader.h
+++ b/src/shell/file_reader.h
@@ -31,7 +31,7 @@ public:
 	static std::optional<FileReader> GetFileReader(const std::string& file);
 
 	void Reset() final;
-	std::string Read() final;
+	std::optional<std::string> Read() final;
 
 	FileReader(const FileReader&)            = delete;
 	FileReader& operator=(const FileReader&) = delete;

--- a/tests/batch_file_tests.cpp
+++ b/tests/batch_file_tests.cpp
@@ -22,17 +22,18 @@
 #include <unordered_map>
 
 #include "shell.h"
+#include "string_utils.h"
 
-class FakeReader final : public ByteReader {
+class FakeReader final : public LineReader {
 public:
 	void Reset() override
 	{
 		index = 0;
 	}
-	std::optional<uint8_t> Read() override
+	std::string Read() override
 	{
 		if (index >= contents.size()) {
-			return std::nullopt;
+			return "";
 		}
 
 		const auto data = contents[index];
@@ -40,7 +41,7 @@ public:
 		return data;
 	}
 
-	explicit FakeReader(std::string&& str) : contents(std::move(str)) {}
+	explicit FakeReader(std::string&& str) : contents(split(std::move(str))) {}
 
 	FakeReader(const FakeReader&)            = delete;
 	FakeReader& operator=(const FakeReader&) = delete;
@@ -49,7 +50,7 @@ public:
 	~FakeReader() override                   = default;
 
 private:
-	std::string contents;
+	std::vector<std::string> contents;
 	decltype(contents)::size_type index = 0;
 };
 

--- a/tests/batch_file_tests.cpp
+++ b/tests/batch_file_tests.cpp
@@ -30,10 +30,10 @@ public:
 	{
 		index = 0;
 	}
-	std::string Read() override
+	std::optional<std::string> Read() override
 	{
 		if (index >= contents.size()) {
-			return "";
+			return {};
 		}
 
 		const auto data = contents[index];


### PR DESCRIPTION
# Description

When dealing with dosbox file IO (ie. DOS_{Open,Read,Seek,Close}File), it works with what dosbox calls file entries. These are the IDs which these functions will take in to find out which file to operate on.

Despite these sounding exactly like file handles, which is the assumption I was under when making FileReader, dosbox's internal system of open files uses a different set of IDs. I'm not sure why this is. There are functions to translate between the two.

From what I can tell, SC2K basically does something strange internally and invalidates the file handles somehow. When the entry was being used to keep track of the file, its status was not being updated. This means it was essentially a dangling handle, which is why it was reading out garbage. With these new changes having the handle being used instead, it seems that its corresponding entry is set to 0xff, which is used as the "null" ID, so it simply stops the rest of the batch file from being read, since the next read fails. This should bring the behavior to parity before this regression.

If I had to guess, the other problems mentioned in the linked issue are likely due to some deeper problem in how files are being handled.

## Related issues

Resolves the regression portion of #3518 

# Manual testing

Since the issue can't be generalized to a simple problem, the only thing that can be done is to test with the problematic batch file to ensure that the issue doesn't persist, and to test with a wide range of batch files to ensure that nothing is broken by the changes.

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [ ] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

