### PR TITLE
Do not treat illegal command line switches as commands

### DIFF
--- a/src/shell/autoexec.cpp
+++ b/src/shell/autoexec.cpp
@@ -339,8 +339,13 @@ AutoExecModule::AutoExecModule(Section* configuration)
 
 	unsigned int index = 1;
 	while (cmdline->FindCommand(index++, argument)) {
-		// Check if argument is a file/directory
+		if (argument.starts_with("-")) {
+			LOG_WARNING("CONFIG: Illegal command line switch '%s'",
+			            argument.c_str());
+			continue;
+		}
 
+		// Check if argument is a file/directory
 		std_fs::path path = argument;
 		bool is_directory = std_fs::is_directory(path);
 		if (!is_directory) {
@@ -357,7 +362,6 @@ AutoExecModule::AutoExecModule(Section* configuration)
 		path = argument;
 
 		// Retrieve file extension
-
 		auto extension_ucase = path.extension().string();
 		if (!extension_ucase.empty() && extension_ucase[0] == '.') {
 			extension_ucase = extension_ucase.substr(1);
@@ -365,7 +369,6 @@ AutoExecModule::AutoExecModule(Section* configuration)
 		upcase(extension_ucase);
 
 		// Check if argument is a batch file
-
 		if (extension_ucase == "BAT") {
 			ReMountDirAsDriveC(path.parent_path().string());
 			// BATch files are called else exit will not work
@@ -376,7 +379,6 @@ AutoExecModule::AutoExecModule(Section* configuration)
 		}
 
 		// Check if argument is a boot image file
-
 		if (extension_ucase == "IMG" || extension_ucase == "IMA") {
 			AddLine(Placement::CommandsAfterAutoexecSection,
 			        CmdBoot + Quote + argument + Quote);
@@ -386,7 +388,6 @@ AutoExecModule::AutoExecModule(Section* configuration)
 		}
 
 		// Check if argument is a CD image
-
 		if (extension_ucase == "ISO" || extension_ucase == "CUE") {
 			if (!cdrom_images.empty()) {
 				cdrom_images += " ";
@@ -396,7 +397,6 @@ AutoExecModule::AutoExecModule(Section* configuration)
 		}
 
 		// Consider argument as executable
-
 		ReMountDirAsDriveC(path.parent_path().string());
 		AddLine(Placement::CommandsAfterAutoexecSection,
 		        path.filename().string());


### PR DESCRIPTION
# Description

Unknown command line switches (like `-nomenu`, supported by DOSBox-X) are now logged and ignored - emulator does not try to execute them anymore.


## Related issues

Fixes https://github.com/dosbox-staging/dosbox-staging/issues/3616


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

