### PR TITLE
Avoid false positive warnings in translations

### DIFF
--- a/src/misc/messages.cpp
+++ b/src/misc/messages.cpp
@@ -122,13 +122,19 @@ static std::unordered_map<std::string, Message> messages;
 static std::deque<std::string> messages_order;
 
 // Add the message if it doesn't exist yet
-void MSG_Add(const char *name, const char *markup_msg)
+void MSG_Add(const char* name, const char* markup_msg)
 {
 	const auto pair = messages.try_emplace(name, markup_msg);
 	if (pair.second) { // if the insertion was successful
 		messages_order.emplace_back(name);
+	} else if ((control->GetLanguage() == "en" || control->GetLanguage().empty()) &&
+	           strcmp(pair.first->second.GetRaw(), markup_msg) != 0) {
+		// Detect duplicates in the English language
+		LOG_WARNING("LANG: Duplicate text added for message '%s'. Second instance is ignored.",
+		            name);
 	} else {
-		LOG_WARNING("LANG: Duplicate text added for message '%s'. Second instance is ignored.", name);
+		// Duplicate ID definitions most likely occured by adding the help in the code
+		// after it was added by a help-file.
 	}
 }
 


### PR DESCRIPTION
# Description

Avoid false positive warnings in translations, indicating a duplicate message.

Only check for duplicates in English, and report them only if the descriptive text differs.

Note that some code-paths indeed add the same translation ID multiple times, but as long as the text is the same, this is ignored. That's something for a future clean-up, I guess.

## Related issues

#3599 


# Manual testing

Ran DOSBox both with English and Dutch translations. No more messages occur. Also avoids the message when a command is executed.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

