### PR TITLE
Cleanup Linux workflows, add LTO build

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -89,7 +89,16 @@ jobs:
       matrix:
         conf:
 
-          - name: GCC 10, Ubuntu 22.04
+          - name: GCC 13, LTO, Ubuntu 22.04
+            os: ubuntu-22.04
+            packages: g++-13
+            build_flags: -Dbuildtype=debug -Db_lto=true --native-file=.github/meson/native-gcc-13.ini
+            compile_flags: -Werror=odr -Werror=lto-type-mismatch -Werror=strict-aliasing
+            max_warnings: 0
+            needs_all_deps: true
+            run_tests: true
+
+          - name: GCC 12, debug, Ubuntu 22.04
             os: ubuntu-22.04
             packages: g++-12
             build_flags: -Dbuildtype=debug --native-file=.github/meson/native-gcc-12.ini
@@ -97,7 +106,7 @@ jobs:
             needs_all_deps: true
             run_tests: true
 
-          - name: Clang 15, Ubuntu 22.04
+          - name: Clang 15, debug, Ubuntu 22.04
             os: ubuntu-22.04
             packages: clang-15
             build_flags: -Dbuildtype=debug --native-file=.github/meson/native-clang-15.ini
@@ -105,14 +114,14 @@ jobs:
             needs_all_deps: true
             run_tests: true
 
-          - name: GCC 12, +debugger
+          - name: GCC 12, heavy debug, Ubuntu 22.04
             os: ubuntu-22.04
             packages: g++-12
             build_flags: -Denable_debugger=heavy --native-file=.github/meson/native-gcc-12.ini
             max_warnings: 0
             needs_all_deps: true
 
-          - name: GCC, Debian 11, ARMv7
+          - name: GCC, debug, ARMv7, Ubuntu 20.04
             os: ubuntu-20.04
             build_flags: -Dbuildtype=debug -Duse_zlib_ng=false --cross-file dosbox-cross
             max_warnings: 0
@@ -122,7 +131,7 @@ jobs:
             deb_vers: 11
             needs_min_deps: false
 
-          - name: GCC, Debian 11, aarch64
+          - name: GCC, debug, AArch64, Ubuntu 20.04
             os: ubuntu-20.04
             build_flags: -Dbuildtype=debug --cross-file dosbox-cross
             max_warnings: 0
@@ -132,7 +141,7 @@ jobs:
             deb_vers: 11
             needs_min_deps: false
 
-          - name: GCC, Debian 11, ppc64le
+          - name: GCC, debug, PPC64le, Ubuntu 20.04
             os: ubuntu-20.04
             build_flags: -Dbuildtype=debug --cross-file dosbox-cross
             max_warnings: 21
@@ -142,9 +151,9 @@ jobs:
             deb_vers: 11
             needs_min_deps: false
 
-          - name: GCC 9, minimum build
+          - name: GCC 10, minimum build, Ubuntu 20.04
             os: ubuntu-20.04
-            packages: g++-9
+            packages: g++-10
             build_flags: >-
               -Dbuildtype=minsize
               -Dunit_tests=disabled
@@ -154,7 +163,7 @@ jobs:
               -Duse_opengl=false
               -Duse_sdl2_net=false
               -Duse_slirp=false
-              --native-file=.github/meson/native-gcc-9.ini
+              --native-file=.github/meson/native-gcc-10.ini
             needs_min_deps: true
             max_warnings: -1
 
@@ -245,6 +254,7 @@ jobs:
 
       - name: Meson setup
         run:  |
+          CFLAGS="${{matrix.conf.compile_flags}}" CXXFLAGS="${{matrix.conf.compile_flags}}" \
           ${{steps.bins.outputs.MESON_BIN}} setup ${{ matrix.conf.build_flags }} build \
           || ( cat build/meson-logs/meson-log.txt ; exit 1 )
 


### PR DESCRIPTION
# Description

Linux workflows cleanup. This PR also adds LTO check to make sure the issue https://github.com/dosbox-staging/dosbox-staging/issues/3519 won't return.


## Related issues

https://github.com/dosbox-staging/dosbox-staging/issues/3519


# Manual testing

I have checked that adding a commit which reverts https://github.com/dosbox-staging/dosbox-staging/commit/8c9b65c2bee5f3c84693581b5496ec3f0d45b313 causes the modified workflows to fail as in issue https://github.com/dosbox-staging/dosbox-staging/issues/3519


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

