### PR TITLE
Use SB* and OPL logging prefixes consistely in all scenarios

### DIFF
--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -367,26 +367,29 @@ static void init_speaker_state()
 	}
 }
 
-static void log_filter_config(const char* output_type, const FilterType filter)
+static void log_filter_config(const char* channel_name, const char* output_type,
+                              const FilterType filter)
 {
+	// clang-format off
 	static const std::map<FilterType, std::string> filter_name_map = {
-	        {FilterType::SB1, "Sound Blaster 1.0"},
-	        {FilterType::SB2, "Sound Blaster 2.0"},
+	        {FilterType::SB1,    "Sound Blaster 1.0"},
+	        {FilterType::SB2,    "Sound Blaster 2.0"},
 	        {FilterType::SBPro1, "Sound Blaster Pro 1"},
 	        {FilterType::SBPro2, "Sound Blaster Pro 2"},
-	        {FilterType::SB16, "Sound Blaster 16"},
+	        {FilterType::SB16,   "Sound Blaster 16"},
 	        {FilterType::Modern, "Modern"},
 	};
+	// clang-format on
 
 	if (filter == FilterType::None) {
-		LOG_MSG("%s: %s filter disabled", log_prefix(), output_type);
+		LOG_MSG("%s: %s filter disabled", channel_name, output_type);
 	} else {
 		auto it = filter_name_map.find(filter);
 		if (it != filter_name_map.end()) {
 			auto filter_type = it->second;
 
 			LOG_MSG("%s: %s %s output filter enabled",
-			        log_prefix(),
+			        channel_name,
 			        filter_type.c_str(),
 			        output_type);
 		}
@@ -550,7 +553,8 @@ static void configure_sb_filter(mixer_channel_t channel,
 		break;
 	}
 
-	log_filter_config("DAC", *filter_type);
+	constexpr auto OutputType = "DAC";
+	log_filter_config(log_prefix(), OutputType, *filter_type);
 	set_filter(channel, config);
 }
 
@@ -607,7 +611,8 @@ static void configure_opl_filter(mixer_channel_t channel,
 	case FilterType::SBPro2: enable_lpf(1, 8000); break;
 	}
 
-	log_filter_config(ChannelName::Opl, *filter_type);
+	constexpr auto OutputType = "OPL";
+	log_filter_config(ChannelName::Opl, OutputType, *filter_type);
 	set_filter(channel, config);
 }
 


### PR DESCRIPTION
# Description

The prefixes were not always applied consistently. This also removes a debug build-only crash when `sbtype = none` is set after `oplmode = opl2`.

This did not affect release builds, but it's annoying, and the logging prefixes were sometimes incorrect.

# Manual testing

1. Run the debug build with `--noprimaryconf`
2. Set `oplmode opl2`
3. Set `sbtype none`
4. The debug assert is not tripped and the log prefixes are correct

Also tried a few more permutations to make sure there are no regressions.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

