### PR TITLE
Fix not being able to set `oplmode = none` regression

### DIFF
--- a/src/hardware/opl.cpp
+++ b/src/hardware/opl.cpp
@@ -219,9 +219,10 @@ public:
 		return true;
 	}
 
-	Capture(RegisterCache *_cache) : header(), cache(_cache)
+	Capture(RegisterCache* _cache) : header(), cache(_cache)
 	{
-		LOG_MSG("CAPTURE: Preparing to capture raw OPL output; capturing will start when OPL output starts");
+		LOG_MSG("CAPTURE: Preparing to capture raw OPL output; "
+		        "capturing will start when OPL output starts");
 		MakeTables();
 	}
 
@@ -589,8 +590,11 @@ void OPL::AudioCallback(const uint16_t requested_frames)
 {
 	assert(channel);
 
-	//if (fifo.size())
-	//	LOG_MSG("OPL: Queued %2lu cycle-accurate frames", fifo.size());
+	// if (fifo.size()) {
+	// 	LOG_MSG("%s: Queued %2lu cycle-accurate frames",
+	// 	        channel->GetName().c_str(),
+	// 	        fifo.size());
+	// }
 
 	auto frames_remaining = requested_frames;
 
@@ -888,7 +892,8 @@ static void OPL_SaveRawEvent(const bool pressed)
 	//	SaveRad();return;
 
 	if (!opl) {
-		LOG_WARNING("OPL: Can't capture the OPL stream because the OPL device is unavailable");
+		LOG_WARNING("OPL: Can't capture the OPL stream because "
+		            "the OPL device is unavailable");
 		return;
 	}
 
@@ -995,7 +1000,8 @@ OPL::OPL(Section *configuration, const OplMode oplmode)
 
 	MAPPER_AddHandler(OPL_SaveRawEvent, SDL_SCANCODE_UNKNOWN, 0, "caprawopl", "Rec. OPL");
 
-	LOG_MSG("OPL: Running %s on ports %xh and %xh",
+	LOG_MSG("%s: Running %s on ports %xh and %xh",
+	        channel->GetName().c_str(),
 	        opl_mode_to_string(mode).c_str(),
 	        base,
 	        port_0x388);
@@ -1003,7 +1009,9 @@ OPL::OPL(Section *configuration, const OplMode oplmode)
 
 OPL::~OPL()
 {
-	LOG_MSG("OPL: Shutting down %s", opl_mode_to_string(mode).c_str());
+	LOG_MSG("%s: Shutting down %s",
+	        channel->GetName().c_str(),
+	        opl_mode_to_string(mode).c_str());
 
 	// Stop playback
 	if (channel) {


### PR DESCRIPTION
# Description

In 0.81.0, we no longer could disable OPL with `oplmode = none`. This is a regression compared to 0.80.1. The only way to disable OPL was to set `sbtype = none`, but that disabled the Sound Blaster as well.

This PR fixes that and also cleans up the `oplmode` and `sbtype` handling. Now we're using pure functions for the parsing, things are less tangled, etc.

OPL logging is also a bit improved.

# Manual testing

Tested setting `oplmode = none` and all sorts of `oplmode` and `sbtype` permutations, including `oplmode = auto`.

Confirmed that `oplmode` and `sbtype` always stay in sync with the actual settings in use.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

