### PR TITLE
Fix various crashes when the host sample rate is set to low values

### DIFF
--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -1147,7 +1147,7 @@ void MixerChannel::SetHighPassFilter(const FilterState state)
 
 	if (do_highpass_filter) {
 		log_filter_settings(name,
-		                    "Highpass",
+		                    "High-pass",
 		                    state,
 		                    filters.highpass.order,
 		                    filters.highpass.cutoff_freq_hz);
@@ -1160,7 +1160,7 @@ void MixerChannel::SetLowPassFilter(const FilterState state)
 
 	if (do_lowpass_filter) {
 		log_filter_settings(name,
-		                    "Lowpass",
+		                    "Low-pass",
 		                    state,
 		                    filters.lowpass.order,
 		                    filters.lowpass.cutoff_freq_hz);
@@ -1219,22 +1219,31 @@ bool MixerChannel::TryParseAndSetCustomFilter(const std::string& filter_prefs)
 	auto set_filter = [&](const std::string& type_pref,
 	                      const std::string& order_pref,
 	                      const std::string& cutoff_freq_pref) {
+		const auto filter_name = (type_pref == "lpf") ? "low-pass"
+		                                              : "high-pass";
+
 		int order;
 		if (!sscanf(order_pref.c_str(), "%d", &order) || order < 1 ||
 		    order > max_filter_order) {
-			LOG_WARNING("%s: Invalid custom filter order: '%s'. Must be an integer between 1 and %d.",
-			            name.c_str(),
-			            order_pref.c_str(),
-			            max_filter_order);
+			LOG_WARNING(
+			        "%s: Invalid custom %s filter order: '%s'. "
+			        "Must be an integer between 1 and %d.",
+			        name.c_str(),
+			        filter_name,
+			        order_pref.c_str(),
+			        max_filter_order);
 			return false;
 		}
 
 		uint16_t cutoff_freq_hz;
 		if (!sscanf(cutoff_freq_pref.c_str(), "%" SCNu16, &cutoff_freq_hz) ||
 		    cutoff_freq_hz <= 0) {
-			LOG_WARNING("%s: Invalid custom filter cutoff frequency: '%s'. Must be a positive number.",
-			            name.c_str(),
-			            cutoff_freq_pref.c_str());
+			LOG_WARNING(
+			        "%s: Invalid custom %s filter cutoff frequency: '%s'. "
+			        "Must be a positive number.",
+			        name.c_str(),
+			        filter_name,
+			        cutoff_freq_pref.c_str());
 			return false;
 		}
 

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -2735,7 +2735,12 @@ static bool init_sdl_sound(Section_prop* section)
 		LOG_WARNING("MIXER: SDL changed the requested sample rate of %d to %d Hz",
 		            mixer.sample_rate_hz.load(),
 		            obtained.freq);
+
 		mixer.sample_rate_hz = check_cast<uint16_t>(obtained.freq);
+		set_section_property_value("mixer",
+		                           "rate",
+		                           format_str("%d",
+		                                      mixer.sample_rate_hz.load()));
 	}
 
 	// Does SDL want a different blocksize?
@@ -2745,7 +2750,11 @@ static bool init_sdl_sound(Section_prop* section)
 		LOG_WARNING("MIXER: SDL changed the requested blocksize of %u to %u frames",
 		            mixer.blocksize,
 		            obtained_blocksize);
+
 		mixer.blocksize = obtained_blocksize;
+		set_section_property_value("mixer",
+		                           "blocksize",
+		                           format_str("%d", mixer.blocksize));
 	}
 
 	LOG_MSG("MIXER: Negotiated %u-channel %u Hz audio of %u-frame blocks",

--- a/src/midi/midi_fluidsynth.cpp
+++ b/src/midi/midi_fluidsynth.cpp
@@ -529,7 +529,8 @@ bool MidiHandlerFluidsynth::Open([[maybe_unused]] const char* conf)
 	const auto render_ahead_ms = MIXER_GetPreBufferMs() * 2;
 
 	// Size the out-bound audio frame FIFO
-	assert(sample_rate_hz > 8000); // sane lower-bound of 8 KHz
+	assertm(sample_rate_hz >= 8000, "Sample rate must be at least 8 kHz");
+
 	const auto audio_frames_per_ms = iround(sample_rate_hz / millis_in_second);
 	audio_frame_fifo.Resize(
 	        check_cast<size_t>(render_ahead_ms * audio_frames_per_ms));

--- a/src/midi/midi_mt32.cpp
+++ b/src/midi/midi_mt32.cpp
@@ -830,7 +830,8 @@ bool MidiHandler_mt32::Open([[maybe_unused]] const char* conf)
 	const auto render_ahead_ms = MIXER_GetPreBufferMs() * 2;
 
 	// Size the out-bound audio frame FIFO
-	assert(sample_rate_hz > 8000); // sane lower-bound of 8 KHz
+	assertm(sample_rate_hz >= 8000, "Sample rate must be at least 8 kHz");
+
 	const auto audio_frames_per_ms = iround(sample_rate_hz / millis_in_second);
 	audio_frame_fifo.Resize(
 	        check_cast<size_t>(render_ahead_ms * audio_frames_per_ms));


### PR DESCRIPTION
# Description

Ok, last one to backport @weirddan455 😄 

---

###  Fix crash when filter cutoff frequencies are not below half of the sample rate

The IIR library rightfully throws an exception when you attempt to set a filter's cutoff frequency at or above the Nyquist rate (half the sample rate). So with this change we're always clamping the filter cutoff frequencies just below the Nyquist rate.

The reason why we're clamping and not turning the filter off is because this is an edge case that usually only happens when using 20,050 or lower host rates, and it's a lot easier to just clamp than to disable the filter and handle the state management correctly.

To trigger the crash, set rate `rate = 11025` in the `[mixer]` section, then run `sbtype sbpro` which will attempt to configure an 8 kHz lowpass filter. You can also trigger it by setting a custom filter, e.g., `sb_filter lpf 1 10000`.

### Fix some audio devices crashing when host sample rate is set to 8000 Hz

FluidSynth and MT-32 would crash with the `rate = 8000` setting, and that's a valid rate we otherwise support in all audio devices.

# Manual testing

I started Prince of Persia after each of these test cases to make sure that the audio output actually works.

## Case 1

1. Set `rate = 11025` in the config.
2. Confirm in the logs that Staging runs at 11,025 Hz.
3. Run `sbtype sbpro1`.
4. No crash and the following debug message appears in the logs:
    <img width="1076" alt="image" src="https://github.com/dosbox-staging/dosbox-staging/assets/698770/bef5e2a7-d037-4ab8-af83-26b3cd4789d4">

## Case 2

1. Start with `--noprimaryconf`
2. Confirm in the logs that Staging runs at 44.1 or 48 kHz.
3. Run `sb_filter lpf 1 40000`.
5. No crash and something like this appears in the logs:
    <img width="1106" alt="image" src="https://github.com/dosbox-staging/dosbox-staging/assets/698770/c6abe166-d721-45d4-b4fb-7e63d7d80637">

## Case 3

1. Set `rate = 8000` in the config.
2. Start with `--noprimaryconf`.
3. FluidSynth is active now, no crash.
    <img width="1134" alt="image" src="https://github.com/dosbox-staging/dosbox-staging/assets/698770/b6827010-aa29-4d9f-8b20-15167bca0038">
6. Run `mididevice mt32`.
7. MT-32 is active now, no crash.
    <img width="1077" alt="image" src="https://github.com/dosbox-staging/dosbox-staging/assets/698770/7eab5790-e336-40a1-ab02-d76f5bc1d773">

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

