### PR TITLE
Avoid the use of std::string_view::data()

### DIFF
--- a/include/dma.h
+++ b/include/dma.h
@@ -83,7 +83,7 @@ public:
 	// Reserves the channel for the owner. If a subsequent reservation is
 	// made then the previously held reservation callback is run to
 	// cleanup/remove that reserver (see the EvictReserver call below).
-	void ReserveFor(const std::string_view new_owner,
+	void ReserveFor(const std::string& new_owner,
 	                const DMA_ReservationCallback new_cb);
 
 private:
@@ -93,7 +93,7 @@ private:
 	                   uint8_t* const buffer);
 
 	DMA_ReservationCallback reservation_callback = {};
-	std::string_view reservation_owner           = {};
+	std::string reservation_owner                = {};
 };
 
 class DmaController {

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -209,9 +209,9 @@ public:
 	void SetLowPassFilter(const FilterState state);
 	void ConfigureHighPassFilter(const uint8_t order, const uint16_t cutoff_freq);
 	void ConfigureLowPassFilter(const uint8_t order, const uint16_t cutoff_freq);
-	bool TryParseAndSetCustomFilter(const std::string_view filter_prefs);
+	bool TryParseAndSetCustomFilter(const std::string& filter_prefs);
 
-	bool ConfigureFadeOut(const std::string_view fadeout_prefs);
+	bool ConfigureFadeOut(const std::string& fadeout_prefs);
 
 	void SetResampleMethod(const ResampleMethod method);
 	void SetZeroOrderHoldUpsamplerTargetFreq(const uint16_t target_freq);
@@ -407,7 +407,7 @@ private:
 		Sleeper() = delete;
 		Sleeper(MixerChannel& c,
 		        const uint16_t sleep_after_ms = default_wait_ms);
-		bool ConfigureFadeOut(const std::string_view prefs);
+		bool ConfigureFadeOut(const std::string& prefs);
 		AudioFrame MaybeFadeOrListen(const AudioFrame& frame);
 		void MaybeSleep();
 		bool WakeUp();

--- a/src/capture/image/png_writer.cpp
+++ b/src/capture/image/png_writer.cpp
@@ -228,7 +228,7 @@ void PngWriter::WritePngInfo(const uint16_t width, const uint16_t height,
 
 	texts[1].compression = PNG_TEXT_COMPRESSION_NONE;
 	texts[1].key         = static_cast<png_charp>(source_keyword);
-	texts[1].text        = const_cast<png_charp>(source_value.data());
+	texts[1].text        = const_cast<png_charp>(source_value.c_str());
 	texts[1].text_length = source_value.size();
 
 	++num_text;

--- a/src/dos/dos_keyboard_layout.cpp
+++ b/src/dos/dos_keyboard_layout.cpp
@@ -22,7 +22,6 @@
 #include <map>
 #include <memory>
 #include <string_view>
-using sv = std::string_view;
 
 #include "../ints/int10.h"
 #include "autoexec.h"
@@ -810,8 +809,8 @@ KeyboardErrorCode KeyboardLayout::ReadCodePageFile(const char *requested_cp_file
 			return KEYB_INVALIDCPFILE;
 		}
 		// Scan for the UPX identifier
-		const auto upx_id     = sv{"UPX!"};
-		const auto scan_buf   = sv{reinterpret_cast<char *>(cpi_buf.data()), scan_size};
+		const auto upx_id     = std::string_view{"UPX!"};
+		const auto scan_buf   = std::string_view{reinterpret_cast<char*>(cpi_buf.data()), scan_size};
 		const auto upx_id_pos = scan_buf.find(upx_id);
 
 		// did we find the UPX identifier?
@@ -1204,7 +1203,7 @@ public:
 
 		// If the use only provided a single value (language), then try using it
 		constexpr bool reason_keyboard_layout = true;
-		const auto layout_is_one_value = sv(layoutname).find(' ') == std::string::npos;
+		const auto layout_is_one_value = layoutname.find(' ') == std::string::npos;
 		if (layout_is_one_value) {
 			if (!DOS_LoadKeyboardLayoutFromLanguage(layoutname.c_str())) {
 				// Success - re-create country information to

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -2735,7 +2735,7 @@ static void MAPPER_SaveBinds() {
 }
 
 static bool load_binds_from_file(const std::string_view mapperfile_path,
-                                 const std::string_view mapperfile_name)
+                                 const std::string& mapperfile_name)
 {
 	// If the filename is empty the user wants defaults
 	if (mapperfile_name == "")
@@ -2767,7 +2767,7 @@ static bool load_binds_from_file(const std::string_view mapperfile_path,
 	// default, the mapperfile is not provided
 	if (!was_loaded && mapperfile_name != MAPPERFILE)
 		LOG_WARNING("MAPPER: Failed loading mapperfile '%s' directly or from resources",
-		            mapperfile_name.data());
+		            mapperfile_name.c_str());
 
 	return was_loaded;
 }

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1268,7 +1268,7 @@ static SDL_Window* SetWindowMode(const RenderingBackend rendering_backend,
 		if (is_vendors_srgb_unreliable) {
 			LOG_WARNING("OPENGL: Not requesting an sRGB framebuffer"
 			            " because %s's driver is unreliable",
-			            gl_vendor.data());
+			            gl_vendor.c_str());
 		} else if (SDL_GL_SetAttribute(SDL_GL_FRAMEBUFFER_SRGB_CAPABLE, 1)) {
 			LOG_ERR("OPENGL: Failed requesting an sRGB framebuffer: %s",
 			        SDL_GetError());
@@ -3348,7 +3348,7 @@ static void set_priority_levels(const std::string& active_pref,
 			return PRIORITY_LEVEL_HIGHEST;
 		}
 		LOG_WARNING("SDL: Invalid 'priority' setting: '%s', using 'auto'",
-		            pref.data());
+		            pref.c_str());
 
 		return PRIORITY_LEVEL_AUTO;
 	};

--- a/src/hardware/dma.cpp
+++ b/src/hardware/dma.cpp
@@ -486,7 +486,7 @@ void DmaChannel::EvictReserver()
 	reservation_owner    = {};
 }
 
-void DmaChannel::ReserveFor(const std::string_view new_owner,
+void DmaChannel::ReserveFor(const std::string& new_owner,
                             const DMA_ReservationCallback new_cb)
 {
 	assert(new_cb);
@@ -494,8 +494,8 @@ void DmaChannel::ReserveFor(const std::string_view new_owner,
 
 	if (HasReservation()) {
 		LOG_MSG("DMA: %s is replacing %s on %d-bit DMA channel %u",
-		        new_owner.data(),
-		        reservation_owner.data(),
+		        new_owner.c_str(),
+		        reservation_owner.c_str(),
 		        is_16bit == 1 ? 16 : 8,
 		        chan_num);
 		EvictReserver();
@@ -532,7 +532,7 @@ DmaChannel::~DmaChannel()
 {
 	if (HasReservation()) {
 		LOG_MSG("DMA: Shutting down %s on %d-bit DMA channel %d",
-		        reservation_owner.data(),
+		        reservation_owner.c_str(),
 		        is_16bit == 1 ? 16 : 8,
 		        chan_num);
 		EvictReserver();

--- a/src/hardware/imfc.cpp
+++ b/src/hardware/imfc.cpp
@@ -13416,7 +13416,7 @@ static void imfc_init(Section* sec)
 	} else if (!channel->TryParseAndSetCustomFilter(filter_choice)) {
 		if (!filter_choice_has_bool) {
 			LOG_WARNING("IMFC: Invalid 'imfc_filter' setting: '%s', using 'off'",
-			            filter_choice.data());
+			            filter_choice.c_str());
 		}
 
 		channel->SetLowPassFilter(FilterState::Off);

--- a/src/hardware/innovation.cpp
+++ b/src/hardware/innovation.cpp
@@ -33,7 +33,7 @@ void Innovation::Open(const std::string_view model_choice,
                       const std::string_view clock_choice,
                       const int filter_strength_6581,
                       const int filter_strength_8580, const int port_choice,
-                      const std::string_view channel_filter_choice)
+                      const std::string& channel_filter_choice)
 {
 	using namespace std::placeholders;
 
@@ -45,13 +45,11 @@ void Innovation::Open(const std::string_view model_choice,
 		return;
 	}
 
-	std::string_view model_name = "";
 	int filter_strength = 0;
 	auto sid_service    = std::make_unique<reSIDfp::SID>();
 
 	// Setup the model and filter
 	if (model_choice == "8580") {
-		model_name = "8580";
 		sid_service->setChipModel(reSIDfp::MOS8580);
 		filter_strength = filter_strength_8580;
 		if (filter_strength > 0) {
@@ -59,7 +57,6 @@ void Innovation::Open(const std::string_view model_choice,
 			sid_service->setFilter8580Curve(filter_strength / 100.0);
 		}
 	} else {
-		model_name = "6581";
 		sid_service->setChipModel(reSIDfp::MOS6581);
 		filter_strength = filter_strength_6581;
 		if (filter_strength > 0) {
@@ -97,7 +94,7 @@ void Innovation::Open(const std::string_view model_choice,
 
 		if (!filter_choice_has_bool) {
 			LOG_WARNING("INNOVATION: Invalid 'innovation_filter' setting: '%s', using 'off'",
-			            channel_filter_choice.data());
+			            channel_filter_choice.c_str());
 		}
 
 		mixer_channel->SetHighPassFilter(FilterState::Off);
@@ -129,16 +126,18 @@ void Innovation::Open(const std::string_view model_choice,
 	// Ready state-values for rendering
 	last_rendered_ms = 0.0;
 
+	// Variable model_name is only used for logging, so use a const char* here
+	const char* model_name = model_choice == "8580" ? "8580" : "6581";
 	constexpr auto us_per_s = 1'000'000.0;
 	if (filter_strength == 0)
 		LOG_MSG("INNOVATION: Running on port %xh with a SID %s at %0.3f MHz",
 		        base_port,
-		        model_name.data(),
+		        model_name,
 		        chip_clock / us_per_s);
 	else
 		LOG_MSG("INNOVATION: Running on port %xh with a SID %s at %0.3f MHz filtering at %d%%",
 		        base_port,
-		        model_name.data(),
+		        model_name,
 		        chip_clock / us_per_s,
 		        filter_strength);
 

--- a/src/hardware/innovation.h
+++ b/src/hardware/innovation.h
@@ -37,7 +37,7 @@ public:
 	void Open(const std::string_view model_choice,
 	          const std::string_view clock_choice, int filter_strength_6581,
 	          int filter_strength_8580, int port_choice,
-	          const std::string_view channel_filter_choice);
+	          const std::string& channel_filter_choice);
 
 	void Close();
 	~Innovation()

--- a/src/hardware/joystick.cpp
+++ b/src/hardware/joystick.cpp
@@ -523,10 +523,10 @@ static void configure_calibration(const Section_prop &settings)
 	if (settings.Get_bool("use_joy_calibration_hotkeys"))
 		activate_calibration_hotkeys();
 
-	auto axis_rates_from_pref = [](const std::string_view pref,
+	auto axis_rates_from_pref = [](const std::string& pref,
 	                               const AxisRateConstants &default_rates) {
 		if (AxisRateConstants parsed_rates = {};
-		    sscanf(pref.data(), "%lf,%lf", &parsed_rates.scalar, &parsed_rates.offset) == 2) {
+		    sscanf(pref.c_str(), "%lf,%lf", &parsed_rates.scalar, &parsed_rates.offset) == 2) {
 			LOG_MSG("JOYSTICK: Loaded custom %c-axis calibration parameters (%.6g,%.6g)",
 			        default_rates.axis,
 			        parsed_rates.scalar,
@@ -537,7 +537,7 @@ static void configure_calibration(const Section_prop &settings)
 			LOG_WARNING("JOYSTICK: Invalid '%c_calibration' setting: '%s', "
 			            "using 'auto'",
 			            default_rates.axis,
-			            pref.data());
+			            pref.c_str());
 		return default_rates;
 	};
 	const auto x_cal_pref   = settings.Get_string("joy_x_calibration");

--- a/src/hardware/lpt_dac.cpp
+++ b/src/hardware/lpt_dac.cpp
@@ -50,7 +50,7 @@ LptDac::LptDac(const std::string_view name, const uint16_t channel_rate_hz,
 	// Setup the mixer callback
 	channel = MIXER_AddChannel(audio_callback,
 	                           channel_rate_hz,
-	                           dac_name.data(),
+	                           dac_name.c_str(),
 	                           features);
 
 	ms_per_frame = millis_in_second / channel->GetSampleRate();
@@ -60,7 +60,7 @@ LptDac::LptDac(const std::string_view name, const uint16_t channel_rate_hz,
 	status_reg.busy  = false;
 }
 
-bool LptDac::TryParseAndSetCustomFilter(const std::string_view filter_choice)
+bool LptDac::TryParseAndSetCustomFilter(const std::string& filter_choice)
 {
 	assert(channel);
 	return channel->TryParseAndSetCustomFilter(filter_choice);
@@ -120,7 +120,7 @@ void LptDac::AudioCallback(const uint16_t requested_frames)
 
 LptDac::~LptDac()
 {
-	LOG_MSG("%s: Shutting down DAC", dac_name.data());
+	LOG_MSG("%s: Shutting down DAC", dac_name.c_str());
 
 	// Update our status to indicate we're no longer ready
 	status_reg.error = true;

--- a/src/hardware/lpt_dac.cpp
+++ b/src/hardware/lpt_dac.cpp
@@ -169,7 +169,7 @@ void LPT_DAC_Init(Section *section)
 		const auto dac_choice_has_bool = parse_bool_setting(dac_choice);
 		if (!dac_choice_has_bool || *dac_choice_has_bool != false) {
 			LOG_WARNING("LPT_DAC: Invalid 'lpt_dac' setting: '%s', using 'none'",
-			            dac_choice.data());
+			            dac_choice.c_str());
 		}
 		return;
 	}
@@ -186,7 +186,7 @@ void LPT_DAC_Init(Section *section)
 			                                       : FilterState::Off;
 		} else {
 			LOG_WARNING("LPT_DAC: Invalid 'lpt_dac_filter' setting: '%s', using 'off'",
-			            filter_choice.data());
+			            filter_choice.c_str());
 			assert(filter_state == FilterState::Off);
 		}
 

--- a/src/hardware/lpt_dac.h
+++ b/src/hardware/lpt_dac.h
@@ -42,7 +42,7 @@ public:
 	virtual void ConfigureFilters(const FilterState state) = 0;
 	virtual void BindToPort(const io_port_t lpt_port)      = 0;
 
-	bool TryParseAndSetCustomFilter(const std::string_view filter_choice);
+	bool TryParseAndSetCustomFilter(const std::string& filter_choice);
 
 protected:
 	LptDac()                          = delete;
@@ -59,7 +59,7 @@ protected:
 	double last_rendered_ms = 0.0;
 	double ms_per_frame     = 0.0;
 
-	std::string_view dac_name = {};
+	std::string dac_name = {};
 
 	// All LPT devices support data write, status read, and control write
 	void BindHandlers(const io_port_t lpt_port, const io_write_f write_data,

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -321,7 +321,7 @@ static void set_global_chorus(const mixer_channel_t& channel)
 	}
 }
 
-static CrossfeedPreset crossfeed_pref_to_preset(const std::string_view pref)
+static CrossfeedPreset crossfeed_pref_to_preset(const std::string& pref)
 {
 	const auto pref_has_bool = parse_bool_setting(pref);
 	if (pref_has_bool) {
@@ -340,7 +340,7 @@ static CrossfeedPreset crossfeed_pref_to_preset(const std::string_view pref)
 	// the conf system programmatically guarantees only the above prefs are
 	// used
 	LOG_WARNING("MIXER: Invalid 'crossfeed' setting: '%s', using 'off'",
-	            pref.data());
+	            pref.c_str());
 	return CrossfeedPreset::None;
 }
 
@@ -402,7 +402,7 @@ void MIXER_SetCrossfeedPreset(const CrossfeedPreset new_preset)
 	}
 }
 
-static ReverbPreset reverb_pref_to_preset(const std::string_view pref)
+static ReverbPreset reverb_pref_to_preset(const std::string& pref)
 {
 	const auto pref_has_bool = parse_bool_setting(pref);
 	if (pref_has_bool) {
@@ -427,7 +427,7 @@ static ReverbPreset reverb_pref_to_preset(const std::string_view pref)
 	// the conf system programmatically guarantees only the above prefs are
 	// used
 	LOG_WARNING("MIXER: Invalid 'reverb' setting: '%s', using 'off'",
-	            pref.data());
+	            pref.c_str());
 	return ReverbPreset::None;
 }
 
@@ -500,7 +500,7 @@ void MIXER_SetReverbPreset(const ReverbPreset new_preset)
 	}
 }
 
-static ChorusPreset chorus_pref_to_preset(const std::string_view pref)
+static ChorusPreset chorus_pref_to_preset(const std::string& pref)
 {
 	const auto pref_has_bool = parse_bool_setting(pref);
 	if (pref_has_bool) {
@@ -519,7 +519,7 @@ static ChorusPreset chorus_pref_to_preset(const std::string_view pref)
 	// the conf system programmatically guarantees only the above prefs are
 	// used
 	LOG_WARNING("MIXER: Invalid 'chorus' setting: '%s', using ' off'",
-	            pref.data());
+	            pref.c_str());
 	return ChorusPreset::None;
 }
 
@@ -1112,7 +1112,7 @@ void MixerChannel::AddSilence()
 }
 
 static void log_filter_settings(const std::string& channel_name,
-                                const std::string_view filter_name,
+                                const std::string& filter_name,
                                 const FilterState state, const uint8_t order,
                                 const uint16_t cutoff_freq)
 {
@@ -1124,7 +1124,7 @@ static void log_filter_settings(const std::string& channel_name,
 
 	LOG_MSG("%s: %s filter enabled%s (%d dB/oct at %u Hz)",
 	        channel_name.c_str(),
-	        filter_name.data(),
+	        filter_name.c_str(),
 	        state == FilterState::ForcedOn ? " (forced)" : "",
 	        order * db_per_order,
 	        cutoff_freq);
@@ -1183,7 +1183,7 @@ void MixerChannel::ConfigureLowPassFilter(const uint8_t order,
 // Tries to set custom filter settings from the passed in filter preferences.
 // Returns true if the custom filters could be successfully set, false
 // otherwise and disables all filters for the channel.
-bool MixerChannel::TryParseAndSetCustomFilter(const std::string_view filter_prefs)
+bool MixerChannel::TryParseAndSetCustomFilter(const std::string& filter_prefs)
 {
 	SetLowPassFilter(FilterState::Off);
 	SetHighPassFilter(FilterState::Off);
@@ -1201,7 +1201,7 @@ bool MixerChannel::TryParseAndSetCustomFilter(const std::string_view filter_pref
 		LOG_WARNING("%s: Invalid custom filter definition: '%s'. Must be "
 		            "specified in \"lfp|hpf ORDER CUTOFF_FREQUENCY\" format",
 		            name.c_str(),
-		            filter_prefs.data());
+		            filter_prefs.c_str());
 		return false;
 	}
 
@@ -1283,7 +1283,7 @@ bool MixerChannel::TryParseAndSetCustomFilter(const std::string_view filter_pref
 			LOG_WARNING("%s: Invalid custom filter definition: '%s'. "
 			            "The two filters must be of different types.",
 			            name.c_str(),
-			            filter_prefs.data());
+			            filter_prefs.c_str());
 			return false;
 		}
 
@@ -1686,13 +1686,13 @@ AudioFrame MixerChannel::ApplyCrossfeed(const AudioFrame frame) const
 }
 
 // Returns true if configuration succeeded and false otherwise
-bool MixerChannel::ConfigureFadeOut(const std::string_view prefs)
+bool MixerChannel::ConfigureFadeOut(const std::string& prefs)
 {
 	return sleeper.ConfigureFadeOut(prefs);
 }
 
 // Returns true if configuration succeeded and false otherwise
-bool MixerChannel::Sleeper::ConfigureFadeOut(const std::string_view prefs)
+bool MixerChannel::Sleeper::ConfigureFadeOut(const std::string& prefs)
 {
 	auto set_wait_and_fade = [&](const int wait_ms, const int fade_ms) {
 		fadeout_or_sleep_after_ms = check_cast<uint16_t>(wait_ms);
@@ -1744,7 +1744,7 @@ bool MixerChannel::Sleeper::ConfigureFadeOut(const std::string_view prefs)
 	            "%d and %d (in milliseconds) and FADE is between %d and "
 	            "%d (in milliseconds). Using 'off'",
 	            channel.GetName().c_str(),
-	            prefs.data(),
+	            prefs.c_str(),
 	            min_wait_ms,
 	            max_wait_ms,
 	            min_fade_ms,

--- a/src/hardware/pcspeaker.cpp
+++ b/src/hardware/pcspeaker.cpp
@@ -53,7 +53,7 @@ void PCSPEAKER_Init(Section *section)
 		pc_speaker = std::make_unique<PcSpeakerImpulse>();
 	} else {
 		LOG_ERR("PCSPEAKER: Invalid PC Speaker model: %s",
-		        model_choice.data());
+		        model_choice.c_str());
 		return;
 	}
 
@@ -70,7 +70,7 @@ void PCSPEAKER_Init(Section *section)
 			}
 		} else {
 			LOG_WARNING("PCSPEAKER: Invalid 'pcspeaker_filter' setting: '%s', using 'off'",
-			            filter_choice.data());
+			            filter_choice.c_str());
 			pc_speaker->SetFilterState(FilterState::Off);
 		}
 	}

--- a/src/hardware/pcspeaker.h
+++ b/src/hardware/pcspeaker.h
@@ -33,7 +33,7 @@ public:
 	virtual ~PcSpeaker() = default;
 
 	virtual void SetFilterState(const FilterState filter_state) = 0;
-	virtual bool TryParseAndSetCustomFilter(const std::string_view filter_choice) = 0;
+	virtual bool TryParseAndSetCustomFilter(const std::string& filter_choice) = 0;
 	virtual void SetCounter(const int cntr, const PitMode pit_mode) = 0;
 	virtual void SetPITControl(const PitMode pit_mode)              = 0;
 	virtual void SetType(const PpiPortB &port_b)                    = 0;

--- a/src/hardware/pcspeaker_discrete.cpp
+++ b/src/hardware/pcspeaker_discrete.cpp
@@ -457,7 +457,7 @@ void PcSpeakerDiscrete::SetFilterState(const FilterState filter_state)
 	}
 }
 
-bool PcSpeakerDiscrete::TryParseAndSetCustomFilter(const std::string_view filter_choice)
+bool PcSpeakerDiscrete::TryParseAndSetCustomFilter(const std::string& filter_choice)
 {
 	assert(channel);
 	return channel->TryParseAndSetCustomFilter(filter_choice);

--- a/src/hardware/pcspeaker_discrete.h
+++ b/src/hardware/pcspeaker_discrete.h
@@ -36,7 +36,7 @@ public:
 	~PcSpeakerDiscrete() final;
 
 	void SetFilterState(const FilterState filter_state) final;
-	bool TryParseAndSetCustomFilter(const std::string_view filter_choice) final;
+	bool TryParseAndSetCustomFilter(const std::string& filter_choice) final;
 	void SetCounter(const int cntr, const PitMode m) final;
 	void SetPITControl(const PitMode) final {}
 	void SetType(const PpiPortB& b) final;

--- a/src/hardware/pcspeaker_impulse.cpp
+++ b/src/hardware/pcspeaker_impulse.cpp
@@ -505,7 +505,7 @@ void PcSpeakerImpulse::SetFilterState(const FilterState filter_state)
 	}
 }
 
-bool PcSpeakerImpulse::TryParseAndSetCustomFilter(const std::string_view filter_choice)
+bool PcSpeakerImpulse::TryParseAndSetCustomFilter(const std::string& filter_choice)
 {
 	assert(channel);
 	return channel->TryParseAndSetCustomFilter(filter_choice);

--- a/src/hardware/pcspeaker_impulse.h
+++ b/src/hardware/pcspeaker_impulse.h
@@ -36,7 +36,7 @@ public:
 	~PcSpeakerImpulse() final;
 
 	void SetFilterState(const FilterState filter_state) final;
-	bool TryParseAndSetCustomFilter(const std::string_view filter_choice) final;
+	bool TryParseAndSetCustomFilter(const std::string& filter_choice) final;
 	void SetCounter(const int cntr, const PitMode pit_mode) final;
 	void SetPITControl(const PitMode pit_mode) final;
 	void SetType(const PpiPortB& port_b) final;

--- a/src/hardware/ps1audio.cpp
+++ b/src/hardware/ps1audio.cpp
@@ -51,7 +51,7 @@ struct Ps1Registers {
 
 class Ps1Dac {
 public:
-	Ps1Dac(const std::string_view filter_choice);
+	Ps1Dac(const std::string& filter_choice);
 	~Ps1Dac();
 
 private:
@@ -120,7 +120,7 @@ static void setup_filter(mixer_channel_t &channel)
 	channel->SetLowPassFilter(FilterState::On);
 }
 
-Ps1Dac::Ps1Dac(const std::string_view filter_choice)
+Ps1Dac::Ps1Dac(const std::string& filter_choice)
 {
 	using namespace std::placeholders;
 
@@ -147,7 +147,7 @@ Ps1Dac::Ps1Dac(const std::string_view filter_choice)
 	} else if (!channel->TryParseAndSetCustomFilter(filter_choice)) {
 		if (!filter_choice_has_bool) {
 			LOG_WARNING("PS1DAC: Invalid 'ps1audio_dac_filter' setting: '%s', using 'off'",
-			            filter_choice.data());
+			            filter_choice.c_str());
 		}
 
 		channel->SetHighPassFilter(FilterState::Off);
@@ -376,7 +376,7 @@ Ps1Dac::~Ps1Dac()
 
 class Ps1Synth {
 public:
-	Ps1Synth(const std::string_view filter_choice);
+	Ps1Synth(const std::string& filter_choice);
 	~Ps1Synth();
 
 private:
@@ -410,7 +410,7 @@ private:
 	double last_rendered_ms     = 0.0;
 };
 
-Ps1Synth::Ps1Synth(const std::string_view filter_choice)
+Ps1Synth::Ps1Synth(const std::string& filter_choice)
         : device(nullptr, nullptr, ps1_psg_clock_hz)
 {
 	using namespace std::placeholders;
@@ -437,7 +437,7 @@ Ps1Synth::Ps1Synth(const std::string_view filter_choice)
 	} else if (!channel->TryParseAndSetCustomFilter(filter_choice)) {
 		if (!filter_choice_has_bool) {
 			LOG_WARNING("PS1: Invalid 'ps1audio_filter' setting: '%s', using 'off'",
-			            filter_choice.data());
+			            filter_choice.c_str());
 		}
 
 		channel->SetHighPassFilter(FilterState::Off);

--- a/src/hardware/reelmagic/driver.cpp
+++ b/src/hardware/reelmagic/driver.cpp
@@ -1407,7 +1407,7 @@ void ReelMagic_Init(Section* sec)
 	if (!wants_card_only && !wants_card_and_driver) {
 		if (!reelmagic_choice_has_bool) {
 			LOG_WARNING("REELMAGIC: Invalid 'reelmagic' value: '%s', shutting down.",
-			            reelmagic_choice.data());
+			            reelmagic_choice.c_str());
 		}
 		return;
 	}

--- a/src/hardware/reelmagic/player.cpp
+++ b/src/hardware/reelmagic/player.cpp
@@ -804,7 +804,7 @@ void ReelMagic_EnableAudioChannel(const bool should_enable)
 	mixer_channel->Set0dbScalar(mpeg1_db0_volume_scalar);
 }
 
-static void set_magic_key(const std::string_view key_choice)
+static void set_magic_key(const std::string& key_choice)
 {
 	if (key_choice == "auto") {
 		_initialMagicKey = common_magic_key;
@@ -815,12 +815,12 @@ static void set_magic_key(const std::string_view key_choice)
 	} else if (key_choice == "thehorde") {
 		_initialMagicKey = thehorde_magic_key;
 		LOG_MSG("REELMAGIC: Using The Horde's key: 0x%x", thehorde_magic_key);
-	} else if (unsigned int k; sscanf(key_choice.data(), "%x", &k) == 1) {
+	} else if (unsigned int k; sscanf(key_choice.c_str(), "%x", &k) == 1) {
 		_initialMagicKey = k;
 		LOG_MSG("REELMAGIC: Using custom key: 0x%x", k);
 	} else {
 		LOG_WARNING("REELMAGIC: Failed parsing key choice '%s', using built-in routines",
-		            key_choice.data());
+		            key_choice.c_str());
 		_initialMagicKey = common_magic_key;
 	}
 }

--- a/src/hardware/tandy_sound.cpp
+++ b/src/hardware/tandy_sound.cpp
@@ -101,7 +101,7 @@ public:
 	static constexpr IOConfig io = {0xc4, 7, 1};
 
 	TandyDAC(const ConfigProfile config_profile,
-	         const std::string_view filter_choice);
+	         const std::string& filter_choice);
 	~TandyDAC();
 
 	bool IsEnabled() const
@@ -133,8 +133,8 @@ private:
 class TandyPSG {
 public:
 	TandyPSG(const ConfigProfile config_profile, const bool is_dac_enabled,
-	         const std::string_view fadeout_choice,
-	         const std::string_view filter_choice);
+	         const std::string& fadeout_choice,
+	         const std::string& filter_choice);
 	~TandyPSG();
 
 private:
@@ -183,7 +183,7 @@ static void setup_filters(mixer_channel_t &channel) {
 }
 
 TandyDAC::TandyDAC(const ConfigProfile config_profile,
-                   const std::string_view filter_choice)
+                   const std::string& filter_choice)
 {
 	using namespace std::placeholders;
 
@@ -217,7 +217,7 @@ TandyDAC::TandyDAC(const ConfigProfile config_profile,
 	} else if (!channel->TryParseAndSetCustomFilter(filter_choice)) {
 		if (!filter_choice_has_bool) {
 			LOG_WARNING("TANDYDAC: Invalid 'tandy_dac_filter' setting: '%s', using 'off'",
-			            filter_choice.data());
+			            filter_choice.c_str());
 		}
 
 		channel->SetHighPassFilter(FilterState::Off);
@@ -425,8 +425,8 @@ void TandyDAC::AudioCallback(uint16_t requested)
 }
 
 TandyPSG::TandyPSG(const ConfigProfile config_profile, const bool is_dac_enabled,
-                   const std::string_view fadeout_choice,
-                   const std::string_view filter_choice)
+                   const std::string& fadeout_choice,
+                   const std::string& filter_choice)
 {
 	using namespace std::placeholders;
 
@@ -474,7 +474,7 @@ TandyPSG::TandyPSG(const ConfigProfile config_profile, const bool is_dac_enabled
 	} else if (!channel->TryParseAndSetCustomFilter(filter_choice)) {
 		if (!filter_choice_has_bool) {
 			LOG_WARNING("TANDY: Invalid 'tandy_filter' value: '%s', using 'off'",
-			            filter_choice.data());
+			            filter_choice.c_str());
 		}
 
 		channel->SetHighPassFilter(FilterState::Off);

--- a/src/hardware/vga_other.cpp
+++ b/src/hardware/vga_other.cpp
@@ -1450,7 +1450,7 @@ static void composite_init(Section *sec)
 			                           : COMPOSITE_STATE::OFF;
 		} else {
 			LOG_WARNING("COMPOSITE: Invalid 'composite' setting: '%s', using 'off'",
-			            state.data());
+			            state.c_str());
 			cga_comp = COMPOSITE_STATE::OFF;
 		}
 	}

--- a/src/midi/midi.cpp
+++ b/src/midi/midi.cpp
@@ -625,7 +625,7 @@ public:
 				midi.is_available = true;
 				midi.handler      = handler;
 				LOG_MSG("MIDI: Opened device: %s",
-				        handler->GetName().data());
+				        handler->GetName().c_str());
 			}
 			return opened;
 		};
@@ -677,7 +677,7 @@ void MIDI_ListAll(Program* caller)
 		const auto device_name = convert_ansi_markup(
 		        "[color=white]%s:[reset]\n");
 
-		caller->WriteOut(device_name.c_str(), handler->GetName().data());
+		caller->WriteOut(device_name.c_str(), handler->GetName().c_str());
 
 		const auto err = handler->ListAll(caller);
 		if (err == MIDI_RC::ERR_DEVICE_NOT_CONFIGURED) {

--- a/src/midi/midi.cpp
+++ b/src/midi/midi.cpp
@@ -649,7 +649,7 @@ public:
 
 		if (!midi.is_available) {
 			LOG_MSG("MIDI: Can't find device: '%s', MIDI is not available",
-			        device_choice.data());
+			        device_choice.c_str());
 		}
 	}
 

--- a/src/midi/midi_alsa.h
+++ b/src/midi/midi_alsa.h
@@ -48,7 +48,7 @@ public:
 	MidiHandler_alsa(const MidiHandler_alsa &) = delete; // prevent copying
 	MidiHandler_alsa &operator=(const MidiHandler_alsa &) = delete; // prevent assignment
 
-	std::string_view GetName() const override
+	std::string GetName() const override
 	{
 		return "alsa";
 	}

--- a/src/midi/midi_coreaudio.h
+++ b/src/midi/midi_coreaudio.h
@@ -76,7 +76,7 @@ public:
 	          soundfont(nullptr)
 	{}
 
-	std::string_view GetName() const override
+	std::string GetName() const override
 	{
 		return "coreaudio";
 	}

--- a/src/midi/midi_coremidi.h
+++ b/src/midi/midi_coremidi.h
@@ -49,7 +49,7 @@ public:
 	          m_pCurPacket(nullptr)
 	{}
 
-	std::string_view GetName() const override
+	std::string GetName() const override
 	{
 		return "coremidi";
 	}

--- a/src/midi/midi_fluidsynth.h
+++ b/src/midi/midi_fluidsynth.h
@@ -40,7 +40,7 @@ public:
 	~MidiHandlerFluidsynth() override;
 	void PrintStats();
 
-	std::string_view GetName() const override
+	std::string GetName() const override
 	{
 		return "fluidsynth";
 	}

--- a/src/midi/midi_handler.h
+++ b/src/midi/midi_handler.h
@@ -42,7 +42,7 @@ public:
 
 	virtual ~MidiHandler() = default;
 
-	virtual std::string_view GetName() const = 0;
+	virtual std::string GetName() const = 0;
 
 	virtual MidiDeviceType GetDeviceType() const
 	{

--- a/src/midi/midi_lasynth_model.cpp
+++ b/src/midi/midi_lasynth_model.cpp
@@ -153,7 +153,7 @@ bool LASynthModel::Load(const service_t& service, const std_fs::path& dir) const
 const char *LASynthModel::GetVersion() const
 {
 	assert(version_pos != std::string::npos);
-	return name.data() + version_pos;
+	return name.c_str() + version_pos;
 }
 
 bool LASynthModel::Matches(const std::string &model_name) const

--- a/src/midi/midi_mt32.cpp
+++ b/src/midi/midi_mt32.cpp
@@ -726,7 +726,7 @@ MIDI_RC MidiHandler_mt32::ListAll(Program* caller)
 		                 rom_info.control_rom_description);
 
 		// Print the loaded ROM's directory
-		const std::string_view dir_label = MSG_Get("MT32_SOURCE_DIR_LABEL");
+		const std::string dir_label = MSG_Get("MT32_SOURCE_DIR_LABEL");
 
 		const auto dir_max_length = INT10_GetTextColumns() -
 		                            (dir_label.length() +
@@ -737,7 +737,7 @@ MIDI_RC MidiHandler_mt32::ListAll(Program* caller)
 
 		caller->WriteOut("%s%s%s\n",
 		                 indent,
-		                 dir_label.data(),
+		                 dir_label.c_str(),
 		                 truncated_dir.c_str());
 	} else {
 		caller->WriteOut("%s%s\n", indent, MSG_Get("MT32_ROM_NOT_LOADED"));

--- a/src/midi/midi_mt32.h
+++ b/src/midi/midi_mt32.h
@@ -58,7 +58,7 @@ public:
 	~MidiHandler_mt32() override;
 	void Close() override;
 
-	std::string_view GetName() const override
+	std::string GetName() const override
 	{
 		return "mt32";
 	}

--- a/src/midi/midi_oss.h
+++ b/src/midi/midi_oss.h
@@ -38,7 +38,7 @@ public:
 
 	~MidiHandler_oss() override;
 
-	std::string_view GetName() const override
+	std::string GetName() const override
 	{
 		return "oss";
 	}

--- a/src/midi/midi_win32.h
+++ b/src/midi/midi_win32.h
@@ -50,7 +50,7 @@ public:
 	MidiHandler_win32(const MidiHandler_win32&) = delete;
 	MidiHandler_win32& operator=(const MidiHandler_win32&) = delete;
 
-	std::string_view GetName() const override
+	std::string GetName() const override
 	{
 		return "win32";
 	}

--- a/src/misc/messages.cpp
+++ b/src/misc/messages.cpp
@@ -231,7 +231,7 @@ bool MSG_Write(const char * location) {
 		return false;
 
 	for (const auto &name : messages_order)
-		fprintf(out, ":%s\n%s\n.\n", name.data(), messages.at(name).GetRaw());
+		fprintf(out, ":%s\n%s\n.\n", name.c_str(), messages.at(name).GetRaw());
 
 	fclose(out);
 	return true;

--- a/tests/dos_files_tests.cpp
+++ b/tests/dos_files_tests.cpp
@@ -55,11 +55,11 @@ namespace {
 
 class DOS_FilesTest : public DOSBoxTestFixture {};
 
-void assert_DTAExtendName(const std::string_view input_fullname,
+void assert_DTAExtendName(const std::string& input_fullname,
                           const std::string_view expected_name,
                           const std::string_view expected_ext)
 {
-	const auto [output_name, output_ext] = DTAExtendName(input_fullname.data());
+	const auto [output_name, output_ext] = DTAExtendName(input_fullname.c_str());
 
 	// mutates input up to dot
 	EXPECT_EQ(output_name, expected_name);


### PR DESCRIPTION
# Description

By definition, std::string_view::data() is not guaranteed to return a zero-terminated string. If a zero-terminated string is expected, this can result in undefined behaviour.

Use std::string::c_str() where appropriate to avoid hidden bugs when a std::string is replaced by a std::string_view.

If a c_str is required (mostly used by logging), convert the std::string_view to a std::string.

## Related issues

#1314 

# Manual testing

Unittests still functional.

Started DOSBox and performed some random commands.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [ ] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

