### PR TITLE
Deactivate IRQ if byte is read from i8042 chip

### DIFF
--- a/src/hardware/input/intel8042.cpp
+++ b/src/hardware/input/intel8042.cpp
@@ -430,6 +430,30 @@ static void restart_kbd_disabled_timer()
 // Controller buffer support
 // ***************************************************************************
 
+static uint8_t get_irq_mouse()
+{
+	return IrqNumMouse;
+}
+
+static uint8_t get_irq_keyboard()
+{
+	if (machine == MCH_PCJR) {
+		return IrqNumKbdPcjr;
+	} else {
+		return IrqNumKbdIbmPc;
+	}
+}
+
+static void activate_irqs_if_needed()
+{
+	if (is_data_from_aux && is_irq_active_aux) {
+		PIC_ActivateIRQ(get_irq_mouse());
+	}
+	if (is_data_from_kbd && is_irq_active_kbd) {
+		PIC_ActivateIRQ(get_irq_keyboard());
+	}
+}
+
 static void flush_buffer()
 {
 	is_data_new      = false;
@@ -510,18 +534,7 @@ static void maybe_transfer_buffer()
 	is_data_from_kbd = buffer[idx].is_from_kbd;
 	is_data_new      = true;
 	restart_delay_timer();
-
-	// If needed, activate interrupt
-	if (is_data_from_aux && is_irq_active_aux) {
-		PIC_ActivateIRQ(IrqNumMouse);
-	}
-	if (is_data_from_kbd && is_irq_active_kbd) {
-		if (machine == MCH_PCJR) {
-			PIC_ActivateIRQ(IrqNumKbdPcjr);
-		} else {
-			PIC_ActivateIRQ(IrqNumKbdIbmPc);
-		}
-	}
+	activate_irqs_if_needed();
 }
 
 static void buffer_add(const uint8_t byte,
@@ -902,6 +915,10 @@ static void execute_command(const Command command, const uint8_t param)
 		// firmware allow everything? writing bits 4,5 and 6
 		// should be safe in real implementation, how about here?
 		sanitize_config_byte();
+		// Make sure only the needed IRQs are activated
+		PIC_DeActivateIRQ(get_irq_mouse());
+		PIC_DeActivateIRQ(get_irq_keyboard());
+		activate_irqs_if_needed();
 		break;
 	case Command::WriteControllerMode: // 0xcb
 		// Changes controller mode to PS/2 or AT
@@ -984,6 +1001,7 @@ static uint8_t read_data_port(io_port_t, io_width_t) // port 0x60
 	}
 
 	if (is_data_from_aux) {
+		PIC_DeActivateIRQ(get_irq_mouse());
 		assert(waiting_bytes_from_aux);
 		--waiting_bytes_from_aux;
 		if (I8042_IsReadyForAuxFrame()) {
@@ -992,6 +1010,7 @@ static uint8_t read_data_port(io_port_t, io_width_t) // port 0x60
 	}
 
 	if (is_data_from_kbd) {
+		PIC_DeActivateIRQ(get_irq_keyboard());
 		assert(waiting_bytes_from_kbd);
 		--waiting_bytes_from_kbd;
 		if (I8042_IsReadyForKbdFrame()) {


### PR DESCRIPTION
# Description

Fixes _Tyrian 2000_ keyboard problem - it seems the game menu code reads the keyboard by itself and gets confused if the IRQ is not deactivated after the data byte from i8042 chip (I/O port 0x60) is read.


## Related issues

https://github.com/dosbox-staging/dosbox-staging/issues/3632


# Manual testing

Check that the menu in the Tyrian 2000 game can be operated normally.


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

