### PR TITLE
Usage of integer types & disabling sign conversion warnings

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -48,7 +48,7 @@ jobs:
             run_tests: false # the shell_cmds_tests hang on arm64
             build_flags: -Dbuildtype=debug
             brew_path: /opt/homebrew
-            max_warnings: 60
+            max_warnings: 42
 
     steps:
       - name: Checkout repository

--- a/include/checks.h
+++ b/include/checks.h
@@ -1,7 +1,7 @@
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *
- *  Copyright (C) 2022-2022  The DOSBox Staging Team
+ *  Copyright (C) 2022-2024  The DOSBox Staging Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -57,7 +57,6 @@
 
 #ifdef __GNUC__
 #	define CHECK_NARROWING() \
-		_Pragma("GCC diagnostic warning \"-Wsign-conversion\"") \
 		_Pragma("GCC diagnostic warning \"-Wconversion\"") \
 		_Pragma("GCC diagnostic warning \"-Wnarrowing\"") \
 		END_MACRO


### PR DESCRIPTION
# Preamble

**kcgen** and **dreamer** have done an outstanding job raising our quality standards by adopting static analysers, enabling extra warnings, and addressing many of those warnings in our codebase. These improvements have undoubtedly made the code safer and more pleasant to work with.

But in some cases, they overshot a bit. We should periodically re-examine these past decisions based on actual experience and be honest with ourselves: does _[insert safety measure]_ really help us make the code safer, or does it only cause us a lot of busywork and complication with marginal or zero returns? We want to spend our limited time and energy we can dedicate to the project on things that really make a difference. If the net effect of a safety/quality measure is negative, we should by no means keep doing it!

# The problem

One of my and @kklobe's biggest pain points when it comes to warnings is the "liberal" use of fixed-width types (`uint8_t`, `uint16_t`, etc.) everywhere in the codebase. Performing arithmetic operations on unsigned types is very error-prone, plus there are the [integer promotion rules](https://www.geeksforgeeks.org/integer-promotions-in-c/) of C/C++, so we end up with lots of casting everywhere.

I strongly believe adopting this approach was a mistake and should be undone. Using fixed-width unsigned types instead of plain old signed `int` everywhere forced us to do a lot of busy work for exactly zero benefits.

In fact, the [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html) suggests using `int` everywhere and only deviating from that if really warranted.

Quoting relevant bits from the [integer types](https://google.github.io/styleguide/cppguide.html#Integer_Types) section (I recommend reading the whole thing):

> We use `int` very often, for integers we know are not going to be too big, e.g., loop counters. **Use plain old `int` for such things.** You should assume that an `int` is at least 32 bits, but don't assume that it has more than 32 bits. If you need a 64-bit integer type, use `int64_t` or `uint64_t`.

> For integers we know can be "big", use `int64_t`.

> **You should not use the unsigned integer types such as `uint32_t`**, unless there is a valid reason such as representing a bit pattern rather than a number, or you need defined overflow modulo 2^N. In particular, **do not use unsigned types to say a number will never be negative**. Instead, use assertions for this.

> Unsigned integers are good for representing bitfields and modular arithmetic. [..] The fact that unsigned arithmetic doesn't model the behavior of a simple integer, but is instead defined by the standard to model modular arithmetic (wrapping around on overflow/underflow), means that a significant class of bugs cannot be diagnosed by the compiler. In other cases, the defined behavior impedes optimization.

All very sane advice and would simplify our lives a lot!

To explain it further, we should only use fixed-width unsigned (or sometimes signed) types in these scenarios:

- Modeling registers that store bit-field patterns in emulated hardware (e.g., the VGA registers).
- Dealing with the contents of DOS-side memory directly.
- Handling the contents of the video memory.
- Representing signed or unsigned 8 or 16-bit PCM streams.
- Dealing with packed network packets or binary file formats.

That's pretty much it. For every other use case—just use plain `ints`!

As a concrete example, this signature

```cpp
void configure_filter(const uint8_t order, const uint16_t cutoff_freq_hz)
```

should be rewritten as

```cpp
void configure_filter(const int order, const int cutoff_freq_hz) {
	assert(order > 0 && order <= 16);
	assert(cutoff_freq_hz > 0);
}
```

Do note we can be more specific in our asserts to check _value ranges_. An `uint8_t` still doesn't say anything about the valid upper limit.

# But wait, there's more!

Yeah, it's C++, man, so there is always more, and life is never simple... 😅 

Yet again, one of the C++ committee's decisions bites us in the ass:

> Because of historical accident, the C++ standard also uses unsigned integers to represent the size of containers - many members of the standards body believe this to be a mistake, but it is effectively impossible to fix at this point.

I'm working on some more extensive mixer refactorings, so I converted `mixer.cpp` to only use `int`s.But many of those `int` loop counters and variables are used to index containers. Net result: 68 new sign conversion warnings. That's because of `Wsign-conversion` introduced in the `CHECK_NARROWING()` macro.

Once `Wsign-conversion` is removed, the number of new warnings goes down to _only two_.

I'm strongly in favour of removing `-Wsign-conversion` altogether. 99% of the time, we're dealing with numbers that are nowhere near the upper limit of the signed 32-bit integer range. Then, if you're dealing with code that uses "big numbers," you should be careful and _test_ your code instead of forcing the whole codebase to silence these harmless sign conversion warnings by littering every second line with casts...

We can still use `CHECK_NARROWING()` as the other two warnings, "-Wconversion" and "-Wnarrowing", seem to be far less noisy. However, we should revisit their usage and weigh up the pros and cons if they become a nuisance.

Once we have reached a consensus on this, I will adjust the warning counts in the workflows.

