### PR TITLE
Advance vcpkg baseline to upgrade to SDL 2.30.0

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -20,11 +20,5 @@
   "vcpkg-configuration": {
     "overlay-ports": ["./vcpkg-overlay"]
   },
-  "builtin-baseline": "80403036a665cb8fcc1a1b3e17593d20b03b2489",
-  "overrides": [
-    { 
-        "name": "sdl2", 
-        "version": "2.26.5"
-    }
-  ]  
+  "builtin-baseline": "ab231c2c666d2aa259a08e48e50dfeffb5c7fbe3"
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "dosbox-staging",
   "description": "DOSBox Staging is a modern continuation of DOSBox with advanced features and current development practices.",
-  "version": "0.81.0",
+  "version": "0.82.0-alpha",
   "dependencies": [
     "fluidsynth",
     "gtest",


### PR DESCRIPTION
# Description

Meson is still stuck at 2.28.5 but I guess it's just a matter of time until someone creates a wrap for 2.30.0 (someone who's not me 😏).

My view is the earlier we start testing 2.30.0 on Windows, the leading platform, the better. Plus we deliberately let the SDL2 versions diverge per platform as needed anyway.


# Manual testing

Built it in MSVC and started up Staging. vcpkg is a dream 😎 

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

