### PR TITLE
Fix the 'In Extremis' game intro getting stuck

### DIFF
--- a/src/hardware/input/keyboard.cpp
+++ b/src/hardware/input/keyboard.cpp
@@ -524,6 +524,9 @@ static void execute_command(const KbdCommand command)
 		// errors - not implemented, as the emulation can
 		// also send whole multi-byte scancode at once
 		warn_resend();
+		// We have to respond, or else the 'In Extremis' game intro
+		// (sends 0xfe and 0xaa commands) hangs with a black screen
+		I8042_AddKbdByte(0xfa); // acknowledge
 		break;
 	case KbdCommand::Reset: // 0xff
 		// Full keyboard reset and self test


### PR DESCRIPTION
# Description

The game _In Extremis_ constantly sends two commands to the keyboard: one (0xaa) is unknown, I have no documentation telling what it does, the other one is 0xfe (resend request), described below, also not handled by our reworked keyboard emulation:

![image](https://github.com/dosbox-staging/dosbox-staging/assets/48332137/86ebab9a-3c81-4102-ac2f-ede164ad876d)



## Related issues

Fixes https://github.com/dosbox-staging/dosbox-staging/issues/3547

# Manual testing

Start the game, the intro should now start running immediately.

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.
