### PR TITLE
Log OpenGL vsync state

### DIFF
--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -2159,6 +2159,18 @@ uint8_t GFX_SetSize(const int render_width_px, const int render_height_px,
 		                       sdl.rendering_backend);
 	}
 
+#if C_OPENGL
+    if (sdl.rendering_backend == RenderingBackend::OpenGl) {
+        static auto last_vsync_state = VsyncState::Unset;
+        const auto vsync_state = static_cast<VsyncState>(SDL_GL_GetSwapInterval());
+        if (last_vsync_state != vsync_state) {
+            last_vsync_state = vsync_state;
+            const auto vsync_state_str = vsync_state_as_string(vsync_state);
+            LOG_INFO("OPENGL: VSync state: %s", vsync_state_str);
+        }
+    }
+#endif
+
 	if (retFlags) {
 		GFX_Start();
 	}


### PR DESCRIPTION
# Description

I was experimenting with different VSync settings on my MacBook M3 with different refresh rates and wanted a log entry so I could verify what state it was in, and thought it might be useful to others.

# Manual testing

Verified log output with `[sdl] vsync = ` set to:

`auto`:
```log
2024-03-28 20:38:44.884 | OPENGL: VSync state: off
```
`on`:
```log
2024-03-28 20:39:53.542 | OPENGL: VSync state: on
```
`off`:
```log
2024-03-28 20:40:32.520 | OPENGL: VSync state: off
```
`adaptive`:
```log
2024-03-28 20:40:50.633 | OPENGL: VSync state: adaptive
```

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

