### PR TITLE
Fix issue with replace()

### DIFF
--- a/include/string_utils.h
+++ b/include/string_utils.h
@@ -242,7 +242,7 @@ constexpr bool iequals(T1&& a, T2&& b)
 
 // Performs a "natural" comparison between A and B, which is case-insensitive
 // and treats number sequenences as whole numbers. Returns true if A < B. This
-// function can be used with higher order sort rountines, like std::sort.
+// function can be used with higher order sort routines, like std::sort.
 //
 // Examples:
 // - ("abc_2", "ABC_10") -> true, because abc_ matches and 2 < 10.

--- a/src/misc/string_utils.cpp
+++ b/src/misc/string_utils.cpp
@@ -108,10 +108,8 @@ void lowcase(std::string &str)
 std::string replace(const std::string &str, char old_char, char new_char) noexcept
 {
 	std::string new_str = str;
-	for (char &c : new_str)
-		if (c == old_char)
-			c = new_char;
-	return str;
+	std::replace(new_str.begin(), new_str.end(), old_char, new_char);
+	return new_str;
 }
 
 void trim(std::string &str, const char trim_chars[])

--- a/tests/string_utils_tests.cpp
+++ b/tests/string_utils_tests.cpp
@@ -534,4 +534,11 @@ TEST(Lowcase, Valid)
 	EXPECT_EQ(perform_lowcase("aBc"), "abc");
 }
 
+TEST(Replace, Valid)
+{
+	EXPECT_EQ(replace("abc", 'c', 'D'), "abD");
+	EXPECT_EQ(replace("abc", 'd', 'D'), "abc");
+	EXPECT_EQ(replace("", 'd', 'D'), "");
+}
+
 } // namespace

--- a/tests/string_utils_tests.cpp
+++ b/tests/string_utils_tests.cpp
@@ -244,7 +244,7 @@ TEST(SafeStrlen, FixedSize)
 	EXPECT_EQ(N - 1, safe_strlen(buffer));
 }
 
-TEST(Split_delit, NoBoundingDelims)
+TEST(Split_delim, NoBoundingDelims)
 {
 	const std::vector<std::string> expected({"a", "/b", "/c/d", "/e/f/"});
 	EXPECT_EQ(split_with_empties("a:/b:/c/d:/e/f/", ':'), expected);
@@ -472,6 +472,66 @@ TEST(FormatString, Valid)
 	EXPECT_EQ(format_str("%d", 42), "42");
 	EXPECT_EQ(format_str("%d\0", 42), "42\0");
 	EXPECT_EQ(format_str("%s%d%s", "abcd", 42, "xyz"), "abcd42xyz");
+}
+
+TEST(IsHexDigits, Valid)
+{
+	EXPECT_TRUE(is_hex_digits("0123456789ABCDEF"));
+	EXPECT_TRUE(is_hex_digits("0123456789abcdef"));
+	EXPECT_TRUE(is_hex_digits(""));
+}
+
+TEST(IsHexDigits, Invalid)
+{
+	EXPECT_FALSE(is_hex_digits("0123456789ABCDEFG"));
+	EXPECT_FALSE(is_hex_digits("0123456789abcdefg"));
+}
+
+TEST(IsDigits, Valid)
+{
+	EXPECT_TRUE(is_digits("0123456789"));
+	EXPECT_TRUE(is_digits(""));
+}
+
+TEST(IsDigits, Invalid)
+{
+	EXPECT_FALSE(is_digits("01234567890ABCDEFG"));
+	EXPECT_FALSE(is_digits("01234567890abcdefg"));
+}
+
+TEST(LTrim, Valid) 
+{
+	auto perform_ltrim = [](const std::string& input) {
+		std::string output = input;
+		ltrim(output);
+		return output;
+	};
+	EXPECT_EQ(perform_ltrim("  ABC"), "ABC");
+	EXPECT_EQ(perform_ltrim("ABC"), "ABC");
+	EXPECT_EQ(perform_ltrim("ABC   "), "ABC   ");
+}
+
+TEST(Upcase, Valid) {
+	auto perform_upcase = [](const std::string& input) {
+		std::string output = input;
+		upcase(output);
+		return output;
+	};
+	EXPECT_EQ(perform_upcase("abc"), "ABC");
+	EXPECT_EQ(perform_upcase("ABC"), "ABC");
+	EXPECT_EQ(perform_upcase("aBc"), "ABC");
+}
+
+TEST(Lowcase, Valid)
+{
+	auto perform_lowcase = [](const std::string& input) {
+		std::string output = input;
+		lowcase(output);
+		return output;
+	};
+	EXPECT_EQ(perform_lowcase("abc"), "abc");
+	EXPECT_EQ(perform_lowcase("ABC"), "abc");
+	EXPECT_EQ(perform_lowcase("aBc"), "abc");
 }
 
 } // namespace


### PR DESCRIPTION
# Description

Add unit-tests for string_utils and fix a problem with replace().

## Related issues

#1314 

# Manual testing

Added unit-test to test the changed code.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [ ] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [x] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

