### PR TITLE
Decouple CMS and OPL emulations

### DIFF
--- a/include/hardware.h
+++ b/include/hardware.h
@@ -29,11 +29,12 @@
 
 class Section;
 
-enum class OplMode { None, Cms, Opl2, DualOpl2, Opl3, Opl3Gold };
+enum class OplMode { None, Opl2, DualOpl2, Opl3, Opl3Gold };
 
 void OPL_Init(Section *sec, OplMode mode);
-void CMS_Init(Section *sec);
 void OPL_ShutDown(Section* sec = nullptr);
+
+void CMS_Init(Section *sec);
 void CMS_ShutDown(Section* sec = nullptr);
 
 bool PS1AUDIO_IsEnabled();

--- a/src/dos/dos_memory.cpp
+++ b/src/dos/dos_memory.cpp
@@ -488,7 +488,7 @@ void DOS_SetupMemory(void) {
 	RealSetVec(0x02,RealMake(ihseg,ihofs));		//BioMenace (segment<0x8000)
 	RealSetVec(0x03,RealMake(ihseg,ihofs));		//Alien Incident (offset!=0)
 	RealSetVec(0x04,RealMake(ihseg,ihofs));		//Shadow President (lower byte of segment!=0)
-	RealSetVec(0x0f,RealMake(ihseg,ihofs));		//Always a tricky one (soundblaster irq)
+	RealSetVec(0x0f,RealMake(ihseg,ihofs));		//Always a tricky one (Sound Blaster irq)
 
 	// Create a dummy device MCB with PSPSeg=0x0008
 	DOS_MCB mcb_devicedummy((uint16_t)DOS_MEM_START);

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -701,7 +701,7 @@ bool localFile::Read(uint8_t *data, uint16_t *size)
 		}
 	}
 
-	/* Fake harddrive motion. Inspector Gadget with soundblaster compatible */
+	/* Fake harddrive motion. Inspector Gadget with Sound Blaster compatible */
 	/* Same for Igor */
 	/* hardrive motion => unmask irq 2. Only do it when it's masked as
 	 * unmasking is realitively heavy to emulate */

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -821,12 +821,21 @@ void DOSBOX_Init()
 	pint->Set_help("The OPL waveform is now sampled at the mixer's playback rate to avoid\n"
 	               "resampling.");
 
-	const char* oplmodes[] = {"auto", "cms", "opl2", "dualopl2", "opl3", "opl3gold", "none", nullptr};
+	pstring = secprop->Add_string("cms", when_idle, "auto");
+	pstring->Set_values({"on", "off", "auto"});
+	pstring->Set_help(
+	        "Enable CMS emulation ('auto' by default).\n"
+	        "  off:   Disable CMS emulation (except when the Game Blaster is selected).\n"
+	        "  on:    Enable CMS emulation on Sound Blaster 1 and 2.\n"
+	        "  auto:  Auto-enable CMS emulation for Sound Blaster 1 and Game Blaster.");
+
+	const char* oplmodes[] = {
+	        "auto", "cms", "opl2", "dualopl2", "opl3", "opl3gold", "none", nullptr};
 	pstring = secprop->Add_string("oplmode", when_idle, "auto");
 	pstring->Set_values(oplmodes);
 	pstring->Set_help("Type of OPL emulation ('auto' by default).\n"
 	                  "On 'auto' the mode is determined by 'sbtype'.\n"
-	                  "All OPL modes are AdLib-compatible, except for 'cms'.");
+	                  "All OPL modes are AdLib-compatible.");
 
 	pstring = secprop->Add_string("opl_fadeout", when_idle, "off");
 	pstring->Set_help(
@@ -838,7 +847,7 @@ void DOSBOX_Init()
 	        "             Where WAIT is how long after the last IO port write fading begins,\n"
 	        "             ranging between 100 and 5000 milliseconds; and FADE is the\n"
 	        "             fade-out period, ranging between 10 and 3000 milliseconds.\n"
-		"             Examples:\n"
+	        "             Examples:\n"
 	        "                300 200 (Wait 300ms before fading out over a 200ms period)\n"
 	        "                1000 3000 (Wait 1s before fading out over a 3s period)");
 

--- a/src/hardware/gameblaster.h
+++ b/src/hardware/gameblaster.h
@@ -62,7 +62,7 @@ private:
 	void WriteDataToRightDevice(io_port_t port, io_val_t value, io_width_t width);
 	void WriteControlToRightDevice(io_port_t port, io_val_t value, io_width_t width);
 
-	// IO callbacks to the GameBlaster detection chip
+	// IO callbacks to the Game Blaster detection chip
 	void WriteToDetectionPort(io_port_t port, io_val_t value, io_width_t width);
 	uint8_t ReadFromDetectionPort(io_port_t port, io_width_t width) const;
 

--- a/src/hardware/opl.cpp
+++ b/src/hardware/opl.cpp
@@ -917,7 +917,6 @@ OPL::OPL(Section *configuration, const OplMode oplmode)
 {
 	using namespace std::placeholders;
 
-	assert(oplmode != OplMode::Cms);
 	assert(oplmode != OplMode::None);
 
 	switch (oplmode) {


### PR DESCRIPTION
# Description

Decouple CMS and OPL emulations.

For SoundBlaster 1, 1.5 and 2, the CMS is (optionally) built-in. For these SoundBlasters, CMS can now be enabled or disabled. GameBlaster is an implementation of CMS and always enables it.

For backward compatibility, CMS can still be selected as the OPL-mode.

## Related issues

#2136
https://github.com/dosbox-staging/dosbox-staging/issues/2111

# Manual testing

Attached the debugger and used the Config commando to cycle through all possibilities.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [ ] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

