### PR TITLE
Port video memory I/O delay tweak from DOSBox-X

### DIFF
--- a/include/vga.h
+++ b/include/vga.h
@@ -1057,9 +1057,11 @@ struct VgaType {
 
 	// Memory for fast (usually 16-colour) rendering,
 	// always twice as big as vmemsize
-	//
 	uint8_t* fastmem  = {};
 	uint32_t vmemsize = 0;
+
+	// How much delay to add to video memory I/O in nanoseconds
+	uint16_t vmem_delay_ns = 0;
 
 #ifdef VGA_KEEP_CHANGES
 	VgaChanges changes = {};

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -553,11 +553,12 @@ void DOSBOX_Init()
 
 	pstring = secprop->Add_string("dos_rate", when_idle, "default");
 	pstring->Set_help(
-	        "Customize the emulated video mode's frame rate, in Hz:\n"
-	        "  default:  The DOS video mode determines the rate (recommended; default).\n"
+	        "Customize the emulated video mode's frame rate.\n"
+	        "  default:  The DOS video mode determines the rate (default).\n"
 	        "  host:     Match the DOS rate to the host rate (see 'host_rate' setting).\n"
-	        "  <value>:  Sets the rate to an exact value, between 24.000 and 1000.000 (Hz).\n"
-	        "We recommend the 'default' rate; otherwise test and set on a per-game basis.");
+	        "  <value>:  Sets the rate to an exact value in between 24.000 and 1000.000 Hz.\n"
+	        "Note: We recommend the 'default' rate, otherwise test and set on a per-game\n"
+	        "      basis.");
 
 	pstring = secprop->Add_string("vesa_modes", only_at_start, "compatible");
 	pstring->Set_values({"compatible", "all", "halfline"});
@@ -568,9 +569,9 @@ void DOSBOX_Init()
 	        "               (default).\n"
 	        "  halfline:    Supports the low-resolution halfline VESA 2.0 mode used by\n"
 	        "               Extreme Assault. Use only if needed, as it's not S3 compatible.\n"
-	        "  all:         All modes for a given video memory size, however some games\n"
-	        "               may not use them properly (flickering) or may need\n"
-	        "               more system memory to use them.");
+	        "  all:         All modes for a given video memory size, however some games may\n"
+	        "               not use them properly (flickering) or may need more system\n"
+	        "               memory to use them.");
 
 	pbool = secprop->Add_bool("vga_8dot_font", only_at_start, false);
 	pbool->Set_help("Use 8-pixel-wide fonts on VGA adapters (disabled by default).");

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -551,6 +551,18 @@ void DOSBOX_Init()
 	        "the selected video adapter ('auto' by default). See the 'machine' setting for\n"
 	        "the list of valid options per adapter.");
 
+	pstring = secprop->Add_string("vmem_delay", only_at_start, "off");
+	pstring->Set_help(
+	        "Set video memory I/O delay emulation ('off' by default).\n"
+	        "  off:      Disable video memory I/O delay emulation (default).\n"
+	        "            This is preferable for most games to avoid slowdowns.\n"
+	        "  on:       Enable I/O delay emulation (3000 ns). This can help reduce or\n"
+	        "            eliminate flicker in Hercules, CGA, EGA, and early VGA games.\n"
+	        "  <value>:  Set I/O delay in nanoseconds. Valid range is 0 to 20000 ns;\n"
+	        "            500 to 5000 ns is the most useful range.\n"
+	        "Note: Only set this on a per-game basis when necessary as it slows down the\n"
+	        "      whole emulator.");
+
 	pstring = secprop->Add_string("dos_rate", when_idle, "default");
 	pstring->Set_help(
 	        "Customize the emulated video mode's frame rate.\n"

--- a/src/hardware/vga_memory.cpp
+++ b/src/hardware/vga_memory.cpp
@@ -25,6 +25,7 @@
 #include <cstring>
 #include <vector>
 
+#include "cpu.h"
 #include "inout.h"
 #include "mem.h"
 #include "mem_host.h"
@@ -117,7 +118,27 @@ inline static uint32_t ModeOperation(uint8_t val) {
 static struct {
 	Bitu base, mask;
 } vgapages;
-	
+
+static void read_delay()
+{
+	if (vga.vmem_delay_ns > 0) {
+		const int32_t delay_cycles = (CPU_CycleMax * vga.vmem_delay_ns) /
+		                             1000000;
+		CPU_Cycles -= delay_cycles;
+		CPU_IODelayRemoved += delay_cycles;
+	}
+}
+
+static void write_delay()
+{
+	if (vga.vmem_delay_ns > 0) {
+		const int32_t delay_cycles = (CPU_CycleMax * vga.vmem_delay_ns * 3) /
+		                             (1000000 * 4);
+		CPU_Cycles -= delay_cycles;
+		CPU_IODelayRemoved += delay_cycles;
+	}
+}
+
 class VGA_UnchainedRead_Handler : public PageHandler {
 public:
 	uint8_t readHandler(PhysPt start)
@@ -137,6 +158,7 @@ public:
 public:
 	uint8_t readb(PhysPt addr) override
 	{
+		read_delay();
 		addr = PAGING_GetPhysicalAddress(addr) & vgapages.mask;
 		addr += vga.svga.bank_read_full;
 		addr = CHECKED2(addr);
@@ -145,6 +167,7 @@ public:
 	
 	uint16_t readw(PhysPt addr) override
 	{
+		read_delay();
 		addr = PAGING_GetPhysicalAddress(addr) & vgapages.mask;
 		addr += vga.svga.bank_read_full;
 		addr = CHECKED2(addr);
@@ -154,6 +177,7 @@ public:
 
 	uint32_t readd(PhysPt addr) override
 	{
+		read_delay();
 		addr = PAGING_GetPhysicalAddress(addr) & vgapages.mask;
 		addr += vga.svga.bank_read_full;
 		addr = CHECKED2(addr);
@@ -201,6 +225,7 @@ public:
 
 	void writeb(PhysPt addr, uint8_t val) override
 	{
+		write_delay();
 		addr = PAGING_GetPhysicalAddress(addr) & vgapages.mask;
 		addr += vga.svga.bank_write_full;
 		addr = CHECKED(addr);
@@ -210,6 +235,7 @@ public:
 
 	void writew(PhysPt addr, uint16_t val) override
 	{
+		write_delay();
 		addr = PAGING_GetPhysicalAddress(addr) & vgapages.mask;
 		addr += vga.svga.bank_write_full;
 		addr = CHECKED(addr);
@@ -220,6 +246,7 @@ public:
 
 	void writed(PhysPt addr, uint32_t val) override
 	{
+		write_delay();
 		addr = PAGING_GetPhysicalAddress(addr) & vgapages.mask;
 		addr += vga.svga.bank_write_full;
 		addr = CHECKED(addr);
@@ -232,6 +259,7 @@ public:
 
 	uint8_t readb(PhysPt addr) override
 	{
+		read_delay();
 		addr = PAGING_GetPhysicalAddress(addr) & vgapages.mask;
 		addr += vga.svga.bank_read_full;
 		addr = CHECKED(addr);
@@ -240,6 +268,7 @@ public:
 
 	uint16_t readw(PhysPt addr) override
 	{
+		read_delay();
 		addr = PAGING_GetPhysicalAddress(addr) & vgapages.mask;
 		addr += vga.svga.bank_read_full;
 		addr = CHECKED(addr);
@@ -249,6 +278,7 @@ public:
 
 	uint32_t readd(PhysPt addr) override
 	{
+		read_delay();
 		addr = PAGING_GetPhysicalAddress(addr) & vgapages.mask;
 		addr += vga.svga.bank_read_full;
 		addr = CHECKED(addr);
@@ -295,6 +325,7 @@ public:
 
 	void writeb(PhysPt addr, uint8_t val) override
 	{
+		write_delay();
 		addr = PAGING_GetPhysicalAddress(addr) & vgapages.mask;
 		addr += vga.svga.bank_write_full;
 		addr = CHECKED2(addr);
@@ -304,6 +335,7 @@ public:
 
 	void writew(PhysPt addr, uint16_t val) override
 	{
+		write_delay();
 		addr = PAGING_GetPhysicalAddress(addr) & vgapages.mask;
 		addr += vga.svga.bank_write_full;
 		addr = CHECKED2(addr);
@@ -314,6 +346,7 @@ public:
 
 	void writed(PhysPt addr, uint32_t val) override
 	{
+		write_delay();
 		addr = PAGING_GetPhysicalAddress(addr) & vgapages.mask;
 		addr += vga.svga.bank_write_full;
 		addr = CHECKED2(addr);
@@ -395,6 +428,7 @@ public:
 
 	uint8_t readb(PhysPt addr) override
 	{
+		read_delay();
 		addr = PAGING_GetPhysicalAddress(addr) & vgapages.mask;
 		addr += vga.svga.bank_read_full;
 		addr = CHECKED(addr);
@@ -403,6 +437,7 @@ public:
 
 	uint16_t readw(PhysPt addr) override
 	{
+		read_delay();
 		addr = PAGING_GetPhysicalAddress(addr) & vgapages.mask;
 		addr += vga.svga.bank_read_full;
 		addr = CHECKED(addr);
@@ -417,6 +452,7 @@ public:
 
 	uint32_t readd(PhysPt addr) override
 	{
+		read_delay();
 		addr = PAGING_GetPhysicalAddress(addr) & vgapages.mask;
 		addr += vga.svga.bank_read_full;
 		addr = CHECKED(addr);
@@ -434,6 +470,7 @@ public:
 
 	void writeb(PhysPt addr, uint8_t val) override
 	{
+		write_delay();
 		addr = PAGING_GetPhysicalAddress(addr) & vgapages.mask;
 		addr += vga.svga.bank_write_full;
 		addr = CHECKED(addr);
@@ -444,6 +481,7 @@ public:
 
 	void writew(PhysPt addr, uint16_t val) override
 	{
+		write_delay();
 		addr = PAGING_GetPhysicalAddress(addr) & vgapages.mask;
 		addr += vga.svga.bank_write_full;
 		addr = CHECKED(addr);
@@ -460,6 +498,7 @@ public:
 
 	void writed(PhysPt addr, uint32_t val) override
 	{
+		write_delay();
 		addr = PAGING_GetPhysicalAddress(addr) & vgapages.mask;
 		addr += vga.svga.bank_write_full;
 		addr = CHECKED(addr);
@@ -496,6 +535,7 @@ public:
 
 	void writeb(PhysPt addr, uint8_t val) override
 	{
+		write_delay();
 		addr = PAGING_GetPhysicalAddress(addr) & vgapages.mask;
 		addr += vga.svga.bank_write_full;
 		addr = CHECKED2(addr);
@@ -505,6 +545,7 @@ public:
 
 	void writew(PhysPt addr, uint16_t val) override
 	{
+		write_delay();
 		addr = PAGING_GetPhysicalAddress(addr) & vgapages.mask;
 		addr += vga.svga.bank_write_full;
 		addr = CHECKED2(addr);
@@ -515,6 +556,7 @@ public:
 
 	void writed(PhysPt addr, uint32_t val) override
 	{
+		write_delay();
 		addr = PAGING_GetPhysicalAddress(addr) & vgapages.mask;
 		addr += vga.svga.bank_write_full;
 		addr = CHECKED2(addr);
@@ -534,6 +576,7 @@ public:
 
 	uint8_t readb(PhysPt addr) override
 	{
+		read_delay();
 		addr = PAGING_GetPhysicalAddress(addr) & vgapages.mask;
 		switch(vga.gfx.read_map_select) {
 		case 0: // character index
@@ -549,6 +592,7 @@ public:
 
 	void writeb(PhysPt addr, uint8_t val) override
 	{
+		write_delay();
 		addr = PAGING_GetPhysicalAddress(addr) & vgapages.mask;
 
 		if (vga.seq.map_mask == 0x4) {
@@ -587,6 +631,7 @@ public:
 	}
 	uint8_t readb(PhysPt addr) override
 	{
+		read_delay();
 		addr = PAGING_GetPhysicalAddress(addr) & vgapages.mask;
 		addr += vga.svga.bank_read_full;
 		addr = CHECKED(addr);
@@ -595,6 +640,7 @@ public:
 
 	uint16_t readw(PhysPt addr) override
 	{
+		read_delay();
 		addr = PAGING_GetPhysicalAddress(addr) & vgapages.mask;
 		addr += vga.svga.bank_read_full;
 		addr = CHECKED(addr);
@@ -603,6 +649,7 @@ public:
 
 	uint32_t readd(PhysPt addr) override
 	{
+		read_delay();
 		addr = PAGING_GetPhysicalAddress(addr) & vgapages.mask;
 		addr += vga.svga.bank_read_full;
 		addr = CHECKED(addr);
@@ -611,6 +658,7 @@ public:
 
 	void writeb(PhysPt addr, uint8_t val) override
 	{
+		write_delay();
 		addr = PAGING_GetPhysicalAddress(addr) & vgapages.mask;
 		addr += vga.svga.bank_write_full;
 		addr = CHECKED(addr);
@@ -620,6 +668,7 @@ public:
 
 	void writew(PhysPt addr, uint16_t val) override
 	{
+		write_delay();
 		addr = PAGING_GetPhysicalAddress(addr) & vgapages.mask;
 		addr += vga.svga.bank_write_full;
 		addr = CHECKED(addr);
@@ -629,6 +678,7 @@ public:
 
 	void writed(PhysPt addr, uint32_t val) override
 	{
+		write_delay();
 		addr = PAGING_GetPhysicalAddress(addr) & vgapages.mask;
 		addr += vga.svga.bank_write_full;
 		addr = CHECKED(addr);
@@ -644,6 +694,7 @@ public:
 	}
 	void writeb(PhysPt addr, uint8_t val) override
 	{
+		write_delay();
 		addr = vga.svga.bank_write_full + (PAGING_GetPhysicalAddress(addr) & 0xffff);
 		addr = CHECKED4(addr);
 		MEM_CHANGED( addr << 3 );
@@ -652,6 +703,7 @@ public:
 
 	void writew(PhysPt addr, uint16_t val) override
 	{
+		write_delay();
 		addr = vga.svga.bank_write_full + (PAGING_GetPhysicalAddress(addr) & 0xffff);
 		addr = CHECKED4(addr);
 		MEM_CHANGED( addr << 3 );
@@ -661,6 +713,7 @@ public:
 
 	void writed(PhysPt addr, uint32_t val) override
 	{
+		write_delay();
 		addr = vga.svga.bank_write_full + (PAGING_GetPhysicalAddress(addr) & 0xffff);
 		addr = CHECKED4(addr);
 		MEM_CHANGED( addr << 3 );
@@ -672,6 +725,7 @@ public:
 
 	uint8_t readb(PhysPt addr) override
 	{
+		read_delay();
 		addr = vga.svga.bank_read_full + (PAGING_GetPhysicalAddress(addr) & 0xffff);
 		addr = CHECKED4(addr);
 		return readHandler(addr);
@@ -679,6 +733,7 @@ public:
 
 	uint16_t readw(PhysPt addr) override
 	{
+		read_delay();
 		addr = vga.svga.bank_read_full + (PAGING_GetPhysicalAddress(addr) & 0xffff);
 		addr = CHECKED4(addr);
 		return static_cast<uint16_t>((readHandler(addr + 0) << 0) |
@@ -687,6 +742,7 @@ public:
 
 	uint32_t readd(PhysPt addr) override
 	{
+		read_delay();
 		addr = vga.svga.bank_read_full + (PAGING_GetPhysicalAddress(addr) & 0xffff);
 		addr = CHECKED4(addr);
 		return static_cast<uint32_t>((readHandler(addr + 0) << 0) |
@@ -705,6 +761,7 @@ public:
 
 	uint8_t readb(PhysPt addr) override
 	{
+		read_delay();
 		addr = PAGING_GetPhysicalAddress(addr) - vga.lfb.addr;
 		addr = CHECKED(addr);
 		return host_readb(&vga.mem.linear[addr]);
@@ -712,6 +769,7 @@ public:
 
 	uint16_t readw(PhysPt addr) override
 	{
+		read_delay();
 		addr = PAGING_GetPhysicalAddress(addr) - vga.lfb.addr;
 		addr = CHECKED(addr);
 		return host_readw_at(vga.mem.linear, addr);
@@ -719,6 +777,7 @@ public:
 
 	uint32_t readd(PhysPt addr) override
 	{
+		read_delay();
 		addr = PAGING_GetPhysicalAddress(addr) - vga.lfb.addr;
 		addr = CHECKED(addr);
 		return host_readd_at(vga.mem.linear, addr);
@@ -726,6 +785,7 @@ public:
 
 	void writeb(PhysPt addr, uint8_t val) override
 	{
+		write_delay();
 		addr = PAGING_GetPhysicalAddress(addr) - vga.lfb.addr;
 		addr = CHECKED(addr);
 		host_writeb(&vga.mem.linear[addr], val);
@@ -734,6 +794,7 @@ public:
 
 	void writew(PhysPt addr, uint16_t val) override
 	{
+		write_delay();
 		addr = PAGING_GetPhysicalAddress(addr) - vga.lfb.addr;
 		addr = CHECKED(addr);
 		host_writew_at(vga.mem.linear, addr, val);
@@ -742,6 +803,7 @@ public:
 
 	void writed(PhysPt addr, uint32_t val) override
 	{
+		write_delay();
 		addr = PAGING_GetPhysicalAddress(addr) - vga.lfb.addr;
 		addr = CHECKED(addr);
 		host_writed_at(vga.mem.linear, addr, val);
@@ -774,36 +836,42 @@ public:
 
 	void writeb(PhysPt addr, uint8_t val) override
 	{
+		write_delay();
 		Bitu port = PAGING_GetPhysicalAddress(addr) & 0xffff;
 		XGA_Write(port, val, io_width_t::byte);
 	}
 
 	void writew(PhysPt addr, uint16_t val) override
 	{
+		write_delay();
 		Bitu port = PAGING_GetPhysicalAddress(addr) & 0xffff;
 		XGA_Write(port, val, io_width_t::word);
 	}
 
 	void writed(PhysPt addr, uint32_t val) override
 	{
+		write_delay();
 		Bitu port = PAGING_GetPhysicalAddress(addr) & 0xffff;
 		XGA_Write(port, val, io_width_t::dword);
 	}
 
 	uint8_t readb(PhysPt addr) override
 	{
+		read_delay();
 		Bitu port = PAGING_GetPhysicalAddress(addr) & 0xffff;
 		return XGA_Read(port, io_width_t::byte);
 	}
 
 	uint16_t readw(PhysPt addr) override
 	{
+		read_delay();
 		Bitu port = PAGING_GetPhysicalAddress(addr) & 0xffff;
 		return XGA_Read(port, io_width_t::word);
 	}
 
 	uint32_t readd(PhysPt addr) override
 	{
+		read_delay();
 		Bitu port = PAGING_GetPhysicalAddress(addr) & 0xffff;
 		return XGA_Read(port, io_width_t::dword);
 	}
@@ -1071,6 +1139,56 @@ static void VGA_Memory_ShutDown(Section * /*sec*/) {
 #endif
 }
 
+static uint32_t determine_vmem_delay_ns()
+{
+	const auto sect = static_cast<Section_prop*>(control->GetSection("dosbox"));
+	assert(sect);
+
+	const auto vmem_delay_str = sect->Get_string("vmem_delay");
+
+	constexpr auto MinDelayNs = 0;
+	constexpr auto MaxDelayNs = 20000;
+	constexpr auto OnDelayNs  = 3000;
+	constexpr auto OffDelayNs = 0;
+
+	auto set_setting_value = [](const std::string& val) {
+		auto* sect_updater = static_cast<Section_prop*>(
+		        control->GetSection("dosbox"));
+		assert(sect_updater);
+
+		sect_updater->Get_prop("vmem_delay")->SetValue(val);
+	};
+
+	if (const auto maybe_bool = parse_bool_setting(vmem_delay_str); maybe_bool) {
+		return *maybe_bool ? OnDelayNs : OffDelayNs;
+
+	} else {
+		// Try to parse it as a number
+		if (const auto maybe_int = parse_int(vmem_delay_str); maybe_int) {
+			const auto vmem_delay_ns = *maybe_int;
+
+			if (vmem_delay_ns < MinDelayNs || vmem_delay_ns > MaxDelayNs) {
+				LOG_ERR("VGA: Invalid 'vmem_delay' setting: %s; "
+				        "must be between %d and %d, using 'off'",
+				        vmem_delay_str.c_str(),
+				        MinDelayNs,
+				        MaxDelayNs);
+
+				set_setting_value("off");
+				return OffDelayNs;
+			} else {
+				return vmem_delay_ns;
+			}
+		} else {
+			LOG_ERR("VGA: Invalid 'vmem_delay' setting: '%s', using 'off'",
+			        vmem_delay_str.c_str());
+
+			set_setting_value("off");
+			return OffDelayNs;
+		}
+	}
+}
+
 void VGA_SetupMemory(Section* sec)
 {
 	vga.svga.bank_read = vga.svga.bank_write = 0;
@@ -1125,5 +1243,12 @@ void VGA_SetupMemory(Section* sec)
 		/* PCJr does not have dedicated graphics memory but uses
 		   conventional memory below 128k */
 		//TODO map?	
+	}
+
+	vga.vmem_delay_ns = determine_vmem_delay_ns();
+
+	if (vga.vmem_delay_ns > 0) {
+		LOG_MSG("VGA: Video memory I/O delay set to %u nanoseconds",
+		        vga.vmem_delay_ns);
 	}
 }


### PR DESCRIPTION
# Description

Inspired by [this comment](https://github.com/dosbox-staging/dosbox-staging/issues/2905#issuecomment-2049181149) by @MX9000, I attempted to port the `vmemdelay` tweak over from DOSBox-X which went surprisingly easily.

What's even better news, it solves the flickering graphics issues in _all_ problematic games that @Python-Exoproject raised! 🥳 These games don't flicker in Daum, so looks like we've managed to discover Daum's "secret ingredient" 😄 

This makes complete sense as these are early VGA or late EGA games so the developers must have assumed slow video memory I/O speeds and coded everything else around that. These games _do flicker_ on my S3 card in my Pentium MMX, which is not too surprising as the S3 cards are one of the fastest late DOS era SVGA boards.

The original DOSBox-X feature has some auto settings, but I dropped that because it didn't do much for me. It basically defaulted to 450 ns on VGA and EGA, and a bit above 3000 ns on CGA. As you can see from my tests, 3000 ns is the magic number that fixes all these games—go below that and the flicker comes gradually back, go above it, it slows down the emulation too much. So I just introduced an `on` setting that sets this to 3000 ns, which seemed reasonable.

As `vmem_delay` emulates the effects of the slow video memory I/O on the CPU (so it effectively throttles the CPU a bit when video memory I/O is happening), this could "even out" the emulation speed in games that run too fast in certain game segments. I saw someone mention that a `vmem_delay` of around 6000 fixes the speed issues in Wing Commander I, but testing that is an exercise for another day ([more info](https://www.vogons.org/viewtopic.php?t=89650)).

Lastly, as this is a very clean patch and an opt-in feature (it's disabled by default), I think it's worthwhile and completely safe to backport it. It increases compatibility with a fair number of games, and eXoDOS would benefit from it and thus further their adoption of Staging.

## Related issues

- https://github.com/dosbox-staging/dosbox-staging/issues/2950
- https://github.com/dosbox-staging/dosbox-staging/issues/2905
- https://github.com/dosbox-staging/dosbox-staging/issues/3244
- https://github.com/dosbox-staging/dosbox-staging/issues/3524

# Manual testing

Tested valid values, invalid values, `on`, `off`, and confirmed the defaulted value after an error is always synced back to `vmem_delay`.

Tested the following games and confirmed the flickering is completely gone with the below settings. Note that for some games `vmem_delay = on` alone is not enough; you also need to use a low enough `cycles` setting.

## Hostage Rescue Mission

```ini
[dosbox]
vmem_delay = on

[cpu]
cycles = 1500
```

## James Bond 007 - The Stealth Affair

VGA (not MCGA) and EGA are now working without flicker.

```ini
[dosbox]
vmem_delay = on

[cpu]
cycles = 3000
```

## Future Wars (floppy version)

The game needs a slow `cycles = 1000` setting as well to completely get rid of the flicker. This is not a problem as it runs at full speed even around 500 cycles (it was written in assembly, most likely).

```ini
[dosbox]
vmem_delay = on

[cpu]
cycles = 1000
```

## Gold of the Aztecs

```ini
[dosbox]
vmem_delay = on

[cpu]
cycles = 3000
```

## Quest for Glory 2

The vertical scrolling of the entire screen in the intro, which starts when the magic carpet leaves the top of the desert scene, is properly timed now (it is ultra-fast and barely noticeable without `vmem_delay`). 

```ini
[dosbox]
vmem_delay = on

[cpu]
cycles = 2400
```

## Corncob Deluxe

`vmemdelay = on` (= 3000) completely gets rid of the flicker in-game, but the credits scroller in the intro is a bit slow. A value of 2000 might be a good compromise at the expense of some in-game flicker.

```ini
[dosbox]
vmem_delay = on

[cpu]
cycles = 3000
```



# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

