### PR TITLE
Inherit batch file echo state from parent

### DIFF
--- a/src/shell/shell_misc.cpp
+++ b/src/shell/shell_misc.cpp
@@ -467,18 +467,20 @@ bool DOS_Shell::ExecuteProgram(std::string_view name, std::string_view args)
 	auto extension = fullname.substr(fullname.size() - extension_size);
 
 	if (iequals(extension, ".BAT")) {
+		const auto current_echo = batchfiles.empty()
+		                             ? echo
+		                             : batchfiles.top().Echo();
 		if (!batchfiles.empty() && !call) {
 			batchfiles.pop();
 		}
 
-		auto reader = FileReader::GetFileReader(fullname);
-		if (reader) {
+		if (auto reader = FileReader::GetFileReader(fullname)) {
 			batchfiles.emplace(*psp,
 			                   std::make_unique<FileReader>(
 			                           std::move(*reader)),
 			                   name,
 			                   args,
-			                   echo);
+			                   current_echo);
 		} else {
 			WriteOut("Could not open %s", fullname.c_str());
 		}


### PR DESCRIPTION
# Description

When a batch file was being instantiated, the echo state from the parent was not being transferred correctly if the parent was another batch file.

The echo status of the current batch file (if currently interpreting a batch file) is now captured before the interpreter for that file is discarded (when invoked without CALL). That status is now passed in to the invoked batch file.

## Related issues

Resolves #3575 

# Manual testing

Added a simple test case to the wiki

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [ ] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

