### PR TITLE
Use legacy palette behaviour on `svga_paradise`

### DIFF
--- a/src/hardware/vga_dac.cpp
+++ b/src/hardware/vga_dac.cpp
@@ -305,8 +305,11 @@ void VGA_DAC_CombineColor(const uint8_t palette_idx, const uint8_t color_idx)
 {
 	vga.dac.combine[palette_idx] = color_idx;
 
-	if (vga.mode != M_LIN8) {
-		// Used by copper demo; almost no video card seems to support it
+	// Mimic the legacy `machine = vgaonly` behaviour when emulating the
+	// Paradise card, which is our closest substitue for it. This fixes the
+	// wrong colours appearing in some rare titles (e.g., Spell It Plus).
+	//
+	if (svgaCard != SVGA_ParadisePVGA1A && vga.mode != M_LIN8) {
 		vga_dac_send_color(palette_idx, color_idx);
 	}
 }


### PR DESCRIPTION
# Description

Mimic the legacy `machine = vgaonly` palette behaviour when emulating the Paradise SVGA card, which is our closest substitute for it and for emulating a pure VGA card. This fixes the wrong colours appearing in some rare titles (e.g., **Spell It Plus**).

Fixes https://github.com/dosbox-staging/dosbox-staging/issues/3580

See code comments for further details and my reasoning for choosing this solution. Basically, detecting "true EGA" modes on VGA with our defaults is _far_ more important than supporting this bottom-of-the-barrel title. But now compatibility with this game is restored by using `svga_paradise`. See this commit's comment for further details: https://github.com/dosbox-staging/dosbox-staging/commit/1fdb907aff43424c024de41a50cc5f08a5ac154c

If it turns out we have similar palette-related regressions in a significant number of non-obscure titles (which seems _not_ to be the case at all so far), I might revisit my "true EGA" mode detection approach in the future. But I spent weeks getting it right, so I'm extremely reluctant to touch it. Therefore, until we have some compelling evidence against my detection method, this solution will do.

## Notes

Now, this might break a few games when using `svga_paradise`... E.g, Drakkhen will show wrong colours. But that game runs fine with `ega` or `svga_s3` 🤷🏻 Ultimately, the Paradise emulation seems incomplete anyway, there's lots of TODOs and comments about missing functionality in `svga_paradise.cpp`, so I'm fine "repurposing" it this way for weird edge cases instead of introducing lots of tweakable VGA related options into the config... Probably the palette emulation is not 100% accurate, but it kinda sorta works OK most of the time... until you start changing things around like I did 😅 

This approach also "segregates" workarounds to revert to the "legacy DOSBox behaviour" into `svga_paradise`, which is nice.

As a related note, I noticed palette-related regressions in some rare demos (e.g. The Good, The Bad & The Ugly) that we introduced after 0.76.0, but these are super hard to track down, and frankly, the vast majority of games don't do such freaky stuff to the VGA hardware like demos... So spending tens or hundreds of hours on extreme edge case regressions like this has a very low payoff. But be my guest to fix it and deal with further regressions resulting from the fix 😏  It's a super boring, fiddly, and thankless job.

# Manual testing

## Regression testing

"True EGA" mode detection continues to work with EGA titles on VGA (e.g., Secret of the Silver Blades, Wasteland, Drakkhen, etc.)

Some games that do weird things to the EGA palette will display wrong colours on `svga_paradise`, but we'll just need to live with that.

## Spell It Plus

Palette is fine when running with `--noprimaryconf --machine svga_paradise`.

<img width="1215" alt="image" src="https://github.com/dosbox-staging/dosbox-staging/assets/698770/f292025b-02c0-4211-a973-d24e1b28090e">

<img width="1215" alt="image" src="https://github.com/dosbox-staging/dosbox-staging/assets/698770/739d778b-1d5b-4771-8f85-5c355e92e703">

## Regression tests




# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

