### PR TITLE
Avoid unnecessary new-lines

### DIFF
--- a/src/midi/midi.cpp
+++ b/src/midi/midi.cpp
@@ -784,7 +784,7 @@ void init_midi_dosbox_settings(Section_prop& secprop)
 	        "Configuration options for the selected MIDI interface (unset by default).\n"
 	        "This is usually the ID or name of the MIDI synthesizer you want\n"
 	        "to use (find the ID/name with the DOS command 'MIXER /LISTMIDI').\n"
-	        "Notes:\n");
+	        "Notes:");
 	str_prop->SetOptionHelp("fluidsynth_or_mt32emu",
 	                        "  - This option has no effect when using the built-in synthesizers\n"
 	                        "    ('mididevice = fluidsynth' or 'mididevice = mt32').");

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -310,7 +310,7 @@ std::string Property::GetHelp() const
 			help_text = format_str(help_text,
 			                       GetDefaultValue().ToString().c_str());
 		}
-		result.append(help_text).append("\n");
+		result.append(help_text);
 	}
 
 	const auto configitem_has_message = [this](const auto& value) {
@@ -322,6 +322,9 @@ std::string Property::GetHelp() const
 	                enabled_options.end(),
 	                configitem_has_message)) {
 		for (const auto& value : enabled_options) {
+			if (!result.empty()) {
+				result.append("\n");
+			}
 			if (iequals(value, propname) &&
 			    MSG_Exists(create_config_item_name(propname, {}).c_str())) {
 				result.append(MSG_Get(
@@ -330,7 +333,6 @@ std::string Property::GetHelp() const
 				result.append(MSG_Get(
 				        create_config_item_name(propname, value).c_str()));
 			}
-			result.append("\n");
 		}
 	}
 	if (result.empty()) {
@@ -350,7 +352,7 @@ std::string Property::GetHelpUtf8() const
 			help_text = format_str(help_text,
 			                       GetDefaultValue().ToString().c_str());
 		}
-		result.append(help_text).append("\n");
+		result.append(help_text);
 	}
 
 	const auto configitem_has_message = [this](const auto& value) {
@@ -362,6 +364,9 @@ std::string Property::GetHelpUtf8() const
 	                enabled_options.end(),
 	                configitem_has_message)) {
 		for (const auto& value : enabled_options) {
+			if (!result.empty()) {
+				result.append("\n");
+			}
 			if (iequals(value, propname) &&
 			    MSG_Exists(create_config_item_name(propname, {}).c_str())) {
 				result.append(MSG_GetRaw(
@@ -370,7 +375,6 @@ std::string Property::GetHelpUtf8() const
 				result.append(MSG_GetRaw(
 				        create_config_item_name(propname, value).c_str()));
 			}
-			result.append("\n");
 		}
 	}
 	if (result.empty()) {


### PR DESCRIPTION
# Description

Only add new-lines when there is already text available. This way, adding spacing to empty lines is avoided.

## Related issues

#3607 

# Manual testing

Generated configuration no longer contains unnecessary new-lines and spaces.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

