### PR TITLE
Improve `sbtype` and `oplmode` descriptions & clean up `sblaster.cpp`

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -86,14 +86,14 @@ AlignConsecutiveAssignments: Consecutive
 AlignOperands:  AlignAfterOperator
 
 ##
-#   // Indents directives after the hash.
+#   // Indents directives before the hash.
 #
 #   #if FOO
-#   #  if BAR
-#   #    include <foo>
-#   #  else
-#   #    include <other>
-#   #  endif
+#     #if BAR
+#       #include <foo>
+#     #else
+#       #include <other>
+#     #endif
 #   #endif
 #
 #   // This much easier to see what's happening versus:
@@ -106,7 +106,7 @@ AlignOperands:  AlignAfterOperator
 #   #endif
 #   #endif
 #
-IndentPPDirectives: None
+IndentPPDirectives: BeforeHash
 
 # Always place function bodies on their own lines because
 # it makes a mess when some are on the same line and others are
@@ -156,8 +156,7 @@ AlwaysBreakTemplateDeclarations: Yes
 #                      "cccc";
 # shortname = "dddd"
 #             "eeee";
-#
-# AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakBeforeMultilineStrings: true
 
 # Insert braces after control statements (``if``, ``else``, ``for``, ``do``,
 #  and ``while``) in C++ unless the control statements are inside macro
@@ -201,10 +200,9 @@ InsertBraces: true
 # }
 #
 
-# Coming in Clang-format-14
-# AlignArrayOfStructures: Left
+# If not None, when using initialization for an array of structs aligns the fields into columns.
 #
-# if not None, when using initialization for an array of structs aligns the fields into columns.
+# NOTE: As of clang-format 15 this option only applied to arrays with equal number of columns per row.
 #
 # Possible values:
 
@@ -227,9 +225,8 @@ InsertBraces: true
 #        };
 #
 # AIAS_None (in configuration: None) Don’t align array initializer columns.
-
-
-
+#
+AlignArrayOfStructures: Right
 
 # Our custom rules are the same as "BreakBeforeBraces: Linux", except
 # additional customization for C++ constructs.

--- a/include/hardware.h
+++ b/include/hardware.h
@@ -1,7 +1,7 @@
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *
- *  Copyright (C) 2023-2023  The DOSBox Staging Team
+ *  Copyright (C) 2023-2024  The DOSBox Staging Team
  *  Copyright (C) 2002-2021  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -38,8 +38,9 @@ void CMS_Init(Section *sec);
 void CMS_ShutDown(Section* sec = nullptr);
 
 bool PS1AUDIO_IsEnabled();
-bool SB_Get_Address(uint16_t &sbaddr, uint8_t &sbirq, uint8_t &sbdma);
-bool TS_Get_Address(Bitu& tsaddr, Bitu& tsirq, Bitu& tsdma);
+bool SB_GetAddress(uint16_t &sbaddr, uint8_t &sbirq, uint8_t &sbdma);
+
+bool TANDYSOUND_GetAddress(Bitu& tsaddr, Bitu& tsirq, Bitu& tsdma);
 
 extern uint8_t adlib_commandreg;
 

--- a/src/dos/program_mixer.cpp
+++ b/src/dos/program_mixer.cpp
@@ -106,8 +106,8 @@ void Executor::operator()(const SetCrossfeedStrength cmd)
 	}
 
 	if (global_command) {
-		for (const auto& [_, channel] : MIXER_GetChannels()) {
-			channel->SetCrossfeedStrength(cmd.strength);
+		for (const auto& [_, ch] : MIXER_GetChannels()) {
+			ch->SetCrossfeedStrength(cmd.strength);
 		}
 	} else {
 		assert(channel);
@@ -123,8 +123,8 @@ void Executor::operator()(const SetReverbLevel cmd)
 	}
 
 	if (global_command) {
-		for (const auto& [_, channel] : MIXER_GetChannels()) {
-			channel->SetReverbLevel(cmd.level);
+		for (const auto& [_, ch] : MIXER_GetChannels()) {
+			ch->SetReverbLevel(cmd.level);
 		}
 	} else {
 		assert(channel);
@@ -140,8 +140,8 @@ void Executor::operator()(const SetChorusLevel cmd)
 	}
 
 	if (global_command) {
-		for (const auto& [_, channel] : MIXER_GetChannels()) {
-			channel->SetChorusLevel(cmd.level);
+		for (const auto& [_, ch] : MIXER_GetChannels()) {
+			ch->SetChorusLevel(cmd.level);
 		}
 	} else {
 		assert(channel);
@@ -504,8 +504,8 @@ std::variant<Error, std::queue<Command>> ParseCommands(
 	std::queue<Command> commands = {};
 
 	// We always implicitly select the "global virtual channel" at the start
-	const SelectChannel cmd = {GlobalVirtualChannelName};
-	commands.emplace(cmd);
+	const SelectChannel select_global_chan_cmd = {GlobalVirtualChannelName};
+	commands.emplace(select_global_chan_cmd);
 
 	auto parse_select_channel_command =
 	        [&](const std::string& channel_name) -> std::optional<SelectChannel> {
@@ -696,8 +696,8 @@ static ChannelInfos create_channel_infos()
 {
 	ChannelInfosMap infos = {};
 
-	for (const auto& [name, channel] : MIXER_GetChannels()) {
-		infos[name] = channel->GetFeatures();
+	for (const auto& [name, ch] : MIXER_GetChannels()) {
+		infos[name] = ch->GetFeatures();
 	}
 
 	return ChannelInfos(infos);

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -757,10 +757,21 @@ void DOSBOX_Init()
 	                                   changeable_at_runtime);
 
 	pstring = secprop->Add_string("sbtype", when_idle, "sb16");
-	pstring->Set_values(
-	        {"sb1", "sb2", "sbpro1", "sbpro2", "sb16", "gb", "none"});
+	pstring->Set_values({"gb", "sb1", "sb2", "sbpro1", "sbpro2", "sb16", "none"});
 	pstring->Set_help("Type of Sound Blaster to emulate ('sb16' by default).\n"
 	                  "'gb' is Game Blaster.");
+	pstring->Set_help(
+	        "Sound Blaster model to emulate ('sb16' by default).\n"
+	        "The models auto-selected with 'oplmode' and 'cms' on 'auto' are also listed.\n"
+	        "  gb:        Game Blaster        - CMS\n"
+	        "  sb1:       Sound Blaster 1.0   - OPL2, CMS\n"
+	        "  sb2:       Sound Blaster 2.0   - OPL2\n"
+	        "  sbpro1:    Sound Blaster Pro   - Dual OPL2\n"
+	        "  sbpro2:    Sound Blaster Pro 2 - OPL3\n"
+	        "  sb16:      Sound Blaster 16    - OPL3 (default)\n"
+	        "  none/off:  Disable Sound Blaster emulation.\n"
+	        "Note: Creative Music System was later rebranded to Game Blaster; they are the\n"
+	        "      same card.");
 
 	phex = secprop->Add_hex("sbbase", when_idle, 0x220);
 	phex->Set_values(

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -804,9 +804,16 @@ void DOSBOX_Init()
 	pstring = secprop->Add_string("oplmode", when_idle, "auto");
 	pstring->Set_values(
 	        {"auto", "cms", "opl2", "dualopl2", "opl3", "opl3gold", "none"});
-	pstring->Set_help("Type of OPL emulation ('auto' by default).\n"
-	                  "On 'auto' the mode is determined by 'sbtype'.\n"
-	                  "All OPL modes are AdLib-compatible.");
+	pstring->Set_help(
+	        "OPL model to emulate ('auto' by default).\n"
+	        "  auto:      Use the appropriate model determined by 'sbtype'.\n"
+	        "  opl2:      OPL2 (mono).\n"
+	        "  dualopl2:  Dual OPL2 (stereo).\n"
+	        "  opl3:      OPL3 (stereo).\n"
+	        "  opl3gold:  OPL3 (stereo) and the optional AdLib Gold Surround module.\n"
+	        "             Use with 'sbtype = sb16' to emulate the AdLib Gold 1000.\n"
+	        "  none/off:  Disable OPL emulation.\n"
+	        "Note: 'sbtype = none' and 'oplmode = opl2' emulates the original AdLib card.");
 
 	pstring = secprop->Add_string("opl_fadeout", when_idle, "off");
 	pstring->Set_help(

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -1640,13 +1640,13 @@ static void dsp_do_command()
 
 	case 0x15:
 		// Wari hack. Waru uses this one instead of 0x14, but some
-		// weird stuff going on there anyway */
+		// weird stuff going on there anyway
 		[[fallthrough]];
 
 	case 0x91:
-		// Singe Cycle 8-Bit DMA High speed DAC */
+		// Singe Cycle 8-Bit DMA High speed DAC
 		// Note: 0x91 is documented only for DSP ver.2.x and 3.x,
-		// not 4.x */
+		// not 4.x
 		dsp_prepare_dma_old(DmaMode::Pcm8Bit, false, false);
 		break;
 
@@ -2499,9 +2499,9 @@ static uint8_t ctmixer_read()
 
 	default:
 		if (((sb.type == SBType::SBPro1 || sb.type == SBType::SBPro2) &&
-		     sb.mixer.index == 0x0c) || // Input control on SBPro */
+		     sb.mixer.index == 0x0c) || // Input control on SBPro
 		    (sb.type == SBType::SB16 && sb.mixer.index >= 0x3b &&
-		     sb.mixer.index <= 0x47)) { // New SB16 registers */
+		     sb.mixer.index <= 0x47)) { // New SB16 registers
 			ret = sb.mixer.unhandled[sb.mixer.index];
 		} else {
 			ret = 0xa;

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -274,14 +274,12 @@ static uint8_t dsp_cmd_len_sb16[256] = {
 static uint8_t asp_regs[256];
 static bool asp_init_in_progress = false;
 
-// clang-format off
 static int e2_incr_table[4][9] = {
-  {  0x01, -0x02, -0x04,  0x08, -0x10,  0x20,  0x40, -0x80, -106 },
-  { -0x01,  0x02, -0x04,  0x08,  0x10, -0x20,  0x40, -0x80,  165 },
-  { -0x01,  0x02,  0x04, -0x08,  0x10, -0x20, -0x40,  0x80, -151 },
-  {  0x01, -0x02,  0x04, -0x08, -0x10,  0x20, -0x40,  0x80,   90 }
+        { 0x01, -0x02, -0x04,  0x08, -0x10,  0x20,  0x40, -0x80, -106},
+        {-0x01,  0x02, -0x04,  0x08,  0x10, -0x20,  0x40, -0x80,  165},
+        {-0x01,  0x02,  0x04, -0x08,  0x10, -0x20, -0x40,  0x80, -151},
+        { 0x01, -0x02,  0x04, -0x08, -0x10,  0x20, -0x40,  0x80,   90}
 };
-// clang-format on
 
 static const char* log_prefix()
 {
@@ -295,6 +293,11 @@ static const char* log_prefix()
 	case SBType::None:
 		assertm(false, "Should not use SBType::None as a log prefix");
 		return "SB";
+	default:
+		assertm(false,
+		        format_str("Invalid SBType value: %d",
+		                   static_cast<int>(sb.type)));
+		return "";
 	}
 }
 
@@ -734,16 +737,15 @@ static std::array<uint8_t, 4> decode_adpcm_2bit(const uint8_t data)
 		252, 4, 252, 4, 252, 4, 252, 4,
 		252, 0, 252, 0
 	};
+	// clang-format on
 
 	static_assert(ARRAY_LEN(ScaleMap) == ARRAY_LEN(AdjustMap));
-	constexpr auto LastIndex = static_cast<uint8_t>(sizeof(ScaleMap) - 1);;
+	constexpr auto LastIndex = static_cast<uint8_t>(sizeof(ScaleMap) - 1);
 
 	return {decode_adpcm_portion((data >> 6) & 0x3, AdjustMap, ScaleMap, LastIndex),
 	        decode_adpcm_portion((data >> 4) & 0x3, AdjustMap, ScaleMap, LastIndex),
 	        decode_adpcm_portion((data >> 2) & 0x3, AdjustMap, ScaleMap, LastIndex),
 	        decode_adpcm_portion((data >> 0) & 0x3, AdjustMap, ScaleMap, LastIndex)};
-
-	// clang-format on
 }
 
 static std::array<uint8_t, 3> decode_adpcm_3bit(const uint8_t data)
@@ -764,15 +766,14 @@ static std::array<uint8_t, 3> decode_adpcm_3bit(const uint8_t data)
 		248, 0, 0, 8, 248, 0, 0, 8,
 		248, 0, 0, 0, 248, 0, 0, 0
 	};
+	// clang-format on
 
 	static_assert(ARRAY_LEN(ScaleMap) == ARRAY_LEN(AdjustMap));
-	constexpr auto LastIndex = static_cast<uint8_t>(sizeof(ScaleMap) - 1);;
+	constexpr auto LastIndex = static_cast<uint8_t>(sizeof(ScaleMap) - 1);
 
 	return {decode_adpcm_portion((data >> 5) & 0x7, AdjustMap, ScaleMap, LastIndex),
 	        decode_adpcm_portion((data >> 2) & 0x7, AdjustMap, ScaleMap, LastIndex),
 	        decode_adpcm_portion((data & 0x3) << 1, AdjustMap, ScaleMap, LastIndex)};
-
-	// clang-format on
 }
 
 static std::array<uint8_t, 2> decode_adpcm_4bit(const uint8_t data)
@@ -795,14 +796,13 @@ static std::array<uint8_t, 2> decode_adpcm_4bit(const uint8_t data)
 		240, 0, 0, 0, 0,  0,  0,  0,
 		240, 0, 0, 0, 0,  0,  0,  0
 	};
+	// clang-format on
 
 	static_assert(ARRAY_LEN(ScaleMap) == ARRAY_LEN(AdjustMap));
-	constexpr auto LastIndex = static_cast<uint8_t>(sizeof(ScaleMap) - 1);;
+	constexpr auto LastIndex = static_cast<uint8_t>(sizeof(ScaleMap) - 1);
 
-	return {decode_adpcm_portion(data >> 4,  AdjustMap, ScaleMap, LastIndex),
+	return {decode_adpcm_portion(data >> 4, AdjustMap, ScaleMap, LastIndex),
 	        decode_adpcm_portion(data & 0xf, AdjustMap, ScaleMap, LastIndex)};
-
-	// clang-format on
 }
 
 template <typename T>
@@ -904,15 +904,18 @@ static void play_dma_transfer(const uint32_t bytes_requested)
 	// Read the actual data, process it and send it off to the mixer
 	switch (sb.dma.mode) {
 	case DmaMode::Adpcm2Bit:
-		std::tie(bytes_read, samples, frames) = decode_adpcm_dma(decode_adpcm_2bit);
+		std::tie(bytes_read, samples, frames) = decode_adpcm_dma(
+		        decode_adpcm_2bit);
 		break;
 
 	case DmaMode::Adpcm3Bit:
-		std::tie(bytes_read, samples, frames) = decode_adpcm_dma(decode_adpcm_3bit);
+		std::tie(bytes_read, samples, frames) = decode_adpcm_dma(
+		        decode_adpcm_3bit);
 		break;
 
 	case DmaMode::Adpcm4Bit:
-		std::tie(bytes_read, samples, frames) = decode_adpcm_dma(decode_adpcm_4bit);
+		std::tie(bytes_read, samples, frames) = decode_adpcm_dma(
+		        decode_adpcm_4bit);
 		break;
 
 	case DmaMode::Pcm8Bit:
@@ -1052,7 +1055,7 @@ static void play_dma_transfer(const uint32_t bytes_requested)
 		break;
 
 	default:
-		LOG_MSG("%s: Unhandled dma mode %d", log_prefix(), sb.dma.mode);
+		LOG_MSG("%s: Unhandled DMA mode %d", log_prefix(), static_cast<int>(sb.dma.mode));
 		sb.mode = DspMode::None;
 		return;
 	}
@@ -1097,13 +1100,20 @@ static void play_dma_transfer(const uint32_t bytes_requested)
 			sb.dma.left = sb.dma.autosize;
 		}
 	}
-	/*
+#if 0
 	LOG_MSG("%s: sb.dma.mode=%d, stereo=%d, signed=%d, bytes_requested=%u,"
-	        "bytes_to_read=%u, bytes_read = %u, samples = %u, frames = %u,
-	dma.left = %u", log_prefix(), sb.dma.mode, sb.dma.stereo, sb.dma.sign,
-	bytes_requested, bytes_to_read, bytes_read, samples, frames,
-	sb.dma.left);
-	*/
+	        "bytes_to_read=%u, bytes_read = %u, samples = %u, frames = %u, dma.left = %u",
+	        log_prefix(),
+	        sb.dma.mode,
+	        sb.dma.stereo,
+	        sb.dma.sign,
+	        bytes_requested,
+	        bytes_to_read,
+	        bytes_read,
+	        samples,
+	        frames,
+	        sb.dma.left);
+#endif
 }
 
 static void suppress_dma_transfer(const uint32_t bytes_to_read)
@@ -1249,7 +1259,7 @@ static void dsp_do_dma_transfer(const DmaMode mode, const uint32_t freq,
 	case DmaMode::Pcm16Bit: sb.dma.mul = (1 << SbShift); break;
 	case DmaMode::Pcm16BitAliased: sb.dma.mul = (1 << SbShift) * 2; break;
 	default:
-		LOG(LOG_SB, LOG_ERROR)("DSP:Illegal transfer mode %d", mode);
+		LOG(LOG_SB, LOG_ERROR)("DSP:Illegal transfer mode %d", static_cast<int>(mode));
 		return;
 	}
 
@@ -1574,8 +1584,12 @@ static void dsp_do_command()
 
 	case 0x0e: // SB16 ASP set register
 		if (sb.type == SBType::SB16) {
-			// LOG(LOG_SB,LOG_NORMAL)("SB16 ASP set
-			// register %X := %X",sb.dsp.in.data[0],sb.dsp.in.data[1]);
+#if 0
+			LOG(LOG_SB, LOG_NORMAL)
+			("SB16 ASP set register %X := %X",
+			 sb.dsp.in.data[0],
+			 sb.dsp.in.data[1]);
+#endif
 			asp_regs[sb.dsp.in.data[0]] = sb.dsp.in.data[1];
 		} else {
 			LOG(LOG_SB, LOG_NORMAL)
@@ -1589,9 +1603,12 @@ static void dsp_do_command()
 			if ((asp_init_in_progress) && (sb.dsp.in.data[0] == 0x83)) {
 				asp_regs[0x83] = ~asp_regs[0x83];
 			}
-			//			LOG(LOG_SB,LOG_NORMAL)("SB16 ASP
-			//get register %X ==
-			//%X",sb.dsp.in.data[0],asp_regs[sb.dsp.in.data[0]]);
+#if 0
+			LOG(LOG_SB, LOG_NORMAL)
+			("SB16 ASP get register %X == X",
+			 sb.dsp.in.data[0],
+			 asp_regs[sb.dsp.in.data[0]]);
+#endif
 			dsp_add_data(asp_regs[sb.dsp.in.data[0]]);
 		} else {
 			LOG(LOG_SB, LOG_NORMAL)
@@ -2138,8 +2155,8 @@ static void ctmixer_write(const uint8_t val)
 		ctmixer_update_volumes();
 		break;
 
-	case 0x06: // FM output selection
-	           // Somewhat obsolete with dual OPL SBpro + FM volume (SB2 Only)
+	case 0x06: { // FM output selection
+		// Somewhat obsolete with dual OPL SBpro + FM volume (SB2 Only)
 		// volume controls both channels
 		set_sb_pro_volume(sb.mixer.fm, (val & 0xf) | (val << 4));
 
@@ -2150,7 +2167,7 @@ static void ctmixer_write(const uint8_t val)
 			("Turned FM one channel off. not implemented %X", val);
 		}
 		// TODO Change FM Mode if only 1 fm channel is selected
-		break;
+	} break;
 
 	case 0x08: // CDA Volume (SB2 Only)
 		set_sb_pro_volume(sb.mixer.cda, (val & 0xf) | (val << 4));

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -2581,7 +2581,7 @@ static void adlib_gusforward(io_port_t, io_val_t value, io_width_t)
 	adlib_commandreg = (uint8_t)(val & 0xff);
 }
 
-bool SB_Get_Address(uint16_t &sbaddr, uint8_t &sbirq, uint8_t &sbdma)
+bool SB_GetAddress(uint16_t &sbaddr, uint8_t &sbirq, uint8_t &sbdma)
 {
 	sbaddr = 0;
 	sbirq  = 0;

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -44,22 +44,22 @@
 #include "support.h"
 
 constexpr uint8_t MIXER_INDEX = 0x04;
-constexpr uint8_t MIXER_DATA = 0x05;
+constexpr uint8_t MIXER_DATA  = 0x05;
 
-constexpr uint8_t DSP_RESET = 0x06;
-constexpr uint8_t DSP_READ_DATA = 0x0A;
-constexpr uint8_t DSP_WRITE_DATA = 0x0C;
+constexpr uint8_t DSP_RESET        = 0x06;
+constexpr uint8_t DSP_READ_DATA    = 0x0A;
+constexpr uint8_t DSP_WRITE_DATA   = 0x0C;
 constexpr uint8_t DSP_WRITE_STATUS = 0x0C;
-constexpr uint8_t DSP_READ_STATUS = 0x0E;
-constexpr uint8_t DSP_ACK_16BIT = 0x0f;
+constexpr uint8_t DSP_READ_STATUS  = 0x0E;
+constexpr uint8_t DSP_ACK_16BIT    = 0x0f;
 
 constexpr uint8_t DSP_NO_COMMAND = 0;
 
 constexpr uint16_t DMA_BUFSIZE = 1024;
-constexpr uint8_t DSP_BUFSIZE = 64;
+constexpr uint8_t DSP_BUFSIZE  = 64;
 constexpr uint16_t DSP_DACSIZE = 512;
 
-constexpr uint8_t SB_SH = 14;
+constexpr uint8_t SB_SH       = 14;
 constexpr uint16_t SB_SH_MASK = ((1 << SB_SH) - 1);
 
 constexpr uint8_t MIN_ADAPTIVE_STEP_SIZE = 0; // max is 32767
@@ -68,10 +68,10 @@ constexpr uint8_t MIN_ADAPTIVE_STEP_SIZE = 0; // max is 32767
 // and resets on startup, resulting a rapid susccession of resets.
 constexpr uint8_t DSP_INITIAL_RESET_LIMIT = 4;
 
-constexpr auto native_dac_rate_hz = 45454;
+constexpr auto native_dac_rate_hz           = 45454;
 constexpr uint16_t default_playback_rate_hz = 22050;
 
-enum {DSP_S_RESET,DSP_S_RESET_WAIT,DSP_S_NORMAL,DSP_S_HIGHSPEED};
+enum { DSP_S_RESET, DSP_S_RESET_WAIT, DSP_S_NORMAL, DSP_S_HIGHSPEED };
 
 enum SB_TYPES {
 	SBT_NONE = 0,
@@ -83,17 +83,9 @@ enum SB_TYPES {
 	SBT_GB   = 7
 };
 
-enum class FilterType {
-	None,
-	SB1,
-	SB2,
-	SBPro1,
-	SBPro2,
-	SB16,
-	Modern
-};
+enum class FilterType { None, SB1, SB2, SBPro1, SBPro2, SB16, Modern };
 
-enum SB_IRQS {SB_IRQ_8,SB_IRQ_16,SB_IRQ_MPU};
+enum SB_IRQS { SB_IRQ_8, SB_IRQ_16, SB_IRQ_MPU };
 
 enum DSP_MODES {
 	MODE_NONE,
@@ -103,108 +95,139 @@ enum DSP_MODES {
 	MODE_DMA_MASKED
 
 };
- 
+
 enum DMA_MODES {
 	DSP_DMA_NONE,
-	DSP_DMA_2,DSP_DMA_3,DSP_DMA_4,DSP_DMA_8,
-	DSP_DMA_16,DSP_DMA_16_ALIASED
+	DSP_DMA_2,
+	DSP_DMA_3,
+	DSP_DMA_4,
+	DSP_DMA_8,
+	DSP_DMA_16,
+	DSP_DMA_16_ALIASED
 };
 
-enum {
-	PLAY_MONO,PLAY_STEREO
-};
+enum { PLAY_MONO, PLAY_STEREO };
 
 struct SB_INFO {
 	uint32_t freq = 0;
+
 	struct {
-		bool stereo = false;
-		bool sign = false;
-		bool autoinit = false;
-		DMA_MODES mode = DSP_DMA_NONE;
-		uint32_t rate = 0;     // sample rate
-		uint32_t mul = 0;      // samples-per-millisecond multipler
+		bool stereo         = false;
+		bool sign           = false;
+		bool autoinit       = false;
+		DMA_MODES mode      = DSP_DMA_NONE;
+		uint32_t rate       = 0; // sample rate
+		uint32_t mul        = 0; // samples-per-millisecond multipler
 		uint32_t singlesize = 0; // size for single cycle transfers
-		uint32_t autosize = 0;   // size for auto init transfers
-		uint32_t left = 0;     // Left in active cycle
-		uint32_t min = 0;
+		uint32_t autosize   = 0; // size for auto init transfers
+		uint32_t left       = 0; // Left in active cycle
+		uint32_t min        = 0;
+
 		union {
-			uint8_t  b8[DMA_BUFSIZE];
+			uint8_t b8[DMA_BUFSIZE];
 			int16_t b16[DMA_BUFSIZE];
 		} buf = {};
-		uint32_t bits = 0;
-		DmaChannel *chan = nullptr;
+
+		uint32_t bits        = 0;
+		DmaChannel* chan     = nullptr;
 		uint32_t remain_size = 0;
 	} dma = {};
+
 	bool speaker = false;
-	bool midi = false;
+	bool midi    = false;
+
 	uint8_t time_constant = 0;
+
 	DSP_MODES mode = MODE_NONE;
-	SB_TYPES type = SBT_NONE;
-	FilterType sb_filter_type = FilterType::None;
-	FilterType opl_filter_type = FilterType::None;
+	SB_TYPES type  = SBT_NONE;
+
+	FilterType sb_filter_type   = FilterType::None;
+	FilterType opl_filter_type  = FilterType::None;
 	FilterState sb_filter_state = FilterState::Off;
+
 	struct {
 		bool pending_8bit;
 		bool pending_16bit;
 	} irq = {};
+
 	struct {
-		uint8_t state = 0;
-		uint8_t cmd = 0;
-		uint8_t cmd_len = 0;
-		uint8_t cmd_in_pos = 0;
+		uint8_t state               = 0;
+		uint8_t cmd                 = 0;
+		uint8_t cmd_len             = 0;
+		uint8_t cmd_in_pos          = 0;
 		uint8_t cmd_in[DSP_BUFSIZE] = {};
+
 		struct {
-			uint8_t lastval = 0; // last values added to the fifo
+			// Last values added to the fifo
+			uint8_t lastval           = 0;
 			uint8_t data[DSP_BUFSIZE] = {};
-			uint8_t pos = 0;  // index of current entry
-			uint8_t used = 0; // number of entries in the fifo
+
+			// Index of current entry
+			uint8_t pos = 0;
+
+			// Number of entries in the fifo
+			uint8_t used = 0;
 		} in = {}, out = {};
-		uint8_t test_register = 0;
+
+		uint8_t test_register        = 0;
 		uint8_t write_status_counter = 0;
-		uint32_t reset_tally = 0;
-		uint8_t cold_warmup_ms = 0;
-		uint8_t hot_warmup_ms = 0;
+		uint32_t reset_tally         = 0;
+		uint8_t cold_warmup_ms       = 0;
+		uint8_t hot_warmup_ms        = 0;
 		uint16_t warmup_remaining_ms = 0;
 	} dsp = {};
+
 	struct {
 		int16_t data[DSP_DACSIZE + 1] = {};
-		uint16_t used = 0; // number of entries in the DAC
-		int16_t last = 0;   // index of current entry
+
+		// Number of entries in the DAC
+		uint16_t used = 0;
+
+		// Index of current entry
+		int16_t last  = 0;
 	} dac = {};
+
 	struct {
-		uint8_t index = 0;
-		uint8_t dac[2] = {};
-		uint8_t fm[2] = {};
-		uint8_t cda[2] = {};
+		uint8_t index     = 0;
+		uint8_t dac[2]    = {};
+		uint8_t fm[2]     = {};
+		uint8_t cda[2]    = {};
 		uint8_t master[2] = {};
-		uint8_t lin[2] = {};
-		uint8_t mic = 0;
-		bool stereo = false;
-		bool enabled = false;
-		bool filtered = false;
+		uint8_t lin[2]    = {};
+		uint8_t mic       = 0;
+		bool stereo       = false;
+		bool enabled      = false;
+		bool filtered     = false;
+
 		uint8_t unhandled[0x48] = {};
 	} mixer = {};
+
 	struct {
 		uint8_t reference = 0;
 		uint16_t stepsize = 0;
-		bool haveref = false;
+		bool haveref      = false;
 	} adpcm = {};
+
 	struct {
 		uint16_t base = 0;
-		uint8_t irq = 0;
-		uint8_t dma8 = 0;
+		uint8_t irq   = 0;
+		uint8_t dma8  = 0;
 		uint8_t dma16 = 0;
 	} hw = {};
+
 	struct {
-		int value = 0;
+		int value      = 0;
 		uint32_t count = 0;
 	} e2 = {};
+
 	mixer_channel_t chan = nullptr;
 };
 
 static SB_INFO sb = {};
 
-// number of bytes in input for commands (sb/sbpro)
+// clang-format off
+
+// Number of bytes in input for commands (sb/sbpro)
 static uint8_t DSP_cmd_len_sb[256] = {
   0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0,  // 0x00
 //  1,0,0,0, 2,0,2,2, 0,0,0,0, 0,0,0,0,  // 0x10
@@ -228,7 +251,7 @@ static uint8_t DSP_cmd_len_sb[256] = {
   0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0   // 0xf0
 };
 
-// number of bytes in input for commands (sb16)
+// Number of bytes in input for commands (sb16)
 static uint8_t DSP_cmd_len_sb16[256] = {
   0,0,0,0, 1,2,0,0, 1,0,0,0, 0,0,2,1,  // 0x00
 //  1,0,0,0, 2,0,2,2, 0,0,0,0, 0,0,0,0,  // 0x10
@@ -251,26 +274,29 @@ static uint8_t DSP_cmd_len_sb16[256] = {
   1,0,1,0, 1,0,0,0, 0,0,0,0, 0,0,0,0,  // 0xe0
   0,0,0,0, 0,0,0,0, 0,1,0,0, 0,0,0,0   // 0xf0
 };
+// clang-format on
 
 static uint8_t ASP_regs[256];
 static bool ASP_init_in_progress = false;
 
+// clang-format off
 static int E2_incr_table[4][9] = {
   {  0x01, -0x02, -0x04,  0x08, -0x10,  0x20,  0x40, -0x80, -106 },
   { -0x01,  0x02, -0x04,  0x08,  0x10, -0x20,  0x40, -0x80,  165 },
   { -0x01,  0x02,  0x04, -0x08,  0x10, -0x20, -0x40,  0x80, -151 },
   {  0x01, -0x02,  0x04, -0x08, -0x10,  0x20, -0x40,  0x80,   90 }
 };
+// clang-format on
 
-static const char * CardType()
+static const char* CardType()
 {
-	constexpr std::array<const char *, 8> types = {"NONE",   "SB1",
-	                                               "SBPRO1", "SB2",
-	                                               "SBPRO2", "UNASSIGNED",
-	                                               "SB16",   "GB"};
+	constexpr std::array<const char*, 8> types = {
+	        "NONE", "SB1", "SBPRO1", "SB2", "SBPRO2", "UNASSIGNED", "SB16", "GB"};
+
 	const size_t type_id = static_cast<size_t>(sb.type);
 	assertm(type_id != 5 && type_id < types.size(),
 	        "sb.type does not match a known Sound Blaster type ID");
+
 	return types[type_id];
 }
 
@@ -285,9 +311,10 @@ static process_dma_f ProcessDMATransfer;
 
 static void DSP_SetSpeaker(bool requested_state)
 {
-	// The speaker-output is always enabled on the SB16; speaker enable/disable
-	// commands are simply ignored. Only the SB Pro and earlier models can
-	// toggle the speaker-output via speaker enable/disable commands.
+	// The speaker-output is always enabled on the SB16; speaker
+	// enable/disable commands are simply ignored. Only the SB Pro and
+	// earlier models can toggle the speaker-output via speaker
+	// enable/disable commands.
 	if (sb.type == SBT_16) {
 		return;
 	}
@@ -320,9 +347,9 @@ static void DSP_SetSpeaker(bool requested_state)
 static void InitializeSpeakerState()
 {
 	if (sb.type == SBT_16) {
-		// Speaker-output (DAC output) is only enabled by default on the SB16
-		// and it cannot be disabled. Because the channel is active, we treat
-		// this as a startup event.
+		// Speaker-output (DAC output) is only enabled by default on the
+		// SB16 and it cannot be disabled. Because the channel is
+		// active, we treat this as a startup event.
 		const bool is_cold_start = sb.dsp.reset_tally <=
 		                           DSP_INITIAL_RESET_LIMIT;
 
@@ -339,7 +366,7 @@ static void InitializeSpeakerState()
 	}
 }
 
-static void log_filter_config(const char *output_type, const FilterType filter)
+static void log_filter_config(const char* output_type, const FilterType filter)
 {
 	static const std::map<FilterType, std::string> filter_name_map = {
 	        {FilterType::SB1, "Sound Blaster 1.0"},
@@ -356,6 +383,7 @@ static void log_filter_config(const char *output_type, const FilterType filter)
 		auto it = filter_name_map.find(filter);
 		if (it != filter_name_map.end()) {
 			auto filter_type = it->second;
+
 			LOG_MSG("%s: %s %s output filter enabled",
 			        CardType(),
 			        filter_type.c_str(),
@@ -377,7 +405,7 @@ struct FilterConfig {
 	uint16_t zoh_rate_hz           = {};
 };
 
-static void set_filter(mixer_channel_t channel, const FilterConfig &config)
+static void set_filter(mixer_channel_t channel, const FilterConfig& config)
 {
 	if (config.hpf_state == FilterState::On ||
 	    config.hpf_state == FilterState::ForcedOn) {
@@ -393,24 +421,25 @@ static void set_filter(mixer_channel_t channel, const FilterConfig &config)
 	}
 	channel->SetLowPassFilter(config.lpf_state);
 
-	if (config.resample_method == ResampleMethod::ZeroOrderHoldAndResample)
+	if (config.resample_method == ResampleMethod::ZeroOrderHoldAndResample) {
 		channel->SetZeroOrderHoldUpsamplerTargetFreq(config.zoh_rate_hz);
+	}
 
 	channel->SetResampleMethod(config.resample_method);
 }
 
-static std::optional<FilterType> determine_filter_type(const std::string &filter_choice,
+static std::optional<FilterType> determine_filter_type(const std::string& filter_choice,
                                                        const SB_TYPES sb_type)
 {
 	if (filter_choice == "auto") {
 		switch (sb_type) {
-		case SBT_NONE: return FilterType::None;   break;
-		case SBT_1:    return FilterType::SB1;    break;
-		case SBT_2:    return FilterType::SB2;    break;
+		case SBT_NONE: return FilterType::None; break;
+		case SBT_1: return FilterType::SB1; break;
+		case SBT_2: return FilterType::SB2; break;
 		case SBT_PRO1: return FilterType::SBPro1; break;
 		case SBT_PRO2: return FilterType::SBPro2; break;
-		case SBT_16:   return FilterType::SB16;   break;
-		case SBT_GB:   return FilterType::None;   break;
+		case SBT_16: return FilterType::SB16; break;
+		case SBT_GB: return FilterType::None; break;
 		}
 	} else if (filter_choice == "off") {
 		return FilterType::None;
@@ -438,7 +467,7 @@ static std::optional<FilterType> determine_filter_type(const std::string &filter
 }
 
 static void configure_sb_filter(mixer_channel_t channel,
-                                const std::string &filter_prefs,
+                                const std::string& filter_prefs,
                                 const bool filter_always_on, const SB_TYPES sb_type)
 {
 	// A bit unfortunate, but we need to enable the ZOH upsampler and the
@@ -447,8 +476,9 @@ static void configure_sb_filter(mixer_channel_t channel,
 	channel->SetZeroOrderHoldUpsamplerTargetFreq(native_dac_rate_hz);
 	channel->SetResampleMethod(ResampleMethod::ZeroOrderHoldAndResample);
 
-	if (channel->TryParseAndSetCustomFilter(filter_prefs))
+	if (channel->TryParseAndSetCustomFilter(filter_prefs)) {
 		return;
+	}
 
 	const auto filter_prefs_parts = split(filter_prefs);
 
@@ -468,7 +498,7 @@ static void configure_sb_filter(mixer_channel_t channel,
 
 	auto enable_zoh_upsampler = [&] {
 		config.resample_method = ResampleMethod::ZeroOrderHoldAndResample;
-		config.zoh_rate_hz     = native_dac_rate_hz;
+		config.zoh_rate_hz = native_dac_rate_hz;
 	};
 
 	const auto filter_type = determine_filter_type(filter_choice, sb_type);
@@ -522,12 +552,13 @@ static void configure_sb_filter(mixer_channel_t channel,
 }
 
 static void configure_opl_filter(mixer_channel_t channel,
-                                 const std::string &filter_prefs,
+                                 const std::string& filter_prefs,
                                  const SB_TYPES sb_type)
 {
 	assert(channel);
-	if (channel->TryParseAndSetCustomFilter(filter_prefs))
+	if (channel->TryParseAndSetCustomFilter(filter_prefs)) {
 		return;
+	}
 
 	const auto filter_prefs_parts = split(filter_prefs);
 
@@ -547,10 +578,11 @@ static void configure_opl_filter(mixer_channel_t channel,
 	const auto filter_type = determine_filter_type(filter_choice, sb_type);
 
 	if (!filter_type) {
-		if (filter_choice != "off")
+		if (filter_choice != "off") {
 			LOG_WARNING("%s: Invalid 'opl_filter' setting: '%s', using 'off'",
 			            CardType(),
 			            filter_choice.c_str());
+		}
 
 		channel->SetHighPassFilter(FilterState::Off);
 		channel->SetLowPassFilter(FilterState::Off);
@@ -579,78 +611,95 @@ static void configure_opl_filter(mixer_channel_t channel,
 static void SB_RaiseIRQ(SB_IRQS type)
 {
 	LOG(LOG_SB, LOG_NORMAL)("Raising IRQ");
+
 	switch (type) {
 	case SB_IRQ_8:
 		if (sb.irq.pending_8bit) {
-//			LOG_MSG("SB: 8bit irq pending");
+			// LOG_MSG("SB: 8bit irq pending");
 			return;
 		}
-		sb.irq.pending_8bit=true;
+		sb.irq.pending_8bit = true;
 		PIC_ActivateIRQ(sb.hw.irq);
 		break;
+
 	case SB_IRQ_16:
 		if (sb.irq.pending_16bit) {
-//			LOG_MSG("SB: 16bit irq pending");
+			// LOG_MSG("SB: 16bit irq pending");
 			return;
 		}
-		sb.irq.pending_16bit=true;
+		sb.irq.pending_16bit = true;
 		PIC_ActivateIRQ(sb.hw.irq);
 		break;
-	default:
-		break;
+
+	default: break;
 	}
 }
 
 static void DSP_FlushData()
 {
 	sb.dsp.out.used = 0;
-	sb.dsp.out.pos = 0;
+	sb.dsp.out.pos  = 0;
 }
 
 static double last_dma_callback = 0.0;
 
 static void DSP_DMA_CallBack(const DmaChannel* chan, DMAEvent event)
 {
-	if (chan!=sb.dma.chan || event==DMA_REACHED_TC) return;
-	else if (event==DMA_MASKED) {
-		if (sb.mode==MODE_DMA) {
-			//Catch up to current time, but don't generate an IRQ!
-			//Fixes problems with later sci games.
+	if (chan != sb.dma.chan || event == DMA_REACHED_TC) {
+		return;
+
+	} else if (event == DMA_MASKED) {
+		if (sb.mode == MODE_DMA) {
+			// Catch up to current time, but don't generate an IRQ!
+			// Fixes problems with later sci games.
 			const auto t = PIC_FullIndex() - last_dma_callback;
 			auto s = static_cast<uint32_t>(sb.dma.rate * t / 1000.0);
+
 			if (s > sb.dma.min) {
-				LOG(LOG_SB,LOG_NORMAL)("limiting amount masked to sb.dma.min");
+				LOG(LOG_SB, LOG_NORMAL)
+				("limiting amount masked to sb.dma.min");
 				s = sb.dma.min;
 			}
+
 			auto min_size = sb.dma.mul >> SB_SH;
-			if (!min_size) min_size = 1;
+			if (!min_size) {
+				min_size = 1;
+			}
 			min_size *= 2;
+
 			if (sb.dma.left > min_size) {
-				if (s > (sb.dma.left - min_size))
+				if (s > (sb.dma.left - min_size)) {
 					s = sb.dma.left - min_size;
+				}
 				// This will trigger an irq, see
 				// PlayDMATransfer, so lets not do that
-				if (!sb.dma.autoinit && sb.dma.left <= sb.dma.min)
+				if (!sb.dma.autoinit && sb.dma.left <= sb.dma.min) {
 					s = 0;
-				if (s)
+				}
+				if (s) {
 					ProcessDMATransfer(s);
+				}
 			}
+
 			sb.mode = MODE_DMA_MASKED;
-//			DSP_ChangeMode(MODE_DMA_MASKED);
-			LOG(LOG_SB,LOG_NORMAL)("DMA masked,stopping output, left %d",chan->curr_count);
+
+			// DSP_ChangeMode(MODE_DMA_MASKED);
+			LOG(LOG_SB, LOG_NORMAL)
+			("DMA masked,stopping output, left %d", chan->curr_count);
 		}
-	} else if (event==DMA_UNMASKED) {
-		if (sb.mode==MODE_DMA_MASKED && sb.dma.mode!=DSP_DMA_NONE) {
+
+	} else if (event == DMA_UNMASKED) {
+		if (sb.mode == MODE_DMA_MASKED && sb.dma.mode != DSP_DMA_NONE) {
 			DSP_ChangeMode(MODE_DMA);
-//			sb.mode=MODE_DMA;
+			// sb.mode=MODE_DMA;
 			FlushRemainingDMATransfer();
+
 			LOG(LOG_SB, LOG_NORMAL)
 			("DMA unmasked,starting output, auto %d block %d",
 			 static_cast<int>(chan->is_autoiniting),
 			 chan->base_count);
 		}
-	}
-	else {
+	} else {
 		E_Exit("Unknown sblaster dma event");
 	}
 }
@@ -663,7 +712,7 @@ static uint8_t decode_adpcm_portion(const int bit_portion,
 	auto& sample = sb.adpcm.reference;
 
 	const auto i = std::clamp(bit_portion + scale, 0, last_index);
-	scale = (scale + adjust_map[i]) & 0xff;
+	scale        = (scale + adjust_map[i]) & 0xff;
 	sample = static_cast<uint8_t>(clamp(sample + scale_map[i], 0, 255));
 	return sample;
 }
@@ -671,18 +720,19 @@ static uint8_t decode_adpcm_portion(const int bit_portion,
 static std::array<uint8_t, 4> decode_ADPCM_2(const uint8_t data)
 {
 	// clang-format off
-
 	constexpr int8_t scale_map[] = {
 		0,  1,  0,  -1, 1,  3,  -1,  -3,
 		2,  6, -2,  -6, 4, 12,  -4, -12,
 		8, 24, -8, -24, 6, 48, -16, -48
 	};
+
 	constexpr uint8_t adjust_map[] = {
 		  0, 4,   0, 4,
 		252, 4, 252, 4, 252, 4, 252, 4,
 		252, 4, 252, 4, 252, 4, 252, 4,
 		252, 0, 252, 0
 	};
+
 	static_assert(ARRAY_LEN(scale_map) == ARRAY_LEN(adjust_map));
 	constexpr auto last_i = static_cast<uint8_t>(sizeof(scale_map) - 1);;
 
@@ -697,7 +747,6 @@ static std::array<uint8_t, 4> decode_ADPCM_2(const uint8_t data)
 static std::array<uint8_t, 3> decode_ADPCM_3(const uint8_t data)
 {
 	// clang-format off
-
 	constexpr int8_t scale_map[40] = {
 		0,  1,  2,  3,  0,  -1,  -2,  -3,
 		1,  3,  5,  7, -1,  -3,  -5,  -7,
@@ -705,6 +754,7 @@ static std::array<uint8_t, 3> decode_ADPCM_3(const uint8_t data)
 		4, 12, 20, 28, -4, -12, -20, -28,
 		5, 15, 25, 35, -5, -15, -25, -35
 	};
+
 	constexpr uint8_t adjust_map[40] = {
 		  0, 0, 0, 8,   0, 0, 0, 8,
 		248, 0, 0, 8, 248, 0, 0, 8,
@@ -712,6 +762,7 @@ static std::array<uint8_t, 3> decode_ADPCM_3(const uint8_t data)
 		248, 0, 0, 8, 248, 0, 0, 8,
 		248, 0, 0, 0, 248, 0, 0, 0
 	};
+
 	static_assert(ARRAY_LEN(scale_map) == ARRAY_LEN(adjust_map));
 	constexpr auto last_i = static_cast<uint8_t>(sizeof(scale_map) - 1);;
 
@@ -725,13 +776,13 @@ static std::array<uint8_t, 3> decode_ADPCM_3(const uint8_t data)
 static std::array<uint8_t, 2> decode_ADPCM_4(const uint8_t data)
 {
 	// clang-format off
-
 	constexpr int8_t scale_map[64] = {
 		0,  1,  2,  3,  4,  5,  6,  7,  0,  -1,  -2,  -3,  -4,  -5,  -6,  -7,
 		1,  3,  5,  7,  9, 11, 13, 15, -1,  -3,  -5,  -7,  -9, -11, -13, -15,
 		2,  6, 10, 14, 18, 22, 26, 30, -2,  -6, -10, -14, -18, -22, -26, -30,
 		4, 12, 20, 28, 36, 44, 52, 60, -4, -12, -20, -28, -36, -44, -52, -60
 	};
+
 	constexpr uint8_t adjust_map[64] = {
 		  0, 0, 0, 0, 0, 16, 16, 16,
 		  0, 0, 0, 0, 0, 16, 16, 16,
@@ -742,6 +793,7 @@ static std::array<uint8_t, 2> decode_ADPCM_4(const uint8_t data)
 		240, 0, 0, 0, 0,  0,  0,  0,
 		240, 0, 0, 0, 0,  0,  0,  0
 	};
+
 	static_assert(ARRAY_LEN(scale_map) == ARRAY_LEN(adjust_map));
 	constexpr auto last_i = static_cast<uint8_t>(sizeof(scale_map) - 1);;
 
@@ -752,30 +804,37 @@ static std::array<uint8_t, 2> decode_ADPCM_4(const uint8_t data)
 }
 
 template <typename T>
-static const T *maybe_silence(const uint32_t num_samples, const T *buffer)
+static const T* maybe_silence(const uint32_t num_samples, const T* buffer)
 {
-	if (!sb.dsp.warmup_remaining_ms)
+	if (!sb.dsp.warmup_remaining_ms) {
 		return buffer;
+	}
 
 	static std::vector<T> quiet_buffer;
 	constexpr auto silent = Mixer_GetSilentDOSSample<T>();
-	if (quiet_buffer.size() < num_samples)
+
+	if (quiet_buffer.size() < num_samples) {
 		quiet_buffer.resize(num_samples, silent);
+	}
 
 	sb.dsp.warmup_remaining_ms--;
 	return quiet_buffer.data();
 }
 
-static uint32_t ReadDMA8(uint32_t bytes_to_read, uint32_t i = 0) {
+static uint32_t ReadDMA8(uint32_t bytes_to_read, uint32_t i = 0)
+{
 	const auto bytes_read = sb.dma.chan->Read(bytes_to_read, sb.dma.buf.b8 + i);
 	assert(bytes_read <= DMA_BUFSIZE * sizeof(sb.dma.buf.b8[0]));
+
 	return check_cast<uint32_t>(bytes_read);
 }
 
-static uint32_t ReadDMA16(uint32_t bytes_to_read, uint32_t i = 0) {
-	const auto unsigned_buf = reinterpret_cast<uint8_t *>(sb.dma.buf.b16 + i);
+static uint32_t ReadDMA16(uint32_t bytes_to_read, uint32_t i = 0)
+{
+	const auto unsigned_buf = reinterpret_cast<uint8_t*>(sb.dma.buf.b16 + i);
 	const auto bytes_read = sb.dma.chan->Read(bytes_to_read, unsigned_buf);
 	assert(bytes_read <= DMA_BUFSIZE * sizeof(sb.dma.buf.b16[0]));
+
 	return check_cast<uint32_t>(bytes_read);
 }
 
@@ -783,21 +842,25 @@ static void PlayDMATransfer(uint32_t bytes_requested)
 {
 	// How many bytes should we read from DMA?
 	const auto lower_bound = sb.dma.autoinit ? bytes_requested : sb.dma.min;
-	const auto bytes_to_read =  sb.dma.left <= lower_bound ? sb.dma.left : bytes_requested;
+	const auto bytes_to_read = sb.dma.left <= lower_bound ? sb.dma.left
+	                                                      : bytes_requested;
 
 	// All three of these must be populated during the DMA sequence to
 	// ensure the proper quantities and unit are being accounted for.
 	// For example: use the channel count to convert from samples to frames.
 	uint32_t bytes_read = 0;
-	uint32_t samples = 0;
-	uint16_t frames = 0;
+	uint32_t samples    = 0;
+	uint16_t frames     = 0;
 
-	/* In DSP_DMA_16_ALIASED mode temporarily divide by 2 to get number of 16-bit
-	samples, because 8-bit DMA Read returns byte size, while in DSP_DMA_16 mode
-	16-bit DMA Read returns word size */
-	const uint8_t dma16_to_sample_divisor = sb.dma.mode == DSP_DMA_16_ALIASED ? 2 : 1;
+	/* In DSP_DMA_16_ALIASED mode temporarily divide by 2 to get number of
+	16-bit samples, because 8-bit DMA Read returns byte size, while in
+	DSP_DMA_16 mode 16-bit DMA Read returns word size */
+	const uint8_t dma16_to_sample_divisor = sb.dma.mode == DSP_DMA_16_ALIASED
+	                                              ? 2
+	                                              : 1;
 
-	// Used to convert from samples to frames (which is what AddSamples unintuitively uses.. )
+	// Used to convert from samples to frames (which is what AddSamples
+	// unintuitively uses.. )
 	const uint8_t channels = sb.dma.stereo ? 2 : 1;
 
 	last_dma_callback = PIC_FullIndex();
@@ -806,156 +869,192 @@ static void PlayDMATransfer(uint32_t bytes_requested)
 
 	auto decode_adpcm_dma =
 	        [&](auto decode_adpcm_fn) -> std::tuple<uint32_t, uint32_t, uint16_t> {
-
 		const uint32_t num_bytes = ReadDMA8(bytes_to_read);
-		uint32_t num_samples = 0;
-		uint16_t num_frames  = 0;
+		uint32_t num_samples     = 0;
+		uint16_t num_frames      = 0;
 
 		// Parse the reference ADPCM byte, if provided
 		uint32_t i = 0;
 		if (num_bytes > 0 && sb.adpcm.haveref) {
 			sb.adpcm.haveref   = false;
 			sb.adpcm.reference = sb.dma.buf.b8[0];
-			sb.adpcm.stepsize=MIN_ADAPTIVE_STEP_SIZE;
+			sb.adpcm.stepsize  = MIN_ADAPTIVE_STEP_SIZE;
 			++i;
 		}
-		// Decode the remaining DMA buffer into samples using the provided function
+		// Decode the remaining DMA buffer into samples using the
+		// provided function
 		while (i < num_bytes) {
 			const auto decoded = decode_adpcm_fn(sb.dma.buf.b8[i]);
-			constexpr auto num_decoded = check_cast<uint8_t>(decoded.size());
-			sb.chan->AddSamples_m8(num_decoded, maybe_silence(num_decoded, decoded.data()));
+			constexpr auto num_decoded = check_cast<uint8_t>(
+			        decoded.size());
+
+			sb.chan->AddSamples_m8(num_decoded,
+			                       maybe_silence(num_decoded,
+			                                     decoded.data()));
 			num_samples += num_decoded;
 			++i;
 		}
-		 // ADPCM is mono
+		// ADPCM is mono
 		num_frames = check_cast<uint16_t>(num_samples);
 		return {num_bytes, num_samples, num_frames};
 	};
 
-	//Read the actual data, process it and send it off to the mixer
+	// Read the actual data, process it and send it off to the mixer
 	switch (sb.dma.mode) {
 	case DSP_DMA_2:
 		std::tie(bytes_read, samples, frames) = decode_adpcm_dma(decode_ADPCM_2);
 		break;
+
 	case DSP_DMA_3:
 		std::tie(bytes_read, samples, frames) = decode_adpcm_dma(decode_ADPCM_3);
 		break;
+
 	case DSP_DMA_4:
 		std::tie(bytes_read, samples, frames) = decode_adpcm_dma(decode_ADPCM_4);
 		break;
+
 	case DSP_DMA_8:
- 		if (sb.dma.stereo) {
+		if (sb.dma.stereo) {
 			bytes_read = ReadDMA8(bytes_to_read, sb.dma.remain_size);
 			samples = bytes_read + sb.dma.remain_size;
-			frames = check_cast<uint16_t>(samples / channels);
+			frames  = check_cast<uint16_t>(samples / channels);
 
 			// Only add whole frames when in stereo DMA mode. The
 			// number of frames comes from the DMA request, and
 			// therefore user-space data.
 			if (frames) {
 				if (sb.dma.sign) {
-					const auto signed_buf = reinterpret_cast<int8_t *>(sb.dma.buf.b8);
+					const auto signed_buf = reinterpret_cast<int8_t*>(
+					        sb.dma.buf.b8);
 					sb.chan->AddSamples_s8s(
 					        frames,
 					        maybe_silence(samples, signed_buf));
 				} else {
 					sb.chan->AddSamples_s8(
 					        frames,
-					        maybe_silence(samples, sb.dma.buf.b8));
+					        maybe_silence(samples,
+					                      sb.dma.buf.b8));
 				}
 			}
 			// Otherwise there's an unhandled dangling sample from
 			// the last round
 			if (samples & 1) {
 				sb.dma.remain_size = 1;
-				sb.dma.buf.b8[0] = sb.dma.buf.b8[samples - 1];
+				sb.dma.buf.b8[0]   = sb.dma.buf.b8[samples - 1];
 			} else {
 				sb.dma.remain_size = 0;
 			}
+
 		} else { // Mono
 			bytes_read = ReadDMA8(bytes_to_read);
-			samples = bytes_read;
-			frames = check_cast<uint16_t>(samples / channels);
-			assert(channels == 1 && frames == samples); // sanity-check mono
+			samples    = bytes_read;
+			frames     = check_cast<uint16_t>(samples / channels);
+			assert(channels == 1 && frames == samples); // sanity-check
+			                                            // mono
 			if (sb.dma.sign) {
-				sb.chan->AddSamples_m8s(frames,
-				         maybe_silence(samples,
-				                       reinterpret_cast<int8_t *>(sb.dma.buf.b8)));
+				sb.chan->AddSamples_m8s(
+				        frames,
+				        maybe_silence(samples,
+				                      reinterpret_cast<int8_t*>(
+				                              sb.dma.buf.b8)));
 			} else {
 				sb.chan->AddSamples_m8(frames,
-				         maybe_silence(samples, sb.dma.buf.b8));
+				                       maybe_silence(samples,
+				                                     sb.dma.buf.b8));
 			}
 		}
 		break;
+
 	case DSP_DMA_16_ALIASED:
 		assert(dma16_to_sample_divisor == 2);
 		[[fallthrough]];
+
 	case DSP_DMA_16:
 		if (sb.dma.stereo) {
 			bytes_read = ReadDMA16(bytes_to_read, sb.dma.remain_size);
-			samples = (bytes_read + sb.dma.remain_size) / dma16_to_sample_divisor;
+			samples = (bytes_read + sb.dma.remain_size) /
+			          dma16_to_sample_divisor;
 			frames = check_cast<uint16_t>(samples / channels);
 
 			// Only add whole frames when in stereo DMA mode
 			if (frames) {
 #if defined(WORDS_BIGENDIAN)
 				if (sb.dma.sign) {
-					sb.chan->AddSamples_s16_nonnative(frames,
-					            maybe_silence(samples, sb.dma.buf.b16));
+					sb.chan->AddSamples_s16_nonnative(
+					        frames,
+					        maybe_silence(samples,
+					                      sb.dma.buf.b16));
 				} else {
-					sb.chan->AddSamples_s16u_nonnative(frames,
-					            maybe_silence(samples, reinterpret_cast<uint16_t *>(sb.dma.buf.b16)));
+					sb.chan->AddSamples_s16u_nonnative(
+					        frames,
+					        maybe_silence(samples,
+					                      reinterpret_cast<uint16_t*>(
+					                              sb.dma.buf.b16)));
 				}
 #else
 				if (sb.dma.sign) {
-					sb.chan->AddSamples_s16(frames,
-					            maybe_silence(samples, sb.dma.buf.b16));
+					sb.chan->AddSamples_s16(
+					        frames,
+					        maybe_silence(samples,
+					                      sb.dma.buf.b16));
 				} else {
-					sb.chan->AddSamples_s16u(frames,
-					            maybe_silence(samples, reinterpret_cast<uint16_t *>(sb.dma.buf.b16)));
+					sb.chan->AddSamples_s16u(
+					        frames,
+					        maybe_silence(samples,
+					                      reinterpret_cast<uint16_t*>(
+					                              sb.dma.buf.b16)));
 				}
 #endif
 			}
 			if (samples & 1) {
-				// Carry over the dangling sample into the next round, or
+				// Carry over the dangling sample into the next
+				// round, or...
 				sb.dma.remain_size = 1;
 				sb.dma.buf.b16[0] = sb.dma.buf.b16[samples - 1];
-			}
-			 else {
-				// The DMA transfer is done
+			} else {
+				// ...the DMA transfer is done
 				sb.dma.remain_size = 0;
 			}
 		} else { // 16-bit mono
 			bytes_read = ReadDMA16(bytes_to_read);
-			samples = bytes_read / dma16_to_sample_divisor;
-			frames = check_cast<uint16_t>(samples / channels);
-			assert(channels == 1 && frames == samples); // sanity-check mono
+			samples    = bytes_read / dma16_to_sample_divisor;
+			frames     = check_cast<uint16_t>(samples / channels);
+			assert(channels == 1 && frames == samples); // sanity-check
+			                                            // mono
 #if defined(WORDS_BIGENDIAN)
 			if (sb.dma.sign) {
-				sb.chan->AddSamples_m16_nonnative(frames,
-				             maybe_silence(samples, sb.dma.buf.b16));
+				sb.chan->AddSamples_m16_nonnative(
+				        frames,
+				        maybe_silence(samples, sb.dma.buf.b16));
 			} else {
-				sb.chan->AddSamples_m16u_nonnative(frames,
-				             maybe_silence(samples,
-				                           reinterpret_cast<uint16_t *>(sb.dma.buf.b16)));
+				sb.chan->AddSamples_m16u_nonnative(
+				        frames,
+				        maybe_silence(samples,
+				                      reinterpret_cast<uint16_t*>(
+				                              sb.dma.buf.b16)));
 			}
 #else
 			if (sb.dma.sign) {
 				sb.chan->AddSamples_m16(frames,
-				             maybe_silence(samples, sb.dma.buf.b16));
+				                        maybe_silence(samples,
+				                                      sb.dma.buf.b16));
 			} else {
-				sb.chan->AddSamples_m16u(frames,
-				             maybe_silence(samples,
-				                           reinterpret_cast<uint16_t *>(sb.dma.buf.b16)));
+				sb.chan->AddSamples_m16u(
+				        frames,
+				        maybe_silence(samples,
+				                      reinterpret_cast<uint16_t*>(
+				                              sb.dma.buf.b16)));
 			}
 #endif
 		}
 		break;
+
 	default:
 		LOG_MSG("%s: Unhandled dma mode %d", CardType(), sb.dma.mode);
-		sb.mode=MODE_NONE;
+		sb.mode = MODE_NONE;
 		return;
 	}
+
 	// Sanity check
 	assertm(frames <= samples, "Frames should never exceed samples");
 
@@ -963,79 +1062,106 @@ static void PlayDMATransfer(uint32_t bytes_requested)
 	sb.dma.left -= bytes_read;
 	if (!sb.dma.left) {
 		PIC_RemoveEvents(ProcessDMATransfer);
-		if (sb.dma.mode >= DSP_DMA_16) 
+
+		if (sb.dma.mode >= DSP_DMA_16) {
 			SB_RaiseIRQ(SB_IRQ_16);
-		else
+		} else {
 			SB_RaiseIRQ(SB_IRQ_8);
+		}
 
 		if (!sb.dma.autoinit) {
-			//Not new single cycle transfer waiting?
+			// Not new single cycle transfer waiting?
 			if (!sb.dma.singlesize) {
-				LOG(LOG_SB, LOG_NORMAL)("Single cycle transfer ended");
-				sb.mode = MODE_NONE;
+				LOG(LOG_SB, LOG_NORMAL)
+				("Single cycle transfer ended");
+				sb.mode     = MODE_NONE;
 				sb.dma.mode = DSP_DMA_NONE;
-			}
-			else {
-				//A single size transfer is still waiting, handle that now
-				sb.dma.left = sb.dma.singlesize;
+			} else {
+				// A single size transfer is still waiting,
+				// handle that now
+				sb.dma.left       = sb.dma.singlesize;
 				sb.dma.singlesize = 0;
-				LOG(LOG_SB, LOG_NORMAL)("Switch to Single cycle transfer begun");
+				LOG(LOG_SB, LOG_NORMAL)
+				("Switch to Single cycle transfer begun");
 			}
 		} else {
 			if (!sb.dma.autosize) {
-				LOG(LOG_SB,LOG_NORMAL)("Auto-init transfer with 0 size");
-				sb.mode=MODE_NONE;
+				LOG(LOG_SB, LOG_NORMAL)
+				("Auto-init transfer with 0 size");
+				sb.mode = MODE_NONE;
 			}
-			//Continue with a new auto init transfer
+			// Continue with a new auto init transfer
 			sb.dma.left = sb.dma.autosize;
-
 		}
 	}
 	/*
 	LOG_MSG("%s: sb.dma.mode=%d, stereo=%d, signed=%d, bytes_requested=%u,"
-	        "bytes_to_read=%u, bytes_read = %u, samples = %u, frames = %u, dma.left = %u",
-	        CardType(), sb.dma.mode, sb.dma.stereo, sb.dma.sign, bytes_requested,
-	        bytes_to_read, bytes_read, samples, frames, sb.dma.left);
+	        "bytes_to_read=%u, bytes_read = %u, samples = %u, frames = %u,
+	dma.left = %u", CardType(), sb.dma.mode, sb.dma.stereo, sb.dma.sign,
+	bytes_requested, bytes_to_read, bytes_read, samples, frames,
+	sb.dma.left);
 	*/
 }
 
 static void SuppressDMATransfer(uint32_t bytes_to_read)
 {
-	if (sb.dma.left < bytes_to_read)
+	if (sb.dma.left < bytes_to_read) {
 		bytes_to_read = sb.dma.left;
+	}
+
 	const auto read = ReadDMA8(bytes_to_read);
-	sb.dma.left-=read;
+
+	sb.dma.left -= read;
 	if (!sb.dma.left) {
-		if (sb.dma.mode >= DSP_DMA_16) SB_RaiseIRQ(SB_IRQ_16);
-		else SB_RaiseIRQ(SB_IRQ_8);
-		//FIX, use the auto to single switch mechanics here as well or find a better way to silence
-		if (sb.dma.autoinit) 
-			sb.dma.left=sb.dma.autosize;
-		else {
-			sb.mode=MODE_NONE;
-			sb.dma.mode=DSP_DMA_NONE;
+		if (sb.dma.mode >= DSP_DMA_16) {
+			SB_RaiseIRQ(SB_IRQ_16);
+		} else {
+			SB_RaiseIRQ(SB_IRQ_8);
+		}
+
+		// FIX, use the auto to single switch mechanics here as well or
+		// find a better way to silence
+		if (sb.dma.autoinit) {
+			sb.dma.left = sb.dma.autosize;
+		} else {
+			sb.mode     = MODE_NONE;
+			sb.dma.mode = DSP_DMA_NONE;
 		}
 	}
+
 	if (sb.dma.left) {
 		const uint32_t bigger = (sb.dma.left > sb.dma.min) ? sb.dma.min
 		                                                   : sb.dma.left;
-		double delay = (bigger * 1000.0) / sb.dma.rate;
+		double delay          = (bigger * 1000.0) / sb.dma.rate;
 		PIC_AddEvent(SuppressDMATransfer, delay, bigger);
 	}
 }
 
 static void FlushRemainingDMATransfer()
 {
-	if (!sb.dma.left)
+	if (!sb.dma.left) {
 		return;
-	if (!sb.speaker && sb.type!=SBT_16) {
+	}
+
+	if (!sb.speaker && sb.type != SBT_16) {
 		const auto num_bytes = std::min(sb.dma.min, sb.dma.left);
-		const double delay = (num_bytes * 1000.0) / sb.dma.rate;
+		const double delay   = (num_bytes * 1000.0) / sb.dma.rate;
+
 		PIC_AddEvent(SuppressDMATransfer, delay, num_bytes);
-		LOG(LOG_SB, LOG_NORMAL)("%s: Silent DMA Transfer scheduling IRQ in %.3f milliseconds", CardType(), delay);
+
+		LOG(LOG_SB, LOG_NORMAL)
+		("%s: Silent DMA Transfer scheduling IRQ in %.3f milliseconds",
+		 CardType(),
+		 delay);
+
 	} else if (sb.dma.left < sb.dma.min) {
 		const double delay = (sb.dma.left * 1000.0) / sb.dma.rate;
-		LOG(LOG_SB, LOG_NORMAL)("%s: Short transfer scheduling IRQ in %.3f milliseconds", CardType(), delay);
+
+		LOG(LOG_SB, LOG_NORMAL)
+		("%s: Short transfer scheduling IRQ in %.3f milliseconds",
+		 CardType(),
+		 delay);
+
 		PIC_AddEvent(ProcessDMATransfer, delay, sb.dma.left);
 	}
 }
@@ -1085,7 +1211,7 @@ static void DSP_RaiseIRQEvent(uint32_t /*val*/)
 }
 
 #if (C_DEBUG)
-static const char *DmaModeName()
+static const char* DmaModeName()
 {
 	switch (sb.dma.mode) {
 	case DSP_DMA_2: return "2-bit ADPCM"; break;
@@ -1100,113 +1226,134 @@ static const char *DmaModeName()
 }
 #endif
 
-static void DSP_DoDMATransfer(const DMA_MODES mode, uint32_t freq, bool autoinit, bool stereo)
+static void DSP_DoDMATransfer(const DMA_MODES mode, uint32_t freq,
+                              bool autoinit, bool stereo)
 {
 	// Fill up before changing state?
 	sb.chan->FillUp();
 
-	//Starting a new transfer will clear any active irqs?
-	sb.irq.pending_8bit = false;
+	// Starting a new transfer will clear any active irqs?
+	sb.irq.pending_8bit  = false;
 	sb.irq.pending_16bit = false;
 	PIC_DeActivateIRQ(sb.hw.irq);
 
 	switch (mode) {
-	case DSP_DMA_2:          sb.dma.mul = (1 << SB_SH) / 4; break;
-	case DSP_DMA_3:          sb.dma.mul = (1 << SB_SH) / 3; break;
-	case DSP_DMA_4:          sb.dma.mul = (1 << SB_SH) / 2; break;
-	case DSP_DMA_8:          sb.dma.mul = (1 << SB_SH); break;
-	case DSP_DMA_16:         sb.dma.mul = (1 << SB_SH); break;
+	case DSP_DMA_2: sb.dma.mul = (1 << SB_SH) / 4; break;
+	case DSP_DMA_3: sb.dma.mul = (1 << SB_SH) / 3; break;
+	case DSP_DMA_4: sb.dma.mul = (1 << SB_SH) / 2; break;
+	case DSP_DMA_8: sb.dma.mul = (1 << SB_SH); break;
+	case DSP_DMA_16: sb.dma.mul = (1 << SB_SH); break;
 	case DSP_DMA_16_ALIASED: sb.dma.mul = (1 << SB_SH) * 2; break;
 	default:
-		LOG(LOG_SB,LOG_ERROR)("DSP:Illegal transfer mode %d", mode);
+		LOG(LOG_SB, LOG_ERROR)("DSP:Illegal transfer mode %d", mode);
 		return;
 	}
 
 	// Going from an active autoinit into a single cycle
 	if (sb.mode >= MODE_DMA && sb.dma.autoinit && !autoinit) {
-		//Don't do anything, the total will flip over on the next transfer
+		// Don't do anything, the total will flip over on the next transfer
 	}
-	//Just a normal single cycle transfer
+	// Just a normal single cycle transfer
 	else if (!autoinit) {
-		sb.dma.left = sb.dma.singlesize;
+		sb.dma.left       = sb.dma.singlesize;
 		sb.dma.singlesize = 0;
 	}
 	// Going into an autoinit transfer
 	else {
-		//Transfer full cycle again
+		// Transfer full cycle again
 		sb.dma.left = sb.dma.autosize;
 	}
 	sb.dma.autoinit = autoinit;
-	sb.dma.mode = mode;
-	sb.dma.stereo = stereo;
-	//Double the reading speed for stereo mode
-	if (sb.dma.stereo)
-		sb.dma.mul*=2;
-	sb.dma.rate=(sb.freq*sb.dma.mul) >> SB_SH;
-	sb.dma.min=(sb.dma.rate*3)/1000;
+	sb.dma.mode     = mode;
+	sb.dma.stereo   = stereo;
+
+	// Double the reading speed for stereo mode
+	if (sb.dma.stereo) {
+		sb.dma.mul *= 2;
+	}
+	sb.dma.rate = (sb.freq * sb.dma.mul) >> SB_SH;
+	sb.dma.min  = (sb.dma.rate * 3) / 1000;
 	set_channel_rate_hz(freq);
 
 	PIC_RemoveEvents(ProcessDMATransfer);
-	//Set to be masked, the dma call can change this again.
+	// Set to be masked, the dma call can change this again.
 	sb.mode = MODE_DMA_MASKED;
 	sb.dma.chan->RegisterCallback(DSP_DMA_CallBack);
 
 #if (C_DEBUG)
 	LOG(LOG_SB, LOG_NORMAL)
-	("DMA Transfer:%s %s %s freq %d rate %d size %d", DmaModeName(),
-	 stereo ? "Stereo" : "Mono", autoinit ? "Auto-Init" : "Single-Cycle",
-	 freq, sb.dma.rate, sb.dma.left);
+	("DMA Transfer:%s %s %s freq %d rate %d size %d",
+	 DmaModeName(),
+	 stereo ? "Stereo" : "Mono",
+	 autoinit ? "Auto-Init" : "Single-Cycle",
+	 freq,
+	 sb.dma.rate,
+	 sb.dma.left);
 #endif
 }
 
-static void DSP_PrepareDMA_Old(DMA_MODES mode,bool autoinit,bool sign) {
-	sb.dma.sign=sign;
-	if (!autoinit)
-		sb.dma.singlesize=1+sb.dsp.in.data[0]+(sb.dsp.in.data[1] << 8);
-	sb.dma.chan=DMA_GetChannel(sb.hw.dma8);
-	DSP_DoDMATransfer(mode,sb.freq / (sb.mixer.stereo ? 2 : 1), autoinit, sb.mixer.stereo);
+static void DSP_PrepareDMA_Old(DMA_MODES mode, bool autoinit, bool sign)
+{
+	sb.dma.sign = sign;
+	if (!autoinit) {
+		sb.dma.singlesize = 1 + sb.dsp.in.data[0] + (sb.dsp.in.data[1] << 8);
+	}
+	sb.dma.chan = DMA_GetChannel(sb.hw.dma8);
+
+	DSP_DoDMATransfer(mode,
+	                  sb.freq / (sb.mixer.stereo ? 2 : 1),
+	                  autoinit,
+	                  sb.mixer.stereo);
 }
 
-static void DSP_PrepareDMA_New(DMA_MODES mode, uint32_t length, bool autoinit, bool stereo)
+static void DSP_PrepareDMA_New(DMA_MODES mode, uint32_t length, bool autoinit,
+                               bool stereo)
 {
 	const auto freq = sb.freq;
 
-	//equal length if data format and dma channel are both 16-bit or 8-bit
-	if (mode==DSP_DMA_16) {
-		if (sb.hw.dma16!=0xff) {
-			sb.dma.chan=DMA_GetChannel(sb.hw.dma16);
-			if (sb.dma.chan==nullptr) {
-				sb.dma.chan=DMA_GetChannel(sb.hw.dma8);
-				mode=DSP_DMA_16_ALIASED;
+	// equal length if data format and dma channel are both 16-bit or 8-bit
+	if (mode == DSP_DMA_16) {
+		if (sb.hw.dma16 != 0xff) {
+			sb.dma.chan = DMA_GetChannel(sb.hw.dma16);
+			if (sb.dma.chan == nullptr) {
+				sb.dma.chan = DMA_GetChannel(sb.hw.dma8);
+				mode        = DSP_DMA_16_ALIASED;
 				length *= 2;
 			}
 		} else {
-			sb.dma.chan=DMA_GetChannel(sb.hw.dma8);
-			mode=DSP_DMA_16_ALIASED;
-			//UNDOCUMENTED:
-			//In aliased mode sample length is written to DSP as number of
-			//16-bit samples so we need double 8-bit DMA buffer length
+			sb.dma.chan = DMA_GetChannel(sb.hw.dma8);
+			mode        = DSP_DMA_16_ALIASED;
+			// UNDOCUMENTED:
+			// In aliased mode sample length is written to DSP as
+			// number of 16-bit samples so we need double 8-bit DMA
+			// buffer length
 			length *= 2;
 		}
-	} else sb.dma.chan=DMA_GetChannel(sb.hw.dma8);
-	//Set the length to the correct register depending on mode
+	} else {
+		sb.dma.chan = DMA_GetChannel(sb.hw.dma8);
+	}
+
+	// Set the length to the correct register depending on mode
 	if (autoinit) {
 		sb.dma.autosize = length;
-	}
-	else {
+	} else {
 		sb.dma.singlesize = length;
 	}
-	DSP_DoDMATransfer(mode,freq,autoinit,stereo);
+
+	DSP_DoDMATransfer(mode, freq, autoinit, stereo);
 }
 
-static void DSP_AddData(uint8_t val) {
-	if (sb.dsp.out.used<DSP_BUFSIZE) {
+static void DSP_AddData(uint8_t val)
+{
+	if (sb.dsp.out.used < DSP_BUFSIZE) {
 		auto start = sb.dsp.out.used + sb.dsp.out.pos;
-		if (start>=DSP_BUFSIZE) start-=DSP_BUFSIZE;
-		sb.dsp.out.data[start]=val;
+		if (start >= DSP_BUFSIZE) {
+			start -= DSP_BUFSIZE;
+		}
+		sb.dsp.out.data[start] = val;
 		sb.dsp.out.used++;
 	} else {
-		LOG(LOG_SB,LOG_ERROR)("DSP:Data Output buffer full");
+		LOG(LOG_SB, LOG_ERROR)("DSP:Data Output buffer full");
 	}
 }
 
@@ -1214,81 +1361,107 @@ static void DSP_FinishReset(uint32_t /*val*/)
 {
 	DSP_FlushData();
 	DSP_AddData(0xaa);
-	sb.dsp.state=DSP_S_NORMAL;
+	sb.dsp.state = DSP_S_NORMAL;
 }
 
-static void DSP_Reset() {
-	LOG(LOG_SB,LOG_ERROR)("DSP:Reset");
+static void DSP_Reset()
+{
+	LOG(LOG_SB, LOG_ERROR)("DSP:Reset");
+
 	PIC_DeActivateIRQ(sb.hw.irq);
 
 	DSP_ChangeMode(MODE_NONE);
 	DSP_FlushData();
-	sb.dsp.cmd=DSP_NO_COMMAND;
-	sb.dsp.cmd_len=0;
-	sb.dsp.in.pos=0;
+
+	sb.dsp.cmd     = DSP_NO_COMMAND;
+	sb.dsp.cmd_len = 0;
+	sb.dsp.in.pos  = 0;
+
 	sb.dsp.write_status_counter = 0;
 	sb.dsp.reset_tally++;
+
 	PIC_RemoveEvents(DSP_FinishReset);
 
-	sb.dma.left=0;
-	sb.dma.singlesize=0;
-	sb.dma.autosize = 0;
-	sb.dma.stereo=false;
-	sb.dma.sign=false;
-	sb.dma.autoinit=false;
-	sb.dma.mode=DSP_DMA_NONE;
-	sb.dma.remain_size=0;
-	if (sb.dma.chan) sb.dma.chan->ClearRequest();
+	sb.dma.left        = 0;
+	sb.dma.singlesize  = 0;
+	sb.dma.autosize    = 0;
+	sb.dma.stereo      = false;
+	sb.dma.sign        = false;
+	sb.dma.autoinit    = false;
+	sb.dma.mode        = DSP_DMA_NONE;
+	sb.dma.remain_size = 0;
 
-	sb.adpcm = {};
-	sb.freq = default_playback_rate_hz;
-	sb.time_constant=45;
-	sb.dac.used=0;
-	sb.dac.last=0;
-	sb.e2.value=0xaa;
-	sb.e2.count=0;
-	sb.irq.pending_8bit=false;
-	sb.irq.pending_16bit=false;
+	if (sb.dma.chan) {
+		sb.dma.chan->ClearRequest();
+	}
+
+	sb.adpcm         = {};
+	sb.freq          = default_playback_rate_hz;
+	sb.time_constant = 45;
+	sb.dac.used      = 0;
+	sb.dac.last      = 0;
+	sb.e2.value      = 0xaa;
+	sb.e2.count      = 0;
+
+	sb.irq.pending_8bit  = false;
+	sb.irq.pending_16bit = false;
+
 	set_channel_rate_hz(default_playback_rate_hz);
+
 	InitializeSpeakerState();
+
 	PIC_RemoveEvents(ProcessDMATransfer);
 }
 
-static void DSP_DoReset(uint8_t val) {
-	if (((val&1)!=0) && (sb.dsp.state!=DSP_S_RESET)) {
+static void DSP_DoReset(uint8_t val)
+{
+	if (((val & 1) != 0) && (sb.dsp.state != DSP_S_RESET)) {
 		// TODO Get out of highspeed mode
 		// Halt the channel so we're silent across reset events.
 		// Channel is re-enabled (if SB16) or via control by the game
 		// (non-SB16).
 		sb.chan->Enable(false);
+
 		DSP_Reset();
-		sb.dsp.state=DSP_S_RESET;
-	} else if (((val&1)==0) && (sb.dsp.state==DSP_S_RESET)) {	// reset off
-		sb.dsp.state=DSP_S_RESET_WAIT;
+
+		sb.dsp.state = DSP_S_RESET;
+	} else if (((val & 1) == 0) && (sb.dsp.state == DSP_S_RESET)) {
+		// reset off
+		sb.dsp.state = DSP_S_RESET_WAIT;
+
 		PIC_RemoveEvents(DSP_FinishReset);
-		PIC_AddEvent(DSP_FinishReset, 20.0 / 1000.0, 0); // 20 microseconds
+		// 20 microseconds
+		PIC_AddEvent(DSP_FinishReset, 20.0 / 1000.0, 0);
+
 		LOG_MSG("%s: DSP was reset", CardType());
 	}
 }
 
 static void DSP_E2_DMA_CallBack(const DmaChannel* /*chan*/, DMAEvent event)
 {
-	if (event==DMA_UNMASKED) {
-		uint8_t val=(uint8_t)(sb.e2.value&0xff);
-		DmaChannel * chan=DMA_GetChannel(sb.hw.dma8);
+	if (event == DMA_UNMASKED) {
+		uint8_t val = (uint8_t)(sb.e2.value & 0xff);
+
+		DmaChannel* chan = DMA_GetChannel(sb.hw.dma8);
+
 		chan->RegisterCallback(nullptr);
-		chan->Write(1,&val);
+		chan->Write(1, &val);
 	}
 }
 
 static void DSP_ADC_CallBack(const DmaChannel* /*chan*/, DMAEvent event)
 {
-	if (event!=DMA_UNMASKED) return;
-	uint8_t val=128;
-	DmaChannel * ch=DMA_GetChannel(sb.hw.dma8);
-	while (sb.dma.left--) {
-		ch->Write(1,&val);
+	if (event != DMA_UNMASKED) {
+		return;
 	}
+
+	uint8_t val    = 128;
+	DmaChannel* ch = DMA_GetChannel(sb.hw.dma8);
+
+	while (sb.dma.left--) {
+		ch->Write(1, &val);
+	}
+
 	SB_RaiseIRQ(SB_IRQ_8);
 	ch->RegisterCallback(nullptr);
 }
@@ -1298,172 +1471,269 @@ static void DSP_ChangeRate(uint32_t freq)
 	if (sb.freq != freq && sb.dma.mode != DSP_DMA_NONE) {
 		sb.chan->FillUp();
 		set_channel_rate_hz(freq / (sb.mixer.stereo ? 2 : 1));
-		sb.dma.rate=(freq*sb.dma.mul) >> SB_SH;
-		sb.dma.min=(sb.dma.rate*3)/1000;
+		sb.dma.rate = (freq * sb.dma.mul) >> SB_SH;
+		sb.dma.min  = (sb.dma.rate * 3) / 1000;
 	}
-	sb.freq=freq;
+	sb.freq = freq;
 }
 
-#define DSP_SB16_ONLY if (sb.type != SBT_16) { LOG(LOG_SB,LOG_ERROR)("DSP:Command %2X requires SB16",sb.dsp.cmd); break; }
-#define DSP_SB2_ABOVE if (sb.type <= SBT_1) { LOG(LOG_SB,LOG_ERROR)("DSP:Command %2X requires SB2 or above",sb.dsp.cmd); break; }
+#define DSP_SB16_ONLY \
+	if (sb.type != SBT_16) { \
+		LOG(LOG_SB, LOG_ERROR) \
+		("DSP:Command %2X requires SB16", sb.dsp.cmd); \
+		break; \
+	}
+#define DSP_SB2_ABOVE \
+	if (sb.type <= SBT_1) { \
+		LOG(LOG_SB, LOG_ERROR) \
+		("DSP:Command %2X requires SB2 or above", sb.dsp.cmd); \
+		break; \
+	}
 
-static void DSP_DoCommand() {
-//	LOG_MSG("DSP Command %X",sb.dsp.cmd);
+static void DSP_DoCommand()
+{
+	//	LOG_MSG("DSP Command %X",sb.dsp.cmd);
 	switch (sb.dsp.cmd) {
 	case 0x04:
 		if (sb.type == SBT_16) {
-			/* SB16 ASP set mode register */
-			if ((sb.dsp.in.data[0]&0xf1)==0xf1) ASP_init_in_progress=true;
-			else ASP_init_in_progress=false;
-			LOG(LOG_SB,LOG_NORMAL)("DSP Unhandled SB16ASP command %X (set mode register to %X)",sb.dsp.cmd,sb.dsp.in.data[0]);
+			// SB16 ASP set mode register
+			if ((sb.dsp.in.data[0] & 0xf1) == 0xf1) {
+				ASP_init_in_progress = true;
+			} else {
+				ASP_init_in_progress = false;
+			}
+
+			LOG(LOG_SB, LOG_NORMAL)
+			("DSP Unhandled SB16ASP command %X (set mode register to %X)",
+			 sb.dsp.cmd,
+			 sb.dsp.in.data[0]);
+
 		} else {
-			/* DSP Status SB 2.0/pro version. NOT SB16. */
+			// DSP Status SB 2.0/pro version. NOT SB16.
 			DSP_FlushData();
-			if (sb.type == SBT_2) DSP_AddData(0x88);
-			else if ((sb.type == SBT_PRO1) || (sb.type == SBT_PRO2)) DSP_AddData(0x7b);
-			else DSP_AddData(0xff);			//Everything enabled
+			if (sb.type == SBT_2) {
+				DSP_AddData(0x88);
+			} else if ((sb.type == SBT_PRO1) || (sb.type == SBT_PRO2)) {
+				DSP_AddData(0x7b);
+			} else {
+				// Everything enabled
+				DSP_AddData(0xff);
+			}
 		}
 		break;
-	case 0x05:	/* SB16 ASP set codec parameter */
-		LOG(LOG_SB,LOG_NORMAL)("DSP Unhandled SB16ASP command %X (set codec parameter)",sb.dsp.cmd);
+
+	case 0x05: // SB16 ASP set codec parameter
+		LOG(LOG_SB, LOG_NORMAL)
+		("DSP Unhandled SB16ASP command %X (set codec parameter)",
+		 sb.dsp.cmd);
 		break;
-	case 0x08:	/* SB16 ASP get version */
-		LOG(LOG_SB,LOG_NORMAL)("DSP Unhandled SB16ASP command %X sub %X",sb.dsp.cmd,sb.dsp.in.data[0]);
+
+	case 0x08: // SB16 ASP get version
+		LOG(LOG_SB, LOG_NORMAL)
+		("DSP Unhandled SB16ASP command %X sub %X",
+		 sb.dsp.cmd,
+		 sb.dsp.in.data[0]);
+
 		if (sb.type == SBT_16) {
 			switch (sb.dsp.in.data[0]) {
-				case 0x03:
-					DSP_AddData(0x18);	// version ID (??)
-					break;
-				default:
-					LOG(LOG_SB,LOG_NORMAL)("DSP Unhandled SB16ASP command %X sub %X",sb.dsp.cmd,sb.dsp.in.data[0]);
-					break;
+			case 0x03:
+				DSP_AddData(0x18); // version ID (??)
+				break;
+			default:
+				LOG(LOG_SB, LOG_NORMAL)
+				("DSP Unhandled SB16ASP command %X sub %X",
+				 sb.dsp.cmd,
+				 sb.dsp.in.data[0]);
+				break;
 			}
 		} else {
-			LOG(LOG_SB,LOG_NORMAL)("DSP Unhandled SB16ASP command %X sub %X",sb.dsp.cmd,sb.dsp.in.data[0]);
+			LOG(LOG_SB, LOG_NORMAL)
+			("DSP Unhandled SB16ASP command %X sub %X",
+			 sb.dsp.cmd,
+			 sb.dsp.in.data[0]);
 		}
 		break;
-	case 0x0e:	/* SB16 ASP set register */
+
+	case 0x0e: // SB16 ASP set register
 		if (sb.type == SBT_16) {
-//			LOG(LOG_SB,LOG_NORMAL)("SB16 ASP set register %X := %X",sb.dsp.in.data[0],sb.dsp.in.data[1]);
+			// LOG(LOG_SB,LOG_NORMAL)("SB16 ASP set
+			// register %X := %X",sb.dsp.in.data[0],sb.dsp.in.data[1]);
 			ASP_regs[sb.dsp.in.data[0]] = sb.dsp.in.data[1];
 		} else {
-			LOG(LOG_SB,LOG_NORMAL)("DSP Unhandled SB16ASP command %X (set register)",sb.dsp.cmd);
+			LOG(LOG_SB, LOG_NORMAL)
+			("DSP Unhandled SB16ASP command %X (set register)",
+			 sb.dsp.cmd);
 		}
 		break;
-	case 0x0f:	/* SB16 ASP get register */
+
+	case 0x0f: // SB16 ASP get register
 		if (sb.type == SBT_16) {
-			if ((ASP_init_in_progress) && (sb.dsp.in.data[0]==0x83)) {
+			if ((ASP_init_in_progress) && (sb.dsp.in.data[0] == 0x83)) {
 				ASP_regs[0x83] = ~ASP_regs[0x83];
 			}
-//			LOG(LOG_SB,LOG_NORMAL)("SB16 ASP get register %X == %X",sb.dsp.in.data[0],ASP_regs[sb.dsp.in.data[0]]);
+			//			LOG(LOG_SB,LOG_NORMAL)("SB16 ASP
+			//get register %X ==
+			//%X",sb.dsp.in.data[0],ASP_regs[sb.dsp.in.data[0]]);
 			DSP_AddData(ASP_regs[sb.dsp.in.data[0]]);
 		} else {
-			LOG(LOG_SB,LOG_NORMAL)("DSP Unhandled SB16ASP command %X (get register)",sb.dsp.cmd);
+			LOG(LOG_SB, LOG_NORMAL)
+			("DSP Unhandled SB16ASP command %X (get register)",
+			 sb.dsp.cmd);
 		}
 		break;
-	case 0x10:	/* Direct DAC */
+
+	case 0x10: // Direct DAC
 		DSP_ChangeMode(MODE_DAC);
-		if (sb.dac.used<DSP_DACSIZE) {
+		if (sb.dac.used < DSP_DACSIZE) {
 			const auto mono_sample = lut_u8to16[sb.dsp.in.data[0]];
 			sb.dac.data[sb.dac.used++] = mono_sample;
 			sb.dac.data[sb.dac.used++] = mono_sample;
 		}
 		break;
-	case 0x24:	/* Singe Cycle 8-Bit DMA ADC */
-		//Directly write to left?
+
+	case 0x24: // Singe Cycle 8-Bit DMA ADC
+		// Directly write to left?
 		sb.dma.left = 1 + sb.dsp.in.data[0] + (sb.dsp.in.data[1] << 8);
-		sb.dma.sign=false;
-		LOG(LOG_SB,LOG_ERROR)("DSP:Faked ADC for %u bytes",sb.dma.left);
+		sb.dma.sign = false;
+		LOG(LOG_SB, LOG_ERROR)
+		("DSP:Faked ADC for %u bytes", sb.dma.left);
 		DMA_GetChannel(sb.hw.dma8)->RegisterCallback(DSP_ADC_CallBack);
 		break;
-	case 0x14:	/* Singe Cycle 8-Bit DMA DAC */
-	case 0x15:	/* Wari hack. Waru uses this one instead of 0x14, but some weird stuff going on there anyway */
-	case 0x91:	/* Singe Cycle 8-Bit DMA High speed DAC */
-		/* Note: 0x91 is documented only for DSP ver.2.x and 3.x, not 4.x */
-		DSP_PrepareDMA_Old(DSP_DMA_8,false,false);
+
+	case 0x14: // Singe Cycle 8-Bit DMA DAC
+		[[fallthrough]];
+
+	case 0x15:
+		// Wari hack. Waru uses this one instead of 0x14, but some
+		// weird stuff going on there anyway */
+		[[fallthrough]];
+
+	case 0x91:
+		// Singe Cycle 8-Bit DMA High speed DAC */
+		// Note: 0x91 is documented only for DSP ver.2.x and 3.x,
+		// not 4.x */
+		DSP_PrepareDMA_Old(DSP_DMA_8, false, false);
 		break;
-	case 0x90:	/* Auto Init 8-bit DMA High Speed */
-	case 0x1c:	/* Auto Init 8-bit DMA */
-		DSP_SB2_ABOVE; /* Note: 0x90 is documented only for DSP ver.2.x and 3.x, not 4.x */
-		DSP_PrepareDMA_Old(DSP_DMA_8,true,false);
+
+	case 0x90: // Auto Init 8-bit DMA High Speed
+		[[fallthrough]];
+
+	case 0x1c: // Auto Init 8-bit DMA
+	           // Note: 0x90 is documented only for DSP ver.2.x and 3.x,
+	           // not 4.x
+		DSP_SB2_ABOVE;
+		DSP_PrepareDMA_Old(DSP_DMA_8, true, false);
 		break;
-	case 0x38:  /* Write to SB MIDI Output */
-		if (sb.midi == true) MIDI_RawOutByte(sb.dsp.in.data[0]);
+
+	case 0x38: // Write to SB MIDI Output
+		if (sb.midi == true) {
+			MIDI_RawOutByte(sb.dsp.in.data[0]);
+		}
 		break;
-	case 0x40:	/* Set Timeconstant */
+
+	case 0x40: // Set Timeconstant
 		DSP_ChangeRate(1000000 / (256 - sb.dsp.in.data[0]));
 		break;
-	case 0x41:	/* Set Output Samplerate */
-	case 0x42:	/* Set Input Samplerate */
-		/* Note: 0x42 is handled like 0x41, needed by Fasttracker II */
+
+	case 0x41: // Set Output Samplerate
+		[[fallthrough]];
+
+	case 0x42: // Set Input Samplerate
+		// Note: 0x42 is handled like 0x41, needed by Fasttracker II
 		DSP_SB16_ONLY;
 		DSP_ChangeRate((sb.dsp.in.data[0] << 8) | sb.dsp.in.data[1]);
 		break;
-	case 0x48:	/* Set DMA Block Size */
+
+	case 0x48: // Set DMA Block Size
 		DSP_SB2_ABOVE;
-		sb.dma.autosize=1+sb.dsp.in.data[0]+(sb.dsp.in.data[1] << 8);
+		sb.dma.autosize = 1 + sb.dsp.in.data[0] + (sb.dsp.in.data[1] << 8);
 		break;
-	case 0x75:	/* 075h : Single Cycle 4-bit ADPCM Reference */
+
+	case 0x75: // 075h : Single Cycle 4-bit ADPCM Reference
 		sb.adpcm.haveref = true;
 		[[fallthrough]];
-	case 0x74:	/* 074h : Single Cycle 4-bit ADPCM */
-		DSP_PrepareDMA_Old(DSP_DMA_4,false,false);
+
+	case 0x74: // 074h : Single Cycle 4-bit ADPCM
+		DSP_PrepareDMA_Old(DSP_DMA_4, false, false);
 		break;
-	case 0x77:	/* 077h : Single Cycle 3-bit(2.6bit) ADPCM Reference*/
+
+	case 0x77: // 077h : Single Cycle 3-bit(2.6bit) ADPCM Reference
 		sb.adpcm.haveref = true;
 		[[fallthrough]];
-	case 0x76:	/* 076h : Single Cycle 3-bit(2.6bit) ADPCM */
-		DSP_PrepareDMA_Old(DSP_DMA_3,false,false);
+
+	case 0x76: // 076h : Single Cycle 3-bit(2.6bit) ADPCM
+		DSP_PrepareDMA_Old(DSP_DMA_3, false, false);
 		break;
-	case 0x7d:	/* Auto Init 4-bit ADPCM Reference */
+
+	case 0x7d: // Auto Init 4-bit ADPCM Reference
 		DSP_SB2_ABOVE;
 		sb.adpcm.haveref = true;
-		DSP_PrepareDMA_Old(DSP_DMA_4,true,false);
+		DSP_PrepareDMA_Old(DSP_DMA_4, true, false);
 		break;
-	case 0x17:	/* 017h : Single Cycle 2-bit ADPCM Reference*/
+
+	case 0x17: // 017h : Single Cycle 2-bit ADPCM Reference
 		sb.adpcm.haveref = true;
 		[[fallthrough]];
-	case 0x16:	/* 016h : Single Cycle 2-bit ADPCM */
-		DSP_PrepareDMA_Old(DSP_DMA_2,false,false);
+
+	case 0x16: // 016h : Single Cycle 2-bit ADPCM
+		DSP_PrepareDMA_Old(DSP_DMA_2, false, false);
 		break;
-	case 0x80:	/* Silence DAC */
+
+	case 0x80: // Silence DAC
 		PIC_AddEvent(&DSP_RaiseIRQEvent,
-		             (1000.0 * (1 + sb.dsp.in.data[0] + (sb.dsp.in.data[1] << 8)) /
+		             (1000.0 *
+		              (1 + sb.dsp.in.data[0] + (sb.dsp.in.data[1] << 8)) /
 		              sb.freq));
 		break;
-	case 0xb0:	case 0xb1:	case 0xb2:	case 0xb3:  case 0xb4:	case 0xb5:	case 0xb6:	case 0xb7:
-	case 0xb8:	case 0xb9:	case 0xba:	case 0xbb:  case 0xbc:	case 0xbd:	case 0xbe:	case 0xbf:
-	case 0xc0:	case 0xc1:	case 0xc2:	case 0xc3:  case 0xc4:	case 0xc5:	case 0xc6:	case 0xc7:
-	case 0xc8:	case 0xc9:	case 0xca:	case 0xcb:  case 0xcc:	case 0xcd:	case 0xce:	case 0xcf:
+
+	// clang-format off
+	// 0xb0 to 0xbf
+	case 0xb0: case 0xb1: case 0xb2: case 0xb3:
+	case 0xb4: case 0xb5: case 0xb6: case 0xb7:
+	case 0xb8: case 0xb9: case 0xba: case 0xbb:
+	case 0xbc: case 0xbd: case 0xbe: case 0xbf:
+
+	// 0xc0 to 0xcf
+	case 0xc0: case 0xc1: case 0xc2: case 0xc3:
+	case 0xc4: case 0xc5: case 0xc6: case 0xc7:
+	case 0xc8: case 0xc9: case 0xca: case 0xcb:
+	case 0xcc: case 0xcd: case 0xce: case 0xcf:
+		// clang-format on
 		DSP_SB16_ONLY;
 		/* Generic 8/16 bit DMA */
-		sb.dma.sign=(sb.dsp.in.data[0] & 0x10) > 0;
+		sb.dma.sign = (sb.dsp.in.data[0] & 0x10) > 0;
 		DSP_PrepareDMA_New((sb.dsp.cmd & 0x10) ? DSP_DMA_16 : DSP_DMA_8,
-			1+sb.dsp.in.data[1]+(sb.dsp.in.data[2] << 8),
-			(sb.dsp.cmd & 0x4)>0,
-			(sb.dsp.in.data[0] & 0x20) > 0
-		);
+		                   1 + sb.dsp.in.data[1] + (sb.dsp.in.data[2] << 8),
+		                   (sb.dsp.cmd & 0x4) > 0,
+		                   (sb.dsp.in.data[0] & 0x20) > 0);
 		break;
-	case 0xd5:	/* Halt 16-bit DMA */
+
+	case 0xd5: // Halt 16-bit DMA
 		DSP_SB16_ONLY;
 		[[fallthrough]];
-	case 0xd0:	/* Halt 8-bit DMA */
-//		DSP_ChangeMode(MODE_NONE);
+
+	case 0xd0: // Halt 8-bit DMA
+		// DSP_ChangeMode(MODE_NONE);
 		LOG(LOG_SB, LOG_NORMAL)("Halt DMA Command");
-//		Games sometimes already program a new dma before stopping, gives noise
-		if (sb.mode==MODE_NONE) {
-			// possibly different code here that does not switch to MODE_DMA_PAUSE
+		// Games sometimes already program a new dma before stopping,
+		// gives noise
+		if (sb.mode == MODE_NONE) {
+			// possibly different code here that does not switch to
+			// MODE_DMA_PAUSE
 		}
-		sb.mode=MODE_DMA_PAUSE;
+		sb.mode = MODE_DMA_PAUSE;
 		PIC_RemoveEvents(ProcessDMATransfer);
 		break;
-	case 0xd1:	/* Enable Speaker */
+
+	case 0xd1: // Enable Speaker
 		DSP_SetSpeaker(true);
 		break;
-	case 0xd3:	/* Disable Speaker */
+
+	case 0xd3: // Disable Speaker
 		DSP_SetSpeaker(false);
 		break;
-	case 0xd8:  /* Speaker status */
+
+	case 0xd8: // Speaker status
 		DSP_SB2_ABOVE;
 		DSP_FlushData();
 		if (sb.speaker) {
@@ -1477,208 +1747,277 @@ static void DSP_DoCommand() {
 			DSP_AddData(0x00);
 		}
 		break;
-	case 0xd6:	/* Continue DMA 16-bit */
+
+	case 0xd6: // Continue DMA 16-bit
 		DSP_SB16_ONLY;
 		[[fallthrough]];
-	case 0xd4:	/* Continue DMA 8-bit*/
+
+	case 0xd4: // Continue DMA 8-bit
 		LOG(LOG_SB, LOG_NORMAL)("Continue DMA command");
-		if (sb.mode==MODE_DMA_PAUSE) {
-			sb.mode=MODE_DMA_MASKED;
-			if (sb.dma.chan!=nullptr) sb.dma.chan->RegisterCallback(DSP_DMA_CallBack);
+
+		if (sb.mode == MODE_DMA_PAUSE) {
+			sb.mode = MODE_DMA_MASKED;
+			if (sb.dma.chan != nullptr) {
+				sb.dma.chan->RegisterCallback(DSP_DMA_CallBack);
+			}
 		}
 		break;
-	case 0xd9:  /* Exit Autoinitialize 16-bit */
+
+	case 0xd9: // Exit Autoinitialize 16-bit
 		DSP_SB16_ONLY;
 		[[fallthrough]];
-	case 0xda:	/* Exit Autoinitialize 8-bit */
+
+	case 0xda: // Exit Autoinitialize 8-bit
 		DSP_SB2_ABOVE;
 		LOG(LOG_SB, LOG_NORMAL)("Exit Autoinit command");
-		sb.dma.autoinit=false;		//Should stop itself
+
+		sb.dma.autoinit = false; // Should stop itself
 		break;
-	case 0xe0:	/* DSP Identification - SB2.0+ */
+
+	case 0xe0: // DSP Identification - SB2.0+
 		DSP_FlushData();
 		DSP_AddData(~sb.dsp.in.data[0]);
 		break;
-	case 0xe1:	/* Get DSP Version */
+
+	case 0xe1: // Get DSP Version
 		DSP_FlushData();
 		switch (sb.type) {
 		case SBT_1:
-			DSP_AddData(0x1);DSP_AddData(0x05);break;
-		case SBT_2:
-			DSP_AddData(0x2);DSP_AddData(0x1);break;
-		case SBT_PRO1:
-			DSP_AddData(0x3);DSP_AddData(0x0);break;
-		case SBT_PRO2:
-			DSP_AddData(0x3);DSP_AddData(0x2);break;
-		case SBT_16:
-			DSP_AddData(0x4);DSP_AddData(0x5);break;
-		default:
+			DSP_AddData(0x1);
+			DSP_AddData(0x05);
 			break;
+		case SBT_2:
+			DSP_AddData(0x2);
+			DSP_AddData(0x1);
+			break;
+		case SBT_PRO1:
+			DSP_AddData(0x3);
+			DSP_AddData(0x0);
+			break;
+		case SBT_PRO2:
+			DSP_AddData(0x3);
+			DSP_AddData(0x2);
+			break;
+		case SBT_16:
+			DSP_AddData(0x4);
+			DSP_AddData(0x5);
+			break;
+		default: break;
 		}
 		break;
-	case 0xe2:	/* Weird DMA identification write routine */
-		{
-			LOG(LOG_SB,LOG_NORMAL)("DSP Function 0xe2");
-		        for (uint8_t i = 0; i < 8; i++)
-			        if ((sb.dsp.in.data[0] >> i) & 0x01)
-				        sb.e2.value += E2_incr_table[sb.e2.count % 4][i];
-		        sb.e2.value += E2_incr_table[sb.e2.count % 4][8];
-		        sb.e2.count++;
-		        DMA_GetChannel(sb.hw.dma8)->RegisterCallback(DSP_E2_DMA_CallBack);
+
+	case 0xe2: // Weird DMA identification write routine
+	{
+		LOG(LOG_SB, LOG_NORMAL)("DSP Function 0xe2");
+		for (uint8_t i = 0; i < 8; i++) {
+			if ((sb.dsp.in.data[0] >> i) & 0x01) {
+				sb.e2.value += E2_incr_table[sb.e2.count % 4][i];
+			}
 		}
-		break;
-	case 0xe3: /* DSP Copyright */
+		sb.e2.value += E2_incr_table[sb.e2.count % 4][8];
+		sb.e2.count++;
+		DMA_GetChannel(sb.hw.dma8)->RegisterCallback(DSP_E2_DMA_CallBack);
+	} break;
+
+	case 0xe3: // DSP Copyright
 		DSP_FlushData();
-		for (const auto c : "COPYRIGHT (C) CREATIVE TECHNOLOGY LTD, 1992.")
+		for (const auto c : "COPYRIGHT (C) CREATIVE TECHNOLOGY LTD, 1992.") {
 			DSP_AddData(static_cast<uint8_t>(c));
+		}
 		break;
-	case 0xe4:	/* Write Test Register */
-		sb.dsp.test_register=sb.dsp.in.data[0];
+
+	case 0xe4: // Write Test Register
+		sb.dsp.test_register = sb.dsp.in.data[0];
 		break;
-	case 0xe8:	/* Read Test Register */
+
+	case 0xe8: // Read Test Register
 		DSP_FlushData();
-		DSP_AddData(sb.dsp.test_register);;
+		DSP_AddData(sb.dsp.test_register);
 		break;
-	case 0xf2:	/* Trigger 8bit IRQ */
-		//Small delay in order to emulate the slowness of the DSP, fixes Llamatron 2012 and Lemmings 3D
+
+	case 0xf2: // Trigger 8bit IRQ
+		// Small delay in order to emulate the slowness of the DSP,
+		// fixes Llamatron 2012 and Lemmings 3D
 		PIC_AddEvent(&DSP_RaiseIRQEvent, 0.01);
+
 		LOG(LOG_SB, LOG_NORMAL)("Trigger 8bit IRQ command");
 		break;
-	case 0xf3:   /* Trigger 16bit IRQ */
+
+	case 0xf3: // Trigger 16bit IRQ
 		DSP_SB16_ONLY;
 		SB_RaiseIRQ(SB_IRQ_16);
+
 		LOG(LOG_SB, LOG_NORMAL)("Trigger 16bit IRQ command");
 		break;
-	case 0xf8:  /* Undocumented, pre-SB16 only */
+
+	case 0xf8: // Undocumented, pre-SB16 only
 		DSP_FlushData();
 		DSP_AddData(0);
 		break;
-	case 0x30: case 0x31:
-		LOG(LOG_SB,LOG_ERROR)("DSP:Unimplemented MIDI I/O command %2X",sb.dsp.cmd);
+
+	case 0x30:
+	case 0x31:
+		LOG(LOG_SB, LOG_ERROR)
+		("DSP:Unimplemented MIDI I/O command %2X", sb.dsp.cmd);
 		break;
-	case 0x34: case 0x35: case 0x36: case 0x37:
+
+	case 0x34:
+	case 0x35:
+	case 0x36:
+	case 0x37:
 		DSP_SB2_ABOVE;
-		LOG(LOG_SB,LOG_ERROR)("DSP:Unimplemented MIDI UART command %2X",sb.dsp.cmd);
+
+		LOG(LOG_SB, LOG_ERROR)
+		("DSP:Unimplemented MIDI UART command %2X", sb.dsp.cmd);
 		break;
-	case 0x7f: case 0x1f:
+
+	case 0x7f:
+	case 0x1f:
 		DSP_SB2_ABOVE;
-		LOG(LOG_SB,LOG_ERROR)("DSP:Unimplemented auto-init DMA ADPCM command %2X",sb.dsp.cmd);
+
+		LOG(LOG_SB, LOG_ERROR)
+		("DSP:Unimplemented auto-init DMA ADPCM command %2X", sb.dsp.cmd);
 		break;
+
 	case 0x20:
-		DSP_AddData(0x7f);   // fake silent input for Creative parrot
+		DSP_AddData(0x7f); // Fake silent input for Creative parrot
 		break;
+
 	case 0x2c:
-	case 0x98: case 0x99: /* Documented only for DSP 2.x and 3.x */
-	case 0xa0: case 0xa8: /* Documented only for DSP 3.x */
-		LOG(LOG_SB,LOG_ERROR)("DSP:Unimplemented input command %2X",sb.dsp.cmd);
+	case 0x98:
+	case 0x99: // Documented only for DSP 2.x and 3.x
+	case 0xa0:
+	case 0xa8: // Documented only for DSP 3.x
+		LOG(LOG_SB, LOG_ERROR)
+		("DSP:Unimplemented input command %2X", sb.dsp.cmd);
 		break;
-	case 0xf9:	/* SB16 ASP ??? */
+
+	case 0xf9: // SB16 ASP ???
 		if (sb.type == SBT_16) {
-			LOG(LOG_SB,LOG_NORMAL)("SB16 ASP unknown function %x",sb.dsp.in.data[0]);
-			// just feed it what it expects
+			LOG(LOG_SB, LOG_NORMAL)
+			("SB16 ASP unknown function %x", sb.dsp.in.data[0]);
+
+			// Just feed it what it expects
 			switch (sb.dsp.in.data[0]) {
-			case 0x0b:
-				DSP_AddData(0x00);
-				break;
-			case 0x0e:
-				DSP_AddData(0xff);
-				break;
-			case 0x0f:
-				DSP_AddData(0x07);
-				break;
-			case 0x23:
-				DSP_AddData(0x00);
-				break;
-			case 0x24:
-				DSP_AddData(0x00);
-				break;
-			case 0x2b:
-				DSP_AddData(0x00);
-				break;
-			case 0x2c:
-				DSP_AddData(0x00);
-				break;
-			case 0x2d:
-				DSP_AddData(0x00);
-				break;
-			case 0x37:
-				DSP_AddData(0x38);
-				break;
-			default:
-				DSP_AddData(0x00);
-				break;
+			case 0x0b: DSP_AddData(0x00); break;
+			case 0x0e: DSP_AddData(0xff); break;
+			case 0x0f: DSP_AddData(0x07); break;
+			case 0x23: DSP_AddData(0x00); break;
+			case 0x24: DSP_AddData(0x00); break;
+			case 0x2b: DSP_AddData(0x00); break;
+			case 0x2c: DSP_AddData(0x00); break;
+			case 0x2d: DSP_AddData(0x00); break;
+			case 0x37: DSP_AddData(0x38); break;
+			default: DSP_AddData(0x00); break;
 			}
 		} else {
-			LOG(LOG_SB,LOG_NORMAL)("SB16 ASP unknown function %X",sb.dsp.cmd);
+			LOG(LOG_SB, LOG_NORMAL)
+			("SB16 ASP unknown function %X", sb.dsp.cmd);
+		}
+		break;
+
+	default:
+		LOG(LOG_SB, LOG_ERROR)
+		("DSP:Unhandled (undocumented) command %2X", sb.dsp.cmd);
+		break;
+	}
+
+	sb.dsp.cmd     = DSP_NO_COMMAND;
+	sb.dsp.cmd_len = 0;
+	sb.dsp.in.pos  = 0;
+}
+
+static void DSP_DoWrite(uint8_t val)
+{
+	switch (sb.dsp.cmd) {
+	case DSP_NO_COMMAND:
+		sb.dsp.cmd = val;
+		if (sb.type == SBT_16) {
+			sb.dsp.cmd_len = DSP_cmd_len_sb16[val];
+		} else {
+			sb.dsp.cmd_len = DSP_cmd_len_sb[val];
+		}
+		sb.dsp.in.pos = 0;
+		if (!sb.dsp.cmd_len) {
+			DSP_DoCommand();
 		}
 		break;
 	default:
-		LOG(LOG_SB,LOG_ERROR)("DSP:Unhandled (undocumented) command %2X",sb.dsp.cmd);
-		break;
-	}
-	sb.dsp.cmd=DSP_NO_COMMAND;
-	sb.dsp.cmd_len=0;
-	sb.dsp.in.pos=0;
-}
-
-static void DSP_DoWrite(uint8_t val) {
-	switch (sb.dsp.cmd) {
-	case DSP_NO_COMMAND:
-		sb.dsp.cmd=val;
-		if (sb.type == SBT_16) sb.dsp.cmd_len=DSP_cmd_len_sb16[val];
-		else sb.dsp.cmd_len=DSP_cmd_len_sb[val];
-		sb.dsp.in.pos=0;
-		if (!sb.dsp.cmd_len) DSP_DoCommand();
-		break;
-	default:
-		sb.dsp.in.data[sb.dsp.in.pos]=val;
+		sb.dsp.in.data[sb.dsp.in.pos] = val;
 		sb.dsp.in.pos++;
-		if (sb.dsp.in.pos>=sb.dsp.cmd_len) DSP_DoCommand();
+		if (sb.dsp.in.pos >= sb.dsp.cmd_len) {
+			DSP_DoCommand();
+		}
 	}
 }
 
-static uint8_t DSP_ReadData() {
-/* Static so it repeats the last value on succesive reads (JANGLE DEMO) */
+static uint8_t DSP_ReadData()
+{
+	/* Static so it repeats the last value on succesive reads (JANGLE DEMO) */
 	if (sb.dsp.out.used) {
-		sb.dsp.out.lastval=sb.dsp.out.data[sb.dsp.out.pos];
+		sb.dsp.out.lastval = sb.dsp.out.data[sb.dsp.out.pos];
 		sb.dsp.out.pos++;
-		if (sb.dsp.out.pos>=DSP_BUFSIZE) sb.dsp.out.pos-=DSP_BUFSIZE;
+		if (sb.dsp.out.pos >= DSP_BUFSIZE) {
+			sb.dsp.out.pos -= DSP_BUFSIZE;
+		}
 		sb.dsp.out.used--;
 	}
 	return sb.dsp.out.lastval;
 }
 
-static float calc_vol(uint8_t amount) {
+static float calc_vol(uint8_t amount)
+{
 	uint8_t count = 31 - amount;
+
 	float db = static_cast<float>(count);
+
 	if (sb.type == SBT_PRO1 || sb.type == SBT_PRO2) {
 		if (count) {
-			if (count < 16) db -= 1.0f;
-			else if (count > 16) db += 1.0f;
-			if (count == 24) db += 2.0f;
-			if (count > 27) return 0.0f; //turn it off.
+			if (count < 16) {
+				db -= 1.0f;
+			} else if (count > 16) {
+				db += 1.0f;
+			}
+			if (count == 24) {
+				db += 2.0f;
+			}
+			if (count > 27) {
+				// Turn it off.
+				return 0.0f;
+			}
 		}
-	} else { //Give the rest, the SB16 scale, as we don't have data.
+	} else {
+		// Give the rest, the SB16 scale, as we don't have data.
 		db *= 2.0f;
-		if (count > 20) db -= 1.0f;
+		if (count > 20) {
+			db -= 1.0f;
+		}
 	}
+
 	return powf(10.0f, -0.05f * db);
 }
-static void CTMIXER_UpdateVolumes() {
-	if (!sb.mixer.enabled) return;
+
+static void CTMIXER_UpdateVolumes()
+{
+	if (!sb.mixer.enabled) {
+		return;
+	}
 
 	float m0 = calc_vol(sb.mixer.master[0]);
 	float m1 = calc_vol(sb.mixer.master[1]);
+
 	auto chan = MIXER_FindChannel(ChannelName::SoundBlasterDac);
 	if (chan) {
 		chan->SetAppVolume({m0 * calc_vol(sb.mixer.dac[0]),
 		                    m1 * calc_vol(sb.mixer.dac[1])});
 	}
+
 	chan = MIXER_FindChannel(ChannelName::Opl);
 	if (chan) {
 		chan->SetAppVolume({m0 * calc_vol(sb.mixer.fm[0]),
 		                    m1 * calc_vol(sb.mixer.fm[1])});
 	}
+
 	chan = MIXER_FindChannel(ChannelName::CdAudio);
 	if (chan) {
 		chan->SetAppVolume({m0 * calc_vol(sb.mixer.cda[0]),
@@ -1686,290 +2025,422 @@ static void CTMIXER_UpdateVolumes() {
 	}
 }
 
-static void CTMIXER_Reset() {
-	sb.mixer.fm[0]=
-	sb.mixer.fm[1]=
-	sb.mixer.cda[0]=
-	sb.mixer.cda[1]=
-	sb.mixer.dac[0]=
-	sb.mixer.dac[1]=31;
-	sb.mixer.master[0]=
-	sb.mixer.master[1]=31;
+static void CTMIXER_Reset()
+{
+	constexpr auto DefaultVolume = 31;
+
+	sb.mixer.fm[0] = DefaultVolume;
+	sb.mixer.fm[1] = DefaultVolume;
+
+	sb.mixer.cda[0] = DefaultVolume;
+	sb.mixer.cda[1] = DefaultVolume;
+
+	sb.mixer.dac[0] = DefaultVolume;
+	sb.mixer.dac[1] = DefaultVolume;
+
+	sb.mixer.master[0] = DefaultVolume;
+	sb.mixer.master[1] = DefaultVolume;
+
 	CTMIXER_UpdateVolumes();
 }
 
-#define SETPROVOL(_WHICH_,_VAL_)										\
-	_WHICH_[0]=   ((((_VAL_) & 0xf0) >> 3)|(sb.type==SBT_16 ? 1:3));	\
-	_WHICH_[1]=   ((((_VAL_) & 0x0f) << 1)|(sb.type==SBT_16 ? 1:3));	\
+#define SETPROVOL(_WHICH_, _VAL_) \
+	_WHICH_[0] = ((((_VAL_)&0xf0) >> 3) | (sb.type == SBT_16 ? 1 : 3)); \
+	_WHICH_[1] = ((((_VAL_)&0x0f) << 1) | (sb.type == SBT_16 ? 1 : 3));
 
-#define MAKEPROVOL(_WHICH_)											\
-	((((_WHICH_[0] & 0x1e) << 3) | ((_WHICH_[1] & 0x1e) >> 1)) |	\
-		((sb.type==SBT_PRO1 || sb.type==SBT_PRO2) ? 0x11:0))
+#define MAKEPROVOL(_WHICH_) \
+	((((_WHICH_[0] & 0x1e) << 3) | ((_WHICH_[1] & 0x1e) >> 1)) | \
+	 ((sb.type == SBT_PRO1 || sb.type == SBT_PRO2) ? 0x11 : 0))
 
-static void DSP_ChangeStereo(bool stereo) {
+static void DSP_ChangeStereo(bool stereo)
+{
 	if (!sb.dma.stereo && stereo) {
 		set_channel_rate_hz(sb.freq / 2);
-		sb.dma.mul*=2;
-		sb.dma.rate=(sb.freq*sb.dma.mul) >> SB_SH;
-		sb.dma.min=(sb.dma.rate*3)/1000;
+		sb.dma.mul *= 2;
+		sb.dma.rate = (sb.freq * sb.dma.mul) >> SB_SH;
+		sb.dma.min  = (sb.dma.rate * 3) / 1000;
+
 	} else if (sb.dma.stereo && !stereo) {
 		set_channel_rate_hz(sb.freq);
-		sb.dma.mul/=2;
-		sb.dma.rate=(sb.freq*sb.dma.mul) >> SB_SH;
-		sb.dma.min=(sb.dma.rate*3)/1000;
+		sb.dma.mul /= 2;
+		sb.dma.rate = (sb.freq * sb.dma.mul) >> SB_SH;
+		sb.dma.min  = (sb.dma.rate * 3) / 1000;
 	}
-	sb.dma.stereo=stereo;
+
+	sb.dma.stereo = stereo;
 }
 
-static void CTMIXER_Write(uint8_t val) {
+static void CTMIXER_Write(uint8_t val)
+{
 	switch (sb.mixer.index) {
-	case 0x00:		/* Reset */
+	case 0x00: // Reset
 		CTMIXER_Reset();
-		LOG(LOG_SB,LOG_WARN)("Mixer reset value %x",val);
+		LOG(LOG_SB, LOG_WARN)("Mixer reset value %x", val);
 		break;
-	case 0x02:		/* Master Volume (SB2 Only) */
-		SETPROVOL(sb.mixer.master,(val&0xf)|(val<<4));
+
+	case 0x02: // Master Volume (SB2 Only)
+		SETPROVOL(sb.mixer.master, (val & 0xf) | (val << 4));
 		CTMIXER_UpdateVolumes();
 		break;
-	case 0x04:		/* DAC Volume (SBPRO) */
-		SETPROVOL(sb.mixer.dac,val);
+
+	case 0x04: // DAC Volume (SBPRO)
+		SETPROVOL(sb.mixer.dac, val);
 		CTMIXER_UpdateVolumes();
 		break;
-	case 0x06:		/* FM output selection, Somewhat obsolete with dual OPL SBpro + FM volume (SB2 Only) */
-		//volume controls both channels
-		SETPROVOL(sb.mixer.fm,(val&0xf)|(val<<4));
+
+	case 0x06: // FM output selection
+	           // Somewhat obsolete with dual OPL SBpro + FM volume (SB2 Only)
+		// volume controls both channels
+		SETPROVOL(sb.mixer.fm, (val & 0xf) | (val << 4));
+
 		CTMIXER_UpdateVolumes();
-		if(val&0x60) LOG(LOG_SB,LOG_WARN)("Turned FM one channel off. not implemented %X",val);
-		//TODO Change FM Mode if only 1 fm channel is selected
+
+		if (val & 0x60) {
+			LOG(LOG_SB, LOG_WARN)
+			("Turned FM one channel off. not implemented %X", val);
+		}
+		// TODO Change FM Mode if only 1 fm channel is selected
 		break;
-	case 0x08:		/* CDA Volume (SB2 Only) */
-		SETPROVOL(sb.mixer.cda,(val&0xf)|(val<<4));
+
+	case 0x08: // CDA Volume (SB2 Only)
+		SETPROVOL(sb.mixer.cda, (val & 0xf) | (val << 4));
 		CTMIXER_UpdateVolumes();
 		break;
-	case 0x0a:		/* Mic Level (SBPRO) or DAC Volume (SB2): 2-bit, 3-bit on SB16 */
-		if (sb.type==SBT_2) {
-			sb.mixer.dac[0]=sb.mixer.dac[1]=((val & 0x6) << 2)|3;
+
+	case 0x0a: // Mic Level (SBPRO) or DAC Volume (SB2)
+		// 2-bit, 3-bit on SB16
+		if (sb.type == SBT_2) {
+			sb.mixer.dac[0] = sb.mixer.dac[1] = ((val & 0x6) << 2) | 3;
 			CTMIXER_UpdateVolumes();
 		} else {
-			sb.mixer.mic=((val & 0x7) << 2)|(sb.type==SBT_16?1:3);
+			sb.mixer.mic = ((val & 0x7) << 2) |
+			               (sb.type == SBT_16 ? 1 : 3);
 		}
 		break;
-	case 0x0e:		/* Output/Stereo Select */
-		sb.mixer.stereo=(val & 0x2) > 0;
-		sb.mixer.filtered=(val & 0x20) > 0;
+
+	case 0x0e: // Output/Stereo Select
+		sb.mixer.stereo   = (val & 0x2) > 0;
+		sb.mixer.filtered = (val & 0x20) > 0;
+
 		if (sb.sb_filter_state != FilterState::ForcedOn) {
 			sb.sb_filter_state = sb.mixer.filtered ? FilterState::On
 			                                       : FilterState::Off;
 			sb.chan->SetLowPassFilter(sb.sb_filter_state);
 		}
-		DSP_ChangeStereo(sb.mixer.stereo);
-		LOG(LOG_SB,LOG_WARN)("Mixer set to %s",sb.dma.stereo ? "STEREO" : "MONO");
-		break;
-	case 0x22:		/* Master Volume (SBPRO) */
-		SETPROVOL(sb.mixer.master,val);
-		CTMIXER_UpdateVolumes();
-		break;
-	case 0x26:		/* FM Volume (SBPRO) */
-		SETPROVOL(sb.mixer.fm,val);
-		CTMIXER_UpdateVolumes();
-		break;
-	case 0x28:		/* CD Audio Volume (SBPRO) */
-		SETPROVOL(sb.mixer.cda,val);
-		CTMIXER_UpdateVolumes();
-		break;
-	case 0x2e:		/* Line-in Volume (SBPRO) */
-		SETPROVOL(sb.mixer.lin,val);
-		break;
-	//case 0x20:		/* Master Volume Left (SBPRO) ? */
-	case 0x30:		/* Master Volume Left (SB16) */
-		if (sb.type==SBT_16) {
-			sb.mixer.master[0]=val>>3;
-			CTMIXER_UpdateVolumes();
-		}
-		break;
-	//case 0x21:		/* Master Volume Right (SBPRO) ? */
-	case 0x31:		/* Master Volume Right (SB16) */
-		if (sb.type==SBT_16) {
-			sb.mixer.master[1]=val>>3;
-			CTMIXER_UpdateVolumes();
-		}
-		break;
-	case 0x32:		/* DAC Volume Left (SB16) */
-		if (sb.type==SBT_16) {
-			sb.mixer.dac[0]=val>>3;
-			CTMIXER_UpdateVolumes();
-		}
-		break;
-	case 0x33:		/* DAC Volume Right (SB16) */
-		if (sb.type==SBT_16) {
-			sb.mixer.dac[1]=val>>3;
-			CTMIXER_UpdateVolumes();
-		}
-		break;
-	case 0x34:		/* FM Volume Left (SB16) */
-		if (sb.type==SBT_16) {
-			sb.mixer.fm[0]=val>>3;
-			CTMIXER_UpdateVolumes();
-		}
-                break;
-	case 0x35:		/* FM Volume Right (SB16) */
-		if (sb.type==SBT_16) {
-			sb.mixer.fm[1]=val>>3;
-			CTMIXER_UpdateVolumes();
-		}
-		break;
-	case 0x36:		/* CD Volume Left (SB16) */
-		if (sb.type==SBT_16) {
-			sb.mixer.cda[0]=val>>3;
-			CTMIXER_UpdateVolumes();
-		}
-		break;
-	case 0x37:		/* CD Volume Right (SB16) */
-		if (sb.type==SBT_16) {
-			sb.mixer.cda[1]=val>>3;
-			CTMIXER_UpdateVolumes();
-		}
-		break;
-	case 0x38:		/* Line-in Volume Left (SB16) */
-		if (sb.type==SBT_16) sb.mixer.lin[0]=val>>3;
-		break;
-	case 0x39:		/* Line-in Volume Right (SB16) */
-		if (sb.type==SBT_16) sb.mixer.lin[1]=val>>3;
-		break;
-	case 0x3a:
-		if (sb.type==SBT_16) sb.mixer.mic=val>>3;
-		break;
-	case 0x80:		/* IRQ Select */
-		sb.hw.irq=0xff;
-		if (val & 0x1) sb.hw.irq=2;
-		else if (val & 0x2) sb.hw.irq=5;
-		else if (val & 0x4) sb.hw.irq=7;
-		else if (val & 0x8) sb.hw.irq=10;
-		break;
-	case 0x81:		/* DMA Select */
-		sb.hw.dma8=0xff;
-		sb.hw.dma16=0xff;
-		if (val & 0x1) sb.hw.dma8=0;
-		else if (val & 0x2) sb.hw.dma8=1;
-		else if (val & 0x8) sb.hw.dma8=3;
-		if (val & 0x20) sb.hw.dma16=5;
-		else if (val & 0x40) sb.hw.dma16=6;
-		else if (val & 0x80) sb.hw.dma16=7;
-		LOG(LOG_SB,LOG_NORMAL)("Mixer select dma8:%x dma16:%x",sb.hw.dma8,sb.hw.dma16);
-		break;
-	default:
 
-		if(	((sb.type == SBT_PRO1 || sb.type == SBT_PRO2) && sb.mixer.index==0x0c) || /* Input control on SBPro */
-			 (sb.type == SBT_16 && sb.mixer.index >= 0x3b && sb.mixer.index <= 0x47)) /* New SB16 registers */
+		DSP_ChangeStereo(sb.mixer.stereo);
+
+		LOG(LOG_SB, LOG_WARN)
+		("Mixer set to %s", sb.dma.stereo ? "STEREO" : "MONO");
+		break;
+
+	case 0x22: // Master Volume (SBPRO)
+		SETPROVOL(sb.mixer.master, val);
+		CTMIXER_UpdateVolumes();
+		break;
+
+	case 0x26: // FM Volume (SBPRO)
+		SETPROVOL(sb.mixer.fm, val);
+		CTMIXER_UpdateVolumes();
+		break;
+
+	case 0x28: // CD Audio Volume (SBPRO)
+		SETPROVOL(sb.mixer.cda, val);
+		CTMIXER_UpdateVolumes();
+		break;
+
+	case 0x2e: // Line-in Volume (SBPRO)
+		SETPROVOL(sb.mixer.lin, val);
+		break;
+
+	// case 0x20:		// Master Volume Left (SBPRO) ?
+	case 0x30: /* Master Volume Left (SB16) */
+		if (sb.type == SBT_16) {
+			sb.mixer.master[0] = val >> 3;
+			CTMIXER_UpdateVolumes();
+		}
+		break;
+
+	// case 0x21:		// Master Volume Right (SBPRO) ?
+	case 0x31: // Master Volume Right (SB16)
+		if (sb.type == SBT_16) {
+			sb.mixer.master[1] = val >> 3;
+			CTMIXER_UpdateVolumes();
+		}
+		break;
+
+	case 0x32: // DAC Volume Left (SB16)
+		if (sb.type == SBT_16) {
+			sb.mixer.dac[0] = val >> 3;
+			CTMIXER_UpdateVolumes();
+		}
+		break;
+
+	case 0x33: // DAC Volume Right (SB16)
+		if (sb.type == SBT_16) {
+			sb.mixer.dac[1] = val >> 3;
+			CTMIXER_UpdateVolumes();
+		}
+		break;
+
+	case 0x34: // FM Volume Left (SB16)
+		if (sb.type == SBT_16) {
+			sb.mixer.fm[0] = val >> 3;
+			CTMIXER_UpdateVolumes();
+		}
+		break;
+
+	case 0x35: // FM Volume Right (SB16)
+		if (sb.type == SBT_16) {
+			sb.mixer.fm[1] = val >> 3;
+			CTMIXER_UpdateVolumes();
+		}
+		break;
+
+	case 0x36: // CD Volume Left (SB16)
+		if (sb.type == SBT_16) {
+			sb.mixer.cda[0] = val >> 3;
+			CTMIXER_UpdateVolumes();
+		}
+		break;
+
+	case 0x37: // CD Volume Right (SB16)
+		if (sb.type == SBT_16) {
+			sb.mixer.cda[1] = val >> 3;
+			CTMIXER_UpdateVolumes();
+		}
+		break;
+
+	case 0x38: // Line-in Volume Left (SB16)
+		if (sb.type == SBT_16) {
+			sb.mixer.lin[0] = val >> 3;
+		}
+		break;
+
+	case 0x39: // Line-in Volume Right (SB16)
+		if (sb.type == SBT_16) {
+			sb.mixer.lin[1] = val >> 3;
+		}
+		break;
+
+	case 0x3a:
+		if (sb.type == SBT_16) {
+			sb.mixer.mic = val >> 3;
+		}
+		break;
+
+	case 0x80: // IRQ Select
+		sb.hw.irq = 0xff;
+
+		if (val & 0x1) {
+			sb.hw.irq = 2;
+		} else if (val & 0x2) {
+			sb.hw.irq = 5;
+		} else if (val & 0x4) {
+			sb.hw.irq = 7;
+		} else if (val & 0x8) {
+			sb.hw.irq = 10;
+		}
+		break;
+
+	case 0x81: // DMA Select
+		sb.hw.dma8  = 0xff;
+		sb.hw.dma16 = 0xff;
+
+		if (val & 0x1) {
+			sb.hw.dma8 = 0;
+		} else if (val & 0x2) {
+			sb.hw.dma8 = 1;
+		} else if (val & 0x8) {
+			sb.hw.dma8 = 3;
+		}
+
+		if (val & 0x20) {
+			sb.hw.dma16 = 5;
+		} else if (val & 0x40) {
+			sb.hw.dma16 = 6;
+		} else if (val & 0x80) {
+			sb.hw.dma16 = 7;
+		}
+
+		LOG(LOG_SB, LOG_NORMAL)
+		("Mixer select dma8:%x dma16:%x", sb.hw.dma8, sb.hw.dma16);
+		break;
+
+	default:
+		if (((sb.type == SBT_PRO1 || sb.type == SBT_PRO2) &&
+		     sb.mixer.index == 0x0c) || // Input control on SBPro
+		    (sb.type == SBT_16 && sb.mixer.index >= 0x3b &&
+		     sb.mixer.index <= 0x47)) { // New SB16 registers
 			sb.mixer.unhandled[sb.mixer.index] = val;
-		LOG(LOG_SB,LOG_WARN)("MIXER:Write %X to unhandled index %X",val,sb.mixer.index);
+		}
+
+		LOG(LOG_SB, LOG_WARN)
+		("MIXER:Write %X to unhandled index %X", val, sb.mixer.index);
 	}
 }
 
-static uint8_t CTMIXER_Read() {
+static uint8_t CTMIXER_Read()
+{
 	uint8_t ret;
-//	if ( sb.mixer.index< 0x80) LOG_MSG("Read mixer %x",sb.mixer.index);
+	// if ( sb.mixer.index< 0x80) LOG_MSG("Read mixer %x",sb.mixer.index);
+
 	switch (sb.mixer.index) {
-	case 0x00:		/* RESET */
+	case 0x00: // RESET
 		return 0x00;
-	case 0x02:		/* Master Volume (SB2 Only) */
-		return ((sb.mixer.master[1]>>1) & 0xe);
-	case 0x22:		/* Master Volume (SBPRO) */
-		return	MAKEPROVOL(sb.mixer.master);
-	case 0x04:		/* DAC Volume (SBPRO) */
+
+	case 0x02: // Master Volume (SB2 Only)
+		return ((sb.mixer.master[1] >> 1) & 0xe);
+
+	case 0x22: // Master Volume (SBPRO)
+		return MAKEPROVOL(sb.mixer.master);
+
+	case 0x04: // DAC Volume (SBPRO)
 		return MAKEPROVOL(sb.mixer.dac);
-	case 0x06:		/* FM Volume (SB2 Only) + FM output selection */
-		return ((sb.mixer.fm[1]>>1) & 0xe);
-	case 0x08:		/* CD Volume (SB2 Only) */
-		return ((sb.mixer.cda[1]>>1) & 0xe);
-	case 0x0a:		/* Mic Level (SBPRO) or Voice (SB2 Only) */
-		if (sb.type==SBT_2) return (sb.mixer.dac[0]>>2);
-		else return ((sb.mixer.mic >> 2) & (sb.type==SBT_16 ? 7:6));
-	case 0x0e:		/* Output/Stereo Select */
-		return 0x11|(sb.mixer.stereo ? 0x02 : 0x00)|(sb.mixer.filtered ? 0x20 : 0x00);
-	case 0x26:		/* FM Volume (SBPRO) */
+
+	case 0x06: // FM Volume (SB2 Only) + FM output selection
+		return ((sb.mixer.fm[1] >> 1) & 0xe);
+
+	case 0x08: // CD Volume (SB2 Only)
+		return ((sb.mixer.cda[1] >> 1) & 0xe);
+
+	case 0x0a: // Mic Level (SBPRO) or Voice (SB2 Only)
+		if (sb.type == SBT_2) {
+			return (sb.mixer.dac[0] >> 2);
+		} else {
+			return ((sb.mixer.mic >> 2) & (sb.type == SBT_16 ? 7 : 6));
+		}
+
+	case 0x0e: // Output/Stereo Select
+		return 0x11 | (sb.mixer.stereo ? 0x02 : 0x00) |
+		       (sb.mixer.filtered ? 0x20 : 0x00);
+
+	case 0x26: // FM Volume (SBPRO)
 		return MAKEPROVOL(sb.mixer.fm);
-	case 0x28:		/* CD Audio Volume (SBPRO) */
+
+	case 0x28: // CD Audio Volume (SBPRO)
 		return MAKEPROVOL(sb.mixer.cda);
-	case 0x2e:		/* Line-IN Volume (SBPRO) */
+
+	case 0x2e: // Line-IN Volume (SBPRO)
 		return MAKEPROVOL(sb.mixer.lin);
-	case 0x30:		/* Master Volume Left (SB16) */
-		if (sb.type==SBT_16) return sb.mixer.master[0]<<3;
-		ret=0xa;
+
+	case 0x30: // Master Volume Left (SB16)
+		if (sb.type == SBT_16) {
+			return sb.mixer.master[0] << 3;
+		}
+		ret = 0xa;
 		break;
-	case 0x31:		/* Master Volume Right (S16) */
-		if (sb.type==SBT_16) return sb.mixer.master[1]<<3;
-		ret=0xa;
+
+	case 0x31: // Master Volume Right (S16)
+		if (sb.type == SBT_16) {
+			return sb.mixer.master[1] << 3;
+		}
+		ret = 0xa;
 		break;
-	case 0x32:		/* DAC Volume Left (SB16) */
-		if (sb.type==SBT_16) return sb.mixer.dac[0]<<3;
-		ret=0xa;
+
+	case 0x32: // DAC Volume Left (SB16)
+		if (sb.type == SBT_16) {
+			return sb.mixer.dac[0] << 3;
+		}
+		ret = 0xa;
 		break;
-	case 0x33:		/* DAC Volume Right (SB16) */
-		if (sb.type==SBT_16) return sb.mixer.dac[1]<<3;
-		ret=0xa;
+
+	case 0x33: // DAC Volume Right (SB16)
+		if (sb.type == SBT_16) {
+			return sb.mixer.dac[1] << 3;
+		}
+		ret = 0xa;
 		break;
-	case 0x34:		/* FM Volume Left (SB16) */
-		if (sb.type==SBT_16) return sb.mixer.fm[0]<<3;
-		ret=0xa;
+
+	case 0x34: // FM Volume Left (SB16)
+		if (sb.type == SBT_16) {
+			return sb.mixer.fm[0] << 3;
+		}
+		ret = 0xa;
 		break;
-	case 0x35:		/* FM Volume Right (SB16) */
-		if (sb.type==SBT_16) return sb.mixer.fm[1]<<3;
-		ret=0xa;
+
+	case 0x35: // FM Volume Right (SB16)
+		if (sb.type == SBT_16) {
+			return sb.mixer.fm[1] << 3;
+		}
+		ret = 0xa;
 		break;
-	case 0x36:		/* CD Volume Left (SB16) */
-		if (sb.type==SBT_16) return sb.mixer.cda[0]<<3;
-		ret=0xa;
+
+	case 0x36: // CD Volume Left (SB16)
+		if (sb.type == SBT_16) {
+			return sb.mixer.cda[0] << 3;
+		}
+		ret = 0xa;
 		break;
-	case 0x37:		/* CD Volume Right (SB16) */
-		if (sb.type==SBT_16) return sb.mixer.cda[1]<<3;
-		ret=0xa;
+
+	case 0x37: // CD Volume Right (SB16)
+		if (sb.type == SBT_16) {
+			return sb.mixer.cda[1] << 3;
+		}
+		ret = 0xa;
 		break;
-	case 0x38:		/* Line-in Volume Left (SB16) */
-		if (sb.type==SBT_16) return sb.mixer.lin[0]<<3;
-		ret=0xa;
+
+	case 0x38: // Line-in Volume Left (SB16)
+		if (sb.type == SBT_16) {
+			return sb.mixer.lin[0] << 3;
+		}
+		ret = 0xa;
 		break;
-	case 0x39:		/* Line-in Volume Right (SB16) */
-		if (sb.type==SBT_16) return sb.mixer.lin[1]<<3;
-		ret=0xa;
+
+	case 0x39: // Line-in Volume Right (SB16)
+		if (sb.type == SBT_16) {
+			return sb.mixer.lin[1] << 3;
+		}
+		ret = 0xa;
 		break;
-	case 0x3a:		/* Mic Volume (SB16) */
-		if (sb.type==SBT_16) return sb.mixer.mic<<3;
-		ret=0xa;
+
+	case 0x3a: // Mic Volume (SB16)
+		if (sb.type == SBT_16) {
+			return sb.mixer.mic << 3;
+		}
+		ret = 0xa;
 		break;
-	case 0x80:		/* IRQ Select */
+
+	case 0x80: // IRQ Select
 		ret = 0;
 		switch (sb.hw.irq) {
-		case 2:  return 0x1;
-		case 5:  return 0x2;
-		case 7:  return 0x4;
+		case 2: return 0x1;
+		case 5: return 0x2;
+		case 7: return 0x4;
 		case 10: return 0x8;
 		}
 		break;
-	case 0x81:		/* DMA Select */
-		ret=0;
+
+	case 0x81: // DMA Select
+		ret = 0;
 		switch (sb.hw.dma8) {
-		case 0:ret|=0x1;break;
-		case 1:ret|=0x2;break;
-		case 3:ret|=0x8;break;
+		case 0: ret |= 0x1; break;
+		case 1: ret |= 0x2; break;
+		case 3: ret |= 0x8; break;
 		}
 		switch (sb.hw.dma16) {
-		case 5:ret|=0x20;break;
-		case 6:ret|=0x40;break;
-		case 7:ret|=0x80;break;
+		case 5: ret |= 0x20; break;
+		case 6: ret |= 0x40; break;
+		case 7: ret |= 0x80; break;
 		}
 		return ret;
-	case 0x82:		/* IRQ Status */
-		return	(sb.irq.pending_8bit ? 0x1 : 0) |
-				(sb.irq.pending_16bit ? 0x2 : 0) | 
-				((sb.type == SBT_16) ? 0x20 : 0);
+
+	case 0x82: // IRQ Status
+		return (sb.irq.pending_8bit ? 0x1 : 0) |
+		       (sb.irq.pending_16bit ? 0x2 : 0) |
+		       ((sb.type == SBT_16) ? 0x20 : 0);
+
 	default:
-		if (	((sb.type == SBT_PRO1 || sb.type == SBT_PRO2) && sb.mixer.index==0x0c) || /* Input control on SBPro */
-			(sb.type == SBT_16 && sb.mixer.index >= 0x3b && sb.mixer.index <= 0x47)) /* New SB16 registers */
+		if (((sb.type == SBT_PRO1 || sb.type == SBT_PRO2) &&
+		     sb.mixer.index == 0x0c) || /* Input control on SBPro */
+		    (sb.type == SBT_16 && sb.mixer.index >= 0x3b &&
+		     sb.mixer.index <= 0x47)) { /* New SB16 registers */
 			ret = sb.mixer.unhandled[sb.mixer.index];
-		else
-			ret=0xa;
-		LOG(LOG_SB,LOG_WARN)("MIXER:Read from unhandled index %X",sb.mixer.index);
+		} else {
+			ret = 0xa;
+		}
+		LOG(LOG_SB, LOG_WARN)
+		("MIXER:Read from unhandled index %X", sb.mixer.index);
 	}
 	return ret;
 }
@@ -1982,15 +2453,18 @@ static bool write_buffer_at_capacity()
 	if (sb.dsp.state != DSP_S_NORMAL) {
 		return true;
 	}
+
 	// Report the buffer as having some room every 8th call, as the buffer
 	// will have run down by some amount after sequential calls.
 	if ((++sb.dsp.write_status_counter % 8) == 0) {
 		return false;
 	}
+
 	// If DMA isn't running then the buffer's definitely not at capacity.
 	if (sb.dma.mode == DSP_DMA_NONE) {
 		return false;
 	}
+
 	// Finally, the DMA buffer is considered full until it's able to accept
 	// a full (64 KB) write; which is once we've hit the minimum threshold.
 	//
@@ -2037,8 +2511,11 @@ static uint8_t read_sb(io_port_t port, io_width_t)
 {
 	switch (port - sb.hw.base) {
 	case MIXER_INDEX: return sb.mixer.index;
+
 	case MIXER_DATA: return CTMIXER_Read();
+
 	case DSP_READ_DATA: return DSP_ReadData();
+
 	case DSP_READ_STATUS: {
 		// TODO See for high speed dma :)
 		if (sb.irq.pending_8bit) {
@@ -2046,18 +2523,23 @@ static uint8_t read_sb(io_port_t port, io_width_t)
 			PIC_DeActivateIRQ(sb.hw.irq);
 		}
 		BufferStatus read_status = {};
-		read_status.has_data = (sb.dsp.out.used != 0);
+		read_status.has_data     = (sb.dsp.out.used != 0);
 		return read_status.data;
 	}
+
 	case DSP_ACK_16BIT: sb.irq.pending_16bit = false; break;
+
 	case DSP_WRITE_STATUS: {
 		BufferStatus write_status = {};
-		write_status.has_data = write_buffer_at_capacity();
+		write_status.has_data     = write_buffer_at_capacity();
 		return write_status.data;
 	}
+
 	case DSP_RESET: return 0xff;
+
 	default:
-		LOG(LOG_SB, LOG_NORMAL)("Unhandled read from SB Port %4X", port);
+		LOG(LOG_SB, LOG_NORMAL)
+		("Unhandled read from SB Port %4X", port);
 		break;
 	}
 	return 0xff;
@@ -2066,12 +2548,19 @@ static uint8_t read_sb(io_port_t port, io_width_t)
 static void write_sb(io_port_t port, io_val_t value, io_width_t)
 {
 	const auto val = check_cast<uint8_t>(value);
+
 	switch (port - sb.hw.base) {
 	case DSP_RESET: DSP_DoReset(val); break;
+
 	case DSP_WRITE_DATA: DSP_DoWrite(val); break;
+
 	case MIXER_INDEX: sb.mixer.index = val; break;
+
 	case MIXER_DATA: CTMIXER_Write(val); break;
-	default: LOG(LOG_SB, LOG_NORMAL)("Unhandled write to SB Port %4X", port); break;
+
+	default:
+		LOG(LOG_SB, LOG_NORMAL)("Unhandled write to SB Port %4X", port);
+		break;
 	}
 }
 
@@ -2086,11 +2575,13 @@ bool SB_Get_Address(uint16_t &sbaddr, uint8_t &sbirq, uint8_t &sbdma)
 	sbaddr = 0;
 	sbirq  = 0;
 	sbdma  = 0;
+
 	if (sb.type != SBT_NONE) {
 		sbaddr = sb.hw.base;
 		sbirq  = sb.hw.irq;
 		sbdma  = sb.hw.dma8;
 	}
+
 	return (sbaddr != 0 && sbirq != 0 && sbdma != 0);
 }
 
@@ -2099,24 +2590,31 @@ static void SBLASTER_CallBack(uint32_t len)
 	switch (sb.mode) {
 	case MODE_NONE:
 	case MODE_DMA_PAUSE:
-	case MODE_DMA_MASKED:
-		sb.chan->AddSilence();
-		break;
+	case MODE_DMA_MASKED: sb.chan->AddSilence(); break;
+
 	case MODE_DAC:
-//		GenerateDACSound(len);
-//		break;
+		// GenerateDACSound(len);
+		// break;
 		if (!sb.dac.used) {
-			sb.mode=MODE_NONE;
+			sb.mode = MODE_NONE;
 			return;
 		}
-		sb.chan->AddStretched(sb.dac.used,sb.dac.data);
-		sb.dac.used=0;
+
+		sb.chan->AddStretched(sb.dac.used, sb.dac.data);
+		sb.dac.used = 0;
 		break;
+
 	case MODE_DMA:
-		len*=sb.dma.mul;
-		if (len&SB_SH_MASK) len+=1 << SB_SH;
-		len>>=SB_SH;
-		if (len>sb.dma.left) len=sb.dma.left;
+		len *= sb.dma.mul;
+		if (len & SB_SH_MASK) {
+			len += 1 << SB_SH;
+		}
+
+		len >>= SB_SH;
+		if (len > sb.dma.left) {
+			len = sb.dma.left;
+		}
+
 		ProcessDMATransfer(len);
 		break;
 	}
@@ -2239,7 +2737,7 @@ void SBLASTER_ShutDown(Section*);
 
 class SBLASTER final {
 private:
-	/* Data */
+	// Data
 	IO_ReadHandleObject read_handlers[0x10]   = {};
 	IO_WriteHandleObject write_handlers[0x10] = {};
 
@@ -2278,7 +2776,10 @@ private:
 		}
 
 		// Update AUTOEXEC.BAT line
-		LOG_MSG("%s: Setting '%s' environment variable to '%s'", CardType(), blaster_env_name, blaster_env_val);
+		LOG_MSG("%s: Setting '%s' environment variable to '%s'",
+		        CardType(),
+		        blaster_env_name,
+		        blaster_env_val);
 		AUTOEXEC_SetVariable(blaster_env_name, blaster_env_val);
 	}
 
@@ -2292,17 +2793,18 @@ public:
 	{
 		assert(conf);
 
-		Section_prop * section=static_cast<Section_prop *>(conf);
+		Section_prop* section = static_cast<Section_prop*>(conf);
 
-		sb.hw.base=section->Get_hex("sbbase");
-
+		sb.hw.base = section->Get_hex("sbbase");
 		sb.hw.irq = static_cast<uint8_t>(section->Get_int("irq"));
 
-		sb.dsp.cold_warmup_ms = check_cast<uint8_t>(section->Get_int("sbwarmup"));
+		sb.dsp.cold_warmup_ms = check_cast<uint8_t>(
+		        section->Get_int("sbwarmup"));
+
 		sb.dsp.hot_warmup_ms = sb.dsp.cold_warmup_ms >> 5;
 
-		sb.mixer.enabled=section->Get_bool("sbmixer");
-		sb.mixer.stereo=false;
+		sb.mixer.enabled = section->Get_bool("sbmixer");
+		sb.mixer.stereo  = false;
 
 
 		// Determine Sound Blaster model
@@ -2370,8 +2872,9 @@ public:
 		sb.hw.dma8 = has_dac ? static_cast<uint8_t>(section->Get_int("dma"))
 		                     : 0;
 
-		// Configure the BIOS DAC callbacks as soon as the card's access ports (
-		// port, IRQ, and potential 8-bit DMA address) are defined.
+		// Configure the BIOS DAC callbacks as soon as the card's access
+		// ports ( port, IRQ, and potential 8-bit DMA address) are
+		// defined.
 		//
 		if (BIOS_ConfigureTandyDacCallbacks()) {
 			// Disable the hot warmup when the SB is being used as
@@ -2385,6 +2888,7 @@ public:
 		if (!has_dac) {
 			return;
 		}
+
 		// The code below here sets up the DAC and DMA channels on all
 		// "sbtype = sb*" Sound Blaster type cards.
 		//
@@ -2398,10 +2902,10 @@ public:
 
 			// Reserve the second DMA channel only if it's unique.
 			if (sb.hw.dma16 != sb.hw.dma8) {
-				dma_channel = DMA_GetChannel(sb.hw.dma16);
-				assert(dma_channel);
-				dma_channel->ReserveFor(CardType(),
-										SBLASTER_ShutDown);
+				        dma_channel = DMA_GetChannel(sb.hw.dma16);
+				        assert(dma_channel);
+				        dma_channel->ReserveFor(CardType(),
+				                                SBLASTER_ShutDown);
 			}
 		}
 
@@ -2409,8 +2913,9 @@ public:
 		                             ChannelFeature::ChorusSend,
 		                             ChannelFeature::DigitalAudio};
 
-		if (sb.type == SBT_PRO1 || sb.type == SBT_PRO2 || sb.type == SBT_16)
+		if (sb.type == SBT_PRO1 || sb.type == SBT_PRO2 || sb.type == SBT_16) {
 			channel_features.insert(ChannelFeature::Stereo);
+		}
 
 		sb.chan = MIXER_AddChannel(&SBLASTER_CallBack,
 		                           default_playback_rate_hz,
@@ -2419,32 +2924,38 @@ public:
 
 		const std::string sb_filter_prefs = section->Get_string("sb_filter");
 
-		const auto sb_filter_always_on = section->Get_bool("sb_filter_always_on");
+		const auto sb_filter_always_on = section->Get_bool(
+		        "sb_filter_always_on");
 
 		configure_sb_filter(sb.chan,
 		                    sb_filter_prefs,
 		                    sb_filter_always_on,
 		                    sb.type);
 
-		sb.dsp.state=DSP_S_NORMAL;
-		sb.dsp.out.lastval=0xaa;
-		sb.dma.chan=nullptr;
+		sb.dsp.state       = DSP_S_NORMAL;
+		sb.dsp.out.lastval = 0xaa;
+		sb.dma.chan        = nullptr;
 
 		for (uint8_t i = 4; i <= 0xf; ++i) {
-			if (i == 8 || i == 9)
+			if (i == 8 || i == 9) {
 				continue;
+			}
+
 			// Disable mixer ports for lower Sound Blaster
-			if ((sb.type == SBT_1 || sb.type == SBT_2) && (i == 4 || i == 5))
+			if ((sb.type == SBT_1 || sb.type == SBT_2) && (i == 4 || i == 5)) {
 				continue;
+			}
 			read_handlers[i].Install(sb.hw.base + i,
 			                         read_sb,
 			                         io_width_t::byte);
+
 			write_handlers[i].Install(sb.hw.base + i,
 			                          write_sb,
 			                          io_width_t::byte);
 		}
-		for (uint16_t i = 0; i < 256; ++i)
+		for (uint16_t i = 0; i < 256; ++i) {
 			ASP_regs[i] = 0;
+		}
 		ASP_regs[5] = 0x01;
 		ASP_regs[9] = 0xf8;
 

--- a/src/hardware/tandy_sound.cpp
+++ b/src/hardware/tandy_sound.cpp
@@ -590,7 +590,7 @@ void TandyPSG::AudioCallback(const uint16_t requested_frames)
 std::unique_ptr<TandyDAC> tandy_dac = {};
 std::unique_ptr<TandyPSG> tandy_psg = {};
 
-bool TS_Get_Address(Bitu &tsaddr, Bitu &tsirq, Bitu &tsdma)
+bool TANDYSOUND_GetAddress(Bitu &tsaddr, Bitu &tsirq, Bitu &tsdma)
 {
 	if (!tandy_dac || !tandy_dac->IsEnabled()) {
 		tsaddr = 0;

--- a/src/hardware/tandy_sound.cpp
+++ b/src/hardware/tandy_sound.cpp
@@ -290,7 +290,7 @@ void TandyDAC::ChangeMode()
 	// For example, a clock divider value of 8 (which is valid) produces a
 	// 450 KHz sampling rate, which is way beyond what Speex can handle.
 	//
-	constexpr auto dac_max_sample_rate_hz = 49000;
+	constexpr auto DacMaxSampleRateHz = 49000;
 
 	// LOG_MSG("TANDYDAC: Mode changed to %d", regs.mode);
 	switch (regs.mode & 3) {
@@ -305,9 +305,12 @@ void TandyDAC::ChangeMode()
 		}
 
 		if (const auto new_sample_rate = tandy_psg_clock_hz / regs.clock_divider;
-		    new_sample_rate < dac_max_sample_rate_hz) {
+		    new_sample_rate < DacMaxSampleRateHz) {
 			assert(channel);
-			channel->FillUp(); // using the prior sample rate
+
+			// Fill using the prior sample rate
+			channel->FillUp();
+
 			channel->SetSampleRate(check_cast<uint16_t>(new_sample_rate));
 
 			const auto vol = static_cast<float>(regs.amplitude) / 7.0f;
@@ -324,9 +327,11 @@ void TandyDAC::ChangeMode()
 					dma.channel->RegisterCallback(callback);
 
 					channel->Enable(true);
-					// LOG_MSG("TANDYDAC: playback started
-					// with freqency %f, volume %f",
-					// sample_rate, vol);
+#if 0
+					LOG_MSG("TANDYDAC: playback started with freqency %i, volume %f",
+					        sample_rate,
+					        vol);
+#endif
 				}
 			}
 		}

--- a/src/hardware/tandy_sound.cpp
+++ b/src/hardware/tandy_sound.cpp
@@ -303,22 +303,30 @@ void TandyDAC::ChangeMode()
 		if (regs.clock_divider == 0) {
 			return;
 		}
-		if (const auto sample_rate = tandy_psg_clock_hz / regs.clock_divider;
-		    sample_rate < dac_max_sample_rate_hz) {
+
+		if (const auto new_sample_rate = tandy_psg_clock_hz / regs.clock_divider;
+		    new_sample_rate < dac_max_sample_rate_hz) {
 			assert(channel);
 			channel->FillUp(); // using the prior sample rate
-			channel->SetSampleRate(check_cast<uint16_t>(sample_rate));
+			channel->SetSampleRate(check_cast<uint16_t>(new_sample_rate));
+
 			const auto vol = static_cast<float>(regs.amplitude) / 7.0f;
+
 			channel->SetAppVolume({vol, vol});
+
 			if ((regs.mode & 0x0c) == 0x0c) {
 				dma.is_done = false;
 				dma.channel = DMA_GetChannel(io.dma);
+
 				if (dma.channel) {
 					const auto callback = std::bind(
 					        &TandyDAC::DmaCallback, this, _1, _2);
 					dma.channel->RegisterCallback(callback);
+
 					channel->Enable(true);
-					// LOG_MSG("TANDYDAC: playback started with freqency %f, volume %f", sample_rate, vol);
+					// LOG_MSG("TANDYDAC: playback started
+					// with freqency %f, volume %f",
+					// sample_rate, vol);
 				}
 			}
 		}

--- a/src/ints/bios.cpp
+++ b/src/ints/bios.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2022-2023  The DOSBox Staging Team
+ *  Copyright (C) 2022-2024  The DOSBox Staging Team
  *  Copyright (C) 2002-2021  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -104,7 +104,7 @@ static bool Tandy_InitializeSB() {
 	uint16_t sbport;
 	uint8_t sbirq;
 	uint8_t sbdma;
-	if (SB_Get_Address(sbport, sbirq, sbdma)) {
+	if (SB_GetAddress(sbport, sbirq, sbdma)) {
 		tandy_sb.port = sbport;
 		tandy_sb.irq = sbirq;
 		tandy_sb.dma = sbdma;
@@ -119,7 +119,7 @@ static bool Tandy_InitializeSB() {
 static bool Tandy_InitializeTS() {
 	/* see if Tandy DAC module available and at what port/IRQ/DMA */
 	Bitu tsport, tsirq, tsdma;
-	if (TS_Get_Address(tsport, tsirq, tsdma)) {
+	if (TANDYSOUND_GetAddress(tsport, tsirq, tsdma)) {
 		tandy_dac.port=(uint16_t)(tsport&0xffff);
 		tandy_dac.irq =(uint8_t)(tsirq&0xff);
 		tandy_dac.dma =(uint8_t)(tsdma&0xff);

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -1630,13 +1630,13 @@ void Config::ParseConfigFiles(const std_fs::path& config_dir)
 
 	// Finally: layer on additional config files specified with the '-conf'
 	// switch
-	for (const auto& config_file : arguments.conf) {
-		if (!ParseConfigFile("custom", config_file)) {
+	for (const auto& conf_file : arguments.conf) {
+		if (!ParseConfigFile("custom", conf_file)) {
 			// Try to load it from the user directory
-			const auto cfg = config_dir / config_file;
+			const auto cfg = config_dir / conf_file;
 			if (!ParseConfigFile("custom", cfg.string())) {
 				LOG_WARNING("CONFIG: Can't open custom config file '%s'",
-				            config_file.c_str());
+				            conf_file.c_str());
 			}
 		}
 	}
@@ -1690,12 +1690,12 @@ const char* Config::SetProp(std::vector<std::string>& pvars)
 
 		if (!sec) {
 			// Not a section: little duplicate from above
-			Section* sec = GetSectionFromProperty(
+			Section* secprop = GetSectionFromProperty(
 			        pvars[0].c_str());
 
-			if (sec) {
+			if (secprop) {
 				pvars.insert(pvars.begin(),
-				             std::string(sec->GetName()));
+				             std::string(secprop->GetName()));
 			} else {
 				safe_sprintf(return_msg,
 				             MSG_Get("PROGRAM_CONFIG_PROPERTY_ERROR"),


### PR DESCRIPTION
# Description

This is some heavy-duty cleanup of `sblaster.cpp` because it looked like the dog's breakfast and I couldn't stand it anymore. The biggest non-superficial improvements are probably the strictly typed enums and making all function args const where possible.

Hopefully I'll be a little bit happier the next time I'm touching this file.

The `sbtype` and `oplmode` descriptions are also vastly improved.

No functional changes.


# Manual testing

Tried a few games and demos, no crashes and the Sound Blaster emulation still works.


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

