### PR TITLE
Improve the IMGMOUNT command's help text

### DIFF
--- a/contrib/resources/translations/en.lng
+++ b/contrib/resources/translations/en.lng
@@ -433,8 +433,14 @@ Usage: [color=light-green]config [reset]-set [color=light-cyan][SECTION][reset] 
 :TITLEBAR_CYCLES_MS
 cycles/ms
 .
+:TITLEBAR_MUTED
+MUTED
+.
 :TITLEBAR_PAUSED
 PAUSED
+.
+:TITLEBAR_HINT_CAPTURED
+mouse captured
 .
 :TITLEBAR_HINT_CAPTURED_HOTKEY
 mouse captured, %s+F10 to release
@@ -581,6 +587,43 @@ Use 'allow' or 'block' to override the SDL_VIDEO_ALLOW_SCREENSAVER environment
 variable which usually blocks the OS screensaver while the emulator is
 running ('auto' by default).
 .
+:CONFIG_WINDOW_TITLEBAR
+Space separated list of information to be displayed in the window's titlebar
+('program=name dosbox=auto cycles=on mouse=full' by default). If a parameter
+is not specified, its default value is used.
+Possible information to display are:
+  animation=<value>:  If set to 'on' (default), animate the audio/video
+                      recording mark. Set to 'off' to disable animation; this
+                      is useful if your screen font produces weird results.
+  program=<value>:    Display the name of the running program.
+                      <value> can be one of:
+                        none/off:  Do not display program name.
+                        name:      Program name, with file extension (default).
+                        path:      Name, extension, and full absolute path.
+                        segment:   Display program memory segment name.
+                        'Title':   Custom name. Alternatively, you can use
+                                   "Title", (Title), <Title> or [Title] form.
+                      Note: With some software (like Windows 3.1x in enhanced
+                      mode) it is impossible to recognize the full program
+                      name or path; in such cases 'segment' is used instead.
+  dosbox=<value>:     Display 'DOSBox Staging' in the title bar.
+                      <value> can be one of:
+                        always:   Always display 'DOSBox Staging'.
+                        auto:     Only display it if no program is running or
+                                  'program=none' is set (default).
+  version=<value>:    Display DOSBox version information.
+                      <value> can be one of:
+                         none/off:  Do not display DOSBox version (default).
+                         simple:    Simple version information.
+                         detailed:  Include Git hash, if available.
+  cycles=<value>:     If set to 'on' (default), show CPU cycles setting.
+                      Set to 'off' to disable cycles setting display.
+  mouse=<value>:      Mouse capturing hint verbosity level:
+                        none/off:  Do not display any mouse hints.
+                        short:     Only display if mouse is captured.
+                        full:      Display verbose information on how to
+                                   capture or release the cursor (default).
+.
 :CONFIG_LANGUAGE
 Select a language to use: 'br', 'de', 'en', 'es', 'fr', 'it', 'nl', 'pl',
 or 'ru' (unset by default; this defaults to English).
@@ -656,6 +699,11 @@ Controls the selection of VESA 1.2 and 2.0 modes offered:
 .
 :CONFIG_VGA_8DOT_FONT
 Use 8-pixel-wide fonts on VGA adapters (disabled by default).
+.
+:CONFIG_VGA_RENDER_PER_SCANLINE
+Emulate accurate per-scanline VGA rendering (enabled by default).
+Currently, you need to disable this for a few games, otherwise they will crash
+at startup (e.g., Deus, Ishar 3, Robinson's Requiem, Time Warriors).
 .
 :CONFIG_SPEED_MODS
 Permit changes known to improve performance (enabled by default).
@@ -1092,8 +1140,9 @@ Note: You can fine-tune each channel's chorus level using the MIXER.
 :CONFIG_MIDIDEVICE
 Set where MIDI data from the emulated MPU-401 MIDI interface is sent
 ('auto' by default):
-  oss:         Use the Linux OSS MIDI playback interface.
-  alsa:        Use the Linux ALSA MIDI playback interface.
+  coremidi:    Any device that has been configured in the macOS
+               Audio MIDI Setup.
+  coreaudio:   Use the built-in macOS MIDI synthesiser.
   fluidsynth:  The built-in FluidSynth MIDI synthesizer (SoundFont player).
                See the [fluidsynth] section for detailed configuration.
   mt32:        The built-in Roland MT-32 synthesizer.
@@ -1111,9 +1160,7 @@ to use (find the ID/name with the DOS command 'MIXER /LISTMIDI').
 Notes:
   - This option has no effect when using the built-in synthesizers
     ('mididevice = fluidsynth' or 'mididevice = mt32').
-  - When using ALSA, use the Linux command 'aconnect -l' to list all open
-    MIDI ports and select one (e.g. 'midiconfig = 14:0' for sequencer
-    client 14, port 0).
+  - When using 'coreaudio', you can specify a SoundFont here.
   - If you're using a physical Roland MT-32 with revision 0 PCB, the hardware
     may require a delay in order to prevent its buffer from overflowing.
     In that case, add 'delaysysex' (e.g. 'midiconfig = 2 delaysysex').
@@ -1624,6 +1671,13 @@ File containing the list of applications and assigned DOS versions, in a
 tab-separated format, used by SETVER.EXE as a persistent storage
 (empty by default).
 .
+:CONFIG_PCJR_MEMORY_CONFIG
+PCjr memory layout ('expanded' by default).
+  expanded:  640 KB total memory with applications residing above 128 KB.
+             Compatible with most games.
+  standard:  128 KB total memory with applications residing below 96 KB.
+             Required for some older games (e.g., Jumpman, Troll).
+.
 :CONFIG_IPX
 Enable IPX over UDP/IP emulation (disabled by default).
 .
@@ -1859,6 +1913,9 @@ Executable file not found: '%s'
 :CONJUNCTION_AND
 and
 .
+:PROGRAM_CONFIG_NOT_CHANGEABLE
+Property '%s' is not changeable at runtime.
+.
 :MIDI_DEVICE_LIST_NOT_SUPPORTED
 Listing not supported
 .
@@ -1952,7 +2009,7 @@ Image file is read-only! Might create problems.
 This command boots DOSBox Staging from either a floppy or hard disk image.
 
 For this command, one can specify a succession of floppy disks swappable by
-pressing %s+F4, and -l specifies the mounted drive to boot from. If no drive
+pressing [color=yellow]%s+F4[reset], and -l specifies the mounted drive to boot from. If no drive
 letter is specified, this defaults to booting from the A drive. The only
 bootable drive letters are A, C, and D. For booting from a hard drive (C or D),
 the image should have already been mounted using the [color=light-blue]IMGMOUNT[reset] command.
@@ -2072,15 +2129,18 @@ Parameters:
              bytes-per-sector,sectors-per-head,heads,cylinders
 
 Notes:
-  - %s+F4 swaps & mounts the next [color=light-cyan]CDROM-SET[reset] or [color=light-cyan]BOOTIMAGE[reset], if provided.
+  - You can use wildcards to mount multiple images, e.g.:
+      [color=light-green]imgmount[reset] [color=white]A[reset] [color=light-cyan]floppy*.img[reset] -t floppy
+  - [color=yellow]%s+F4[reset] swaps & mounts the next [color=light-cyan]CDROM-SET[reset] or [color=light-cyan]BOOTIMAGE[reset], if provided.
   - The -ro flag mounts the disk image in read-only (write-protected) mode.
   - The -ide flag emulates an IDE controller with attached IDE CD drive, useful
     for CD-based games that need a real DOS environment via bootable HDD image.
 
 Examples:
-  [color=light-green]imgmount[reset] [color=white]D[reset] [color=light-cyan]/home/USERNAME/games/doom.iso[reset] -t cdrom
+  [color=light-green]imgmount[reset] [color=white]D[reset] [color=light-cyan]/Users/USERNAME/Games/doom.iso[reset] -t cdrom
   [color=light-green]imgmount[reset] [color=white]D[reset] [color=light-cyan]cd/quake1.cue[reset] -t cdrom
   [color=light-green]imgmount[reset] [color=white]A[reset] [color=light-cyan]floppy1.img floppy2.img floppy3.img[reset] -t floppy -ro
+  [color=light-green]imgmount[reset] [color=white]A[reset] [color=light-cyan]floppy*.img[reset] -t floppy -ro
   [color=light-green]imgmount[reset] [color=white]C[reset] [color=light-cyan]bootable.img[reset] -t hdd -fs none -size 512,63,32,1023
 
 .
@@ -2089,19 +2149,19 @@ Must specify drive letter to mount image at.
 
 .
 :PROGRAM_IMGMOUNT_SPECIFY2
-Must specify drive number (0 or 3) to mount image at (0,1=fda,fdb;2,3=hda,hdb).
+Must specify drive number (0 or 3) to mount image at (0,1=fda,fdb; 2,3=hda,hdb).
 
 .
 :PROGRAM_IMGMOUNT_SPECIFY_GEOMETRY
-For [color=brown]CD-ROM[reset] images:   [color=light-blue]IMGMOUNT drive-letter location-of-image -t iso[reset]
-
-For [color=brown]hardrive[reset] images: Must specify drive geometry for hard drives:
-bytes-per-sector,sectors-per-head,heads,cylinders
-[color=light-blue]IMGMOUNT drive-letter location-of-image -size bps,spc,hpc,cyl[reset]
+For CD-ROM images:
+  [color=light-green]imgmount[reset] [color=white]DRIVE[reset] [color=light-cyan]IMAGEFILE[reset] -t iso
+For hard drive images, must specify drive geometry:
+  bytes-per-sector,sectors-per-head,heads,cylinders
+  [color=light-green]imgmount[reset] [color=white]DRIVE[reset] [color=light-cyan]IMAGEFILE[reset] -size bps,spc,hpc,cyl
 
 .
 :PROGRAM_IMGMOUNT_STATUS_NONE
-No drive available
+No drive available.
 
 .
 :PROGRAM_IMGMOUNT_IDE_CONTROLLERS_UNAVAILABLE
@@ -2135,7 +2195,7 @@ Image file not found.
 
 .
 :PROGRAM_IMGMOUNT_MOUNT
-To mount directories, use the [color=light-blue]MOUNT[reset] command, not the [color=light-blue]IMGMOUNT[reset] command.
+To mount directories, use the [color=light-green]MOUNT[reset] command, not the [color=green-blue]IMGMOUNT[reset] command.
 
 .
 :PROGRAM_IMGMOUNT_ALREADY_MOUNTED
@@ -2147,15 +2207,11 @@ Can't create drive from file.
 
 .
 :PROGRAM_IMGMOUNT_MOUNT_NUMBER
-Drive number %d mounted as %s
+Drive number %d mounted as %s.
 
 .
 :PROGRAM_IMGMOUNT_NON_LOCAL_DRIVE
 The image must be on a host or local drive.
-
-.
-:PROGRAM_IMGMOUNT_MULTIPLE_NON_CUEISO_FILES
-Using multiple files is only supported for CUE/ISO images.
 
 .
 :PROGRAM_INTRO_HELP
@@ -2704,7 +2760,7 @@ Notes:
 
 Examples:
   [color=light-green]mount[reset] [color=white]C[reset] [color=light-cyan]~/dosgames[reset]
-  [color=light-green]mount[reset] [color=white]D[reset] [color=light-cyan]"/media/USERNAME/Game CD"[reset] -t cdrom -usecd 0
+  [color=light-green]mount[reset] [color=white]D[reset] [color=light-cyan]"/Volumes/Game CD"[reset] -t cdrom -usecd 0
   [color=light-green]mount[reset] [color=white]C[reset] [color=light-cyan]my_savegame_files[reset] -t overlay
 
 .
@@ -2780,10 +2836,6 @@ Something went wrong.
 .
 :PROGRAM_MOUNT_OVERLAY_STATUS
 Overlay %s on drive %c mounted.
-
-.
-:PROGRAM_MOUNT_MOVE_Z_ERROR_1
-Can't move drive Z. Drive %c is mounted already.
 
 .
 :PROGRAM_MOUSECTL_HELP_LONG

--- a/src/dos/program_boot.cpp
+++ b/src/dos/program_boot.cpp
@@ -563,7 +563,7 @@ void BOOT::AddMessages()
 	MSG_Add("PROGRAM_BOOT_PRINT_ERROR",
 	        "This command boots DOSBox Staging from either a floppy or hard disk image.\n\n"
 	        "For this command, one can specify a succession of floppy disks swappable by\n"
-	        "pressing %s+F4, and -l specifies the mounted drive to boot from. If no drive\n"
+	        "pressing [color=yellow]%s+F4[reset], and -l specifies the mounted drive to boot from. If no drive\n"
 	        "letter is specified, this defaults to booting from the A drive. The only\n"
 	        "bootable drive letters are A, C, and D. For booting from a hard drive (C or D),\n"
 	        "the image should have already been mounted using the [color=light-blue]IMGMOUNT[reset] command.\n\n"

--- a/src/dos/program_imgmount.cpp
+++ b/src/dos/program_imgmount.cpp
@@ -648,38 +648,53 @@ void IMGMOUNT::AddMessages()
 
 	MSG_Add("PROGRAM_IMGMOUNT_SPECIFY_DRIVE",
 	        "Must specify drive letter to mount image at.\n");
+
 	MSG_Add("PROGRAM_IMGMOUNT_SPECIFY2",
-	        "Must specify drive number (0 or 3) to mount image at (0,1=fda,fdb;2,3=hda,hdb).\n");
+	        "Must specify drive number (0 or 3) to mount image at (0,1=fda,fdb; 2,3=hda,hdb).\n");
+
 	MSG_Add("PROGRAM_IMGMOUNT_SPECIFY_GEOMETRY",
-	        "For [color=brown]CD-ROM[reset] images:   [color=light-blue]IMGMOUNT drive-letter location-of-image -t iso[reset]\n"
-	        "\n"
-	        "For [color=brown]hardrive[reset] images: Must specify drive geometry for hard drives:\n"
-	        "bytes-per-sector,sectors-per-head,heads,cylinders\n"
-	        "[color=light-blue]IMGMOUNT drive-letter location-of-image -size bps,spc,hpc,cyl[reset]\n");
-	MSG_Add("PROGRAM_IMGMOUNT_STATUS_NONE", "No drive available\n");
+	        "For CD-ROM images:\n"
+	        "  [color=light-green]imgmount[reset] [color=white]DRIVE[reset] [color=light-cyan]IMAGEFILE[reset] -t iso\n"
+	        "For hard drive images, must specify drive geometry:\n"
+	        "  bytes-per-sector,sectors-per-head,heads,cylinders\n"
+	        "  [color=light-green]imgmount[reset] [color=white]DRIVE[reset] [color=light-cyan]IMAGEFILE[reset] -size bps,spc,hpc,cyl\n");
+
+	MSG_Add("PROGRAM_IMGMOUNT_STATUS_NONE", "No drive available.\n");
+
 	MSG_Add("PROGRAM_IMGMOUNT_IDE_CONTROLLERS_UNAVAILABLE",
 	        "No available IDE controllers. Drive will not have IDE emulation.\n");
+
 	MSG_Add("PROGRAM_IMGMOUNT_INVALID_IMAGE",
 	        "Could not load image file.\n"
 	        "Check that the path is correct and the image is accessible.\n");
+
 	MSG_Add("PROGRAM_IMGMOUNT_INVALID_GEOMETRY",
 	        "Could not extract drive geometry from image.\n"
 	        "Use parameter -size bps,spc,hpc,cyl to specify the geometry.\n");
+
 	MSG_Add("PROGRAM_IMGMOUNT_TYPE_UNSUPPORTED",
 	        "Type '%s' is unsupported. Specify 'floppy', 'hdd', 'cdrom', or 'iso'.\n");
+
 	MSG_Add("PROGRAM_IMGMOUNT_FORMAT_UNSUPPORTED",
 	        "Format '%s' is unsupported. Specify 'fat', 'iso', or 'none'.\n");
+
 	MSG_Add("PROGRAM_IMGMOUNT_SPECIFY_FILE",
 	        "Must specify file-image to mount.\n");
+
 	MSG_Add("PROGRAM_IMGMOUNT_FILE_NOT_FOUND", "Image file not found.\n");
+
 	MSG_Add("PROGRAM_IMGMOUNT_MOUNT",
-	        "To mount directories, use the [color=light-blue]MOUNT[reset] command, not the [color=light-blue]IMGMOUNT[reset] command.\n");
+	        "To mount directories, use the [color=light-green]MOUNT[reset] command, not the [color=green-blue]IMGMOUNT[reset] command.\n");
+
 	MSG_Add("PROGRAM_IMGMOUNT_ALREADY_MOUNTED",
 	        "Drive already mounted at that letter.\n");
+
 	MSG_Add("PROGRAM_IMGMOUNT_CANT_CREATE", "Can't create drive from file.\n");
-	MSG_Add("PROGRAM_IMGMOUNT_MOUNT_NUMBER", "Drive number %d mounted as %s\n");
+	MSG_Add("PROGRAM_IMGMOUNT_MOUNT_NUMBER", "Drive number %d mounted as %s.\n");
+
 	MSG_Add("PROGRAM_IMGMOUNT_NON_LOCAL_DRIVE",
 	        "The image must be on a host or local drive.\n");
+
 	MSG_Add("PROGRAM_IMGMOUNT_MULTIPLE_NON_CUEISO_FILES",
 	        "Using multiple files is only supported for CUE/ISO images.\n");
 }

--- a/src/dos/program_imgmount.cpp
+++ b/src/dos/program_imgmount.cpp
@@ -694,7 +694,4 @@ void IMGMOUNT::AddMessages()
 
 	MSG_Add("PROGRAM_IMGMOUNT_NON_LOCAL_DRIVE",
 	        "The image must be on a host or local drive.\n");
-
-	MSG_Add("PROGRAM_IMGMOUNT_MULTIPLE_NON_CUEISO_FILES",
-	        "Using multiple files is only supported for CUE/ISO images.\n");
 }

--- a/src/dos/program_imgmount.cpp
+++ b/src/dos/program_imgmount.cpp
@@ -624,7 +624,7 @@ void IMGMOUNT::AddMessages()
 	        "Notes:\n"
 			"  - You can use wildcards to mount multiple images, e.g.:\n"
 			"      [color=light-green]imgmount[reset] [color=white]A[reset] [color=light-cyan]floppy*.img[reset] -t floppy\n"
-	        "  - %s+F4 swaps & mounts the next [color=light-cyan]CDROM-SET[reset] or [color=light-cyan]BOOTIMAGE[reset], if provided.\n"
+	        "  - [color=yellow]%s+F4[reset] swaps & mounts the next [color=light-cyan]CDROM-SET[reset] or [color=light-cyan]BOOTIMAGE[reset], if provided.\n"
 	        "  - The -ro flag mounts the disk image in read-only (write-protected) mode.\n"
 	        "  - The -ide flag emulates an IDE controller with attached IDE CD drive, useful\n"
 	        "    for CD-based games that need a real DOS environment via bootable HDD image.\n"

--- a/src/dos/program_imgmount.cpp
+++ b/src/dos/program_imgmount.cpp
@@ -622,6 +622,8 @@ void IMGMOUNT::AddMessages()
 	        "             bytes-per-sector,sectors-per-head,heads,cylinders\n"
 	        "\n"
 	        "Notes:\n"
+			"  - You can use wildcards to mount multiple images, e.g.:\n"
+			"      [color=light-green]imgmount[reset] [color=white]A[reset] [color=light-cyan]floppy*.img[reset] -t floppy\n"
 	        "  - %s+F4 swaps & mounts the next [color=light-cyan]CDROM-SET[reset] or [color=light-cyan]BOOTIMAGE[reset], if provided.\n"
 	        "  - The -ro flag mounts the disk image in read-only (write-protected) mode.\n"
 	        "  - The -ide flag emulates an IDE controller with attached IDE CD drive, useful\n"
@@ -629,21 +631,16 @@ void IMGMOUNT::AddMessages()
 	        "\n"
 	        "Examples:\n"
 #if defined(WIN32)
-	        "  [color=light-green]imgmount[reset] [color=white]D[reset] [color=light-cyan]C:\\games\\doom.iso[reset] -t cdrom\n"
-	        "  [color=light-green]imgmount[reset] [color=white]D[reset] [color=light-cyan]cd/quake1.cue[reset] -t cdrom\n"
-	        "  [color=light-green]imgmount[reset] [color=white]A[reset] [color=light-cyan]floppy1.img floppy2.img floppy3.img[reset] -t floppy -ro\n"
-	        "  [color=light-green]imgmount[reset] [color=white]C[reset] [color=light-cyan]bootable.img[reset] -t hdd -fs none -size 512,63,32,1023\n"
+	        "  [color=light-green]imgmount[reset] [color=white]D[reset] [color=light-cyan]C:\\Games\\doom.iso[reset] -t cdrom\n"
 #elif defined(MACOSX)
-	        "  [color=light-green]imgmount[reset] [color=white]D[reset] [color=light-cyan]/Users/USERNAME/games/doom.iso[reset] -t cdrom\n"
-	        "  [color=light-green]imgmount[reset] [color=white]D[reset] [color=light-cyan]cd/quake1.cue[reset] -t cdrom\n"
-	        "  [color=light-green]imgmount[reset] [color=white]A[reset] [color=light-cyan]floppy1.img floppy2.img floppy3.img[reset] -t floppy -ro\n"
-	        "  [color=light-green]imgmount[reset] [color=white]C[reset] [color=light-cyan]bootable.img[reset] -t hdd -fs none -size 512,63,32,1023\n"
+	        "  [color=light-green]imgmount[reset] [color=white]D[reset] [color=light-cyan]/Users/USERNAME/Games/doom.iso[reset] -t cdrom\n"
 #else
 	        "  [color=light-green]imgmount[reset] [color=white]D[reset] [color=light-cyan]/home/USERNAME/games/doom.iso[reset] -t cdrom\n"
+#endif
 	        "  [color=light-green]imgmount[reset] [color=white]D[reset] [color=light-cyan]cd/quake1.cue[reset] -t cdrom\n"
 	        "  [color=light-green]imgmount[reset] [color=white]A[reset] [color=light-cyan]floppy1.img floppy2.img floppy3.img[reset] -t floppy -ro\n"
+	        "  [color=light-green]imgmount[reset] [color=white]A[reset] [color=light-cyan]floppy*.img[reset] -t floppy -ro\n"
 	        "  [color=light-green]imgmount[reset] [color=white]C[reset] [color=light-cyan]bootable.img[reset] -t hdd -fs none -size 512,63,32,1023\n"
-#endif
 	);
 
 	MSG_Add("PROGRAM_IMGMOUNT_SPECIFY_DRIVE",


### PR DESCRIPTION
# Description

Most notably, now we're mentioning the very handy wildcard support.


## Related issues

Partially addresses https://github.com/dosbox-staging/dosbox-staging/issues/2509

# Manual testing

<img width="1072" alt="image" src="https://github.com/dosbox-staging/dosbox-staging/assets/698770/ae474341-c299-4723-baa7-8fbf7757c334">


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

