### PR TITLE
Simplify "EGA mode with VGA palette" detection & make it more robust

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -376,7 +376,7 @@ MaxEmptyLinesToKeep: 1
 
 # No empty line at the start of a block.
 #
-KeepEmptyLinesAtTheStartOfBlocks: false
+KeepEmptyLinesAtTheStartOfBlocks: true
 
 # Line breaking penalties
 #

--- a/include/vga.h
+++ b/include/vga.h
@@ -124,6 +124,10 @@ enum VGAModes {
 constexpr auto NumCgaColors = 16;
 constexpr auto NumVgaColors = 256;
 
+constexpr auto NumVgaSequencerRegisters = 0x05;
+constexpr auto NumVgaGraphicsRegisters  = 0x09;
+constexpr auto NumVgaAttributeRegisters = 0x15;
+
 constexpr auto vesa_2_0_modes_start = 0x120;
 
 constexpr uint16_t EGA_HALF_CLOCK = 1 << 0;

--- a/include/vga.h
+++ b/include/vga.h
@@ -1092,9 +1092,6 @@ struct VgaType {
 	// that, we stop checking palette changes until the next screen mode
 	// change.
 	bool ega_mode_with_vga_colors = false;
-
-	// Flag to signal that we're in the middle of a mode change.
-	bool mode_change_in_progress = false;
 };
 
 // Hercules & CGA monochrome palette

--- a/include/vga.h
+++ b/include/vga.h
@@ -375,7 +375,7 @@ struct VgaS3 {
 	uint8_t reg_55 = 0;
 	uint8_t reg_58 = 0;
 	uint8_t reg_6b = 0; // LFB BIOS scratchpad
-	                    //
+
 	uint8_t ex_hor_overflow = 0;
 	uint8_t ex_ver_overflow = 0;
 
@@ -383,7 +383,7 @@ struct VgaS3 {
 	uint8_t misc_control_2    = 0;
 	uint8_t ext_mem_ctrl      = 0;
 	uint16_t xga_screen_width = 0; // from 640 to 1600
-	                               //
+
 	VGAModes xga_color_mode = {};
 
 	struct clk_t {
@@ -396,7 +396,7 @@ struct VgaS3 {
 	clk_t mclk   = {};
 
 	struct pll_t {
-		// Extended Sequencer Access Rgister SR8 (pp. 124)
+		// Extended Sequencer Access Register SR8 (pp. 124)
 		uint8_t lock = 0;
 
 		// CLKSYN Control 2 Register SR15 (pp. 130)

--- a/include/video.h
+++ b/include/video.h
@@ -167,15 +167,16 @@ struct VideoMode {
 	// EGA modes and most sub-400-line (S)VGA & VESA modes)
 	bool is_double_scanned_mode = false;
 
-	// True for all (S)VGA and VESA modes, and for 200-line EGA modes on VGA
-	// that reprogram the default canonical 16-colour CGA palette BIOS to
-	// custom 18-bit VGA colours.
+	// True for all (S)VGA and VESA modes, and for EGA modes on emulated VGA
+	// adapters that reprogram the default canonical 16-colour CGA palette
+	// to custom 18-bit VGA DAC colours.
 	//
 	// Useful for differentiating "true EGA" modes used for backwards
 	// compatibility on VGA (i.e., to run EGA games) from "repurposed" EGA
-	// modes (typical for demos and ports of Amiga action/platformer games;
-	// many of these use the planar 320x200 16-colour EGA mode to achieve
-	// faster smooth-scrolling, but with custom 18-bit VGA colours).
+	// modes (typical used in demos and ports of Amiga action/platformer
+	// games; many of these use the planar 320x200 16-colour EGA mode to
+	// achieve faster smooth-scrolling, but with custom 18-bit VGA DAC
+	// colours).
 	bool has_vga_colors = false;
 
 	constexpr bool operator==(const VideoMode& that) const

--- a/src/hardware/vga.cpp
+++ b/src/hardware/vga.cpp
@@ -482,10 +482,18 @@ void SVGA_Setup_Driver(void) {
 
 const VideoMode& VGA_GetCurrentVideoMode()
 {
-	// This function would most likely return the previous video mode if
-	// called in the middle of a mode change.
-	assert(!vga.mode_change_in_progress);
-
+	// This function is only 100% safe to call from *outside* of the VGA
+	// code! Outside of the VGA and video BIOS related code, this function
+	// is safe to call and should always return the current video mode.
+	//
+	// Care must be taken when using this function from within the VGA and
+	// video BIOS related code. Depending on how and where you use it, it
+	// *might* return the *previous* video mode in some circumstances if you
+	// end up calling in the middle of a mode change! In such scenarios, you
+	// might want to prefer reading `CurMode` directly which is more likely
+	// to contain the current mode, or the mode that's currently being set
+	// up.
+	//
 	return vga.draw.image_info.video_mode;
 }
 

--- a/src/hardware/vga_dac.cpp
+++ b/src/hardware/vga_dac.cpp
@@ -72,26 +72,26 @@ static bool is_ega_color(const Rgb666 color)
 	       palette.ega.cend();
 }
 
-// In the automatic "video mode specific" CRT emulation mode (glshader =
-// crt-auto), we want "true EGA" games on emulated VGA adapters to use the
-// single scanline EGA shader. "True EGA" games set up an EGA mode and
-// don't change the palette to use 18-bit VGA colours. These games look
-// identical on VGA and EGA, except for the VGA double scanning.
+// In the automatic "video mode specific" CRT emulation mode (`glshader =
+// crt-auto`), we want "true EGA" games on emulated VGA adapters to use the
+// single scanline EGA shader. "True EGA" games set up an EGA mode and don't
+// change the palette to use 18-bit VGA colours. These games look identical on
+// VGA and EGA, except for the VGA double scanning.
 //
 // Some games (most notably Amiga and Atari ST ports) "repurpose" the
-// 16-colour EGA modes on VGA: they set up an EGA mode first, then change
-// the default CGA/EGA palette to a custom set of sixteen 18-bit RGB
-// colours (many Amiga and Atari ST games used a 16-colour palette out of
-// 4096 (Amiga) or 512 (Atari ST) colours). As these games can only run on
-// VGA adapters, we double scan them in 'crt-auto' mode (although it can
-// be argued that this case calls for single scanning to mimic the
-// single-scanned home computer monitor look. But we're emulating PC
-// compatibles here and how people experienced these games on PC hardware,
-// so double scanning it is).
+// 16-colour EGA modes on VGA: they set up an EGA mode first, then change the
+// default CGA/EGA palette to a custom set of sixteen 18-bit RGB colours (many
+// Amiga and Atari ST games use a 16-colour palette out of the 4096 (Amiga) or
+// 512 (Atari ST) available colours). As these games can only run on VGA
+// adapters, we double scan them in `crt-auto` mode, although it can be argued
+// that this case calls for single scanning to mimic the single-scanned home
+// computer monitor look. But we're emulating PC compatibles here and the aim
+// is to accurately replicate how people experienced these games on PC
+// hardware, so double scanning it is.
 //
-// Detecting EGA modes using custom VGA colours is accomplished by setting
-// the `ega_mode_with_vga_colors` flag to true when the first non-EGA
-// palette colour is set after a mode switch.
+// Detecting EGA modes using custom VGA colours is accomplished by setting the
+// `ega_mode_with_vga_colors` flag to true when the first non-EGA palette
+// colour is set after a mode change has been completed.
 //
 // Note that custom CGA colours (via the `cga_colors` config setting) are
 // handled correctly as well.
@@ -100,23 +100,17 @@ static void vga_dac_send_color(const uint8_t palette_idx, const uint8_t color_id
 {
 	const auto rgb666 = vga.dac.rgb[color_idx];
 
-	// We might be in the middle of a mode change, so we can't use
-	// VGA_GetCurrentVideoMode() here. That's because the INT 10H mode
-	// change BIOS routine needs to set up the Palette and Color Registers
-	// which will trigger this function.
-	const auto bios_mode_number = CurMode->mode;
-
-	const auto is_640x350_16color_mode = (bios_mode_number == 0x10);
-
+	constexpr auto ega_mode_640x350_16color = 0x10;
 #if 0
-	bool log_warning = false;
-	if (is_640x350_16color_mode) {
-		log_warning = !is_ega_color(rgb666);
-	} else {
-		log_warning = !is_cga_color(rgb666);
-	}
+	// We might be in the middle of a mode change, so we can't use
+	// VGA_GetCurrentVideoMode().
+	const auto log_warning = (CurMode->mode == ega_mode_640x350_16color)
+	                               ? !is_ega_color(rgb666)
+	                               : !is_cga_color(rgb666);
 
-	auto msg = format_str("palette_idx: %d, color_idx: %d", palette_idx, color_idx);
+	const auto msg = format_str("palette_idx: %d, color_idx: %d",
+	                            palette_idx,
+	                            color_idx);
 	if (log_warning) {
 		LOG_WARNING("VGA: %s, color: %02x %02x %02x",
 		            msg.c_str(),
@@ -127,35 +121,48 @@ static void vga_dac_send_color(const uint8_t palette_idx, const uint8_t color_id
 		LOG_TRACE("VGA: %s", msg.c_str());
 	}
 #endif
-
-	// If a palette entry was set to a non-EGA colour after the mode change
-	// was completed, we need to notify the renderer so it can re-init
-	// itself and potentially switch the current shader.
+	// We only want to trigger the "VGA DAC colours in EGA mode" detection
+	// logic when we're outside of a video mode change. Mode changes also
+	// set up the default CGA and EGA palette appropriate for the given
+	// mode, and that would only confuse and complicate the detection logic.
 	//
-	if (machine == MCH_VGA && !vga.ega_mode_with_vga_colors &&
-	    !vga.mode_change_in_progress &&
-	    bios_mode_number <= MaxEgaBiosModeNumber) {
-		bool non_ega_color = false;
+	// In theory, if a program completely bypassed the INT 10h set video
+	// mode call and performed the mode change 100% itself by writing to the
+	// VGA registers directly, that would cause this logic not to trigger.
+	// Fortunately, no commercial game developers seemed to use such
+	// horrible practices.
+	//
+	if (machine == MCH_VGA && !vga.mode_change_in_progress &&
+	    !vga.ega_mode_with_vga_colors) {
 
-		if (is_640x350_16color_mode) {
-			// The 640x350 16-colour EGA mode (mode 10h) is special:
-			// the 16 colors can be freely chosen from a gamut of 64
-			// colours (6-bit RGB).
-			non_ega_color = !is_ega_color(rgb666);
-		} else {
-			// In all other EGA modes, the fixed "canonical
-			// 16-element CGA palette" (as emulated by VGA cards) is
-			// used.
-			non_ega_color = !is_cga_color(rgb666);
-		}
+		const auto curr_mode = VGA_GetCurrentVideoMode();
 
-		if (non_ega_color) {
+		const auto is_non_ega_color = [&]() {
+			if (curr_mode.bios_mode_number == ega_mode_640x350_16color) {
+				// The 640x350 16-colour EGA mode (mode 10h) is
+				// special: the 16 colors can be freely chosen
+				// from a gamut of 64 colours (6-bit RGB).
+				return !is_ega_color(rgb666);
+			} else {
+				// In all other EGA modes, the fixed "canonical
+				// 16-element CGA palette" (as emulated by VGA
+				// cards) is used.
+				return !is_cga_color(rgb666);
+			}
+		};
+
+		if (curr_mode.bios_mode_number <= MaxEgaBiosModeNumber &&
+		    is_non_ega_color()) {
+
 			vga.ega_mode_with_vga_colors = true;
-#if 0
-			LOG_TRACE(
+
+			LOG_DEBUG(
 			        "VGA: EGA mode with VGA palette detected, "
 			        "notifying renderer");
-#endif
+
+			// Notify the renderer so it can re-init itself and
+			// potentially switch the current shader (i.e., from an
+			// EGA shader to a VGA one).
 			RENDER_NotifyEgaModeWithVgaPalette();
 		}
 	}

--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -2931,6 +2931,10 @@ static void finalise_mode_change()
 	// If this assumption turns out to be false, we'll need to
 	// revisit the logic that resets this flag.
 	vga.mode_change_in_progress = false;
+
+#ifdef DEBUG_VGA_DRAW
+	LOG_TRACE("VGA: vga.mode_change_in_progress END");
+#endif
 }
 
 void VGA_SetupDrawing(uint32_t /*val*/)

--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -2924,27 +2924,12 @@ ImageInfo setup_drawing()
 	return img_info;
 }
 
-static void finalise_mode_change()
-{
-	// The assumption is that all mode changes eventually call
-	// VGA_SetupDrawing() which concludes the mode change process.
-	// If this assumption turns out to be false, we'll need to
-	// revisit the logic that resets this flag.
-	vga.mode_change_in_progress = false;
-
-#ifdef DEBUG_VGA_DRAW
-	LOG_TRACE("VGA: vga.mode_change_in_progress END");
-#endif
-}
-
 void VGA_SetupDrawing(uint32_t /*val*/)
 {
 	if (vga.mode == M_ERROR) {
 		PIC_RemoveEvents(VGA_VerticalTimer);
 		PIC_RemoveEvents(VGA_PanningLatch);
 		PIC_RemoveEvents(VGA_DisplayStartLatch);
-
-		finalise_mode_change();
 		return;
 	}
 
@@ -3014,8 +2999,6 @@ void VGA_SetupDrawing(uint32_t /*val*/)
 
 		previous_video_mode = image_info.video_mode;
 	}
-
-	finalise_mode_change();
 }
 
 void VGA_KillDrawing(void) {

--- a/src/ints/int10.cpp
+++ b/src/ints/int10.cpp
@@ -75,7 +75,7 @@ static Bitu INT10_Handler(void) {
 		break;
 	case 0x05:								/* Set Active Page */
 		if ((reg_al & 0x80) && IS_TANDY_ARCH) {
-			uint8_t crtcpu=real_readb(BIOSMEM_SEG, BIOSMEM_CRTCPU_PAGE);		
+			uint8_t crtcpu=real_readb(BIOSMEM_SEG, BIOSMEM_CRTCPU_PAGE);
 			switch (reg_al) {
 			case 0x80:
 				reg_bh=crtcpu & 7;
@@ -100,7 +100,7 @@ static Bitu INT10_Handler(void) {
 			real_writeb(BIOSMEM_SEG, BIOSMEM_CRTCPU_PAGE,crtcpu);
 		}
 		else INT10_SetActivePage(reg_al);
-		break;	
+		break;
 	case 0x06:								/* Scroll Up */
 		INT10_ScrollWindow(reg_ch,reg_cl,reg_dh,reg_dl,-reg_al,reg_bh,0xFF);
 		break;
@@ -109,7 +109,7 @@ static Bitu INT10_Handler(void) {
 		break;
 	case 0x08:								/* Read character & attribute at cursor */
 		INT10_ReadCharAttr(&reg_ax,reg_bh);
-		break;						
+		break;
 	case 0x09:								/* Write Character & Attribute at cursor CX times */
 		if (real_readb(BIOSMEM_SEG,BIOSMEM_CURRENT_MODE)==0x11)
 			INT10_WriteChar(reg_al,(reg_bl&0x80)|0x3f,reg_bh,reg_cx,true);
@@ -143,7 +143,7 @@ static Bitu INT10_Handler(void) {
 		reg_al=real_readb(BIOSMEM_SEG,BIOSMEM_CURRENT_MODE);
 		if (IS_EGAVGA_ARCH) reg_al|=real_readb(BIOSMEM_SEG,BIOSMEM_VIDEO_CTL)&0x80;
 		reg_ah=(uint8_t)real_readw(BIOSMEM_SEG,BIOSMEM_NB_COLS);
-		break;					
+		break;
 	case 0x10:								/* Palette functions */
 		if (!IS_EGAVGA_ARCH && (reg_al>0x02)) break;
 		else if (!IS_VGA_ARCH && (reg_al>0x03)) break;
@@ -206,7 +206,7 @@ static Bitu INT10_Handler(void) {
 		}
 		break;
 	case 0x11:								/* Character generator functions */
-		if (!IS_EGAVGA_ARCH) 
+		if (!IS_EGAVGA_ARCH)
 			break;
 		if ((reg_al & 0xf0) == 0x10)
 			MOUSEDOS_BeforeNewVideoMode();
@@ -306,7 +306,7 @@ graphics_chars:
 				reg_bp=RealOffset(int10.rom.font_16_alternate);
 				break;
 			default:
-				LOG(LOG_INT10,LOG_ERROR)("Function 11:30 Request for font %2X",reg_bh);	
+				LOG(LOG_INT10,LOG_ERROR)("Function 11:30 Request for font %2X",reg_bh);
 				break;
 			}
 			if ((reg_bh<=7) || (svgaCard==SVGA_TsengET4K)) {
@@ -322,11 +322,11 @@ graphics_chars:
 			MOUSEDOS_AfterNewVideoMode(false);
 		break;
 	case 0x12:								/* alternate function select */
-		if (!IS_EGAVGA_ARCH) 
+		if (!IS_EGAVGA_ARCH)
 			break;
 		switch (reg_bl) {
 		case 0x10:							/* Get EGA Information */
-			reg_bh=(real_readw(BIOSMEM_SEG,BIOSMEM_CRTC_ADDRESS)==0x3B4);	
+			reg_bh=(real_readw(BIOSMEM_SEG,BIOSMEM_CRTC_ADDRESS)==0x3B4);
 			reg_bl=3;	//256 kb
 			reg_cl=real_readb(BIOSMEM_SEG,BIOSMEM_SWITCHES) & 0x0F;
 			reg_ch=real_readb(BIOSMEM_SEG,BIOSMEM_SWITCHES) >> 4;
@@ -334,14 +334,14 @@ graphics_chars:
 		case 0x20:							/* Set alternate printscreen */
 			break;
 		case 0x30:							/* Select vertical resolution */
-			{   
+			{
 				if (!IS_VGA_ARCH) break;
 				LOG(LOG_INT10,LOG_WARN)("Function 12:Call %2X (select vertical resolution)",reg_bl);
 				if (reg_al > 2) {
 					reg_al = 0;	// invalid VGA subfunction
 					break;
 				}
-				uint8_t modeset_ctl = real_readb(BIOSMEM_SEG,BIOSMEM_MODESET_CTL);
+				uint8_t modeset_ctl = real_readb(BIOSMEM_SEG, BiosDataArea::VgaFlagsRecOffset);
 				uint8_t video_switches = real_readb(BIOSMEM_SEG,BIOSMEM_SWITCHES)&0xf0;
 				switch(reg_al) {
 				case 0: // 200
@@ -363,25 +363,25 @@ graphics_chars:
 					video_switches |= 8;	// ega normal/cga emulation
 					break;
 				}
-				real_writeb(BIOSMEM_SEG,BIOSMEM_MODESET_CTL,modeset_ctl);
+				real_writeb(BIOSMEM_SEG, BiosDataArea::VgaFlagsRecOffset,modeset_ctl);
 				real_writeb(BIOSMEM_SEG,BIOSMEM_SWITCHES,video_switches);
 				reg_al=0x12;	// success
 				break;
 			}
 		case 0x31:							/* Palette loading on modeset */
-			{   
+			{
 				if (!IS_VGA_ARCH) break;
 				if (svgaCard==SVGA_TsengET4K) reg_al&=1;
 				if (reg_al>1) {
 					reg_al=0;		//invalid subfunction
 					break;
 				}
-				uint8_t temp = real_readb(BIOSMEM_SEG,BIOSMEM_MODESET_CTL) & 0xf7;
+				uint8_t temp = real_readb(BIOSMEM_SEG, BiosDataArea::VgaFlagsRecOffset) & 0xf7;
 				if (reg_al&1) temp|=8;		// enable if al=0
-				real_writeb(BIOSMEM_SEG,BIOSMEM_MODESET_CTL,temp);
+				real_writeb(BIOSMEM_SEG, BiosDataArea::VgaFlagsRecOffset, temp);
 				reg_al=0x12;
-				break;	
-			}		
+				break;
+			}
 		case 0x32:							/* Video addressing */
 			if (!IS_VGA_ARCH) break;
 			LOG(LOG_INT10,LOG_ERROR)("Function 12:Call %2X not handled",reg_bl);
@@ -390,21 +390,21 @@ graphics_chars:
 			else reg_al=0x12;			//fake a success call
 			break;
 		case 0x33: /* SWITCH GRAY-SCALE SUMMING */
-			{   
+			{
 				if (!IS_VGA_ARCH) break;
 				if (svgaCard==SVGA_TsengET4K) reg_al&=1;
 				if (reg_al>1) {
 					reg_al=0;
 					break;
 				}
-				uint8_t temp = real_readb(BIOSMEM_SEG,BIOSMEM_MODESET_CTL) & 0xfd;
+				uint8_t temp = real_readb(BIOSMEM_SEG, BiosDataArea::VgaFlagsRecOffset) & 0xfd;
 				if (!(reg_al&1)) temp|=2;		// enable if al=0
-				real_writeb(BIOSMEM_SEG,BIOSMEM_MODESET_CTL,temp);
+				real_writeb(BIOSMEM_SEG, BiosDataArea::VgaFlagsRecOffset, temp);
 				reg_al=0x12;
-				break;	
-			}		
+				break;
+			}
 		case 0x34: /* ALTERNATE FUNCTION SELECT (VGA) - CURSOR EMULATION */
-			{   
+			{
 				// bit 0: 0=enable, 1=disable
 				if (!IS_VGA_ARCH) break;
 				if (svgaCard==SVGA_TsengET4K) reg_al&=1;
@@ -415,8 +415,8 @@ graphics_chars:
 				uint8_t temp = real_readb(BIOSMEM_SEG,BIOSMEM_VIDEO_CTL) & 0xfe;
 				real_writeb(BIOSMEM_SEG,BIOSMEM_VIDEO_CTL,temp|reg_al);
 				reg_al=0x12;
-				break;	
-			}		
+				break;
+			}
 		case 0x35:
 			if (!IS_VGA_ARCH) break;
 			LOG(LOG_INT10,LOG_ERROR)("Function 12:Call %2X not handled",reg_bl);
@@ -430,10 +430,10 @@ graphics_chars:
 			}
 			IO_Write(0x3c4,0x1);
 			uint8_t clocking = IO_Read(0x3c5);
-			
+
 			if (reg_al==0) clocking &= ~0x20;
 			else clocking |= 0x20;
-			
+
 			IO_Write(0x3c4,0x1);
 			IO_Write(0x3c5,clocking);
 
@@ -539,7 +539,7 @@ graphics_chars:
 					break;
 			}
 			break;
-		case 0x05:							
+		case 0x05:
 			if (reg_bh==0) {				/* Set CPU Window */
 				reg_ah=VESA_SetCPUWindow(reg_bl,reg_dl);
 				reg_al=0x4f;
@@ -674,12 +674,12 @@ static void INT10_Seg40Init(void) {
 	if (IS_EGAVGA_ARCH) {
 		// Set the default char height
 		real_writeb(BIOSMEM_SEG,BIOSMEM_CHAR_HEIGHT,16);
-		// Clear the screen 
+		// Clear the screen
 		real_writeb(BIOSMEM_SEG,BIOSMEM_VIDEO_CTL,0x60);
 		// Set the basic screen we have
 		real_writeb(BIOSMEM_SEG,BIOSMEM_SWITCHES,0xF9);
 		// Set the basic modeset options
-		real_writeb(BIOSMEM_SEG,BIOSMEM_MODESET_CTL,0x51);
+		real_writeb(BIOSMEM_SEG, BiosDataArea::VgaFlagsRecOffset, 0x51);
 		// Set the pointer to video save pointer table
 		real_writed(BIOSMEM_SEG,BIOSMEM_VS_POINTER,int10.rom.video_save_pointers);
 	}
@@ -736,7 +736,7 @@ void INT10_Init(Section* /*sec*/) {
 	INT10_InitVGA();
 	if (IS_TANDY_ARCH) SetupTandyBios();
 	/* Setup the INT 10 vector */
-	call_10=CALLBACK_Allocate();	
+	call_10=CALLBACK_Allocate();
 	CALLBACK_Setup(call_10,&INT10_Handler,CB_IRET,"Int 10 video");
 	RealSetVec(0x10,CALLBACK_RealPointer(call_10));
 	//Init the 0x40 segment and init the datastructures in the video rom area

--- a/src/ints/int10.cpp
+++ b/src/ints/int10.cpp
@@ -679,7 +679,7 @@ static void INT10_Seg40Init(void) {
 		// Set the basic screen we have
 		real_writeb(BIOSMEM_SEG,BIOSMEM_SWITCHES,0xF9);
 		// Set the basic modeset options
-		real_writeb(BIOSMEM_SEG, BiosDataArea::VgaFlagsRecOffset, 0x51);
+		real_writeb(BIOSMEM_SEG, BiosDataArea::VgaFlagsRecOffset,0x51);
 		// Set the pointer to video save pointer table
 		real_writed(BIOSMEM_SEG,BIOSMEM_VS_POINTER,int10.rom.video_save_pointers);
 	}

--- a/src/ints/int10.h
+++ b/src/ints/int10.h
@@ -294,6 +294,7 @@ void INT10_SetupPalette();
 
 bool INT10_SetVideoMode(uint16_t mode);
 void INT10_SetCurMode(void);
+bool INT10_VideoModeChangeInProgress();
 
 bool INT10_IsTextMode(const VideoModeBlock& mode_block);
 
@@ -394,5 +395,6 @@ bool INT10_VideoState_Restore(Bitu state,RealPt buffer);
 /* Video Parameter Tables */
 uint16_t INT10_SetupVideoParameterTable(PhysPt basepos);
 void INT10_SetupBasicVideoParameterTable(void);
+
 
 #endif

--- a/src/ints/int10.h
+++ b/src/ints/int10.h
@@ -69,10 +69,6 @@ constexpr uint16_t VgaFlagsRecOffset = 0x89;
 #define BIOSMEM_VIDEO_CTL     0x87
 #define BIOSMEM_SWITCHES      0x88
 
-// Bit flags containing to the status of the VGA (VGA only)
-// Ref: http://www.techhelpmanual.com/73-vgaflagsrec.html
-#define BIOSMEM_MODESET_CTL   0x89
-
 // Current display combo (VGA only)
 //
 // One field of the VgaSavePtr2Rec points to a VgaDccRec.  This structure is

--- a/src/ints/int10_modes.cpp
+++ b/src/ints/int10_modes.cpp
@@ -605,9 +605,9 @@ static bool SetCurMode(const std::vector<VideoModeBlock>& modeblock, uint16_t mo
 				vga.mode_change_in_progress = true;
 
 				// Clear flag when setting up a new mode. This
-				// will only be set to true when the first
-				// non-EGA DAC palette colour is set in an EGA
-				// mode on a VGA adapter.
+				// flag is only set when a non-EGA DAC palette
+				// colour is set in an EGA mode on an emulated
+				// VGA adapter after the mode change is completed.
 				vga.ega_mode_with_vga_colors = false;
 
 				return true;

--- a/src/ints/int10_modes.cpp
+++ b/src/ints/int10_modes.cpp
@@ -39,7 +39,8 @@
 
 #define SEQ_REGS 0x05
 #define GFX_REGS 0x09
-#define ATT_REGS 0x15
+
+constexpr auto NumAttributeRegisters = 0x15;
 
 // clang-format off
 std::vector<VideoModeBlock> ModeList_VGA = {
@@ -1586,9 +1587,12 @@ bool INT10_SetVideoMode(uint16_t mode)
 		IO_Write(0x3ce,ct);
 		IO_Write(0x3cf,gfx_data[ct]);
 	}
-	uint8_t att_data[ATT_REGS];
-	memset(att_data,0,ATT_REGS);
-	att_data[0x12]=0xf;				//Always have all color planes enabled
+
+	uint8_t att_data[NumAttributeRegisters];
+	memset(att_data, 0, NumAttributeRegisters);
+	// Always have all color planes enabled
+	att_data[0x12] = 0xf;
+
 	//  Program Attribute Controller
 	switch (CurMode->type) {
 	case M_EGA:
@@ -1706,7 +1710,7 @@ att_text16:
 #if 0
 		LOG_DEBUG("INT10H: Set up Palette Registers");
 #endif
-		for (auto ct = 0; ct < ATT_REGS; ++ct) {
+		for (auto ct = 0; ct < NumAttributeRegisters; ++ct) {
 			IO_Write(0x3c0, ct);
 			IO_Write(0x3c0, att_data[ct]);
 		}
@@ -1809,7 +1813,7 @@ att_text16:
 			}
 		}
 	} else {
-		for (auto ct = 0x10; ct < ATT_REGS; ++ct) {
+		for (auto ct = 0; ct < NumAttributeRegisters; ++ct) {
 			// Skip overscan register
 			if (ct == 0x11) {
 				continue;

--- a/src/ints/int10_modes.cpp
+++ b/src/ints/int10_modes.cpp
@@ -37,9 +37,8 @@
 #include "vga.h"
 #include "video.h"
 
-#define SEQ_REGS 0x05
-#define GFX_REGS 0x09
-
+constexpr auto NumSequencerRegisters = 0x05;
+constexpr auto NumGraphicsRegisters  = 0x09;
 constexpr auto NumAttributeRegisters = 0x15;
 
 // clang-format off
@@ -1152,10 +1151,13 @@ bool INT10_SetVideoMode(uint16_t mode)
 	}
 	IO_Write(0x3c2,misc_output);		//Setup for 3b4 or 3d4
 
-	//  Program Sequencer
-	uint8_t seq_data[SEQ_REGS];
-	memset(seq_data,0,SEQ_REGS);
-	seq_data[1]|=0x01;	//8 dot fonts by default
+	// Program sequencer
+	uint8_t seq_data[NumSequencerRegisters];
+	memset(seq_data, 0, NumSequencerRegisters);
+
+	// 8 dot fonts by default
+	seq_data[1] |= 0x01;
+
 	if (CurMode->special & EGA_HALF_CLOCK)
 		seq_data[1] |= 0x08; // Check for half clock
 	if ((machine == MCH_EGA) && (CurMode->special & EGA_HALF_CLOCK))
@@ -1207,11 +1209,14 @@ bool INT10_SetVideoMode(uint16_t mode)
 		assert(false);
 		break;
 	}
-	for (uint8_t ct=0;ct<SEQ_REGS;ct++) {
-		IO_Write(0x3c4,ct);
-		IO_Write(0x3c5,seq_data[ct]);
+
+	for (auto ct = 0; ct < NumSequencerRegisters; ++ct) {
+		IO_Write(0x3c4, ct);
+		IO_Write(0x3c5, seq_data[ct]);
 	}
-	vga.config.compatible_chain4 = true; // this may be changed by SVGA chipset emulation
+
+	// This may be changed by the SVGA chipset emulation
+	vga.config.compatible_chain4 = true;
 
 	//  Program CRTC
 	//  First disable write protection
@@ -1528,13 +1533,18 @@ bool INT10_SetVideoMode(uint16_t mode)
 		IO_WriteB(crtc_base,0x67);IO_WriteB(crtc_base+1,misc_control_2);
 	}
 
-	//  Write Misc Output
-	IO_Write(0x3c2,misc_output);
-	//  Program Graphics controller
-	uint8_t gfx_data[GFX_REGS];
-	memset(gfx_data,0,GFX_REGS);
-	gfx_data[0x7] = 0xf;  //  Color don't care
-	gfx_data[0x8] = 0xff; //  BitMask
+	// Write misc output
+	IO_Write(0x3c2, misc_output);
+
+	// Program graphics controller
+	uint8_t gfx_data[NumGraphicsRegisters];
+	memset(gfx_data, 0, NumGraphicsRegisters);
+
+	// Color don't care
+	gfx_data[0x7] = 0xf;
+	// BitMask
+	gfx_data[0x8] = 0xff;
+
 	switch (CurMode->type) {
 	case M_TEXT:
 		gfx_data[0x5]|=0x10;		//Odd-Even Mode
@@ -1583,9 +1593,9 @@ bool INT10_SetVideoMode(uint16_t mode)
 		assert(false);
 		break;
 	}
-	for (uint8_t ct=0;ct<GFX_REGS;ct++) {
-		IO_Write(0x3ce,ct);
-		IO_Write(0x3cf,gfx_data[ct]);
+	for (auto ct = 0; ct < NumGraphicsRegisters; ++ct) {
+		IO_Write(0x3ce, ct);
+		IO_Write(0x3cf, gfx_data[ct]);
 	}
 
 	uint8_t att_data[NumAttributeRegisters];

--- a/src/ints/int10_modes.cpp
+++ b/src/ints/int10_modes.cpp
@@ -593,7 +593,7 @@ bool INT10_VideoModeChangeInProgress()
 	return video_mode_change_in_progress;
 }
 
-static bool SetCurMode(const std::vector<VideoModeBlock>& modeblock, uint16_t mode)
+static bool set_cur_mode(const std::vector<VideoModeBlock>& modeblock, uint16_t mode)
 {
 	size_t i = 0;
 	while (modeblock[i].mode != 0xffff) {
@@ -660,40 +660,47 @@ void INT10_SetCurMode(void) {
 
 		switch (machine) {
 		case MCH_CGA:
-			if (bios_mode<7) mode_changed=SetCurMode(ModeList_OTHER,bios_mode);
+			if (bios_mode < 7) {
+				mode_changed = set_cur_mode(ModeList_OTHER, bios_mode);
+			}
 			break;
 
 		case MCH_PCJR:
 		case MCH_TANDY:
-			if (bios_mode!=7 && bios_mode<=0xa) mode_changed=SetCurMode(ModeList_OTHER,bios_mode);
+			if (bios_mode != 7 && bios_mode <= 0xa) {
+				mode_changed = set_cur_mode(ModeList_OTHER, bios_mode);
+			}
 			break;
 
 		case MCH_HERC:
-			if (bios_mode<7) mode_changed=SetCurMode(ModeList_OTHER,bios_mode);
-			else if (bios_mode == 7) {
+			if (bios_mode < 7) {
+				mode_changed = set_cur_mode(ModeList_OTHER, bios_mode);
+			} else if (bios_mode == 7) {
 				mode_changed = true;
 				CurMode = Hercules_Mode.begin();
 			}
 			break;
 
 		case MCH_EGA:
-			mode_changed=SetCurMode(ModeList_EGA,bios_mode);
+			mode_changed = set_cur_mode(ModeList_EGA, bios_mode);
 			break;
 
 		case MCH_VGA:
 			switch (svgaCard) {
 			case SVGA_TsengET4K:
 			case SVGA_TsengET3K:
-				mode_changed=SetCurMode(ModeList_VGA_Tseng,bios_mode);
+				mode_changed = set_cur_mode(ModeList_VGA_Tseng,
+				                            bios_mode);
 				break;
 			case SVGA_ParadisePVGA1A:
-				mode_changed=SetCurMode(ModeList_VGA_Paradise,bios_mode);
+				mode_changed = set_cur_mode(ModeList_VGA_Paradise,
+				                            bios_mode);
 				break;
 			case SVGA_S3Trio:
 				if (bios_mode>=0x68 && CurMode->mode==(bios_mode+0x98)) break;
 				// fall-through
 			default:
-				mode_changed = SetCurMode(ModeList_VGA, bios_mode);
+				mode_changed = set_cur_mode(ModeList_VGA, bios_mode);
 				break;
 			}
 			if (mode_changed && CurMode->type == M_TEXT) {
@@ -728,7 +735,7 @@ bool INT10_IsTextMode(const VideoModeBlock& mode_block)
 	}
 }
 
-static void FinishSetMode(bool clearmem) {
+static void finish_set_mode(bool clearmem) {
 	//  Clear video memory if needs be
 	if (clearmem) {
 		switch (CurMode->type) {
@@ -836,24 +843,26 @@ static bool INT10_SetVideoMode_OTHER(uint16_t mode, bool clearmem)
 	case MCH_TANDY:
 		if (mode>0xa) return false;
 		if (mode==7) mode=0; // PCJR defaults to 0 on invalid mode 7
-		if (!SetCurMode(ModeList_OTHER,mode)) {
+		if (!set_cur_mode(ModeList_OTHER, mode)) {
 			log_invalid_video_mode_error(mode);
 			return false;
 		}
 		break;
+
 	case MCH_HERC:
 		// Allow standard color modes if equipment word is not set to mono (Victory Road)
 		if ((real_readw(BIOSMEM_SEG,BIOSMEM_INITIAL_MODE)&0x30)!=0x30 && mode<7) {
-			if (!SetCurMode(ModeList_OTHER, mode)) {
+			if (!set_cur_mode(ModeList_OTHER, mode)) {
 				log_invalid_video_mode_error(mode);
 				return false;
 			}
-			FinishSetMode(clearmem);
+			finish_set_mode(clearmem);
 			return true;
 		}
 		CurMode = Hercules_Mode.begin();
 		mode=7; // in case the video parameter table is modified
 		break;
+
 	case MCH_EGA:
 	case MCH_VGA:
 		// This code should be unreachable, as MCH_EGA and MCH_VGA are
@@ -1045,7 +1054,7 @@ static bool INT10_SetVideoMode_OTHER(uint16_t mode, bool clearmem)
 			IO_WriteW(crtc_base, i | (real_readb(RealSegment(vparams),
 				RealOffset(vparams) + i + crtc_block_index*16) << 8));
 	}
-	FinishSetMode(clearmem);
+	finish_set_mode(clearmem);
 
 	return true;
 }
@@ -1102,19 +1111,21 @@ bool INT10_SetVideoMode(uint16_t mode)
 		switch(svgaCard) {
 		case SVGA_TsengET4K:
 		case SVGA_TsengET3K:
-			if (!SetCurMode(ModeList_VGA_Tseng,mode)){
+			if (!set_cur_mode(ModeList_VGA_Tseng, mode)) {
 				log_invalid_video_mode_error(mode);
 				return false;
 			}
 			break;
+
 		case SVGA_ParadisePVGA1A:
-			if (!SetCurMode(ModeList_VGA_Paradise,mode)){
+			if (!set_cur_mode(ModeList_VGA_Paradise, mode)) {
 				log_invalid_video_mode_error(mode);
 				return false;
 			}
 			break;
+
 		default:
-			if (!SetCurMode(ModeList_VGA, mode)) {
+			if (!set_cur_mode(ModeList_VGA, mode)) {
 				log_invalid_video_mode_error(mode);
 				return false;
 			}
@@ -1123,7 +1134,7 @@ bool INT10_SetVideoMode(uint16_t mode)
 			set_text_lines();
 		}
 	} else {
-		if (!SetCurMode(ModeList_EGA,mode)){
+		if (!set_cur_mode(ModeList_EGA, mode)) {
 			log_invalid_video_mode_error(mode);
 			return false;
 		}
@@ -1986,7 +1997,7 @@ att_text16:
 		svga.set_video_mode(crtc_base, &modeData);
 	}
 
-	FinishSetMode(clearmem);
+	finish_set_mode(clearmem);
 
 	//  Set vga attrib register into defined state
 	IO_Read(mono_mode ? 0x3ba : 0x3da);

--- a/src/ints/int10_modes.cpp
+++ b/src/ints/int10_modes.cpp
@@ -603,6 +603,9 @@ static bool SetCurMode(const std::vector<VideoModeBlock>& modeblock, uint16_t mo
 
 				// The flag will be reset by VGA_SetupDrawing()
 				// at the end of the mode change process.
+#if 0
+				LOG_TRACE("VGA: vga.mode_change_in_progress START");
+#endif
 				vga.mode_change_in_progress = true;
 
 				// Clear flag when setting up a new mode. This
@@ -1685,6 +1688,24 @@ att_text16:
 	IO_Read(mono_mode ? 0x3ba : 0x3da);
 
 	if ((modeset_ctl & 8)==0) {
+		// Set up Palette Registers
+#if 0
+		LOG_DEBUG("INT10H: Set up Palette Registers");
+#endif
+		for (uint8_t ct = 0; ct < ATT_REGS; ct++) {
+			IO_Write(0x3c0, ct);
+			IO_Write(0x3c0, att_data[ct]);
+		}
+
+		vga.config.pel_panning = 0;
+
+		// Disable palette access
+		IO_Write(0x3c0, 0x20);
+		IO_Write(0x3c0, 0x00);
+
+		// Reset PEL mask
+		IO_Write(0x3c6, 0xff);
+
 		// Set up Color Registers (DAC colours)
 #if 0
 		LOG_DEBUG("INT10H: Set up Color Registers");
@@ -1748,24 +1769,6 @@ dac_text16:
 			assert(false);
 			break;
 		}
-
-		// Set up Palette Registers
-#if 0
-		LOG_DEBUG("INT10H: Set up Palette Registers");
-#endif
-		for (uint8_t ct = 0; ct < ATT_REGS; ct++) {
-			IO_Write(0x3c0, ct);
-			IO_Write(0x3c0, att_data[ct]);
-		}
-
-		vga.config.pel_panning = 0;
-
-		// Disable palette access
-		IO_Write(0x3c0, 0x20);
-		IO_Write(0x3c0, 0x00);
-
-		// Reset PEL mask
-		IO_Write(0x3c6, 0xff);
 
 		if (IS_VGA_ARCH) {
 			//  check if gray scale summing is enabled

--- a/src/ints/int10_modes.cpp
+++ b/src/ints/int10_modes.cpp
@@ -37,10 +37,6 @@
 #include "vga.h"
 #include "video.h"
 
-constexpr auto NumSequencerRegisters = 0x05;
-constexpr auto NumGraphicsRegisters  = 0x09;
-constexpr auto NumAttributeRegisters = 0x15;
-
 // clang-format off
 std::vector<VideoModeBlock> ModeList_VGA = {
   //     mode     type     sw    sh    tw  th  cw ch  pt pstart    plength htot  vtot  hde  vde    special flags
@@ -1152,8 +1148,8 @@ bool INT10_SetVideoMode(uint16_t mode)
 	IO_Write(0x3c2,misc_output);		//Setup for 3b4 or 3d4
 
 	// Program sequencer
-	uint8_t seq_data[NumSequencerRegisters];
-	memset(seq_data, 0, NumSequencerRegisters);
+	uint8_t seq_data[NumVgaSequencerRegisters];
+	memset(seq_data, 0, NumVgaSequencerRegisters);
 
 	// 8 dot fonts by default
 	seq_data[1] |= 0x01;
@@ -1210,7 +1206,7 @@ bool INT10_SetVideoMode(uint16_t mode)
 		break;
 	}
 
-	for (auto ct = 0; ct < NumSequencerRegisters; ++ct) {
+	for (auto ct = 0; ct < NumVgaSequencerRegisters; ++ct) {
 		IO_Write(0x3c4, ct);
 		IO_Write(0x3c5, seq_data[ct]);
 	}
@@ -1537,8 +1533,8 @@ bool INT10_SetVideoMode(uint16_t mode)
 	IO_Write(0x3c2, misc_output);
 
 	// Program graphics controller
-	uint8_t gfx_data[NumGraphicsRegisters];
-	memset(gfx_data, 0, NumGraphicsRegisters);
+	uint8_t gfx_data[NumVgaGraphicsRegisters];
+	memset(gfx_data, 0, NumVgaGraphicsRegisters);
 
 	// Color don't care
 	gfx_data[0x7] = 0xf;
@@ -1593,13 +1589,13 @@ bool INT10_SetVideoMode(uint16_t mode)
 		assert(false);
 		break;
 	}
-	for (auto ct = 0; ct < NumGraphicsRegisters; ++ct) {
+	for (auto ct = 0; ct < NumVgaGraphicsRegisters; ++ct) {
 		IO_Write(0x3ce, ct);
 		IO_Write(0x3cf, gfx_data[ct]);
 	}
 
-	uint8_t att_data[NumAttributeRegisters];
-	memset(att_data, 0, NumAttributeRegisters);
+	uint8_t att_data[NumVgaAttributeRegisters];
+	memset(att_data, 0, NumVgaAttributeRegisters);
 	// Always have all color planes enabled
 	att_data[0x12] = 0xf;
 
@@ -1720,7 +1716,7 @@ att_text16:
 #if 0
 		LOG_DEBUG("INT10H: Set up Palette Registers");
 #endif
-		for (auto ct = 0; ct < NumAttributeRegisters; ++ct) {
+		for (auto ct = 0; ct < NumVgaAttributeRegisters; ++ct) {
 			IO_Write(0x3c0, ct);
 			IO_Write(0x3c0, att_data[ct]);
 		}
@@ -1823,7 +1819,7 @@ att_text16:
 			}
 		}
 	} else {
-		for (auto ct = 0; ct < NumAttributeRegisters; ++ct) {
+		for (auto ct = 0; ct < NumVgaAttributeRegisters; ++ct) {
 			// Skip overscan register
 			if (ct == 0x11) {
 				continue;

--- a/src/ints/int10_modes.cpp
+++ b/src/ints/int10_modes.cpp
@@ -624,7 +624,7 @@ static bool SetCurMode(const std::vector<VideoModeBlock>& modeblock, uint16_t mo
 
 static void SetTextLines(void) {
 	// check for scanline backwards compatibility (VESA text modes??)
-	switch (real_readb(BIOSMEM_SEG,BIOSMEM_MODESET_CTL)&0x90) {
+	switch (real_readb(BIOSMEM_SEG, BiosDataArea::VgaFlagsRecOffset) & 0x90) {
 	case 0x80: // 200 lines emulation
 		if (CurMode->mode <= 3) {
 			CurMode = ModeList_VGA_Text_200lines.begin() + CurMode->mode;
@@ -1063,7 +1063,7 @@ bool INT10_SetVideoMode(uint16_t mode)
 	//  First read mode setup settings from bios area
 	//	uint8_t video_ctl=real_readb(BIOSMEM_SEG,BIOSMEM_VIDEO_CTL);
 	//	uint8_t vga_switches=real_readb(BIOSMEM_SEG,BIOSMEM_SWITCHES);
-	uint8_t modeset_ctl = real_readb(BIOSMEM_SEG, BIOSMEM_MODESET_CTL);
+	uint8_t modeset_ctl = real_readb(BIOSMEM_SEG, BiosDataArea::VgaFlagsRecOffset);
 
 	if (IS_VGA_ARCH) {
 		if (svga.accepts_mode) {
@@ -1772,8 +1772,9 @@ dac_text16:
 
 		if (IS_VGA_ARCH) {
 			//  check if gray scale summing is enabled
-			if (real_readb(BIOSMEM_SEG,BIOSMEM_MODESET_CTL) & 2) {
-				INT10_PerformGrayScaleSumming(0,256);
+			if (real_readb(BIOSMEM_SEG, BiosDataArea::VgaFlagsRecOffset) &
+			    2) {
+				INT10_PerformGrayScaleSumming(0, 256);
 			}
 		}
 	} else {

--- a/src/ints/int10_modes.cpp
+++ b/src/ints/int10_modes.cpp
@@ -586,6 +586,13 @@ static void log_invalid_video_mode_error(const uint16_t mode) {
 	LOG_ERR("INT10H: Trying to set invalid video mode: %02Xh", mode);
 }
 
+bool video_mode_change_in_progress = false;
+
+bool INT10_VideoModeChangeInProgress()
+{
+	return video_mode_change_in_progress;
+}
+
 static bool SetCurMode(const std::vector<VideoModeBlock>& modeblock, uint16_t mode)
 {
 	size_t i = 0;
@@ -596,13 +603,12 @@ static bool SetCurMode(const std::vector<VideoModeBlock>& modeblock, uint16_t mo
 			if (!int10.vesa_oldvbe ||
 			    ModeList_VGA[i].mode < vesa_2_0_modes_start) {
 				CurMode = modeblock.begin() + i;
-
-				// The flag will be reset by VGA_SetupDrawing()
-				// at the end of the mode change process.
 #if 0
-				LOG_TRACE("VGA: vga.mode_change_in_progress START");
+				if (!video_mode_change_in_progress) {
+					LOG_ERR("INT10: video_mode_change_in_progress START");
+				}
 #endif
-				vga.mode_change_in_progress = true;
+				video_mode_change_in_progress = true;
 
 				// Clear flag when setting up a new mode. This
 				// flag is only set when a non-EGA DAC palette
@@ -701,6 +707,13 @@ void INT10_SetCurMode(void) {
 		if (mode_changed) {
 		//	LOG_MSG("INT10H: BIOS video mode changed to %02Xh", bios_mode);
 		}
+
+#if 0
+		if (video_mode_change_in_progress) {
+			LOG_ERR("INT10: video_mode_change_in_progress END");
+		}
+#endif
+		video_mode_change_in_progress = false;
 	}
 }
 
@@ -803,6 +816,13 @@ static void FinishSetMode(bool clearmem) {
 	for (uint8_t ct=0;ct<8;ct++) INT10_SetCursorPos(0,0,ct);
 	// Set active page 0
 	INT10_SetActivePage(0);
+
+#if 0
+	if (video_mode_change_in_progress) {
+		LOG_ERR("INT10: video_mode_change_in_progress END");
+	}
+#endif
+	video_mode_change_in_progress = false;
 }
 
 static bool INT10_SetVideoMode_OTHER(uint16_t mode, bool clearmem)
@@ -1026,6 +1046,7 @@ static bool INT10_SetVideoMode_OTHER(uint16_t mode, bool clearmem)
 				RealOffset(vparams) + i + crtc_block_index*16) << 8));
 	}
 	FinishSetMode(clearmem);
+
 	return true;
 }
 

--- a/src/ints/int10_pal.cpp
+++ b/src/ints/int10_pal.cpp
@@ -235,7 +235,7 @@ void INT10_GetAllPaletteRegisters(PhysPt data) {
 
 void INT10_SetSingleDACRegister(uint8_t index,uint8_t red,uint8_t green,uint8_t blue) {
 	IO_Write(VGAREG_DAC_WRITE_ADDRESS,(uint8_t)index);
-	if ((real_readb(BIOSMEM_SEG,BIOSMEM_MODESET_CTL)&0x06)==0) {
+	if ((real_readb(BIOSMEM_SEG, BiosDataArea::VgaFlagsRecOffset) & 0x06) == 0) {
 		IO_Write(VGAREG_DAC_DATA,red);
 		IO_Write(VGAREG_DAC_DATA,green);
 		IO_Write(VGAREG_DAC_DATA,blue);
@@ -258,7 +258,7 @@ void INT10_GetSingleDACRegister(uint8_t index,uint8_t * red,uint8_t * green,uint
 
 void INT10_SetDACBlock(uint16_t index,uint16_t count,PhysPt data) {
  	IO_Write(VGAREG_DAC_WRITE_ADDRESS,(uint8_t)index);
-	if ((real_readb(BIOSMEM_SEG,BIOSMEM_MODESET_CTL)&0x06)==0) {
+	if ((real_readb(BIOSMEM_SEG, BiosDataArea::VgaFlagsRecOffset) & 0x06) == 0) {
 		for (;count>0;count--) {
 			IO_Write(VGAREG_DAC_DATA,mem_readb(data++));
 			IO_Write(VGAREG_DAC_DATA,mem_readb(data++));


### PR DESCRIPTION
# Description

Fixes https://github.com/dosbox-staging/dosbox-staging/issues/2938

Thanks to  @Python-Exoproject raising the above report, I was kinda forced to re-evaluate my "EGA mode with VGA palette" detection approach in `crt-auto` mode. In the end, I've managed to simplify it and make it a lot safer.

Key points:

- I mucked around with the order of setting up the palette on mode changes previously, which caused this regression (to my credit, everything I tried worked fine _except_ for this single obscure game). Now the legacy DOSBox palette setup method has 100% been restored during INT 10h mode changes.
- I had two paths to detect EGA modes with VGA palette: _during_ the video mode change, and _after_ it. It turns out the first one can be removed safely, which is logical—all games set up the VGA palette _outside_ of the BIOS mode change, of course. It's just my previous method did not clearly delinate the BIOS part and the rest of the mode change logic which is spread across a few files of the code, and this led to various complications in the implementation.
- There's a fair amount of very trivial and safe refactoring commits that can be cleanly backported. I tried it and it works fine in 0.81.1, and there's just a single extremely minor conflict.

Definitely review commit by commit.

I've expanded the [Video emulation tests](https://github.com/dosbox-staging/dosbox-staging/wiki/Video-emulation-tests) page with all relevant material.

## Related issues

- https://github.com/dosbox-staging/dosbox-staging/pull/2819
- https://github.com/dosbox-staging/dosbox-staging/pull/3354
- https://github.com/dosbox-staging/dosbox-staging/pull/3589

# Manual testing

- Confirmed the **Spong** regression is fixed (the game needs 30k cycles).

- Confirmed **Spell It Plus** is still fine with `machine = svga_paradise`.

- Confirmed that **Exobius** works fine.

- Executed all manual tests from here: https://github.com/dosbox-staging/dosbox-staging/pull/3354

- Tested these games that use the **320x200 0Dh EGA mode with VGA colours**. Confirmed a double scanning VGA shader gets picked in `crt-auto` mode:
	- Blues Brothers
	- Cadaver
	- Duke Nukem II
	- Gods
	- Heimdall
	- Immortal, The
	- Magic Pockets
	- Metal Mutant
	- Out of this World (Another World)
	- Prehistorik 2
	- Rastan
	- Rick Dangerous 2
	- Speedball 2
	- Starblade
	- Xenon 2 - Megablast
	- Zool

- Tested **Rastan** which uses the **640x200 0Eh EGA mode with VGA colours**. Confirmed a double scanning VGA shader gets picked up.

- Confirmed that **Darkseed** which uses the **640x350 EGA mode with VGA colours** picks up a VGA shader.

- Tested a bunch of "true EGA" games and confirmed they all pick up a single scanning EGA shader:
   - Aranchnophobia
   - Catacomb 3-D
   - Dragon Wars
   - Drakkhen
   - Spellcasting 201
   - Space Quest III
   - Wasteland


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

