### PR TITLE
Config setting defaulting/syncing improvements & fixes

### DIFF
--- a/include/control.h
+++ b/include/control.h
@@ -125,7 +125,7 @@ public:
 		return sectionlist.end();
 	}
 
-	Section* GetSection(const std::string& section_name) const;
+	Section* GetSection(const std::string_view section_name) const;
 	Section* GetSectionFromProperty(const char* prop) const;
 
 	void OverwriteAutoexec(const std::string& conf, const std::string& line);

--- a/include/setup.h
+++ b/include/setup.h
@@ -406,7 +406,7 @@ public:
 	                                      const std::string& sep);
 
 	Property* Get_prop(int index);
-	Property* Get_prop(const std::string& propname);
+	Property* Get_prop(const std::string_view propname);
 
 	int Get_int(const std::string& _propname) const;
 

--- a/include/setup.h
+++ b/include/setup.h
@@ -45,6 +45,10 @@ std::optional<bool> parse_bool_setting(const std::string_view setting);
 bool has_true(const std::string_view setting);
 bool has_false(const std::string_view setting);
 
+void set_section_property_value(const std::string_view section_name,
+                                const std::string_view property_name,
+                                const std::string_view property_value);
+
 class Hex {
 private:
 	int value;

--- a/src/capture/image/image_capturer.cpp
+++ b/src/capture/image/image_capturer.cpp
@@ -26,6 +26,7 @@
 #include "std_filesystem.h"
 
 #include "checks.h"
+#include "setup.h"
 #include "string_utils.h"
 
 CHECK_NARROWING();
@@ -43,10 +44,16 @@ ImageCapturer::ImageCapturer(const std::string& grouped_mode_prefs)
 
 void ImageCapturer::ConfigureGroupedMode(const std::string& prefs)
 {
+	constexpr const char* DefaultSetting = "upscaled";
+
 	auto set_defaults = [&] {
 		grouped_mode.wants_raw      = false;
 		grouped_mode.wants_upscaled = true;
 		grouped_mode.wants_rendered = false;
+
+		set_section_property_value("capture",
+		                           "default_image_capture_formats",
+		                           DefaultSetting);
 	};
 
 	grouped_mode.wants_raw      = false;
@@ -55,15 +62,19 @@ void ImageCapturer::ConfigureGroupedMode(const std::string& prefs)
 
 	const auto formats = split_with_empties(prefs, ' ');
 	if (formats.size() == 0) {
-		LOG_WARNING("CAPTURE: 'default_image_capture_formats' not specified, "
-		            "using 'upscaled'");
+		LOG_WARNING(
+		        "CAPTURE: 'default_image_capture_formats' not specified, "
+		        "using '%s'",
+		        DefaultSetting);
 		set_defaults();
 		return;
 	}
 	if (formats.size() > 3) {
-		LOG_WARNING("CAPTURE: Invalid 'default_image_capture_formats' setting: '%s'. "
-		            "Must not contain more than 3 formats, using 'upscaled'.",
-		            prefs.c_str());
+		LOG_WARNING(
+		        "CAPTURE: Invalid 'default_image_capture_formats' setting: '%s'. "
+		        "Must not contain more than 3 formats, using '%s'.",
+		        prefs.c_str(),
+		        DefaultSetting);
 		set_defaults();
 		return;
 	}
@@ -76,10 +87,12 @@ void ImageCapturer::ConfigureGroupedMode(const std::string& prefs)
 		} else if (format == "rendered") {
 			grouped_mode.wants_rendered = true;
 		} else {
-			LOG_WARNING("CAPTURE: Invalid 'default_image_capture_formats' setting: '%s'. "
-			            "Valid formats are 'raw', 'upscaled', and 'rendered'; "
-			            "using 'upscaled'.",
-			            format.c_str());
+			LOG_WARNING(
+			        "CAPTURE: Invalid 'default_image_capture_formats' setting: '%s'. "
+			        "Valid formats are 'raw', 'upscaled', and 'rendered'; "
+			        "using '%s'.",
+			        format.c_str(),
+			        DefaultSetting);
 			set_defaults();
 			return;
 		}

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -1292,9 +1292,7 @@ void RENDER_AddConfigSection(const config_ptr_t& conf)
 
 void RENDER_SyncMonochromePaletteSetting(const enum MonochromePalette palette)
 {
-	const auto string_prop = get_render_section()->GetStringProp(
-	        "monochrome_palette");
-	string_prop->SetValue(to_string(palette));
+	set_section_property_value("render", "monochrome_palette", to_string(palette));
 }
 
 static bool handle_shader_changes()

--- a/src/gui/titlebar.cpp
+++ b/src/gui/titlebar.cpp
@@ -603,11 +603,7 @@ static void sync_config()
 		}
 	}
 
-	assert(control);
-	auto section = static_cast<Section_prop*>(control->GetSection("sdl"));
-	assert(section);
-	const auto string_prop = section->GetStringProp("window_titlebar");
-	string_prop->SetValue(setting_str);
+	set_section_property_value("sdl", "window_titlebar", setting_str);
 }
 
 static void parse_config(const std::string& new_setting_str)
@@ -725,7 +721,7 @@ static void parse_config(const std::string& new_setting_str)
 			continue;
 		}
 
-		LOG_WARNING("SDL: Invalid 'window_titlebar' setting '%s', ignoring",
+		LOG_WARNING("SDL: Invalid 'window_titlebar' setting: '%s', ignoring",
 		            setting_str.c_str());
 		config_needs_sync = true;
 	}

--- a/src/hardware/gameblaster.cpp
+++ b/src/hardware/gameblaster.cpp
@@ -96,22 +96,27 @@ void GameBlaster::Open(const int port_choice, const std::string &card_choice,
 	// The filter parameters have been tweaked by analysing real hardware
 	// recordings. The results are virtually indistinguishable from the
 	// real thing by ear only.
-	const auto filter_choice_has_bool = parse_bool_setting(filter_choice);
-	if (filter_choice_has_bool && *filter_choice_has_bool == true) {
-		constexpr auto order          = 1;
-		constexpr auto cutoff_freq_hz = 6000;
-		channel->ConfigureLowPassFilter(order, cutoff_freq_hz);
+	//
+	auto enable_filter = [&]() {
+		constexpr auto Order        = 1;
+		constexpr auto CutoffFreqHz = 6000;
+
+		channel->ConfigureLowPassFilter(Order, CutoffFreqHz);
 		channel->SetLowPassFilter(FilterState::On);
+	};
 
-	} else if (!channel->TryParseAndSetCustomFilter(filter_choice)) {
-		if (!filter_choice_has_bool) {
-			LOG_WARNING("CMS: Invalid 'cms_filter' setting: '%s', using 'off'",
-			            filter_choice.c_str());
-
-			set_section_property_value("sblaster", "cms_filter", "off");
+	if (const auto maybe_bool = parse_bool_setting(filter_choice)) {
+		if (*maybe_bool) {
+			enable_filter();
+		} else {
+			channel->SetLowPassFilter(FilterState::Off);
 		}
+	} else if (!channel->TryParseAndSetCustomFilter(filter_choice)) {
+		LOG_WARNING("CMS: Invalid 'cms_filter' setting: '%s', using 'on'",
+		            filter_choice.c_str());
 
-		channel->SetLowPassFilter(FilterState::Off);
+		set_section_property_value("sblaster", "cms_filter", "on");
+		enable_filter();
 	}
 
 	// Calculate rates and ratio based on the mixer's rate

--- a/src/hardware/gameblaster.cpp
+++ b/src/hardware/gameblaster.cpp
@@ -107,6 +107,8 @@ void GameBlaster::Open(const int port_choice, const std::string &card_choice,
 		if (!filter_choice_has_bool) {
 			LOG_WARNING("CMS: Invalid 'cms_filter' setting: '%s', using 'off'",
 			            filter_choice.c_str());
+
+			set_section_property_value("sblaster", "cms_filter", "off");
 		}
 
 		channel->SetLowPassFilter(FilterState::Off);

--- a/src/hardware/gameblaster.cpp
+++ b/src/hardware/gameblaster.cpp
@@ -113,14 +113,14 @@ void GameBlaster::Open(const int port_choice, const std::string &card_choice,
 	}
 
 	// Calculate rates and ratio based on the mixer's rate
-	const auto frame_rate_hz = channel->GetSampleRate();
+	const auto sample_rate_hz = channel->GetSampleRate();
 
 	// Set up the resampler to convert from the render rate to the mixer's
 	// frame rate
-	const auto max_rate_hz = std::max(frame_rate_hz * 0.9 / 2, 8000.0);
+	const auto max_rate_hz = std::max(sample_rate_hz * 0.9 / 2, 8000.0);
 	for (auto& r : resamplers) {
 		r.reset(reSIDfp::TwoPassSincResampler::create(render_rate_hz,
-		                                              frame_rate_hz,
+		                                              sample_rate_hz,
 		                                              max_rate_hz));
 	}
 

--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -291,7 +291,7 @@ private:
 	// Playback related
 	double last_rendered_ms = 0.0;
 	double ms_per_render    = 0.0;
-	int frame_rate_hz       = 0;
+	uint16_t sample_rate_hz = 0;
 
 	uint8_t &adlib_command_reg = adlib_commandreg;
 
@@ -665,11 +665,12 @@ void Gus::ActivateVoices(uint8_t requested_voices)
 		// Gravis' calculation to convert from number of active voices
 		// to playback frame rate. Ref: UltraSound Lowlevel ToolKit
 		// v2.22 (21 December 1994), pp. 3 of 113.
-		frame_rate_hz = static_cast<int>(1000000.0 /
-		                                 (1.619695497 * active_voices));
-		ms_per_render = millis_in_second / frame_rate_hz;
+		sample_rate_hz = static_cast<uint16_t>(
+		        1000000.0 / (1.619695497 * active_voices));
 
-		audio_channel->SetSampleRate(frame_rate_hz);
+		ms_per_render = millis_in_second / sample_rate_hz;
+
+		audio_channel->SetSampleRate(sample_rate_hz);
 	}
 }
 
@@ -757,11 +758,17 @@ void Gus::BeginPlayback()
 {
 	dac_enabled = ((register_data & 0x200) != 0);
 	irq_enabled = ((register_data & 0x400) != 0);
+
 	audio_channel->Enable(true);
+
 	if (prev_logged_voices != active_voices) {
-		LOG_MSG("GUS: Activated %u voices at %d Hz", active_voices, frame_rate_hz);
+		LOG_MSG("GUS: Activated %u voices at %d Hz",
+		        active_voices,
+		        sample_rate_hz);
+
 		prev_logged_voices = active_voices;
 	}
+
 	is_running = true;
 }
 

--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -640,6 +640,8 @@ Gus::Gus(const io_port_t port_pref, const uint8_t dma_pref, const uint8_t irq_pr
 
 		audio_channel->SetHighPassFilter(FilterState::Off);
 		audio_channel->SetLowPassFilter(FilterState::Off);
+
+		set_section_property_value("gus", "gus_filter", "off");
 	}
 
 	ms_per_render = millis_in_second / audio_channel->GetSampleRate();

--- a/src/hardware/imfc.cpp
+++ b/src/hardware/imfc.cpp
@@ -3168,7 +3168,6 @@ private:
 	std::queue<AudioFrame> fifo   = {};
 	double last_rendered_ms       = 0.0;
 	double ms_per_render          = 0.0;
-	int frame_rate_hz             = 0;
 
 	int tl_tab[TL_TAB_LEN]{};
 	unsigned int sin_tab[SIN_LEN]{};

--- a/src/hardware/imfc.cpp
+++ b/src/hardware/imfc.cpp
@@ -13419,6 +13419,8 @@ static void imfc_init(Section* sec)
 		}
 
 		channel->SetLowPassFilter(FilterState::Off);
+
+		set_section_property_value("imfc", "imfc_filter", "off");
 	}
 
 	const auto port = static_cast<io_port_t>(conf->Get_hex("imfc_base"));

--- a/src/hardware/imfc.cpp
+++ b/src/hardware/imfc.cpp
@@ -13403,24 +13403,29 @@ static void imfc_init(Section* sec)
 	// https://www.youtube.com/watch?v=WHVWDi15AIw. The results are
 	// virtually indistinguishable from the real thing by ear and spectrum
 	// analysis.
-	const std::string filter_choice = conf->Get_string("imfc_filter");
-	const auto filter_choice_has_bool = parse_bool_setting(filter_choice);
+	//
+	auto enable_filter = [&]() {
+		constexpr auto Order        = 2;
+		constexpr auto CutoffFreqHz = 3500;
 
-	if (filter_choice_has_bool && *filter_choice_has_bool == true) {
-		constexpr auto order          = 2;
-		constexpr auto cutoff_freq_hz = 3500;
-		channel->ConfigureLowPassFilter(order, cutoff_freq_hz);
+		channel->ConfigureLowPassFilter(Order, CutoffFreqHz);
 		channel->SetLowPassFilter(FilterState::On);
+	};
 
-	} else if (!channel->TryParseAndSetCustomFilter(filter_choice)) {
-		if (!filter_choice_has_bool) {
-			LOG_WARNING("IMFC: Invalid 'imfc_filter' setting: '%s', using 'off'",
-			            filter_choice.c_str());
+	const std::string filter_choice = conf->Get_string("imfc_filter");
+
+	if (const auto maybe_bool = parse_bool_setting(filter_choice)) {
+		if (*maybe_bool) {
+			enable_filter();
+		} else {
+			channel->SetLowPassFilter(FilterState::Off);
 		}
+	} else if (!channel->TryParseAndSetCustomFilter(filter_choice)) {
+		LOG_WARNING("IMFC: Invalid 'imfc_filter' setting: '%s', using 'on'",
+		            filter_choice.c_str());
 
-		channel->SetLowPassFilter(FilterState::Off);
-
-		set_section_property_value("imfc", "imfc_filter", "off");
+		set_section_property_value("imfc", "imfc_filter", "on");
+		enable_filter();
 	}
 
 	const auto port = static_cast<io_port_t>(conf->Get_hex("imfc_base"));

--- a/src/hardware/innovation.cpp
+++ b/src/hardware/innovation.cpp
@@ -101,15 +101,15 @@ void Innovation::Open(const std::string_view model_choice,
 		mixer_channel->SetLowPassFilter(FilterState::Off);
 	}
 
-	const auto frame_rate_hz = mixer_channel->GetSampleRate();
+	const auto sample_rate_hz = mixer_channel->GetSampleRate();
 
 	// Determine the passband frequency, which is capped at 90% of Nyquist.
-	const double passband = 0.9 * frame_rate_hz / 2;
+	const double passband = 0.9 * sample_rate_hz / 2;
 
 	// Assign the sampling parameters
 	sid_service->setSamplingParameters(chip_clock,
 	                                   reSIDfp::RESAMPLE,
-	                                   frame_rate_hz,
+	                                   sample_rate_hz,
 	                                   passband);
 
 	// Setup and assign the port address

--- a/src/hardware/innovation.cpp
+++ b/src/hardware/innovation.cpp
@@ -99,6 +99,8 @@ void Innovation::Open(const std::string_view model_choice,
 
 		mixer_channel->SetHighPassFilter(FilterState::Off);
 		mixer_channel->SetLowPassFilter(FilterState::Off);
+
+		set_section_property_value("innovation", "innovation_filter", "off");
 	}
 
 	const auto sample_rate_hz = mixer_channel->GetSampleRate();

--- a/src/hardware/input/mouse_config.cpp
+++ b/src/hardware/input/mouse_config.cpp
@@ -160,6 +160,17 @@ static void SetSensitivity(const std::string_view sensitivity_str)
 	const auto& user_default = mouse_predefined.sensitivity_user_default;
 	const auto default_value = coeff * user_default;
 
+	auto set_mouse_sensitivity_setting = [](const int value) {
+		set_section_property_value("mouse",
+		                           "mouse_sensitivity",
+		                           format_str("%d", value));
+	};
+	auto set_mouse_sensitivity_settings = [](const int val_x, const int val_y) {
+		set_section_property_value("mouse",
+		                           "mouse_sensitivity",
+		                           format_str("%d %d", val_x, val_y));
+	};
+
 	// Split input string into values
 	auto values_str = split(sensitivity_str, " \t,;");
 	if (values_str.size() > 2) {
@@ -167,6 +178,8 @@ static void SetSensitivity(const std::string_view sensitivity_str)
 		            user_default);
 		mouse_config.sensitivity_coeff_x = default_value;
 		mouse_config.sensitivity_coeff_y = default_value;
+
+		set_mouse_sensitivity_setting(user_default);
 		return;
 	}
 
@@ -174,6 +187,8 @@ static void SetSensitivity(const std::string_view sensitivity_str)
 	if (values_str.empty()) {
 		mouse_config.sensitivity_coeff_x = default_value;
 		mouse_config.sensitivity_coeff_y = default_value;
+
+		set_mouse_sensitivity_setting(user_default);
 		return;
 	}
 
@@ -183,6 +198,7 @@ static void SetSensitivity(const std::string_view sensitivity_str)
 	bool out_of_range   = false;
 	const int value_min = -mouse_predefined.sensitivity_user_max;
 	const int value_max = mouse_predefined.sensitivity_user_max;
+
 	for (auto& value_str : values_str) {
 		// Remove trailing '%' signs, if present
 		if (value_str.ends_with('%')) {
@@ -192,9 +208,12 @@ static void SetSensitivity(const std::string_view sensitivity_str)
 		const auto value = parse_int(value_str);
 		if (!value) {
 			LOG_WARNING("MOUSE: Invalid 'mouse_sensitivity' setting: '%s', using '%d'",
-			            value_str.c_str(), user_default);
+			            value_str.c_str(),
+			            user_default);
 			mouse_config.sensitivity_coeff_x = default_value;
 			mouse_config.sensitivity_coeff_y = default_value;
+
+			set_mouse_sensitivity_setting(user_default);
 			return;
 		}
 
@@ -213,13 +232,18 @@ static void SetSensitivity(const std::string_view sensitivity_str)
 
 	// Set the actual values
 	assert(values_int.size() == 1 || values_int.size() == 2);
-	const auto value_float_0 = static_cast<float>(values_int[0]);
+	const auto value_float_0         = static_cast<float>(values_int[0]);
 	mouse_config.sensitivity_coeff_x = coeff * value_float_0;
+
 	if (values_int.size() == 2) {
 		const auto value_float_1 = static_cast<float>(values_int[1]);
 		mouse_config.sensitivity_coeff_y = coeff * value_float_1;
+
+		set_mouse_sensitivity_settings(values_int[0], values_int[1]);
 	} else {
 		mouse_config.sensitivity_coeff_y = mouse_config.sensitivity_coeff_x;
+
+		set_mouse_sensitivity_setting(values_int[0]);
 	}
 
 	return;

--- a/src/hardware/lpt_dac.cpp
+++ b/src/hardware/lpt_dac.cpp
@@ -145,7 +145,7 @@ void LPT_DAC_ShutDown([[maybe_unused]] Section *sec)
 	lpt_dac.reset();
 }
 
-void LPT_DAC_Init(Section *section)
+void LPT_DAC_Init(Section* section)
 {
 	assert(section);
 
@@ -154,17 +154,17 @@ void LPT_DAC_Init(Section *section)
 
 	// Get the user's LPT DAC choices
 	assert(section);
-	const auto prop = static_cast<Section_prop *>(section);
+	const auto prop = static_cast<Section_prop*>(section);
 
 	const std::string dac_choice = prop->Get_string("lpt_dac");
 
-	if (dac_choice == "disney")
+	if (dac_choice == "disney") {
 		lpt_dac = std::make_unique<Disney>();
-	else if (dac_choice == "covox")
+	} else if (dac_choice == "covox") {
 		lpt_dac = std::make_unique<Covox>();
-	else if (dac_choice == "ston1")
+	} else if (dac_choice == "ston1") {
 		lpt_dac = std::make_unique<StereoOn1>();
-	else {
+	} else {
 		// The remaining setting is to turn the LPT DAC off
 		const auto dac_choice_has_bool = parse_bool_setting(dac_choice);
 		if (!dac_choice_has_bool || *dac_choice_has_bool != false) {
@@ -177,22 +177,20 @@ void LPT_DAC_Init(Section *section)
 	// Let the DAC apply its own filter type
 	const std::string filter_choice = prop->Get_string("lpt_dac_filter");
 	assert(lpt_dac);
+
 	if (!lpt_dac->TryParseAndSetCustomFilter(filter_choice)) {
-		auto filter_state = FilterState::Off;
-		const auto filter_choice_has_bool = parse_bool_setting(filter_choice);
-
-		if (filter_choice_has_bool) {
-			filter_state = *filter_choice_has_bool ? FilterState::On
-			                                       : FilterState::Off;
+		if (const auto maybe_bool = parse_bool_setting(filter_choice)) {
+			lpt_dac->ConfigureFilters(*maybe_bool ? FilterState::On
+			                                      : FilterState::Off);
 		} else {
-			LOG_WARNING("LPT_DAC: Invalid 'lpt_dac_filter' setting: '%s', using 'off'",
-			            filter_choice.c_str());
-			assert(filter_state == FilterState::Off);
+			LOG_WARNING(
+			        "LPT_DAC: Invalid 'lpt_dac_filter' setting: '%s', "
+			        "using 'on'",
+			        filter_choice.c_str());
 
-			set_section_property_value("speaker", "lpt_dac_filter", "off");
+			set_section_property_value("speaker", "lpt_dac_filter", "on");
+			lpt_dac->ConfigureFilters(FilterState::On);
 		}
-
-		lpt_dac->ConfigureFilters(filter_state);
 	}
 
 	lpt_dac->BindToPort(Lpt1Port);

--- a/src/hardware/lpt_dac.cpp
+++ b/src/hardware/lpt_dac.cpp
@@ -188,6 +188,8 @@ void LPT_DAC_Init(Section *section)
 			LOG_WARNING("LPT_DAC: Invalid 'lpt_dac_filter' setting: '%s', using 'off'",
 			            filter_choice.c_str());
 			assert(filter_state == FilterState::Off);
+
+			set_section_property_value("speaker", "lpt_dac_filter", "off");
 		}
 
 		lpt_dac->ConfigureFilters(filter_state);

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -1752,7 +1752,7 @@ bool MixerChannel::Sleeper::ConfigureFadeOut(const std::string& prefs)
 	LOG_WARNING("%s: Invalid custom fade-out definition: '%s'. Must be "
 	            "specified in \"WAIT FADE\" format where WAIT is between "
 	            "%d and %d (in milliseconds) and FADE is between %d and "
-	            "%d (in milliseconds). Using 'off'",
+	            "%d (in milliseconds); using 'off'.",
 	            channel.GetName().c_str(),
 	            prefs.c_str(),
 	            min_wait_ms,

--- a/src/hardware/opl.cpp
+++ b/src/hardware/opl.cpp
@@ -1058,7 +1058,9 @@ OPL::OPL(Section* configuration, const OplMode oplmode)
 	channel->Set0dbScalar(opl_volume_scale_factor);
 
 	// Setup fadeout
-	channel->ConfigureFadeOut(section->Get_string("opl_fadeout"));
+	if (!channel->ConfigureFadeOut(section->Get_string("opl_fadeout"))) {
+		set_section_property_value("sblaster", "opl_fadeout", "off");
+	}
 
 	ctrl.wants_dc_bias_removed = section->Get_bool("opl_remove_dc_bias");
 	if (ctrl.wants_dc_bias_removed) {

--- a/src/hardware/pcspeaker.cpp
+++ b/src/hardware/pcspeaker.cpp
@@ -47,33 +47,35 @@ void PCSPEAKER_Init(Section *section)
 
 	if (model_choice_has_bool && *model_choice_has_bool == false) {
 		return;
+
 	} else if (model_choice == "discrete") {
 		pc_speaker = std::make_unique<PcSpeakerDiscrete>();
+
 	} else if (model_choice == "impulse") {
 		pc_speaker = std::make_unique<PcSpeakerImpulse>();
+
 	} else {
 		LOG_ERR("PCSPEAKER: Invalid PC Speaker model: %s",
 		        model_choice.c_str());
 		return;
 	}
+	assert(pc_speaker);
 
 	// Get the user's filering choice
 	const std::string filter_choice = prop->Get_string("pcspeaker_filter");
 
-	assert(pc_speaker);
-
 	if (!pc_speaker->TryParseAndSetCustomFilter(filter_choice)) {
-		const auto filter_choice_has_bool = parse_bool_setting(filter_choice);
-		if (filter_choice_has_bool) {
-			if (*filter_choice_has_bool) {
-				pc_speaker->SetFilterState(FilterState::On);
-			}
+		if (const auto maybe_bool = parse_bool_setting(filter_choice)) {
+			pc_speaker->SetFilterState(*maybe_bool ? FilterState::On
+			                                       : FilterState::Off);
 		} else {
-			LOG_WARNING("PCSPEAKER: Invalid 'pcspeaker_filter' setting: '%s', using 'off'",
-			            filter_choice.c_str());
-			pc_speaker->SetFilterState(FilterState::Off);
+			LOG_WARNING(
+			        "PCSPEAKER: Invalid 'pcspeaker_filter' setting: '%s', "
+			        "using 'on'",
+			        filter_choice.c_str());
 
-			set_section_property_value("speaker", "pcspeaker_filter", "off");
+			pc_speaker->SetFilterState(FilterState::On);
+			set_section_property_value("speaker", "pcspeaker_filter", "on");
 		}
 	}
 

--- a/src/hardware/pcspeaker.cpp
+++ b/src/hardware/pcspeaker.cpp
@@ -72,6 +72,8 @@ void PCSPEAKER_Init(Section *section)
 			LOG_WARNING("PCSPEAKER: Invalid 'pcspeaker_filter' setting: '%s', using 'off'",
 			            filter_choice.c_str());
 			pc_speaker->SetFilterState(FilterState::Off);
+
+			set_section_property_value("speaker", "pcspeaker_filter", "off");
 		}
 	}
 

--- a/src/hardware/ps1audio.cpp
+++ b/src/hardware/ps1audio.cpp
@@ -107,17 +107,22 @@ private:
 	bool can_trigger_irq = false;
 };
 
-static void setup_filter(mixer_channel_t& channel)
+static void setup_filter(mixer_channel_t& channel, const bool filter_enabled)
 {
-	constexpr auto hp_order          = 3;
-	constexpr auto hp_cutoff_freq_hz = 160;
-	channel->ConfigureHighPassFilter(hp_order, hp_cutoff_freq_hz);
-	channel->SetHighPassFilter(FilterState::On);
+	if (filter_enabled) {
+		constexpr auto HpfOrder        = 3;
+		constexpr auto HpfCutoffFreqHz = 160;
+		channel->ConfigureHighPassFilter(HpfOrder, HpfCutoffFreqHz);
+		channel->SetHighPassFilter(FilterState::On);
 
-	constexpr auto lp_order          = 1;
-	constexpr auto lp_cutoff_freq_hz = 2100;
-	channel->ConfigureLowPassFilter(lp_order, lp_cutoff_freq_hz);
-	channel->SetLowPassFilter(FilterState::On);
+		constexpr auto LpfOrder        = 1;
+		constexpr auto LpfCutoffFreqHz = 2100;
+		channel->ConfigureLowPassFilter(LpfOrder, LpfCutoffFreqHz);
+		channel->SetLowPassFilter(FilterState::On);
+	} else {
+		channel->SetHighPassFilter(FilterState::Off);
+		channel->SetLowPassFilter(FilterState::Off);
+	}
 }
 
 Ps1Dac::Ps1Dac(const std::string& filter_choice)
@@ -134,26 +139,24 @@ Ps1Dac::Ps1Dac(const std::string& filter_choice)
 	                            ChannelFeature::ChorusSend,
 	                            ChannelFeature::DigitalAudio});
 
-	// Setup filters
-	const auto filter_choice_has_bool = parse_bool_setting(filter_choice);
-
-	if (filter_choice_has_bool && *filter_choice_has_bool == true) {
+	// Setup DAC filters
+	if (const auto maybe_bool = parse_bool_setting(filter_choice)) {
 		// Using the same filter settings for the DAC as for the PSG
 		// synth. It's unclear whether this is accurate, but in any
 		// case, the filters do a good approximation of how a small
 		// integrated speaker would sound.
-		setup_filter(channel);
+		const auto filter_enabled = *maybe_bool;
+		setup_filter(channel, filter_enabled);
 
 	} else if (!channel->TryParseAndSetCustomFilter(filter_choice)) {
-		if (!filter_choice_has_bool) {
-			LOG_WARNING("PS1DAC: Invalid 'ps1audio_dac_filter' setting: '%s', using 'off'",
-			            filter_choice.c_str());
-		}
+		LOG_WARNING(
+		        "PS1DAC: Invalid 'ps1audio_dac_filter' setting: '%s', "
+		        "using 'on'",
+		        filter_choice.c_str());
 
-		channel->SetHighPassFilter(FilterState::Off);
-		channel->SetLowPassFilter(FilterState::Off);
-
-		set_section_property_value("speaker", "ps1audio_dac_filter", "off");
+		const auto filter_enabled = true;
+		setup_filter(channel, filter_enabled);
+		set_section_property_value("speaker", "ps1audio_dac_filter", "on");
 	}
 
 	// Register DAC per-port read handlers
@@ -427,25 +430,23 @@ Ps1Synth::Ps1Synth(const std::string& filter_choice)
 	                            ChannelFeature::ChorusSend,
 	                            ChannelFeature::Synthesizer});
 
-	// Setup filters
-	const auto filter_choice_has_bool = parse_bool_setting(filter_choice);
-
-	if (filter_choice_has_bool && *filter_choice_has_bool == true) {
+	// Setup PSG filters
+	if (const auto maybe_bool = parse_bool_setting(filter_choice)) {
 		// The filter parameters have been tweaked by analysing real
 		// hardware recordings. The results are virtually
 		// indistinguishable from the real thing by ear only.
-		setup_filter(channel);
+		const auto filter_enabled = *maybe_bool;
+		setup_filter(channel, filter_enabled);
 
 	} else if (!channel->TryParseAndSetCustomFilter(filter_choice)) {
-		if (!filter_choice_has_bool) {
-			LOG_WARNING("PS1: Invalid 'ps1audio_filter' setting: '%s', using 'off'",
-			            filter_choice.c_str());
-		}
+		LOG_WARNING(
+		        "PS1: Invalid 'ps1audio_filter' setting: '%s', "
+		        "using 'on'",
+		        filter_choice.c_str());
 
-		channel->SetHighPassFilter(FilterState::Off);
-		channel->SetLowPassFilter(FilterState::Off);
-
-		set_section_property_value("speaker", "ps1audio_filter", "off");
+		const auto filter_enabled = true;
+		setup_filter(channel, filter_enabled);
+		set_section_property_value("speaker", "ps1audio_filter", "on");
 	}
 
 	// Setup the resampler

--- a/src/hardware/ps1audio.cpp
+++ b/src/hardware/ps1audio.cpp
@@ -152,6 +152,8 @@ Ps1Dac::Ps1Dac(const std::string& filter_choice)
 
 		channel->SetHighPassFilter(FilterState::Off);
 		channel->SetLowPassFilter(FilterState::Off);
+
+		set_section_property_value("speaker", "ps1audio_dac_filter", "off");
 	}
 
 	// Register DAC per-port read handlers
@@ -442,6 +444,8 @@ Ps1Synth::Ps1Synth(const std::string& filter_choice)
 
 		channel->SetHighPassFilter(FilterState::Off);
 		channel->SetLowPassFilter(FilterState::Off);
+
+		set_section_property_value("speaker", "ps1audio_filter", "off");
 	}
 
 	// Setup the resampler

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -507,6 +507,8 @@ static void configure_sb_filter_for_model(mixer_channel_t channel,
 
 		channel->SetHighPassFilter(FilterState::Off);
 		channel->SetLowPassFilter(FilterState::Off);
+
+		set_section_property_value("sblaster", "sb_filter", "off");
 		return;
 	}
 
@@ -599,6 +601,8 @@ static void configure_opl_filter_for_model(mixer_channel_t opl_channel,
 
 		opl_channel->SetHighPassFilter(FilterState::Off);
 		opl_channel->SetLowPassFilter(FilterState::Off);
+
+		set_section_property_value("sblaster", "opl_filter", "off");
 		return;
 	}
 

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -601,10 +601,13 @@ static void configure_opl_filter_for_model(mixer_channel_t opl_channel,
 
 			set_section_property_value("sblaster", "opl_filter", "auto");
 
-			const auto filter_type = determine_filter_type("auto",
-			                                               sb_type);
-			assert(filter_type);
-			return *filter_type;
+			if (const auto filter_type = determine_filter_type("auto", sb_type);
+			    filter_type) {
+				return *filter_type;
+			} else {
+				assert(false);
+				return FilterType::None;
+			}
 		}
 	}();
 

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -498,21 +498,21 @@ static void configure_sb_filter_for_model(mixer_channel_t channel,
 		config.zoh_rate_hz = NativeDacRateHz;
 	};
 
-	const auto filter_type = determine_filter_type(filter_choice, sb_type);
+	const auto filter_type = [&]() {
+		if (const auto maybe_filter_type = determine_filter_type(filter_choice,
+		                                                         sb_type)) {
+			return *maybe_filter_type;
+		} else {
+			LOG_WARNING("%s: Invalid 'sb_filter' setting: '%s', using 'modern'",
+			            sb_log_prefix(),
+			            filter_choice.c_str());
 
-	if (!filter_type) {
-		LOG_WARNING("%s: Invalid 'sb_filter' setting: '%s', using 'off'",
-		            sb_log_prefix(),
-		            filter_choice.c_str());
+			set_section_property_value("sblaster", "sb_filter", "modern");
+			return FilterType::Modern;
+		}
+	}();
 
-		channel->SetHighPassFilter(FilterState::Off);
-		channel->SetLowPassFilter(FilterState::Off);
-
-		set_section_property_value("sblaster", "sb_filter", "off");
-		return;
-	}
-
-	switch (*filter_type) {
+	switch (filter_type) {
 	case FilterType::None: enable_zoh_upsampler(); break;
 
 	case FilterType::SB1:
@@ -547,7 +547,7 @@ static void configure_sb_filter_for_model(mixer_channel_t channel,
 	}
 
 	constexpr auto OutputType = "DAC";
-	log_filter_config(sb_log_prefix(), OutputType, *filter_type);
+	log_filter_config(sb_log_prefix(), OutputType, filter_type);
 	set_filter(channel, config);
 }
 

--- a/src/hardware/tandy_sound.cpp
+++ b/src/hardware/tandy_sound.cpp
@@ -226,6 +226,8 @@ TandyDAC::TandyDAC(const ConfigProfile config_profile,
 
 		channel->SetHighPassFilter(FilterState::Off);
 		channel->SetLowPassFilter(FilterState::Off);
+
+		set_section_property_value("speaker", "tandy_dac_filter", "off");
 	}
 
 	// Register DAC per-port read handlers
@@ -497,6 +499,8 @@ TandyPSG::TandyPSG(const ConfigProfile config_profile, const bool is_dac_enabled
 
 		channel->SetHighPassFilter(FilterState::Off);
 		channel->SetLowPassFilter(FilterState::Off);
+
+		set_section_property_value("speaker", "tandy_filter", "off");
 	}
 
 	// Setup the resampler

--- a/src/hardware/tandy_sound.cpp
+++ b/src/hardware/tandy_sound.cpp
@@ -486,7 +486,9 @@ TandyPSG::TandyPSG(const ConfigProfile config_profile, const bool is_dac_enabled
 	                            ChannelFeature::Synthesizer});
 
 	// Setup fadeout
-	channel->ConfigureFadeOut(fadeout_choice);
+	if (!channel->ConfigureFadeOut(fadeout_choice)) {
+		set_section_property_value("speaker", "tandy_fadeout", "off");
+	}
 
 	// Set up PSG filters
 	if (const auto maybe_bool = parse_bool_setting(filter_choice)) {

--- a/src/hardware/vga_memory.cpp
+++ b/src/hardware/vga_memory.cpp
@@ -1151,20 +1151,16 @@ static uint32_t determine_vmem_delay_ns()
 	constexpr auto OnDelayNs  = 3000;
 	constexpr auto OffDelayNs = 0;
 
-	auto set_setting_value = [](const std::string& val) {
-		auto* sect_updater = static_cast<Section_prop*>(
-		        control->GetSection("dosbox"));
-		assert(sect_updater);
-
-		sect_updater->Get_prop("vmem_delay")->SetValue(val);
+	auto set_default_vmem_delay_setting = []() {
+		set_section_property_value("dosbox", "vmem_delay", "off");
 	};
 
-	if (const auto maybe_bool = parse_bool_setting(vmem_delay_str); maybe_bool) {
+	if (const auto maybe_bool = parse_bool_setting(vmem_delay_str)) {
 		return *maybe_bool ? OnDelayNs : OffDelayNs;
 
 	} else {
 		// Try to parse it as a number
-		if (const auto maybe_int = parse_int(vmem_delay_str); maybe_int) {
+		if (const auto maybe_int = parse_int(vmem_delay_str)) {
 			const auto vmem_delay_ns = *maybe_int;
 
 			if (vmem_delay_ns < MinDelayNs || vmem_delay_ns > MaxDelayNs) {
@@ -1174,7 +1170,7 @@ static uint32_t determine_vmem_delay_ns()
 				        MinDelayNs,
 				        MaxDelayNs);
 
-				set_setting_value("off");
+				set_default_vmem_delay_setting();
 				return OffDelayNs;
 			} else {
 				return vmem_delay_ns;
@@ -1183,7 +1179,7 @@ static uint32_t determine_vmem_delay_ns()
 			LOG_ERR("VGA: Invalid 'vmem_delay' setting: '%s', using 'off'",
 			        vmem_delay_str.c_str());
 
-			set_setting_value("off");
+			set_default_vmem_delay_setting();
 			return OffDelayNs;
 		}
 	}

--- a/src/midi/midi_fluidsynth.cpp
+++ b/src/midi/midi_fluidsynth.cpp
@@ -518,6 +518,8 @@ bool MidiHandlerFluidsynth::Open([[maybe_unused]] const char* conf)
 
 		fluidsynth_channel->SetHighPassFilter(FilterState::Off);
 		fluidsynth_channel->SetLowPassFilter(FilterState::Off);
+
+		set_section_property_value("fluidsynth", "fsynth_filter", "off");
 	}
 
 	// Double the baseline PCM prebuffer because MIDI is demanding and

--- a/src/midi/midi_fluidsynth.cpp
+++ b/src/midi/midi_fluidsynth.cpp
@@ -256,12 +256,12 @@ bool MidiHandlerFluidsynth::Open([[maybe_unused]] const char* conf)
 	// Per the FluidSynth API, the sample-rate should be part of the
 	// settings used to instantiate the synth, so we use the mixer's native
 	// rate to configure FluidSynth.
-	const auto audio_frame_rate_hz = MIXER_GetSampleRate();
-	ms_per_audio_frame             = millis_in_second / audio_frame_rate_hz;
+	const auto sample_rate_hz = MIXER_GetSampleRate();
+	ms_per_audio_frame        = millis_in_second / sample_rate_hz;
 
 	fluid_settings_setnum(fluid_settings.get(),
 	                      "synth.sample-rate",
-	                      audio_frame_rate_hz);
+	                      sample_rate_hz);
 
 	fsynth_ptr_t fluid_synth(new_fluid_synth(fluid_settings.get()),
 	                         delete_fluid_synth);
@@ -496,7 +496,7 @@ bool MidiHandlerFluidsynth::Open([[maybe_unused]] const char* conf)
 	                                      std::placeholders::_1);
 
 	auto fluidsynth_channel = MIXER_AddChannel(mixer_callback,
-	                                           audio_frame_rate_hz,
+	                                           sample_rate_hz,
 	                                           ChannelName::FluidSynth,
 	                                           {ChannelFeature::Sleep,
 	                                            ChannelFeature::Stereo,
@@ -527,8 +527,8 @@ bool MidiHandlerFluidsynth::Open([[maybe_unused]] const char* conf)
 	const auto render_ahead_ms = MIXER_GetPreBufferMs() * 2;
 
 	// Size the out-bound audio frame FIFO
-	assert(audio_frame_rate_hz > 8000); // sane lower-bound of 8 KHz
-	const auto audio_frames_per_ms = iround(audio_frame_rate_hz / millis_in_second);
+	assert(sample_rate_hz > 8000); // sane lower-bound of 8 KHz
+	const auto audio_frames_per_ms = iround(sample_rate_hz / millis_in_second);
 	audio_frame_fifo.Resize(
 	        check_cast<size_t>(render_ahead_ms * audio_frames_per_ms));
 

--- a/src/midi/midi_mt32.cpp
+++ b/src/midi/midi_mt32.cpp
@@ -819,6 +819,8 @@ bool MidiHandler_mt32::Open([[maybe_unused]] const char* conf)
 
 		mixer_channel->SetHighPassFilter(FilterState::Off);
 		mixer_channel->SetLowPassFilter(FilterState::Off);
+
+		set_section_property_value("mt32", "mt32_filter", "off");
 	}
 
 	// Double the baseline PCM prebuffer because MIDI is demanding and

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -955,7 +955,7 @@ Property* Section_prop::Get_prop(int index)
 	return nullptr;
 }
 
-Property* Section_prop::Get_prop(const std::string& propname)
+Property* Section_prop::Get_prop(const std::string_view propname)
 {
 	for (Property* property : properties) {
 		if (property->propname == propname) {

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -1739,8 +1739,6 @@ void MSG_Init(Section_prop*);
 // -conf's, and finally the local dosbox.conf
 void Config::ParseConfigFiles(const std_fs::path& config_dir)
 {
-	std::string config_file;
-
 	// First: parse the user's primary 'dosbox-staging.conf' config file
 	const bool load_primary_config = !arguments.noprimaryconf;
 

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -1386,10 +1386,10 @@ Config::~Config()
 	}
 }
 
-Section* Config::GetSection(const std::string& section_name) const
+Section* Config::GetSection(const std::string_view section_name) const
 {
 	for (auto* el : sectionlist) {
-		if (!strcasecmp(el->GetName(), section_name.c_str())) {
+		if (iequals(el->GetName(), section_name)) {
 			return el;
 		}
 	}

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -1610,6 +1610,20 @@ bool has_false(const std::string_view setting)
 	return (has_bool && *has_bool == false);
 }
 
+void set_section_property_value(const std::string_view section_name,
+                                const std::string_view property_name,
+                                const std::string_view property_value)
+{
+	auto* sect_updater = static_cast<Section_prop*>(
+	        control->GetSection(section_name));
+	assertm(sect_updater, "Invalid section name");
+
+	auto* property = sect_updater->Get_prop(property_name);
+	assertm(property, "Invalid property name");
+
+	property->SetValue(std::string(property_value));
+}
+
 void Config::ParseEnv()
 {
 #if defined(_MSC_VER) || (defined(__MINGW32__) && defined(__clang__))


### PR DESCRIPTION
# Description

The main change here is fixing how the defaulting happens when a config param is set to an invalid value:

- Defaulting all `*_filter` settings to the real defaults when an invalid value is set, not just setting them to `off`.
- Syncing the config setting to the default when this happens (e.g., when you set `sb_filter = asdf`, the `sb_filter` property will be defaulted to `auto` instead of containing the `asdf` value).
- I've applied the same syncing when defaulting happens to all the other settings I could find.

Moreover:

- `windowresolution` can now be changed at runtime.
- Invalid `windowresolution` settings now reset the default window size, not set it to 640x480 pixels (which is passable on non-high DPI displays, but on my Retina MacBook this resulted in a tiny window).

# Manual testing

This seems like a lot of changes, but there are no interdependencies between them, and they're all relatively simple. 

I've tested every single setting with all possible values as I went, so I have a very high confidence that everything works correctly.

Because of this this, I really want to backport this.

Once this is backported, we're ready for 0.81.1 as far as I'm concerned 🥳 

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

