### PR TITLE
Update string_utils to use C++20 constructs

### DIFF
--- a/include/string_utils.h
+++ b/include/string_utils.h
@@ -91,10 +91,6 @@ size_t safe_strlen(char (&str)[N]) noexcept
 	return strnlen(str, N - 1);
 }
 
-bool starts_with(const std::string_view str, const std::string_view prefix) noexcept;
-
-bool ends_with(const std::string_view str, const std::string_view suffix) noexcept;
-
 std::string strip_prefix(const std::string_view str,
                          const std::string_view prefix) noexcept;
 

--- a/include/string_utils.h
+++ b/include/string_utils.h
@@ -250,7 +250,7 @@ char* strip_word(char*& line);
 std::string strip_word(std::string& line);
 
 std::string replace(const std::string& str, char old_char, char new_char) noexcept;
-void trim(std::string& str, const char trim_chars[] = " \r\t\f\n");
+void trim(std::string& str, const std::string_view trim_chars = " \r\t\f\n");
 void upcase(std::string& str);
 void lowcase(std::string& str);
 void strip_punctuation(std::string& str);

--- a/src/capture/capture.cpp
+++ b/src/capture/capture.cpp
@@ -203,7 +203,7 @@ static std::optional<int32_t> find_highest_capture_index(const CaptureType type)
 		auto stem = entry.path().stem().string();
 		lowcase(stem);
 
-		if (starts_with(stem, filename_start)) {
+		if (stem.starts_with(filename_start)) {
 			auto index_str = strip_prefix(stem, filename_start);
 
 			// Strip "-raw" or "-rendered" postfix if it's there

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -939,7 +939,7 @@ static std::optional<ViewportSettings> parse_relative_viewport_modes(const std::
 
 static std::optional<ViewportSettings> parse_viewport_settings(const std::string& pref)
 {
-	if (starts_with(pref, "relative")) {
+	if (pref.starts_with("relative")) {
 		return parse_relative_viewport_modes(pref);
 	} else {
 		return parse_fit_viewport_modes(pref);

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -1891,10 +1891,10 @@ static void change_action_text(const char* text, const Rgb888& col)
 static std::string humanize_key_name(const CBindList &binds, const std::string &fallback)
 {
 	auto trim_prefix = [](const std::string& bind_name) {
-		if (starts_with(bind_name, "Left ")) {
+		if (bind_name.starts_with("Left ")) {
 			return bind_name.substr(sizeof("Left"));
 		}
-		if (starts_with(bind_name, "Right ")) {
+		if (bind_name.starts_with("Right ")) {
 			return bind_name.substr(sizeof("Right"));
 		}
 		return bind_name;

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -629,7 +629,7 @@ static uint32_t opengl_driver_crash_workaround(const RenderingBackend rendering_
 		return 0;
 	}
 
-	if (starts_with(sdl.render_driver, "opengl")) {
+	if (sdl.render_driver.starts_with("opengl")) {
 		return SDL_WINDOW_OPENGL;
 	}
 
@@ -648,7 +648,7 @@ static uint32_t opengl_driver_crash_workaround(const RenderingBackend rendering_
 		if (info.flags & SDL_RENDERER_TARGETTEXTURE)
 			break;
 	}
-	default_driver_is_opengl = starts_with(info.name, "opengl");
+	default_driver_is_opengl = std::string_view(info.name).starts_with("opengl");
 	return (default_driver_is_opengl ? SDL_WINDOW_OPENGL : 0);
 }
 
@@ -2888,12 +2888,12 @@ static SDL_Point window_bounds_from_label(const std::string& pref,
 	constexpr int LargePercent  = 90;
 
 	const int percent = [&] {
-		if (starts_with(pref, "s")) {
+		if (pref.starts_with('s')) {
 			return SmallPercent;
-		} else if (starts_with(pref, "m") || pref == "default" ||
+		} else if (pref.starts_with('m') || pref == "default" ||
 		           pref.empty()) {
 			return MediumPercent;
-		} else if (starts_with(pref, "l")) {
+		} else if (pref.starts_with('l')) {
 			return LargePercent;
 		} else if (pref == "desktop") {
 			return 100;
@@ -3146,7 +3146,7 @@ static void set_output(Section* sec, const bool wants_aspect_ratio_correction)
 		SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "nearest");
 
 #if C_OPENGL
-	} else if (starts_with(output, "opengl")) {
+	} else if (output.starts_with("opengl")) {
 		if (output == "opengl") {
 			sdl.want_rendering_backend = RenderingBackend::OpenGl;
 			sdl.interpolation_mode = InterpolationMode::Bilinear;

--- a/src/hardware/input/mouse_config.cpp
+++ b/src/hardware/input/mouse_config.cpp
@@ -212,7 +212,7 @@ static void SetSensitivity(const std::string_view sensitivity_str)
 	const int value_max = mouse_predefined.sensitivity_user_max;
 	for (auto& value_str : values_str) {
 		// Remove trailing '%' signs, if present
-		if (ends_with(value_str, "%")) {
+		if (value_str.ends_with('%')) {
 			value_str.pop_back();
 		}
 

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -1188,7 +1188,7 @@ bool MixerChannel::TryParseAndSetCustomFilter(const std::string_view filter_pref
 	SetLowPassFilter(FilterState::Off);
 	SetHighPassFilter(FilterState::Off);
 
-	if (!(starts_with(filter_prefs, "lpf") || starts_with(filter_prefs, "hpf"))) {
+	if (!(filter_prefs.starts_with("lpf") || filter_prefs.starts_with("hpf"))) {
 		return false;
 	}
 

--- a/src/ints/int10_modes.cpp
+++ b/src/ints/int10_modes.cpp
@@ -2274,10 +2274,10 @@ static cga_colors_t configure_cga_colors()
 	if (cga_colors_setting == "default") {
 		return cga_colors_default;
 
-	} else if (starts_with(cga_colors_setting, "tandy")) {
+	} else if (cga_colors_setting.starts_with("tandy")) {
 		return handle_cga_colors_prefs_tandy(cga_colors_setting);
 
-	} else if (starts_with(cga_colors_setting, "ibm5153")) {
+	} else if (cga_colors_setting.starts_with("ibm5153")) {
 		return handle_cga_colors_prefs_ibm5153(cga_colors_setting);
 
 	} else if (cga_colors_setting == "tandy-warm") {

--- a/src/misc/fs_utils_posix.cpp
+++ b/src/misc/fs_utils_posix.cpp
@@ -183,7 +183,7 @@ static std::optional<FatAttributeFlags> xattr_to_fat_attribs(const std::string& 
 {
 	constexpr uint8_t HexBase = 16;
 
-	if (xattr.size() <= XattrMaxLength && starts_with(xattr, "0x") &&
+	if (xattr.size() <= XattrMaxLength && xattr.starts_with("0x") &&
 	    xattr.size() >= XattrMinLength) {
 		const auto value = parse_int(xattr.substr(2), HexBase);
 		if (value) {

--- a/src/misc/messages.cpp
+++ b/src/misc/messages.cpp
@@ -256,13 +256,13 @@ void MSG_Init([[maybe_unused]] Section_prop *section)
 	const auto lang = control->GetLanguage();
 
 	// If the language is english, then use the internal message
-	if (lang.empty() || starts_with(lang, "en")) {
+	if (lang.empty() || lang.starts_with("en")) {
 		LOG_MSG("LANG: Using internal English language messages");
 		return;
 	}
 
 	bool result = false;
-	if (ends_with(lang, ".lng"))
+	if (lang.ends_with(".lng"))
 		result = load_message_file(GetResourcePath(subdir, lang));
 	else
 		// If a short-hand name was provided then add the file extension

--- a/src/misc/string_utils.cpp
+++ b/src/misc/string_utils.cpp
@@ -294,27 +294,9 @@ void strip_punctuation(std::string &str)
 	          str.end());
 }
 
-// TODO in C++20: replace with str.starts_with(prefix)
-bool starts_with(const std::string_view str, const std::string_view prefix) noexcept
-{
-	if (prefix.length() > str.length()) {
-		return false;
-	}
-	return std::equal(prefix.begin(), prefix.end(), str.begin());
-}
-
-// TODO in C++20: replace with str.ends_with(suffix)
-bool ends_with(const std::string_view str, const std::string_view suffix) noexcept
-{
-	if (suffix.length() > str.length()) {
-		return false;
-	}
-	return std::equal(suffix.rbegin(), suffix.rend(), str.rbegin());
-}
-
 std::string strip_prefix(const std::string_view str, const std::string_view prefix) noexcept
 {
-	if (starts_with(str, prefix)) {
+	if (str.starts_with(prefix)) {
 		return std::string(str.substr(prefix.size()));
 	}
 	return std::string(str);
@@ -322,7 +304,7 @@ std::string strip_prefix(const std::string_view str, const std::string_view pref
 
 std::string strip_suffix(const std::string_view str, const std::string_view suffix) noexcept
 {
-	if (ends_with(str, suffix)) {
+	if (str.ends_with(suffix)) {
 		return std::string(str.substr(0, str.size() - suffix.size()));
 	}
 	return std::string(str);
@@ -331,7 +313,7 @@ std::string strip_suffix(const std::string_view str, const std::string_view suff
 void clear_language_if_default(std::string &l)
 {
 	lowcase(l);
-	if (l.size() < 2 || starts_with(l, "c.") || l == "posix") {
+	if (l.size() < 2 || l.starts_with("c.") || l == "posix") {
 		l.clear();
 	}
 }
@@ -381,7 +363,7 @@ std::optional<float> parse_percentage(const std::string_view s,
                                       const bool is_percent_sign_optional)
 {
 	if (!is_percent_sign_optional) {
-		if (!ends_with(s, "%")) {
+		if (!s.ends_with('%')) {
 			return {};
 		}
 	}

--- a/src/misc/string_utils.cpp
+++ b/src/misc/string_utils.cpp
@@ -27,21 +27,12 @@
 
 bool is_hex_digits(const std::string_view s) noexcept
 {
-	for (const auto ch : s) {
-		if (!isxdigit(ch)) {
-			return false;
-		}
-	}
-	return true;
+	return std::all_of(s.begin(), s.end(), &isxdigit);
 }
 
 bool is_digits(const std::string_view s) noexcept
 {
-	for (const auto ch : s) {
-		if (!isdigit(ch))
-			return false;
-	}
-	return true;
+	return std::all_of(s.begin(), s.end(), &isdigit);
 }
 
 void strreplace(char *str, char o, char n)
@@ -54,7 +45,9 @@ void strreplace(char *str, char o, char n)
 }
 
 void ltrim(std::string &str) {
-    str.erase(str.begin(), std::find_if(str.begin(), str.end(), [](int c) {return !isspace(c);}));
+	str.erase(str.begin(), std::find_if(str.begin(), str.end(), [](int c) {
+		          return !isspace(c);
+	          }));
 }
 
 char *ltrim(char *str)
@@ -112,7 +105,7 @@ std::string replace(const std::string &str, char old_char, char new_char) noexce
 	return new_str;
 }
 
-void trim(std::string &str, const char trim_chars[])
+void trim(std::string &str, const std::string_view trim_chars)
 {
 	const auto empty_pfx = str.find_first_not_of(trim_chars);
 	if (empty_pfx == std::string::npos) {
@@ -271,14 +264,14 @@ std::string strip_word(std::string& line)
 	if (line[0] == '"') {
 		size_t end_quote = line.find('"', 1);
 		if (end_quote != std::string::npos) {
-			std::string word = line.substr(1, end_quote - 1);
+			const std::string word = line.substr(1, end_quote - 1);
 			line.erase(0, end_quote + 1);
 			ltrim(line);
 			return word;
 		}
 	}
 	auto end_word = std::find_if(line.begin(), line.end(), [](int c) {return isspace(c);});
-	std::string word(line.begin(), end_word);
+	const std::string word(line.begin(), end_word);
 	if (end_word != line.end()) {
 		++end_word;
 	}

--- a/src/misc/string_utils.cpp
+++ b/src/misc/string_utils.cpp
@@ -183,8 +183,9 @@ std::string join_with_commas(const std::vector<std::string>& items,
 
 	std::string result = {};
 
-	const auto and_pair = std::string(" ") + and_conjunction.data() + " ";
-	const auto and_multi = std::string(", ") + and_conjunction.data() + " ";
+	// C++26 should add the missing operator+(std::string, std::string_view)
+	const auto and_pair = std::string(" ").append(and_conjunction) + " ";
+	const auto and_multi = std::string(", ").append(and_conjunction) + " ";
 
 	std::string separator = (num_items == 2u) ? and_pair : ", ";
 

--- a/src/shell/autoexec.cpp
+++ b/src/shell/autoexec.cpp
@@ -474,7 +474,7 @@ void AutoExecModule::ProcessConfigFile(const Section_line& section,
 		}
 
 		lowcase(tmp);
-		if (tmp.substr(0, 4) != "echo" || !ends_with(tmp, "off")) {
+		if (tmp.substr(0, 4) != "echo" || !tmp.ends_with("off")) {
 			return false;
 		}
 

--- a/tests/string_utils_tests.cpp
+++ b/tests/string_utils_tests.cpp
@@ -126,37 +126,6 @@ TEST(NaturalCompare, AtEndNum)
 	EXPECT_TRUE(natural_compare("Ab999", "aB1000"));
 }
 
-
-TEST(StartsWith, Prefix)
-{
-	EXPECT_TRUE(starts_with("abcd", "ab"));
-	EXPECT_TRUE(starts_with(std::string{"abcd"}, "ab"));
-}
-
-TEST(StartsWith, NotPrefix)
-{
-	EXPECT_FALSE(starts_with("abcd", "xy"));
-	EXPECT_FALSE(starts_with(std::string{"abcd"}, "xy"));
-}
-
-TEST(StartsWith, TooLongPrefix)
-{
-	EXPECT_FALSE(starts_with("ab", "abcd"));
-	EXPECT_FALSE(starts_with(std::string{"ab"}, "abcd"));
-}
-
-TEST(StartsWith, EmptyPrefix)
-{
-	EXPECT_TRUE(starts_with("abcd", ""));
-	EXPECT_TRUE(starts_with(std::string{"abcd"}, ""));
-}
-
-TEST(StartsWith, EmptyString)
-{
-	EXPECT_FALSE(starts_with("", "ab"));
-	EXPECT_FALSE(starts_with(std::string{""}, "ab"));
-}
-
 TEST(SafeSprintF, PreventOverflow)
 {
 	char buf[3];


### PR DESCRIPTION
# Description

Use the starts_with and end_with that comes with C++20.

Avoid the use of std::string_view::data(), since that might return a non-zero-terminated string.

Note that std::ranges is not supported in GCC-9 and Apple Clang 14, so its use is avoided.

## Related issues

#1314 

# Manual testing

Unittests should cover everything.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [ ] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [x] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

