### PR TITLE
Unify use of prop->Set_values

### DIFF
--- a/include/setup.h
+++ b/include/setup.h
@@ -134,7 +134,6 @@ public:
 
 	virtual ~Property() = default;
 
-	void Set_values(const char* const* in);
 	void Set_values(const std::vector<std::string>& in);
 	void SetDeprecatedWithAlternateValue(const char* deprecated_value,
 	                                     const char* alternate_value);

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -1040,9 +1040,7 @@ static void init_render_settings(Section_prop& secprop)
 	        "                       to emulate the horizontal and vertical stretch controls\n"
 	        "                       of CRT monitors.");
 
-	const char* aspect_values[] = {
-	        "auto", "on", "square-pixels", "off", "stretch", nullptr};
-	string_prop->Set_values(aspect_values);
+	string_prop->Set_values({"auto", "on", "square-pixels", "off", "stretch"});
 
 	string_prop = secprop.Add_string("integer_scaling", always, "auto");
 	string_prop->Set_help(
@@ -1061,9 +1059,7 @@ static void init_render_settings(Section_prop& secprop)
 	        "  off:         No integer scaling constraint is applied; the image fills the\n"
 	        "               viewport while maintaining the configured aspect ratio.");
 
-	const char* integer_scaling_values[] = {
-	        "auto", "vertical", "horizontal", "off", nullptr};
-	string_prop->Set_values(integer_scaling_values);
+	string_prop->Set_values({"auto", "vertical", "horizontal", "off"});
 
 	string_prop = secprop.Add_path("viewport", always, "fit");
 	string_prop->Set_help(
@@ -1101,12 +1097,10 @@ static void init_render_settings(Section_prop& secprop)
 	        "Works only with the 'hercules' and 'cga_mono' machine types.\n"
 	        "Note: You can also cycle through the available palettes via hotkeys.");
 
-	const char* mono_pal[] = {MonochromePaletteAmber,
-	                          MonochromePaletteGreen,
-	                          MonochromePaletteWhite,
-	                          MonochromePalettePaperwhite,
-	                          nullptr};
-	string_prop->Set_values(mono_pal);
+	string_prop->Set_values({MonochromePaletteAmber,
+	                         MonochromePaletteGreen,
+	                         MonochromePaletteWhite,
+	                         MonochromePalettePaperwhite});
 
 	string_prop = secprop.Add_string("cga_colors", only_at_start, "default");
 	string_prop->Set_help(

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -4289,9 +4289,7 @@ static void config_add_sdl()
 	        "  N:         Specify custom refresh rate in Hz (decimal values are allowed;\n"
 	        "             23.000 is the allowed minimum).");
 
-	const char* vsync_prefs[] = {"auto", "on", "adaptive", "off", "yield", nullptr};
 	pstring = sdl_sec->Add_string("vsync", always, "auto");
-
 	pstring->Set_help(
 	        "Set the host video driver's vertical synchronization (vsync) mode:\n"
 	        "  auto:      Limit vsync to beneficial cases, such as when using an\n"
@@ -4307,7 +4305,7 @@ static void config_add_sdl()
 	        "  off:       Attempt to disable vsync to allow quicker frame presentation at\n"
 	        "             the risk of tearing in some games.\n"
 	        "  yield:     Let the host's video driver control video synchronization.");
-	pstring->Set_values(vsync_prefs);
+	pstring->Set_values({"auto", "on", "adaptive", "off", "yield"});
 
 	pint = sdl_sec->Add_int("vsync_skip", on_start, 0);
 	pint->Set_help("Number of microseconds to allow rendering to block before skipping the\n"
@@ -4315,7 +4313,6 @@ static void config_add_sdl()
 	               "at 70 Hz. 0 disables this and will always render (default).");
 	pint->SetMinMax(0, 14000);
 
-	const char *presentation_modes[] = {"auto", "cfr", "vfr", nullptr};
 	pstring = sdl_sec->Add_string("presentation_mode", always, "auto");
 	pstring->Set_help(
 	        "Select the frame presentation mode:\n"
@@ -4323,16 +4320,7 @@ static void config_add_sdl()
 	        "         based on host and DOS frame rates (default).\n"
 	        "  cfr:   Always present DOS frames at a constant frame rate.\n"
 	        "  vfr:   Always present changed DOS frames at a variable frame rate.");
-	pstring->Set_values(presentation_modes);
-
-	const char* outputs[] =
-	{ "texture",
-	  "texturenb",
-#if C_OPENGL
-	  "opengl",
-	  "openglnb",
-#endif
-	  nullptr };
+	pstring->Set_values({"auto", "cfr", "vfr"});
 
 #if C_OPENGL
 	Pstring = sdl_sec->Add_string("output", always, "opengl");
@@ -4349,7 +4337,12 @@ static void config_add_sdl()
 	Pstring->SetDeprecatedWithAlternateValue("surface", "texture");
 #endif
 	Pstring->SetDeprecatedWithAlternateValue("texturepp", "texture");
-	Pstring->Set_values(outputs);
+	Pstring->Set_values({
+		"texture", "texturenb",
+#if C_OPENGL
+		"opengl", "openglnb",
+#endif
+	});
 
 	pstring = sdl_sec->Add_string("texture_renderer", always, "auto");
 	pstring->Set_help("Render driver to use in 'texture' output mode ('auto' by default).\n"
@@ -4374,20 +4367,11 @@ static void config_add_sdl()
 	                 "('auto auto' by default)\n"
 	                 "'auto' lets the host operating system manage the priority.");
 
-	const char *priority_level_choices[] = {
-	        "auto",
-	        "lowest",
-	        "lower",
-	        "normal",
-	        "higher",
-	        "highest",
-	        nullptr,
-	};
 	psection = Pmulti->GetSection();
-	psection->Add_string("active", always, priority_level_choices[0])
-	        ->Set_values(priority_level_choices);
-	psection->Add_string("inactive", always, priority_level_choices[0])
-	        ->Set_values(priority_level_choices);
+	psection->Add_string("active", always, "auto")
+	        ->Set_values({"auto", "lowest", "lower", "normal", "higher", "highest"});
+	psection->Add_string("inactive", always, "auto")
+	        ->Set_values({"auto", "lowest", "lower", "normal", "higher", "highest"});
 
 	pbool = sdl_sec->Add_bool("mute_when_inactive", on_start, false);
 	pbool->Set_help("Mute the sound when the window is inactive (disabled by default).");
@@ -4408,8 +4392,7 @@ static void config_add_sdl()
 	        "Use 'allow' or 'block' to override the SDL_VIDEO_ALLOW_SCREENSAVER environment\n"
 	        "variable which usually blocks the OS screensaver while the emulator is\n"
 	        "running ('auto' by default).");
-	const char *ssopts[] = {"auto", "allow", "block", nullptr};
-	pstring->Set_values(ssopts);
+	pstring->Set_values({"auto", "allow", "block"});
 
 	TITLEBAR_AddConfig(*sdl_sec);
 }

--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -1679,22 +1679,18 @@ void init_gus_dosbox_settings(Section_prop &secprop)
 
 	auto *hex_prop = secprop.Add_hex("gusbase", when_idle, 0x240);
 	assert(hex_prop);
-	const char *const bases[] = {"240", "220", "260", "280",  "2a0",
-	                             "2c0", "2e0", "300", nullptr};
-	hex_prop->Set_values(bases);
+	hex_prop->Set_values(
+	        {"240", "220", "260", "280", "2a0", "2c0", "2e0", "300"});
 	hex_prop->Set_help("The IO base address of the Gravis UltraSound (240 by default).");
 
 	auto *int_prop = secprop.Add_int("gusirq", when_idle, 5);
 	assert(int_prop);
-	const char *const irqs[] = {"3",  "5",  "7",  "9",
-	                            "10", "11", "12", nullptr};
-	int_prop->Set_values(irqs);
+	int_prop->Set_values({"3", "5", "7", "9", "10", "11", "12"});
 	int_prop->Set_help("The IRQ number of the Gravis UltraSound (5 by default).");
 
 	int_prop = secprop.Add_int("gusdma", when_idle, 3);
 	assert(int_prop);
-	const char *const dmas[] = {"0", "1", "3", "5", "6", "7", nullptr};
-	int_prop->Set_values(dmas);
+	int_prop->Set_values({"0", "1", "3", "5", "6", "7"});
 	int_prop->Set_help("The DMA channel of the Gravis UltraSound (3 by default).");
 
 	auto* str_prop = secprop.Add_string("ultradir", when_idle, "C:\\ULTRASND");

--- a/src/hardware/imfc.cpp
+++ b/src/hardware/imfc.cpp
@@ -13444,15 +13444,13 @@ void init_imfc_dosbox_settings(Section_prop& secprop)
 
 	const auto hex_prop = secprop.Add_hex("imfc_base", when_idle, 0x2A20);
 	assert(hex_prop);
-	const char* const bases[] = {"2A20", "2A30", nullptr};
-	hex_prop->Set_values(bases);
+	hex_prop->Set_values({"2A20", "2A30"});
 	hex_prop->Set_help(
 	        "The IO base address of the IBM Music Feature Card (2A20 by default).");
 
 	const auto int_prop = secprop.Add_int("imfc_irq", when_idle, 3);
 	assert(int_prop);
-	const char* const irqs[] = {"2", "3", "4", "5", "6", "7", nullptr};
-	int_prop->Set_values(irqs);
+	int_prop->Set_values({"2", "3", "4", "5", "6", "7"});
 	int_prop->Set_help(
 	        "The IRQ number of the IBM Music Feature Card (3 by default).");
 

--- a/src/hardware/innovation.cpp
+++ b/src/hardware/innovation.cpp
@@ -278,8 +278,7 @@ static void init_innovation_dosbox_settings(Section_prop& sec_prop)
 
 	// Chip type
 	auto* str_prop = sec_prop.Add_string("sidmodel", when_idle, "none");
-	const char* sid_models[] = {"auto", "6581", "8580", "none", nullptr};
-	str_prop->Set_values(sid_models);
+	str_prop->Set_values({"auto", "6581", "8580", "none"});
 	str_prop->Set_help(
 	        "Model of chip to emulate in the Innovation SSI-2001 card:\n"
 	        "  auto:  Use the 6581 chip.\n"
@@ -291,8 +290,7 @@ static void init_innovation_dosbox_settings(Section_prop& sec_prop)
 
 	// Chip clock frequency
 	str_prop = sec_prop.Add_string("sidclock", when_idle, "default");
-	const char* sid_clocks[] = {"default", "c64ntsc", "c64pal", "hardsid", nullptr};
-	str_prop->Set_values(sid_clocks);
+	str_prop->Set_values({"default", "c64ntsc", "c64pal", "hardsid"});
 	str_prop->Set_help(
 	        "The SID chip's clock frequency, which is jumperable on reproduction cards:\n"
 	        "  default:  0.895 MHz, per the original SSI-2001 card (default).\n"
@@ -302,8 +300,7 @@ static void init_innovation_dosbox_settings(Section_prop& sec_prop)
 
 	// IO Address
 	auto* hex_prop          = sec_prop.Add_hex("sidport", when_idle, 0x280);
-	const char* sid_ports[] = {"240", "260", "280", "2a0", "2c0", nullptr};
-	hex_prop->Set_values(sid_ports);
+	hex_prop->Set_values({"240", "260", "280", "2a0", "2c0"});
 	hex_prop->Set_help(
 	        "The IO port address of the Innovation SSI-2001 (280 by default).");
 

--- a/src/hardware/input/mouse_config.cpp
+++ b/src/hardware/input/mouse_config.cpp
@@ -53,33 +53,6 @@ constexpr auto model_com_2button_msm_str  = "2button+msm";
 constexpr auto model_com_3button_msm_str  = "3button+msm";
 constexpr auto model_com_wheel_msm_str    = "wheel+msm";
 
-static const char *list_capture_types[] = {
-	capture_type_seamless_str,
-	capture_type_onclick_str,
-	capture_type_onstart_str,
-	capture_type_nomouse_str,
-	nullptr
-};
-
-static const char* list_models_ps2[] = {
-	model_ps2_standard_str,
-        model_ps2_intellimouse_str,
-        model_ps2_explorer_str,
-        model_ps2_nomouse_str,
-        nullptr
-};
-
-static const char *list_models_com[] = {
-	model_com_2button_str,
-	model_com_3button_str,
-	model_com_wheel_str,
-	model_com_msm_str,
-	model_com_2button_msm_str,
-	model_com_3button_msm_str,
-	model_com_wheel_msm_str,
-	nullptr
-};
-
 static const std::vector<uint16_t> list_rates = {
         // Commented out values are probably not interesting
         // for the end user as "boosted" sampling rate
@@ -335,7 +308,10 @@ static void config_init(Section_prop &secprop)
 	prop_str = secprop.Add_string("mouse_capture", always,
 	                              capture_type_onclick_str);
 	assert(prop_str);
-	prop_str->Set_values(list_capture_types);
+	prop_str->Set_values({capture_type_seamless_str,
+	                      capture_type_onclick_str,
+	                      capture_type_onstart_str,
+	                      capture_type_nomouse_str});
 	prop_str->Set_help(
 	        "Set the mouse capture behaviour:\n"
 	        "  onclick:   Capture the mouse when clicking any mouse button in the window\n"
@@ -406,7 +382,10 @@ static void config_init(Section_prop &secprop)
 	                              only_at_start,
 	                              model_ps2_explorer_str);
 	assert(prop_str);
-	prop_str->Set_values(list_models_ps2);
+	prop_str->Set_values({model_ps2_standard_str,
+	                      model_ps2_intellimouse_str,
+	                      model_ps2_explorer_str,
+	                      model_ps2_nomouse_str});
 	prop_str->Set_help(
 	        "PS/2 AUX port mouse model:\n"
 	        "  standard:      3 buttons, standard PS/2 mouse.\n"
@@ -418,7 +397,13 @@ static void config_init(Section_prop &secprop)
 	                              only_at_start,
 	                              model_com_wheel_msm_str);
 	assert(prop_str);
-	prop_str->Set_values(list_models_com);
+	prop_str->Set_values({model_com_2button_str,
+	                      model_com_3button_str,
+	                      model_com_wheel_str,
+	                      model_com_msm_str,
+	                      model_com_2button_msm_str,
+	                      model_com_3button_msm_str,
+	                      model_com_wheel_msm_str});
 	prop_str->Set_help(
 	        "COM (serial) port default mouse model:\n"
 	        "  2button:      2 buttons, Microsoft mouse.\n"

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -2904,16 +2904,13 @@ void init_mixer_dosbox_settings(Section_prop& sec_prop)
 
 	auto int_prop = sec_prop.Add_int("rate", only_at_start, default_rate);
 	assert(int_prop);
-	const char* rates[] = {
-	        "8000", "11025", "16000", "22050", "32000", "44100", "48000", nullptr};
-	int_prop->Set_values(rates);
+	int_prop->Set_values(
+	        {"8000", "11025", "16000", "22050", "32000", "44100", "48000"});
 	int_prop->Set_help("Mixer sample rate (48000 by default).");
 
-	const char* blocksizes[] = {
-	        "128", "256", "512", "1024", "2048", "4096", "8192", nullptr};
-
 	int_prop = sec_prop.Add_int("blocksize", only_at_start, default_blocksize);
-	int_prop->Set_values(blocksizes);
+	int_prop->Set_values(
+	        {"128", "256", "512", "1024", "2048", "4096", "8192"});
 	int_prop->Set_help(format_str(
 	        "Mixer block size in sample frames (%d by default). Larger values might help\n"
 	        "with sound stuttering but the sound will also be more lagged.",
@@ -2939,7 +2936,6 @@ void init_mixer_dosbox_settings(Section_prop& sec_prop)
 	                    "  off:  Disable compressor.\n"
 	                    "  on:   Enable compressor (default).");
 
-	const char* crossfeed_presets[] = {"off", "on", "light", "normal", "strong", nullptr};
 	auto string_prop = sec_prop.Add_string("crossfeed", when_idle, "off");
 	string_prop->Set_help(
 	        "Enable crossfeed globally on all stereo channels for headphone listening:\n"
@@ -2949,11 +2945,9 @@ void init_mixer_dosbox_settings(Section_prop& sec_prop)
 	        "  normal:  Normal crossfeed (strength 40).\n"
 	        "  strong:  Strong crossfeed (strength 65).\n"
 	        "Note: You can fine-tune each channel's crossfeed strength using the MIXER.");
-	string_prop->Set_values(crossfeed_presets);
+	string_prop->Set_values({"off", "on", "light", "normal", "strong"});
 
-	const char* reverb_presets[] = {
-	        "off", "on", "tiny", "small", "medium", "large", "huge", nullptr};
-	string_prop = sec_prop.Add_string("reverb", when_idle, reverb_presets[0]);
+	string_prop = sec_prop.Add_string("reverb", when_idle, "off");
 	string_prop->Set_help(
 	        "Enable reverb globally to add a sense of space to the sound:\n"
 	        "  off:     No reverb (default).\n"
@@ -2969,9 +2963,9 @@ void init_mixer_dosbox_settings(Section_prop& sec_prop)
 	        "  huge:    A stronger variant of the large hall preset; works really well\n"
 	        "           in some games with more atmospheric soundtracks.\n"
 	        "Note: You can fine-tune each channel's reverb level using the MIXER.");
-	string_prop->Set_values(reverb_presets);
+	string_prop->Set_values(
+	        {"off", "on", "tiny", "small", "medium", "large", "huge"});
 
-	const char* chorus_presets[] = {"off", "on", "light", "normal", "strong", nullptr};
 	string_prop = sec_prop.Add_string("chorus", when_idle, "off");
 	string_prop->Set_help(
 	        "Enable chorus globally to add a sense of stereo movement to the sound:\n"
@@ -2982,7 +2976,7 @@ void init_mixer_dosbox_settings(Section_prop& sec_prop)
 	        "  normal:  Normal chorus that works well with a wide variety of games.\n"
 	        "  strong:  An obvious and upfront chorus effect.\n"
 	        "Note: You can fine-tune each channel's chorus level using the MIXER.");
-	string_prop->Set_values(chorus_presets);
+	string_prop->Set_values({"off", "on", "light", "normal", "strong"});
 
 	MAPPER_AddHandler(handle_toggle_mute, SDL_SCANCODE_F8, PRIMARY_MOD, "mute", "Mute");
 }

--- a/src/hardware/vga_other.cpp
+++ b/src/hardware/vga_other.cpp
@@ -1477,18 +1477,16 @@ static void composite_settings(Section_prop& secprop)
 {
 	constexpr auto when_idle = Property::Changeable::WhenIdle;
 
-	const char* states[] = {"auto", "on", "off", nullptr};
 	auto str_prop = secprop.Add_string("composite", when_idle, "auto");
-	str_prop->Set_values(states);
+	str_prop->Set_values({"auto", "on", "off"});
 	str_prop->Set_help(
 	        "Enable composite mode on start (only for 'cga', 'pcjr', and 'tandy' machine\n"
 	        "types; 'auto' by default). 'auto' lets the program decide.\n"
 	        "Note: Fine-tune the settings below (i.e., 'hue') using the composite hotkeys,\n"
 	        "      then copy the new settings from the logs into your config.");
 
-	const char* eras[] = {"auto", "old", "new", nullptr};
 	str_prop           = secprop.Add_string("era", when_idle, "auto");
-	str_prop->Set_values(eras);
+	str_prop->Set_values({"auto", "old", "new"});
 	str_prop->Set_help("Era of composite technology ('auto' by default).\n"
 	                   "When 'auto', PCjr uses 'new', and CGA/Tandy use 'old'.");
 

--- a/src/midi/midi.cpp
+++ b/src/midi/midi.cpp
@@ -725,7 +725,7 @@ void init_midi_dosbox_settings(Section_prop& secprop)
 	constexpr auto when_idle = Property::Changeable::WhenIdle;
 
 	auto* str_prop = secprop.Add_string("mididevice", when_idle, "auto");
-	const char* midi_devices[] =
+	const std::vector<std::string> midi_devices =
 	{ "auto",
 #if defined(MACOSX)
 #if C_COREMIDI
@@ -748,8 +748,7 @@ void init_midi_dosbox_settings(Section_prop& secprop)
 #if C_MT32EMU
 	  "mt32",
 #endif
-	  "none",
-	  nullptr };
+	  "none"};
 
 	str_prop->Set_values(midi_devices);
 	str_prop->Set_help(
@@ -808,8 +807,7 @@ void init_midi_dosbox_settings(Section_prop& secprop)
 	        "    In that case, add 'delaysysex' (e.g. 'midiconfig = 2 delaysysex').");
 
 	str_prop = secprop.Add_string("mpu401", when_idle, "intelligent");
-	const char* mputypes[] = {"intelligent", "uart", "none", nullptr};
-	str_prop->Set_values(mputypes);
+	str_prop->Set_values({"intelligent", "uart", "none"});
 	str_prop->Set_help("MPU-401 mode to emulate ('intelligent' by default).");
 
 	auto* bool_prop = secprop.Add_bool("raw_midi_output", when_idle, false);

--- a/src/midi/midi_mt32.cpp
+++ b/src/midi/midi_mt32.cpp
@@ -306,29 +306,26 @@ static void init_mt32_dosbox_settings(Section_prop& sec_prop)
 {
 	constexpr auto when_idle = Property::Changeable::WhenIdle;
 
-	const char* models[] = {"auto",
-	                        Cm32lModelName,
-	                        cm32l_102_model.GetName(),
-	                        cm32l_100_model.GetName(),
-	                        cm32ln_100_model.GetName(),
-
-	                        Mt32ModelName,
-	                        Mt32OldModelName,
-	                        mt32_107_model.GetName(),
-	                        mt32_106_model.GetName(),
-	                        mt32_105_model.GetName(),
-	                        mt32_104_model.GetName(),
-	                        mt32_bluer_model.GetName(),
-
-	                        Mt32NewModelName,
-	                        mt32_207_model.GetName(),
-	                        mt32_206_model.GetName(),
-	                        mt32_204_model.GetName(),
-	                        mt32_203_model.GetName(),
-	                        nullptr};
-
 	auto* str_prop = sec_prop.Add_string("model", when_idle, "auto");
-	str_prop->Set_values(models);
+	str_prop->Set_values({"auto",
+	                      Cm32lModelName,
+	                      cm32l_102_model.GetName(),
+	                      cm32l_100_model.GetName(),
+	                      cm32ln_100_model.GetName(),
+
+	                      Mt32ModelName,
+	                      Mt32OldModelName,
+	                      mt32_107_model.GetName(),
+	                      mt32_106_model.GetName(),
+	                      mt32_105_model.GetName(),
+	                      mt32_104_model.GetName(),
+	                      mt32_bluer_model.GetName(),
+
+	                      Mt32NewModelName,
+	                      mt32_207_model.GetName(),
+	                      mt32_206_model.GetName(),
+	                      mt32_204_model.GetName(),
+	                      mt32_203_model.GetName()});
 	str_prop->Set_help(
 	        "The Roland MT-32/CM-32ML model to use.\n"
 	        "You must have the ROM files for the selected model available (see 'romdir').\n"

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -690,20 +690,6 @@ void Property::MaybeSetBoolValid(const std::string_view valid_value)
 	}
 }
 
-void Property::Set_values(const char* const* in)
-{
-	Value::Etype type = default_value.type;
-
-	int i = 0;
-
-	while (in[i]) {
-		MaybeSetBoolValid(in[i]);
-		Value val(in[i], type);
-		valid_values.push_back(val);
-		i++;
-	}
-}
-
 void Property::SetDeprecatedWithAlternateValue(const char* deprecated_value,
                                                const char* alternate_value)
 {

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -460,12 +460,12 @@ static std::unique_ptr<Config> specify_drive_config()
 
 	// Define the allowed keys and types
 	constexpr auto on_startup = Property::Changeable::OnlyAtStart;
-	const char *drive_types[] = {"dir", "floppy", "cdrom", "overlay", nullptr};
-	(void)prop->Add_string("type", on_startup, "")->Set_values(drive_types);
-	(void)prop->Add_string("label", on_startup, "");
-	(void)prop->Add_string("path", on_startup, "");
-	(void)prop->Add_string("override_drive", on_startup, "");
-	(void)prop->Add_bool("verbose", on_startup, true);
+	prop->Add_string("type", on_startup, "")
+	        ->Set_values({"dir", "floppy", "cdrom", "overlay"});
+	prop->Add_string("label", on_startup, "");
+	prop->Add_string("path", on_startup, "");
+	prop->Add_string("override_drive", on_startup, "");
+	prop->Add_bool("verbose", on_startup, true);
 
 	return conf;
 }


### PR DESCRIPTION
# Description

Only Set_values(const std::vector<string>& in) remains.

# Manual testing

DOSBox starts, help is functional.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

