### PR TITLE
Better build version handling at runtime

### DIFF
--- a/.github/workflows/pvs-studio.yml
+++ b/.github/workflows/pvs-studio.yml
@@ -112,7 +112,7 @@ jobs:
 
       - name: Summarize report
         env:
-          MAX_BUGS: 109
+          MAX_BUGS: 108
         run: |
           echo "Full report is included in build Artifacts"
           echo

--- a/include/mapper.h
+++ b/include/mapper.h
@@ -54,6 +54,8 @@ constexpr uint32_t MMOD3 = 0x4;
 
 typedef void(MAPPER_Handler)(bool pressed);
 
+std::string MAPPER_GetDefaultMapperfileName();
+
 /* Associate function handler with a key combination
  *
  * handler     - function to be triggered

--- a/include/mapper.h
+++ b/include/mapper.h
@@ -29,8 +29,6 @@
 
 #include <SDL.h>
 
-#define MAPPERFILE "mapper-sdl2-" VERSION ".map"
-
 constexpr uint32_t MMOD1 = 0x1;
 #define MMOD1_NAME "Ctrl"
 constexpr uint32_t MMOD2 = 0x2;

--- a/src/capture/image/png_writer.cpp
+++ b/src/capture/image/png_writer.cpp
@@ -206,11 +206,14 @@ void PngWriter::WritePngInfo(const uint16_t width, const uint16_t height,
 
 	char software_keyword[] = "Software";
 	static_assert(sizeof(software_keyword) < 80, "libpng limit");
-	char software_value[] = CANONICAL_PROJECT_NAME " " VERSION;
+
+	auto software_value = format_string("%s %s",
+	                                    CANONICAL_PROJECT_NAME,
+	                                    DOSBOX_GetDetailedVersion());
 
 	texts[0].compression = PNG_TEXT_COMPRESSION_NONE;
 	texts[0].key         = static_cast<png_charp>(software_keyword);
-	texts[0].text        = static_cast<png_charp>(software_value);
+	texts[0].text        = static_cast<png_charp>(software_value.data());
 	texts[0].text_length = sizeof(software_value);
 
 	auto num_text = 1;
@@ -218,7 +221,7 @@ void PngWriter::WritePngInfo(const uint16_t width, const uint16_t height,
 	char source_keyword[] = "Source";
 	static_assert(sizeof(source_keyword) < 80, "libpng limit");
 
-	const auto source_value = format_string(
+	auto source_value = format_string(
 	        "source resolution: %dx%d; source pixel aspect ratio: %d:%d (1:%1.6f)",
 	        video_mode.width,
 	        video_mode.height,
@@ -228,7 +231,7 @@ void PngWriter::WritePngInfo(const uint16_t width, const uint16_t height,
 
 	texts[1].compression = PNG_TEXT_COMPRESSION_NONE;
 	texts[1].key         = static_cast<png_charp>(source_keyword);
-	texts[1].text        = const_cast<png_charp>(source_value.data());
+	texts[1].text        = static_cast<png_charp>(source_value.data());
 	texts[1].text_length = source_value.size();
 
 	++num_text;

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -27,15 +27,6 @@
 // Name of project, lower-case without spaces
 #define CANONICAL_PROJECT_NAME "@project_name@"
 
-// Emulator Semantic Version (MAJOR.MINOR.PATCH), incremented as follows:
-//  - MAJOR version when you make incompatible API changes
-//  - MINOR version when you add functionality in a backwards compatible manner
-//  - PATCH version when you make backwards compatible bug fixes
-// Additional labels for pre-release and build metadata are available as extensions to the MAJOR.MINOR.PATCH format.
-// Ref: https://semver.org/
-
-#define VERSION "@version@"
-
 /* Strings to be returned by virtual drivers, etc.
 */
 

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -1264,6 +1264,10 @@ protected:
 	uint16_t button_state = 0;
 };
 
+std::string MAPPER_GetDefaultMapperfileName()
+{
+	return std::string("mapper-sdl2-") + DOSBOX_GetDetailedVersion() + ".map";
+}
 
 void MAPPER_TriggerEvent(const CEvent *event, const bool deactivation_state) {
 	assert(event);

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -2768,7 +2768,7 @@ static bool load_binds_from_file(const std::string_view mapperfile_path,
 
 	// Only report load failures for customized mapperfiles because by
 	// default, the mapperfile is not provided
-	if (!was_loaded && mapperfile_name != MAPPERFILE)
+	if (!was_loaded && mapperfile_name != MAPPER_GetDefaultMapperfileName())
 		LOG_WARNING("MAPPER: Failed loading mapperfile '%s' directly or from resources",
 		            mapperfile_name.data());
 

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -4480,7 +4480,7 @@ static void config_add_sdl() {
 	pbool = sdl_sec->Add_bool("pause_when_inactive", on_start, false);
 	pbool->Set_help("Pause emulation when the window is inactive (disabled by default).");
 
-	pstring = sdl_sec->Add_path("mapperfile", always, MAPPERFILE);
+	pstring = sdl_sec->Add_path("mapperfile", always, MAPPER_GetDefaultMapperfileName().c_str());
 	pstring->Set_help(
 	        "Path to the mapper file ('mapper-sdl2-XYZ.map' by default, where XYZ is the\n"
 	        "current version). Pre-configured maps are bundled in 'resources/mapperfiles'.\n"
@@ -4688,7 +4688,7 @@ static int erase_primary_config_file()
 
 static int erase_mapper_file()
 {
-	const auto path = GetConfigDir() / MAPPERFILE;
+	const auto path = GetConfigDir() / MAPPER_GetDefaultMapperfileName();
 
 	if (!path_exists(path)) {
 		printf("Default mapper file does not exist at path '%s'\n",

--- a/src/hardware/serialport/softmodem.cpp
+++ b/src/hardware/serialport/softmodem.cpp
@@ -609,8 +609,15 @@ void CSerialModem::DoCommand()
 		}
 		case 'I': // Some strings about firmware
 			switch (ScanNumber(scanbuf)) {
-			case 3: SendLine("DOSBox Emulated Modem Firmware V1.00"); break;
-			case 4: SendLine("Modem compiled for DOSBox version " VERSION); break;
+			case 3:
+				SendLine("DOSBox Emulated Modem Firmware V1.00");
+				break;
+			case 4: {
+				const auto line = format_string(
+				        "Modem compiled for DOSBox version %s",
+				        DOSBOX_GetDetailedVersion());
+				SendLine(line.c_str());
+			} break;
 			}
 			break;
 		case 'E': // Echo on/off

--- a/src/ints/int10_vesa.cpp
+++ b/src/ints/int10_vesa.cpp
@@ -48,7 +48,6 @@ static struct {
 static const std::string string_oem         = "S3 Incorporated. Trio64";
 static const std::string string_vendorname  = DOSBOX_TEAM;
 static const std::string string_productname = DOSBOX_NAME;
-static const std::string string_productrev  = VERSION;
 
 #ifdef _MSC_VER
 #pragma pack (1)
@@ -144,6 +143,7 @@ uint8_t VESA_GetSVGAInformation(const uint16_t segment, const uint16_t offset)
 
 		// Product revision
 		mem_writed(buffer + 0x1e, RealMake(segment, vbe2_pos));
+		const auto string_productrev = DOSBOX_GetDetailedVersion();
 		write_string(string_productrev, vbe2_pos);
 	} else {
 		// OEM string

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -398,9 +398,11 @@ void CONFIG::Run(void)
 		case P_LISTCONF: {
 			Bitu size = control->configfiles.size();
 			const std_fs::path config_path = GetConfigDir();
+
 			WriteOut(MSG_Get("PROGRAM_CONFIG_CONFDIR"),
-			         VERSION,
+			         DOSBOX_GetDetailedVersion(),
 			         config_path.c_str());
+
 			if (size == 0) {
 				WriteOut(MSG_Get("PROGRAM_CONFIG_NOCONFIGFILE"));
 			} else {

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -1012,7 +1012,7 @@ bool Config::WriteConfig(const std_fs::path& path) const
 	}
 
 	// Print start of config file and add a return to improve readibility
-	fprintf(outfile, MSG_GetRaw("CONFIGFILE_INTRO"), VERSION);
+	fprintf(outfile, MSG_GetRaw("CONFIGFILE_INTRO"), DOSBOX_GetDetailedVersion());
 	fprintf(outfile, "\n");
 
 	for (auto tel = sectionlist.cbegin(); tel != sectionlist.cend(); ++tel) {


### PR DESCRIPTION
# Description

In my recent attempt to build 0.81.1, in the macOS build the correct **0.81.1** version shows up in most places, but `mapperfile` still got a `0.82.0-alpha` suffix because... reasons 🤷🏻 

![image](https://github.com/dosbox-staging/dosbox-staging/assets/698770/3dffa1f9-1192-4489-87e7-7eb8324ba8ad)

The log complains about this too:

<img width="1027" alt="image" src="https://github.com/dosbox-staging/dosbox-staging/assets/698770/162e55ab-e771-481c-9dd0-a22a00d4c8e1">

It turns out although we have a `DOSBOX_GetDetailedVersion()` function that gets injected `VCS_TAG` during the build process, and which correctly returns `0.81.1` in this case, there is also the legacy `VERSION` C `#define` which is injected in a different way, and the two have drifted. Blergh.

Yeah, I could figure out the difference and fix `VERSION` for this particular build, but I simply don't wanna. I want to use a _single source of truth_ for querying the version number at runtime and use `DOSBOX_GetDetailedVersion()` consistently everywhere. Which is what this PR does.

We have enough version number duplications in various resource files, the Meson config, etc., sbuto at least only use a single method at the C++ code level.

I will forward port this to `main` manually later.

# Manual testing

Stuff still compiles and the version number printed out in the intro screen is not broken. But it's tricky to test this properly; the true test will be to build a tagged build once this is merged.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

