### PR TITLE
Fix the width of VGA text modes being incorrectly set sometimes

### DIFF
--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -2661,8 +2661,6 @@ ImageInfo setup_drawing()
 
 		vga.draw.blocks = horiz_end;
 
-		video_mode.width = horiz_end * vga.draw.pixels_per_character;
-
 		double_width = vga.seq.clocking_mode.is_pixel_doubling &&
 		               vga.draw.pixel_doubling_allowed;
 
@@ -2670,6 +2668,7 @@ ImageInfo setup_drawing()
 			vga.draw.pixels_per_character = vga.seq.clocking_mode.is_eight_dot_mode
 			                                      ? PixelsPerChar::Eight
 			                                      : PixelsPerChar::Nine;
+
 			pixel_format = PixelFormat::BGRX32_ByteArray;
 
 			render_pixel_aspect_ratio = calc_pixel_aspect_from_timings(
@@ -2678,6 +2677,8 @@ ImageInfo setup_drawing()
 			// Text mode double scanning can only be done by setting
 			// the Double Scanning bit.
 			video_mode.is_double_scanned_mode = is_vga_scan_doubling_bit_set();
+
+			video_mode.width = horiz_end * vga.draw.pixels_per_character;
 
 			if (video_mode.is_double_scanned_mode) {
 				video_mode.height = vert_end / 2;
@@ -2699,6 +2700,7 @@ ImageInfo setup_drawing()
 		} else { // M_EGA
 			vga.draw.pixels_per_character = PixelsPerChar::Eight;
 
+			video_mode.width  = horiz_end * vga.draw.pixels_per_character;
 			video_mode.height = vert_end;
 
 			render_width  = video_mode.width;


### PR DESCRIPTION
# Description

142c329 caused a regression where the width calculation of the VGA text modes did not take 8 vs 9-dot VGA fonts into account correctly.

E.g., the 720x400 mode 03h VGA text mode with 9-dot fonts was incorrectly set to 640x400 with `glshader = none` or `sharp`.

`crt-auto` modes appeared to work fine, at least at startup. But this was by fluke and weird problems could happen after certain mode change sequences.

Thanks to @NicknineTheEagle for reporting the issue 🎖️ 🖖🏻 

## Related issues

- https://github.com/dosbox-staging/dosbox-staging/pull/3568

- https://github.com/dosbox-staging/dosbox-staging/issues/3536

# Manual testing

1. Started up Staging with the default config plus `glshader = crt-auto | crt-auto-arcade | none | sharp`.
2. Repeated 1 with `vga_8dot_font = on`.
3. Repeated 1 with `machine = ega`.
4. Repeated 1 with the game Indenture.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

