### PR TITLE
Fix crash when quitting while in fullscreen mode

### DIFF
--- a/src/dos/program_serial.cpp
+++ b/src/dos/program_serial.cpp
@@ -176,7 +176,8 @@ void SERIAL::Run()
 		}
 		if (serialports[port_index] != nullptr) {
 			serialports[port_index]->serialType = desired_type;
-			serialports[port_index]->commandLineString = commandLineString;
+			serialports[port_index]->commandLineString = std::move(
+			        commandLineString);
 		}
 		delete commandLine;
 		showPort(port_index);

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -2738,8 +2738,9 @@ static bool load_binds_from_file(const std::string_view mapperfile_path,
                                  const std::string& mapperfile_name)
 {
 	// If the filename is empty the user wants defaults
-	if (mapperfile_name == "")
+	if (mapperfile_name.empty()) {
 		return false;
+	}
 
 	auto try_loading = [](const std_fs::path &mapper_path) -> bool {
 		constexpr auto optional = ResourceImportance::Optional;

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -2687,10 +2687,9 @@ static void clean_up_sdl_resources()
 static void GUI_ShutDown(Section *)
 {
 	GFX_Stop();
+
 	if (sdl.draw.callback)
 		(sdl.draw.callback)( GFX_CallBackStop );
-	if (sdl.desktop.fullscreen)
-		GFX_SwitchFullScreen();
 
 	GFX_SetMouseCapture(false);
 	GFX_SetMouseVisibility(true);


### PR DESCRIPTION
# Description

Fixes https://github.com/dosbox-staging/dosbox-staging/issues/3544

This fixes a crash caused by sdlmain's entangled nature and the general ad hoc randomness of the current shutdown order.

Also fixing some recently introduced PVS-Studio warnings.

Exiting fullscreen before quitting is a silly thing to do anyway. Why would that even be needed? No game does that...


# Manual testing

Quitting with Cmd+Q on macOS from fullscreen mode no longer causes a crash.


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

