### PR TITLE
Fix CDROM_Interface pointer ownership issue

### DIFF
--- a/src/dos/cdrom.cpp
+++ b/src/dos/cdrom.cpp
@@ -28,6 +28,10 @@
 #include "pic.h"
 #include "string_utils.h"
 
+namespace CDROM {
+std::array<std::unique_ptr<CDROM_Interface>, MaxNumDosDriveLetters> cdroms;
+}
+
 // ******************************************************
 // Fake CDROM
 // ******************************************************

--- a/src/dos/cdrom.h
+++ b/src/dos/cdrom.h
@@ -110,10 +110,12 @@ public:
 	virtual bool PauseAudio         (bool resume) = 0;
 	virtual bool StopAudio          () = 0;
 	virtual void ChannelControl     (TCtrl ctrl) = 0;
+	virtual bool ReadSector         (uint8_t* buffer, const bool raw, const uint32_t sector) = 0;
 	virtual bool ReadSectors        (PhysPt buffer, const bool raw, const uint32_t sector, const uint16_t num) = 0;
 	virtual bool ReadSectorsHost    (void* buffer, bool raw, unsigned long sector, unsigned long num) = 0;
 	virtual bool LoadUnloadMedia    (bool unload) = 0;
 	virtual void InitNewMedia       () {}
+	virtual bool HasDataTrack       () const = 0;
 	virtual bool HasFullMscdexSupport() = 0;
 
 protected:
@@ -156,6 +158,11 @@ public:
 
 	void ChannelControl([[maybe_unused]] TCtrl ctrl) override {}
 
+	bool ReadSector(uint8_t* /*buffer*/, const bool /*raw*/,
+	                const uint32_t /*sector*/) override
+	{
+		return true;
+	}
 	bool ReadSectors(PhysPt /*buffer*/, const bool /*raw*/,
 	                 const uint32_t /*sector*/, const uint16_t /*num*/) override
 	{
@@ -168,6 +175,10 @@ public:
 		return true;
 	}
 	bool LoadUnloadMedia(bool /*unload*/) override
+	{
+		return true;
+	}
+	bool HasDataTrack() const override
 	{
 		return true;
 	}
@@ -303,8 +314,8 @@ public:
 	bool ReadSectorsHost(void* buffer, bool raw, unsigned long sector,
 	                     unsigned long num) override;
 	bool LoadUnloadMedia(bool unload) override;
-	bool ReadSector(uint8_t* buffer, const bool raw, const uint32_t sector);
-	bool HasDataTrack();
+	bool ReadSector(uint8_t* buffer, const bool raw, const uint32_t sector) override;
+	bool HasDataTrack() const override;
 	bool HasFullMscdexSupport() override
 	{
 		return true;
@@ -408,11 +419,13 @@ public:
 	                 unsigned char& index, TMSF& relPos, TMSF& absPos) override;
 	bool GetMediaTrayStatus(bool& mediaPresent, bool& mediaChanged,
 	                        bool& trayOpen) override;
+	bool ReadSector(uint8_t* buffer, const bool raw, const uint32_t sector) override;
 	bool ReadSectors(PhysPt buffer, const bool raw, const uint32_t sector,
 	                 const uint16_t num) override;
 	bool ReadSectorsHost(void* buffer, bool raw, unsigned long sector,
 	                     unsigned long num) override;
 	bool LoadUnloadMedia(bool unload) override;
+	bool HasDataTrack() const override;
 	bool HasFullMscdexSupport() override
 	{
 		return true;
@@ -442,11 +455,13 @@ public:
 	                 unsigned char& index, TMSF& relPos, TMSF& absPos) override;
 	bool GetMediaTrayStatus(bool& mediaPresent, bool& mediaChanged,
 	                        bool& trayOpen) override;
+	bool ReadSector(uint8_t* buffer, const bool raw, const uint32_t sector) override;
 	bool ReadSectors(PhysPt buffer, const bool raw, const uint32_t sector,
 	                 const uint16_t num) override;
 	bool ReadSectorsHost(void* buffer, bool raw, unsigned long sector,
 	                     unsigned long num) override;
 	bool LoadUnloadMedia(bool unload) override;
+	bool HasDataTrack() const override;
 	bool HasFullMscdexSupport() override
 	{
 		return true;

--- a/src/dos/cdrom.h
+++ b/src/dos/cdrom.h
@@ -63,6 +63,9 @@
 #define AUDIO_DECODE_BUFFER_SIZE 16512u
 #define SAMPLES_PER_REDBOOK_FRAME (BYTES_PER_RAW_REDBOOK_FRAME / REDBOOK_BPS)
 
+// Number of letters in the English alphabet (A to Z)
+constexpr auto MaxNumDosDriveLetters = 26;
+
 struct TMSF
 {
 	unsigned char min;
@@ -121,6 +124,10 @@ public:
 protected:
 	void LagDriveResponse() const;
 };
+
+namespace CDROM {
+extern std::array<std::unique_ptr<CDROM_Interface>, MaxNumDosDriveLetters> cdroms;
+}
 
 class CDROM_Interface_Fake final : public CDROM_Interface {
 public:
@@ -292,7 +299,7 @@ public:
 		bool                       mode2      = false;
 	};
 
-	CDROM_Interface_Image(uint8_t sub_unit);
+	CDROM_Interface_Image();
 
 	~CDROM_Interface_Image() override;
 	void InitNewMedia() override {}
@@ -320,7 +327,6 @@ public:
 	{
 		return true;
 	}
-	static CDROM_Interface_Image* images[26];
 
 private:
 	static struct imagePlayer {

--- a/src/dos/cdrom_image.cpp
+++ b/src/dos/cdrom_image.cpp
@@ -479,15 +479,13 @@ int CDROM_Interface_Image::AudioFile::getLength()
 
 // initialize static members
 int CDROM_Interface_Image::refCount = 0;
-CDROM_Interface_Image* CDROM_Interface_Image::images[26] = {};
 CDROM_Interface_Image::imagePlayer CDROM_Interface_Image::player;
 
-CDROM_Interface_Image::CDROM_Interface_Image(uint8_t sub_unit)
+CDROM_Interface_Image::CDROM_Interface_Image()
         : tracks{},
           readBuffer{},
           mcn("")
 {
-	images[sub_unit] = this;
 	if (refCount == 0) {
 		if (!player.channel) {
 			const auto mixer_callback = std::bind(&CDROM_Interface_Image::CDAudioCallBack,

--- a/src/dos/cdrom_image.cpp
+++ b/src/dos/cdrom_image.cpp
@@ -1370,7 +1370,7 @@ bool CDROM_Interface_Image::AddTrack(Track &curr,
 	return true;
 }
 
-bool CDROM_Interface_Image::HasDataTrack(void)
+bool CDROM_Interface_Image::HasDataTrack() const
 {
 	//Data track has attribute 0x40
 	for (const auto &track : tracks) {

--- a/src/dos/cdrom_ioctl_linux.cpp
+++ b/src/dos/cdrom_ioctl_linux.cpp
@@ -229,6 +229,12 @@ bool CDROM_Interface_Ioctl::GetMediaTrayStatus(bool& mediaPresent,
 	return true;
 }
 
+bool CDROM_Interface_Ioctl::ReadSector(uint8_t* /*buffer*/, const bool /*raw*/,
+                                       const uint32_t /*sector*/)
+{
+	return false; /*TODO*/
+}
+
 bool CDROM_Interface_Ioctl::ReadSectors(PhysPt buffer, const bool raw,
                                         const uint32_t sector, const uint16_t num)
 {
@@ -355,6 +361,11 @@ std::vector<int16_t> CDROM_Interface_Ioctl::ReadAudio(const uint32_t sector, con
 	}
 
 	return audio_samples;
+}
+
+bool CDROM_Interface_Ioctl::HasDataTrack() const
+{
+	return true; /*TODO*/
 }
 
 #endif // Linux

--- a/src/dos/dos_mscdex.cpp
+++ b/src/dos/dos_mscdex.cpp
@@ -287,7 +287,7 @@ static std::unique_ptr<CDROM_Interface> create_cdrom_interface(const char *path)
 
 	if (!is_directory(path)) {
 		if (auto cdrom_interface = std::make_unique<CDROM_Interface_Image>();
-		                                   cdrom_interface->SetDevice(path)) {
+		    cdrom_interface->SetDevice(path)) {
 			return cdrom_interface;
 		} else {
 			return {};

--- a/src/dos/dos_mscdex.cpp
+++ b/src/dos/dos_mscdex.cpp
@@ -1456,6 +1456,10 @@ bool MSCDEX_HasMediaChanged(uint8_t subUnit)
 }
 
 void MSCDEX_ShutDown(Section* /*sec*/) {
+	std::for_each(CDROM::cdroms.begin(),
+	              CDROM::cdroms.end(),
+	              [](auto& cdrom_ptr) { cdrom_ptr.reset(); });
+
 	delete mscdex;
 	mscdex = nullptr;
 	curReqheaderPtr = 0;

--- a/src/dos/dos_mscdex.h
+++ b/src/dos/dos_mscdex.h
@@ -25,7 +25,7 @@
 int   MSCDEX_AddDrive(char driveLetter, const char *physicalPath, uint8_t &subUnit);
 int   MSCDEX_RemoveDrive(char driveLetter);
 bool  MSCDEX_HasDrive(char driveLetter);
-void  MSCDEX_ReplaceDrive(CDROM_Interface *cdrom, uint8_t subUnit);
+void  MSCDEX_ReplaceDrive(std::unique_ptr<CDROM_Interface> cdrom, uint8_t subUnit);
 uint8_t MSCDEX_GetSubUnit(char driveLetter);
 bool  MSCDEX_GetVolumeName(uint8_t subUnit, char *name);
 bool  MSCDEX_HasMediaChanged(uint8_t subUnit);


### PR DESCRIPTION
# Description

There is now only one owner of CDROM_Interface pointers.

## Related issues

#3620 

# Manual testing

Tried mounting a CD-ROM or image in several ways, and they still work.


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [ ] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

