### PR TITLE
Update English (en) translation for 0.81.1

### DIFF
--- a/contrib/resources/translations/en.lng
+++ b/contrib/resources/translations/en.lng
@@ -639,12 +639,24 @@ Video memory in MB (1-8) or KB (256 to 8192). 'auto' uses the default for
 the selected video adapter ('auto' by default). See the 'machine' setting for
 the list of valid options per adapter.
 .
+:CONFIG_VMEM_DELAY
+Set video memory I/O delay emulation ('off' by default).
+  off:      Disable video memory I/O delay emulation (default).
+            This is preferable for most games to avoid slowdowns.
+  on:       Enable I/O delay emulation (3000 ns). This can help reduce or
+            eliminate flicker in Hercules, CGA, EGA, and early VGA games.
+  <value>:  Set I/O delay in nanoseconds. Valid range is 0 to 20000 ns;
+            500 to 5000 ns is the most useful range.
+Note: Only set this on a per-game basis when necessary as it slows down the
+      whole emulator.
+.
 :CONFIG_DOS_RATE
-Customize the emulated video mode's frame rate, in Hz:
-  default:  The DOS video mode determines the rate (recommended; default).
+Customize the emulated video mode's frame rate.
+  default:  The DOS video mode determines the rate (default).
   host:     Match the DOS rate to the host rate (see 'host_rate' setting).
-  <value>:  Sets the rate to an exact value, between 24.000 and 1000.000 (Hz).
-We recommend the 'default' rate; otherwise test and set on a per-game basis.
+  <value>:  Sets the rate to an exact value in between 24.000 and 1000.000 Hz.
+Note: We recommend the 'default' rate, otherwise test and set on a per-game
+      basis.
 .
 :CONFIG_VESA_MODES
 Controls the selection of VESA 1.2 and 2.0 modes offered:
@@ -653,9 +665,9 @@ Controls the selection of VESA 1.2 and 2.0 modes offered:
                (default).
   halfline:    Supports the low-resolution halfline VESA 2.0 mode used by
                Extreme Assault. Use only if needed, as it's not S3 compatible.
-  all:         All modes for a given video memory size, however some games
-               may not use them properly (flickering) or may need
-               more system memory to use them.
+  all:         All modes for a given video memory size, however some games may
+               not use them properly (flickering) or may need more system
+               memory to use them.
 .
 :CONFIG_VGA_8DOT_FONT
 Use 8-pixel-wide fonts on VGA adapters (disabled by default).


### PR DESCRIPTION
# Description

A few more last-minute changes have been made to the language strings, so I'm giving translators a chance to update their translations for 0.81.1. Ideally, we'd like to release that in a week from now, so by about 20 Apr.

**Do note this is for the `release/0.81.x` branch, NOT `main`!**

We've made some more substantial changes to our language strings in `main`, so the course of action is:

- Raise PR against `release/0.81.x`
- Then forward-port your changes, so raise another PR against `main` (or you can do that later at the end of the 0.82.0 release cycle; up to you)

Pinging our translators who contributed to 0.81.0 (plus @Torinde):

@ftortoriello  @altiereslima  @FeralChild64  @farsil  @japsmits @Burrito78  @Torinde 


# Manual testing

N/A


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [ ] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

