### PR TITLE
Jn/ega on vga fix

### DIFF
--- a/include/vga.h
+++ b/include/vga.h
@@ -1087,6 +1087,9 @@ struct VgaType {
 	// change.
 	bool ega_mode_with_vga_colors = false;
 
+	// Whether EGA mode with VGA colour detection is enabled or not.
+	bool detect_ega_mode_with_vga_colors = true;
+
 	// Flag to signal that we're in the middle of a mode change.
 	bool mode_change_in_progress = false;
 };

--- a/src/hardware/vga_dac.cpp
+++ b/src/hardware/vga_dac.cpp
@@ -72,6 +72,30 @@ static bool is_ega_color(const Rgb666 color)
 	       palette.ega.cend();
 }
 
+// In the automatic "video mode specific" CRT emulation mode (glshader =
+// crt-auto), we want "true EGA" games on emulated VGA adapters to use the
+// single scanline EGA shader. "True EGA" games set up an EGA mode and
+// don't change the palette to use 18-bit VGA colours. These games look
+// identical on VGA and EGA, except for the VGA double scanning.
+//
+// Some games (most notably Amiga and Atari ST ports) "repurpose" the
+// 16-colour EGA modes on VGA: they set up an EGA mode first, then change
+// the default CGA/EGA palette to a custom set of sixteen 18-bit RGB
+// colours (many Amiga and Atari ST games used a 16-colour palette out of
+// 4096 (Amiga) or 512 (Atari ST) colours). As these games can only run on
+// VGA adapters, we double scan them in 'crt-auto' mode (although it can
+// be argued that this case calls for single scanning to mimic the
+// single-scanned home computer monitor look. But we're emulating PC
+// compatibles here and how people experienced these games on PC hardware,
+// so double scanning it is).
+//
+// Detecting EGA modes using custom VGA colours is accomplished by setting
+// the `ega_mode_with_vga_colors` flag to true when the first non-EGA
+// palette colour is set after a mode switch.
+//
+// Note that custom CGA colours (via the `cga_colors` config setting) are
+// handled correctly as well.
+//
 static void vga_dac_send_color(const uint8_t palette_idx, const uint8_t color_idx)
 {
 	const auto rgb666 = vga.dac.rgb[color_idx];
@@ -82,24 +106,32 @@ static void vga_dac_send_color(const uint8_t palette_idx, const uint8_t color_id
 	// which will trigger this function.
 	const auto bios_mode_number = CurMode->mode;
 
-	// In the automatic "video mode specific" CRT emulation mode, we want
-	// "true EGA" games (EGA modes with the default EGA palette on VGA) to
-	// use the single-scanline EGA shader. But VGA games that just happen to
-	// use EGA modes but with a 18-bit VGA palette should be rendered with
-	// the double-scanned VGA shader.
-	//
-	// This is accomplished by setting the `ega_mode_with_vga_colors` flag
-	// to true when the first non-EGA palette colour is set after a mode
-	// switch.
-	//
-	// Note that custom CGA colours (via the `cga_colors` setting) are
-	// handled correctly as well.
-	//
-	if (machine == MCH_VGA && !vga.ega_mode_with_vga_colors &&
+	const auto is_640x350_16color_mode = (bios_mode_number == 0x10);
+
+#if 1
+	bool log_warning = false;
+	if (is_640x350_16color_mode) {
+		log_warning = !is_ega_color(rgb666);
+	} else {
+		log_warning = !is_cga_color(rgb666);
+	}
+
+	auto msg = format_str("palette_idx: %d, color_idx: %d", palette_idx, color_idx);
+	if (log_warning) {
+		LOG_WARNING("%s, color: %02x %02x %02x",
+		            msg.c_str(),
+		            rgb666.red,
+		            rgb666.green,
+		            rgb666.blue);
+	} else {
+		LOG_TRACE(msg);
+	}
+#endif
+
+	if (vga.detect_ega_mode_with_vga_colors && machine == MCH_VGA &&
+	    !vga.ega_mode_with_vga_colors &&
 	    bios_mode_number <= MaxEgaBiosModeNumber) {
 		bool non_ega_color = false;
-
-		const auto is_640x350_16color_mode = (bios_mode_number == 0x10);
 
 		if (is_640x350_16color_mode) {
 			// The 640x350 16-colour EGA mode (mode 10h) is special:

--- a/src/hardware/vga_dac.cpp
+++ b/src/hardware/vga_dac.cpp
@@ -337,9 +337,17 @@ void VGA_DAC_CombineColor(const uint8_t palette_idx, const uint8_t color_idx)
 {
 	vga.dac.combine[palette_idx] = color_idx;
 
-	if (vga.mode != M_LIN8) {
-		// Used by copper demo; almost no video card seems to support it
-		vga_dac_send_color(palette_idx, color_idx);
+	switch (vga.mode) {
+	case M_LIN8: break;
+	case M_VGA:
+		// Mimic the legacy palette behaviour when emulating the Paradise
+		// card (the oldest SVGA card we emulate). This fixes the wrong
+		// colours appearing in some rare titles (e.g., Spell It Plus).
+		if (svgaCard == SVGA_ParadisePVGA1A) {
+			break;
+		}
+		[[fallthrough]];
+	default: vga_dac_send_color(palette_idx, color_idx);
 	}
 }
 


### PR DESCRIPTION
# Description

_Describe a summary of your changes clearly and concisely, including motivation and context._
_Breaking changes need extra explanation on backward compatibility considerations._

_Feel free to include additional details, but please respect the reviewer's time and keep it brief._


## Related issues

_Related issues can be listed here (remove the section if not applicable.)_


# Manual testing

_Please describe the tests that you ran to verify your changes._

_Provide clear instructions so the reviewers can reproduce and verify your results._

_Include relevant details for your test configuration, operating system, etc._

_Ideally, you would also test your changes with a [sanitizer build](https://github.com/dosbox-staging/dosbox-staging/blob/main/BUILD.md#make-a-sanitizer-build) and confirm no issues were found._


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [ ] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [ ] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [ ] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

