### PR TITLE
Fix not being able to select Game Blaster / CMS emulation

### DIFF
--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -2190,8 +2190,7 @@ static SB_TYPES determine_sbtype(const std::string& pref)
 static OplMode determine_oplmode(const std::string& pref, const SB_TYPES sb_type)
 {
 	if (pref == "cms") {
-		// Skip for backward compatibility with existing configurations
-		return OplMode::None;
+		return OplMode::Cms;
 
 	} else if (pref == "opl2") {
 		return OplMode::Opl2;
@@ -2208,7 +2207,7 @@ static OplMode determine_oplmode(const std::string& pref, const SB_TYPES sb_type
 	} else if (pref == "auto") {
 		// Invalid settings result in defaulting to 'auto'
 		switch (sb_type) {
-		case SBT_GB: return OplMode::None;
+		case SBT_GB: return OplMode::Cms;
 		case SBT_1: return OplMode::Opl2;
 		case SBT_2: return OplMode::Opl2;
 		case SBT_PRO1: return OplMode::DualOpl2;


### PR DESCRIPTION
# Description

Introduced by a botched backport in 5293a50b0ca14d8 by _yours truly_. Mea cupla. But @Burrito78 found it, yay 🥳 

Fixes https://github.com/dosbox-staging/dosbox-staging/issues/3636

# Manual testing

- `oplmode cms` now enables the CMS ✅ 
- `sbtype gb` now enables the CMS (when `oplmode` is on `auto`, which is the default) ✅ 
- `oplmode opl2` still enables both OPL and CMS ✅ 
- `oplmode none` still works (disables both OPL and CMS) ✅ 

Tested **Passport to Adventure** with CMS, OPL and PC Speaker sound. ✅ 

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

