### PR TITLE
Update string_utils to C++20

### DIFF
--- a/include/string_utils.h
+++ b/include/string_utils.h
@@ -91,10 +91,6 @@ size_t safe_strlen(char (&str)[N]) noexcept
 	return strnlen(str, N - 1);
 }
 
-bool starts_with(const std::string_view str, const std::string_view prefix) noexcept;
-
-bool ends_with(const std::string_view str, const std::string_view suffix) noexcept;
-
 std::string strip_prefix(const std::string_view str,
                          const std::string_view prefix) noexcept;
 

--- a/include/string_utils.h
+++ b/include/string_utils.h
@@ -250,7 +250,7 @@ char* strip_word(char*& line);
 std::string strip_word(std::string& line);
 
 std::string replace(const std::string& str, char old_char, char new_char) noexcept;
-void trim(std::string& str, const char trim_chars[] = " \r\t\f\n");
+void trim(std::string& str, const std::string_view trim_chars = " \r\t\f\n");
 void upcase(std::string& str);
 void lowcase(std::string& str);
 void strip_punctuation(std::string& str);

--- a/include/string_utils.h
+++ b/include/string_utils.h
@@ -238,7 +238,7 @@ constexpr bool iequals(T1&& a, T2&& b)
 
 // Performs a "natural" comparison between A and B, which is case-insensitive
 // and treats number sequenences as whole numbers. Returns true if A < B. This
-// function can be used with higher order sort rountines, like std::sort.
+// function can be used with higher order sort routines, like std::sort.
 //
 // Examples:
 // - ("abc_2", "ABC_10") -> true, because abc_ matches and 2 < 10.

--- a/src/capture/capture.cpp
+++ b/src/capture/capture.cpp
@@ -203,7 +203,7 @@ static std::optional<int32_t> find_highest_capture_index(const CaptureType type)
 		auto stem = entry.path().stem().string();
 		lowcase(stem);
 
-		if (starts_with(stem, filename_start)) {
+		if (stem.starts_with(filename_start)) {
 			auto index_str = strip_prefix(stem, filename_start);
 
 			// Strip "-raw" or "-rendered" postfix if it's there

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -939,7 +939,7 @@ static std::optional<ViewportSettings> parse_relative_viewport_modes(const std::
 
 static std::optional<ViewportSettings> parse_viewport_settings(const std::string& pref)
 {
-	if (starts_with(pref, "relative")) {
+	if (pref.starts_with("relative")) {
 		return parse_relative_viewport_modes(pref);
 	} else {
 		return parse_fit_viewport_modes(pref);

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -1891,10 +1891,10 @@ static void change_action_text(const char* text, const Rgb888& col)
 static std::string humanize_key_name(const CBindList &binds, const std::string &fallback)
 {
 	auto trim_prefix = [](const std::string& bind_name) {
-		if (starts_with(bind_name, "Left ")) {
+		if (bind_name.starts_with("Left ")) {
 			return bind_name.substr(sizeof("Left"));
 		}
-		if (starts_with(bind_name, "Right ")) {
+		if (bind_name.starts_with("Right ")) {
 			return bind_name.substr(sizeof("Right"));
 		}
 		return bind_name;

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -690,7 +690,7 @@ static uint32_t opengl_driver_crash_workaround(const RenderingBackend rendering_
 		return 0;
 	}
 
-	if (starts_with(sdl.render_driver, "opengl")) {
+	if (sdl.render_driver.starts_with("opengl")) {
 		return SDL_WINDOW_OPENGL;
 	}
 
@@ -709,7 +709,7 @@ static uint32_t opengl_driver_crash_workaround(const RenderingBackend rendering_
 		if (info.flags & SDL_RENDERER_TARGETTEXTURE)
 			break;
 	}
-	default_driver_is_opengl = starts_with(info.name, "opengl");
+	default_driver_is_opengl = std::string_view(info.name).starts_with("opengl");
 	return (default_driver_is_opengl ? SDL_WINDOW_OPENGL : 0);
 }
 
@@ -3001,12 +3001,12 @@ static SDL_Point window_bounds_from_label(const std::string& pref,
 	constexpr int LargePercent  = 90;
 
 	const int percent = [&] {
-		if (starts_with(pref, "s")) {
+		if (pref.starts_with('s')) {
 			return SmallPercent;
-		} else if (starts_with(pref, "m") || pref == "default" ||
+		} else if (pref.starts_with('m') || pref == "default" ||
 		           pref.empty()) {
 			return MediumPercent;
-		} else if (starts_with(pref, "l")) {
+		} else if (pref.starts_with('l')) {
 			return LargePercent;
 		} else if (pref == "desktop") {
 			return 100;
@@ -3260,7 +3260,7 @@ static void set_output(Section* sec, const bool wants_aspect_ratio_correction)
 		SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "nearest");
 
 #if C_OPENGL
-	} else if (starts_with(output, "opengl")) {
+	} else if (output.starts_with("opengl")) {
 		if (output == "opengl") {
 			sdl.want_rendering_backend = RenderingBackend::OpenGl;
 			sdl.interpolation_mode = InterpolationMode::Bilinear;

--- a/src/hardware/input/mouse_config.cpp
+++ b/src/hardware/input/mouse_config.cpp
@@ -212,7 +212,7 @@ static void SetSensitivity(const std::string_view sensitivity_str)
 	const int value_max = mouse_predefined.sensitivity_user_max;
 	for (auto& value_str : values_str) {
 		// Remove trailing '%' signs, if present
-		if (ends_with(value_str, "%")) {
+		if (value_str.ends_with('%')) {
 			value_str.pop_back();
 		}
 

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -1187,7 +1187,7 @@ bool MixerChannel::TryParseAndSetCustomFilter(const std::string_view filter_pref
 	SetLowPassFilter(FilterState::Off);
 	SetHighPassFilter(FilterState::Off);
 
-	if (!(starts_with(filter_prefs, "lpf") || starts_with(filter_prefs, "hpf"))) {
+	if (!(filter_prefs.starts_with("lpf") || filter_prefs.starts_with("hpf"))) {
 		return false;
 	}
 

--- a/src/ints/int10_modes.cpp
+++ b/src/ints/int10_modes.cpp
@@ -2274,10 +2274,10 @@ static cga_colors_t configure_cga_colors()
 	if (cga_colors_setting == "default") {
 		return cga_colors_default;
 
-	} else if (starts_with(cga_colors_setting, "tandy")) {
+	} else if (cga_colors_setting.starts_with("tandy")) {
 		return handle_cga_colors_prefs_tandy(cga_colors_setting);
 
-	} else if (starts_with(cga_colors_setting, "ibm5153")) {
+	} else if (cga_colors_setting.starts_with("ibm5153")) {
 		return handle_cga_colors_prefs_ibm5153(cga_colors_setting);
 
 	} else if (cga_colors_setting == "tandy-warm") {

--- a/src/misc/fs_utils_posix.cpp
+++ b/src/misc/fs_utils_posix.cpp
@@ -183,7 +183,7 @@ static std::optional<FatAttributeFlags> xattr_to_fat_attribs(const std::string& 
 {
 	constexpr uint8_t HexBase = 16;
 
-	if (xattr.size() <= XattrMaxLength && starts_with(xattr, "0x") &&
+	if (xattr.size() <= XattrMaxLength && xattr.starts_with("0x") &&
 	    xattr.size() >= XattrMinLength) {
 		const auto value = parse_int(xattr.substr(2), HexBase);
 		if (value) {

--- a/src/misc/messages.cpp
+++ b/src/misc/messages.cpp
@@ -256,13 +256,13 @@ void MSG_Init([[maybe_unused]] Section_prop *section)
 	const auto lang = control->GetLanguage();
 
 	// If the language is english, then use the internal message
-	if (lang.empty() || starts_with(lang, "en")) {
+	if (lang.empty() || lang.starts_with("en")) {
 		LOG_MSG("LANG: Using internal English language messages");
 		return;
 	}
 
 	bool result = false;
-	if (ends_with(lang, ".lng"))
+	if (lang.ends_with(".lng"))
 		result = load_message_file(GetResourcePath(subdir, lang));
 	else
 		// If a short-hand name was provided then add the file extension

--- a/src/misc/string_utils.cpp
+++ b/src/misc/string_utils.cpp
@@ -99,10 +99,8 @@ void lowcase(std::string &str)
 std::string replace(const std::string &str, char old_char, char new_char) noexcept
 {
 	std::string new_str = str;
-	for (char &c : new_str)
-		if (c == old_char)
-			c = new_char;
-	return str;
+	std::ranges::replace(new_str, old_char, new_char);
+	return new_str;
 }
 
 void trim(std::string &str, const std::string_view trim_chars)

--- a/src/misc/string_utils.cpp
+++ b/src/misc/string_utils.cpp
@@ -27,21 +27,12 @@
 
 bool is_hex_digits(const std::string_view s) noexcept
 {
-	for (const auto ch : s) {
-		if (!isxdigit(ch)) {
-			return false;
-		}
-	}
-	return true;
+	return std::ranges::all_of(s, &isxdigit);
 }
 
 bool is_digits(const std::string_view s) noexcept
 {
-	for (const auto ch : s) {
-		if (!isdigit(ch))
-			return false;
-	}
-	return true;
+	return std::ranges::all_of(s, &isdigit);
 }
 
 void strreplace(char *str, char o, char n)
@@ -54,7 +45,7 @@ void strreplace(char *str, char o, char n)
 }
 
 void ltrim(std::string &str) {
-    str.erase(str.begin(), std::find_if(str.begin(), str.end(), [](int c) {return !isspace(c);}));
+    str.erase(str.begin(), std::ranges::find_if(str, [](int c) {return !isspace(c);}));
 }
 
 char *ltrim(char *str)
@@ -96,13 +87,13 @@ char *lowcase(char *str)
 void upcase(std::string &str)
 {
 	int (*tf)(int) = std::toupper;
-	std::transform(str.begin(), str.end(), str.begin(), tf);
+	std::ranges::transform(str, str.begin(), tf);
 }
 
 void lowcase(std::string &str)
 {
 	int (*tf)(int) = std::tolower;
-	std::transform(str.begin(), str.end(), str.begin(), tf);
+	std::ranges::transform(str, str.begin(), tf);
 }
 
 std::string replace(const std::string &str, char old_char, char new_char) noexcept
@@ -114,7 +105,7 @@ std::string replace(const std::string &str, char old_char, char new_char) noexce
 	return str;
 }
 
-void trim(std::string &str, const char trim_chars[])
+void trim(std::string &str, const std::string_view trim_chars)
 {
 	const auto empty_pfx = str.find_first_not_of(trim_chars);
 	if (empty_pfx == std::string::npos) {
@@ -273,14 +264,14 @@ std::string strip_word(std::string& line)
 	if (line[0] == '"') {
 		size_t end_quote = line.find('"', 1);
 		if (end_quote != std::string::npos) {
-			std::string word = line.substr(1, end_quote - 1);
+			const std::string word = line.substr(1, end_quote - 1);
 			line.erase(0, end_quote + 1);
 			ltrim(line);
 			return word;
 		}
 	}
-	auto end_word = std::find_if(line.begin(), line.end(), [](int c) {return isspace(c);});
-	std::string word(line.begin(), end_word);
+	auto end_word = std::ranges::find_if(line, [](int c) {return isspace(c);});
+	const std::string word(line.begin(), end_word);
 	if (end_word != line.end()) {
 		++end_word;
 	}

--- a/src/misc/string_utils.cpp
+++ b/src/misc/string_utils.cpp
@@ -21,19 +21,18 @@
 #include "string_utils.h"
 
 #include <algorithm>
-#include <ranges>
 #include <stdexcept>
 #include <string>
 #include <vector>
 
 bool is_hex_digits(const std::string_view s) noexcept
 {
-	return std::ranges::all_of(s, &isxdigit);
+	return std::all_of(s.begin(), s.end(), &isxdigit);
 }
 
 bool is_digits(const std::string_view s) noexcept
 {
-	return std::ranges::all_of(s, &isdigit);
+	return std::all_of(s.begin(), s.end(), &isdigit);
 }
 
 void strreplace(char *str, char o, char n)
@@ -46,7 +45,9 @@ void strreplace(char *str, char o, char n)
 }
 
 void ltrim(std::string &str) {
-    str.erase(str.begin(), std::ranges::find_if(str, [](int c) {return !isspace(c);}));
+	str.erase(str.begin(), std::find_if(str.begin(), str.end(), [](int c) {
+		          return !isspace(c);
+	          }));
 }
 
 char *ltrim(char *str)
@@ -88,19 +89,19 @@ char *lowcase(char *str)
 void upcase(std::string &str)
 {
 	int (*tf)(int) = std::toupper;
-	std::ranges::transform(str, str.begin(), tf);
+	std::transform(str.begin(), str.end(), str.begin(), tf);
 }
 
 void lowcase(std::string &str)
 {
 	int (*tf)(int) = std::tolower;
-	std::ranges::transform(str, str.begin(), tf);
+	std::transform(str.begin(), str.end(), str.begin(), tf);
 }
 
 std::string replace(const std::string &str, char old_char, char new_char) noexcept
 {
 	std::string new_str = str;
-	std::ranges::replace(new_str, old_char, new_char);
+	std::replace(new_str.begin(), new_str.end(), old_char, new_char);
 	return new_str;
 }
 
@@ -269,7 +270,7 @@ std::string strip_word(std::string& line)
 			return word;
 		}
 	}
-	auto end_word = std::ranges::find_if(line, [](int c) {return isspace(c);});
+	auto end_word = std::find_if(line.begin(), line.end(), [](int c) {return isspace(c);});
 	const std::string word(line.begin(), end_word);
 	if (end_word != line.end()) {
 		++end_word;

--- a/src/misc/string_utils.cpp
+++ b/src/misc/string_utils.cpp
@@ -296,27 +296,9 @@ void strip_punctuation(std::string &str)
 	          str.end());
 }
 
-// TODO in C++20: replace with str.starts_with(prefix)
-bool starts_with(const std::string_view str, const std::string_view prefix) noexcept
-{
-	if (prefix.length() > str.length()) {
-		return false;
-	}
-	return std::equal(prefix.begin(), prefix.end(), str.begin());
-}
-
-// TODO in C++20: replace with str.ends_with(suffix)
-bool ends_with(const std::string_view str, const std::string_view suffix) noexcept
-{
-	if (suffix.length() > str.length()) {
-		return false;
-	}
-	return std::equal(suffix.rbegin(), suffix.rend(), str.rbegin());
-}
-
 std::string strip_prefix(const std::string_view str, const std::string_view prefix) noexcept
 {
-	if (starts_with(str, prefix)) {
+	if (str.starts_with(prefix)) {
 		return std::string(str.substr(prefix.size()));
 	}
 	return std::string(str);
@@ -324,7 +306,7 @@ std::string strip_prefix(const std::string_view str, const std::string_view pref
 
 std::string strip_suffix(const std::string_view str, const std::string_view suffix) noexcept
 {
-	if (ends_with(str, suffix)) {
+	if (str.ends_with(suffix)) {
 		return std::string(str.substr(0, str.size() - suffix.size()));
 	}
 	return std::string(str);
@@ -333,7 +315,7 @@ std::string strip_suffix(const std::string_view str, const std::string_view suff
 void clear_language_if_default(std::string &l)
 {
 	lowcase(l);
-	if (l.size() < 2 || starts_with(l, "c.") || l == "posix") {
+	if (l.size() < 2 || l.starts_with("c.") || l == "posix") {
 		l.clear();
 	}
 }
@@ -383,7 +365,7 @@ std::optional<float> parse_percentage(const std::string_view s,
                                       const bool is_percent_sign_optional)
 {
 	if (!is_percent_sign_optional) {
-		if (!ends_with(s, "%")) {
+		if (!s.ends_with('%')) {
 			return {};
 		}
 	}

--- a/src/misc/string_utils.cpp
+++ b/src/misc/string_utils.cpp
@@ -21,6 +21,7 @@
 #include "string_utils.h"
 
 #include <algorithm>
+#include <ranges>
 #include <stdexcept>
 #include <string>
 #include <vector>

--- a/src/shell/autoexec.cpp
+++ b/src/shell/autoexec.cpp
@@ -474,7 +474,7 @@ void AutoExecModule::ProcessConfigFile(const Section_line& section,
 		}
 
 		lowcase(tmp);
-		if (tmp.substr(0, 4) != "echo" || !ends_with(tmp, "off")) {
+		if (tmp.substr(0, 4) != "echo" || !tmp.ends_with("off")) {
 			return false;
 		}
 

--- a/tests/string_utils_tests.cpp
+++ b/tests/string_utils_tests.cpp
@@ -126,37 +126,6 @@ TEST(NaturalCompare, AtEndNum)
 	EXPECT_TRUE(natural_compare("Ab999", "aB1000"));
 }
 
-
-TEST(StartsWith, Prefix)
-{
-	EXPECT_TRUE(starts_with("abcd", "ab"));
-	EXPECT_TRUE(starts_with(std::string{"abcd"}, "ab"));
-}
-
-TEST(StartsWith, NotPrefix)
-{
-	EXPECT_FALSE(starts_with("abcd", "xy"));
-	EXPECT_FALSE(starts_with(std::string{"abcd"}, "xy"));
-}
-
-TEST(StartsWith, TooLongPrefix)
-{
-	EXPECT_FALSE(starts_with("ab", "abcd"));
-	EXPECT_FALSE(starts_with(std::string{"ab"}, "abcd"));
-}
-
-TEST(StartsWith, EmptyPrefix)
-{
-	EXPECT_TRUE(starts_with("abcd", ""));
-	EXPECT_TRUE(starts_with(std::string{"abcd"}, ""));
-}
-
-TEST(StartsWith, EmptyString)
-{
-	EXPECT_FALSE(starts_with("", "ab"));
-	EXPECT_FALSE(starts_with(std::string{""}, "ab"));
-}
-
 TEST(SafeSprintF, PreventOverflow)
 {
 	char buf[3];

--- a/tests/string_utils_tests.cpp
+++ b/tests/string_utils_tests.cpp
@@ -244,7 +244,7 @@ TEST(SafeStrlen, FixedSize)
 	EXPECT_EQ(N - 1, safe_strlen(buffer));
 }
 
-TEST(Split_delit, NoBoundingDelims)
+TEST(Split_delim, NoBoundingDelims)
 {
 	const std::vector<std::string> expected({"a", "/b", "/c/d", "/e/f/"});
 	EXPECT_EQ(split_with_empties("a:/b:/c/d:/e/f/", ':'), expected);
@@ -472,6 +472,66 @@ TEST(FormatString, Valid)
 	EXPECT_EQ(format_str("%d", 42), "42");
 	EXPECT_EQ(format_str("%d\0", 42), "42\0");
 	EXPECT_EQ(format_str("%s%d%s", "abcd", 42, "xyz"), "abcd42xyz");
+}
+
+TEST(IsHexDigits, Valid)
+{
+	EXPECT_TRUE(is_hex_digits("0123456789ABCDEF"));
+	EXPECT_TRUE(is_hex_digits("0123456789abcdef"));
+	EXPECT_TRUE(is_hex_digits(""));
+}
+
+TEST(IsHexDigits, Invalid)
+{
+	EXPECT_FALSE(is_hex_digits("0123456789ABCDEFG"));
+	EXPECT_FALSE(is_hex_digits("0123456789abcdefg"));
+}
+
+TEST(IsDigits, Valid)
+{
+	EXPECT_TRUE(is_digits("0123456789"));
+	EXPECT_TRUE(is_digits(""));
+}
+
+TEST(IsDigits, Invalid)
+{
+	EXPECT_FALSE(is_digits("01234567890ABCDEFG"));
+	EXPECT_FALSE(is_digits("01234567890abcdefg"));
+}
+
+TEST(LTrim, Valid) 
+{
+	auto perform_ltrim = [](const std::string& input) {
+		std::string output = input;
+		ltrim(output);
+		return output;
+	};
+	EXPECT_EQ(perform_ltrim("  ABC"), "ABC");
+	EXPECT_EQ(perform_ltrim("ABC"), "ABC");
+	EXPECT_EQ(perform_ltrim("ABC   "), "ABC   ");
+}
+
+TEST(Upcase, Valid) {
+	auto perform_upcase = [](const std::string& input) {
+		std::string output = input;
+		upcase(output);
+		return output;
+	};
+	EXPECT_EQ(perform_upcase("abc"), "ABC");
+	EXPECT_EQ(perform_upcase("ABC"), "ABC");
+	EXPECT_EQ(perform_upcase("aBc"), "ABC");
+}
+
+TEST(Lowcase, Valid)
+{
+	auto perform_lowcase = [](const std::string& input) {
+		std::string output = input;
+		lowcase(output);
+		return output;
+	};
+	EXPECT_EQ(perform_lowcase("abc"), "abc");
+	EXPECT_EQ(perform_lowcase("ABC"), "abc");
+	EXPECT_EQ(perform_lowcase("aBc"), "abc");
 }
 
 } // namespace

--- a/tests/string_utils_tests.cpp
+++ b/tests/string_utils_tests.cpp
@@ -503,4 +503,11 @@ TEST(Lowcase, Valid)
 	EXPECT_EQ(perform_lowcase("aBc"), "abc");
 }
 
+TEST(Replace, Valid)
+{
+	EXPECT_EQ(replace("abc", 'c', 'D'), "abD");
+	EXPECT_EQ(replace("abc", 'd', 'D'), "abc");
+	EXPECT_EQ(replace("", 'd', 'D'), "");
+}
+
 } // namespace


### PR DESCRIPTION
# Description

Update string_utils to use C++20 constructs. Replace the starts_with and end_with functions with calls to their std::string and std::string_view counterparts.

Remove the unused (and buggy) replace() method.

Add unit tests to ensure the changed code still works.

## Related issues

#1314 

# Manual testing

Updated unit tests to include tests of the changed code.

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [ ] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [x] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

