### PR TITLE
Show the mixer who's boss 😎 

### DIFF
--- a/include/audio_frame.h
+++ b/include/audio_frame.h
@@ -36,9 +36,19 @@ struct AudioFrame {
 	          right(r)
 	{}
 
+	constexpr AudioFrame(const float m)
+	        : left(m),
+	          right(m)
+	{}
+
 	constexpr AudioFrame(const int16_t l, const int16_t r)
 	        : left(l),
 	          right(r)
+	{}
+
+	constexpr AudioFrame(const int16_t m)
+	        : left(m),
+	          right(m)
 	{}
 
 	// Indexing

--- a/include/audio_frame.h
+++ b/include/audio_frame.h
@@ -1,7 +1,7 @@
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *
- *  Copyright (C) 2022-2023  The DOSBox Staging Team
+ *  Copyright (C) 2022-2024  The DOSBox Staging Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -41,6 +41,7 @@ struct AudioFrame {
 	          right(r)
 	{}
 
+	// Indexing
 	constexpr float& operator[](const size_t i) noexcept
 	{
 		assert(i < 2);
@@ -52,9 +53,45 @@ struct AudioFrame {
 		return i == 0 ? left : right;
 	}
 
+	// Equality
 	constexpr bool operator==(const AudioFrame& that) const
 	{
 		return (left == that.left && right == that.right);
+	}
+
+	// Accumulation
+	constexpr AudioFrame& operator+=(const AudioFrame& that)
+	{
+		*this = *this + that;
+		return *this;
+	}
+
+	constexpr AudioFrame operator+(const AudioFrame& that) const
+	{
+		return {left + that.left, right + that.right};
+	}
+
+	// Gain
+	constexpr AudioFrame& operator*=(const float gain)
+	{
+		*this = *this * gain;
+		return *this;
+	}
+
+	constexpr AudioFrame operator*(const float gain) const
+	{
+		return {left * gain, right * gain};
+	}
+
+	constexpr AudioFrame& operator*=(const AudioFrame& gain)
+	{
+		*this = *this * gain;
+		return *this;
+	}
+
+	constexpr AudioFrame operator*(const AudioFrame& gain) const
+	{
+		return {left * gain.left, right * gain.right};
 	}
 };
 

--- a/include/channel_names.h
+++ b/include/channel_names.h
@@ -1,7 +1,7 @@
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *
- *  Copyright (C) 2023-2023  The DOSBox Staging Team
+ *  Copyright (C) 2023-2024  The DOSBox Staging Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/include/checks.h
+++ b/include/checks.h
@@ -34,7 +34,7 @@
 // because they would be fatal (ie, -Werror) or too verbose (ie, -Wnarrowing
 // generating 3,400+ warnings!)
 //
-// So this per-file approach lets us focus down one file at a time and then
+// So this per file approach lets us focus down one file at a time and then
 // declare that it's free from the issue(s) we're checking.
 //
 // Usage:
@@ -43,10 +43,10 @@
 //
 // How to add new checks:
 //
-//   1. Assess how much work it would be to enable it at the project-level. If
+//   1. Assess how much work it would be to enable it at the project level. If
 //      the check is too burdensome, then carry on.
 //
-//   2. The C98 and c++11 standards supports the _Pragma() function to add
+//   2. The C98 and C++11 standards supports the _Pragma() function to add
 //      #pragma strings. We can use it to add compiler-specific features.
 //
 //   3. Finish the macro with END_MACRO to swalllow the semicolon and avoid
@@ -55,9 +55,12 @@
 #define END_MACRO \
 	struct END_MACRO_##__FILE__##__LINE__ {}
 
+// `-Wconversion` enables a few noisy warnings wholesale that we then need
+// to disable manually.
 #ifdef __GNUC__
 #	define CHECK_NARROWING() \
 		_Pragma("GCC diagnostic warning \"-Wconversion\"") \
+		_Pragma("GCC diagnostic ignored \"-Wsign-conversion\"") \
 		_Pragma("GCC diagnostic warning \"-Wnarrowing\"") \
 		END_MACRO
 #else

--- a/include/control.h
+++ b/include/control.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2019-2023  The DOSBox Staging Team
+ *  Copyright (C) 2019-2024  The DOSBox Staging Team
  *  Copyright (C) 2002-2021  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/include/dosbox.h
+++ b/include/dosbox.h
@@ -75,8 +75,8 @@ void DOSBOX_Init(void);
 void DOSBOX_SetMachineTypeFromConfig(Section_prop* section);
 
 class Config;
-using config_ptr_t = std::unique_ptr<Config>;
-extern config_ptr_t control;
+using ConfigPtr = std::unique_ptr<Config>;
+extern ConfigPtr control;
 
 enum SVGACards {
 	SVGA_None,

--- a/include/hardware.h
+++ b/include/hardware.h
@@ -42,22 +42,22 @@ bool PS1AUDIO_IsEnabled();
 bool SB_GetAddress(uint16_t &sbaddr, uint8_t &sbirq, uint8_t &sbdma);
 
 // Sound Blaster and ESS configuration and initialisation
-void SB_AddConfigSection(const config_ptr_t &conf);
+void SB_AddConfigSection(const ConfigPtr &conf);
 
 // CMS/Game Blaster, OPL, and ESFM configuration and initialisation
-void OPL_AddConfigSettings(const config_ptr_t &conf);
+void OPL_AddConfigSettings(const ConfigPtr &conf);
 
 bool TANDYSOUND_GetAddress(Bitu& tsaddr, Bitu& tsirq, Bitu& tsdma);
 
 extern uint8_t adlib_commandreg;
 
 // Gravis UltraSound configuration and initialisation
-void GUS_AddConfigSection(const config_ptr_t &conf);
+void GUS_AddConfigSection(const ConfigPtr &conf);
 
 // IBM Music Feature Card configuration and initialisation
-void IMFC_AddConfigSection(const config_ptr_t& conf);
+void IMFC_AddConfigSection(const ConfigPtr& conf);
 
 // Innovation SSI-2001 configuration and initialisation
-void INNOVATION_AddConfigSection(const config_ptr_t &conf);
+void INNOVATION_AddConfigSection(const ConfigPtr &conf);
 
 #endif

--- a/include/mapper.h
+++ b/include/mapper.h
@@ -1,7 +1,7 @@
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *
- *  Copyright (C) 2020-2022  The DOSBox Staging Team
+ *  Copyright (C) 2020-2024  The DOSBox Staging Team
  *  Copyright (C) 2002-2021  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/include/math_utils.h
+++ b/include/math_utils.h
@@ -1,7 +1,7 @@
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *
- *  Copyright (C) 2020-2023  The DOSBox Staging Team
+ *  Copyright (C) 2020-2024  The DOSBox Staging Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/include/math_utils.h
+++ b/include/math_utils.h
@@ -104,6 +104,22 @@ inline int ifloor(const float x)
 	return static_cast<int>(floorf(x));
 }
 
+inline int iceil(double x)
+{
+	assert(std::isfinite(x));
+	assert(x >= (std::numeric_limits<int>::min)());
+	assert(x <= (std::numeric_limits<int>::max)());
+	return static_cast<int>(ceil(x));
+}
+
+inline int iceil(const float x)
+{
+	assert(std::isfinite(x));
+	assert(x >= static_cast<float>((std::numeric_limits<int>::min)()));
+	assert(x <= static_cast<float>((std::numeric_limits<int>::max)()));
+	return static_cast<int>(ceilf(x));
+}
+
 // Determine if two numbers are equal "enough" based on an epsilon value.
 // Uses a dynamic adjustment based on the magnitude of the numbers.
 // Based on ideas from Bruce Dawson's blog post:

--- a/include/midi.h
+++ b/include/midi.h
@@ -1,7 +1,7 @@
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *
- *  Copyright (C) 2020-2023  The DOSBox Staging Team
+ *  Copyright (C) 2020-2024  The DOSBox Staging Team
  *  Copyright (C) 2002-2021  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/include/midi.h
+++ b/include/midi.h
@@ -236,13 +236,13 @@ struct MidiWork {
 };
 
 #if C_FLUIDSYNTH
-void FLUID_AddConfigSection(const config_ptr_t& conf);
+void FLUID_AddConfigSection(const ConfigPtr& conf);
 #endif
 
 #if C_MT32EMU
-void MT32_AddConfigSection(const config_ptr_t& conf);
+void MT32_AddConfigSection(const ConfigPtr& conf);
 #endif
 
-void MIDI_AddConfigSection(const config_ptr_t& conf);
+void MIDI_AddConfigSection(const ConfigPtr& conf);
 
 #endif

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -50,11 +50,11 @@ using MIXER_Handler = std::function<void(int frames)>;
 
 enum class MixerState { Uninitialized, NoSound, On, Muted };
 
-static constexpr int MixerBufferLength = 16 * 1024;
-static constexpr int MixerBufferMask   = MixerBufferLength - 1;
+static constexpr int MixerBufferByteSize = 16 * 1024;
+static constexpr int MixerBufferMask     = MixerBufferByteSize - 1;
 
 // TODO This is hacky and should be removed. Only the PS1 Audio uses it.
-extern uint8_t MixTemp[MixerBufferLength];
+extern uint8_t MixTemp[MixerBufferByteSize];
 
 // TODO This seems like is a general-purpose lookup, consider moving it
 extern int16_t lut_u8to16[UINT8_MAX + 1];
@@ -64,7 +64,7 @@ constexpr auto Min16BitSampleValue = INT16_MIN;
 
 static constexpr auto MaxFilterOrder = 16;
 
-static constexpr auto MillisInSecond   = 1000.0;
+static constexpr auto MillisInSecond  = 1000.0;
 static constexpr auto MillisInSecondF = 1000.0f;
 
 static constexpr int UseMixerRate = 0;

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -360,8 +360,8 @@ private:
 
 	struct {
 		int target_rate_hz = 0;
-		float pos               = 0.0f;
-		float step              = 0.0f;
+		float pos          = 0.0f;
+		float step         = 0.0f;
 	} zoh_upsampler = {};
 
 	struct {
@@ -371,13 +371,13 @@ private:
 	struct {
 		struct {
 			std::array<Iir::Butterworth::HighPass<max_filter_order>, 2> hpf = {};
-			int order           = 0;
+			int order          = 0;
 			int cutoff_freq_hz = 0;
 		} highpass = {};
 
 		struct {
 			std::array<Iir::Butterworth::LowPass<max_filter_order>, 2> lpf = {};
-			int order           = 0;
+			int order          = 0;
 			int cutoff_freq_hz = 0;
 		} lowpass = {};
 	} filters               = {};
@@ -406,8 +406,7 @@ private:
 	class Sleeper {
 	public:
 		Sleeper() = delete;
-		Sleeper(MixerChannel& c,
-		        const int sleep_after_ms = default_wait_ms);
+		Sleeper(MixerChannel& c, const int sleep_after_ms = default_wait_ms);
 		bool ConfigureFadeOut(const std::string& prefs);
 		AudioFrame MaybeFadeOrListen(const AudioFrame& frame);
 		void MaybeSleep();
@@ -423,10 +422,10 @@ private:
 		static constexpr auto default_wait_ms = 500;
 		static constexpr auto max_wait_ms     = 5000;
 
-		int64_t woken_at_ms                = {};
-		float fadeout_level                = {};
-		float fadeout_decrement_per_ms     = {};
-		int fadeout_or_sleep_after_ms = {};
+		int64_t woken_at_ms            = {};
+		float fadeout_level            = {};
+		float fadeout_decrement_per_ms = {};
+		int fadeout_or_sleep_after_ms  = {};
 
 		bool wants_fadeout = false;
 		bool had_signal    = false;

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -434,16 +434,16 @@ private:
 	const bool do_sleep = false;
 };
 
-using mixer_channel_t = std::shared_ptr<MixerChannel>;
+using MixerChannelPtr = std::shared_ptr<MixerChannel>;
 
-mixer_channel_t MIXER_AddChannel(MIXER_Handler handler,
+MixerChannelPtr MIXER_AddChannel(MIXER_Handler handler,
                                  const int sample_rate_hz, const char* name,
                                  const std::set<ChannelFeature>& features);
 
-mixer_channel_t MIXER_FindChannel(const char* name);
-std::map<std::string, mixer_channel_t>& MIXER_GetChannels();
+MixerChannelPtr MIXER_FindChannel(const char* name);
+std::map<std::string, MixerChannelPtr>& MIXER_GetChannels();
 
-void MIXER_DeregisterChannel(mixer_channel_t& channel);
+void MIXER_DeregisterChannel(MixerChannelPtr& channel);
 
 // Mixer configuration and initialization
 void MIXER_AddConfigSection(const config_ptr_t& conf);

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -62,12 +62,12 @@ extern int16_t lut_u8to16[UINT8_MAX + 1];
 constexpr auto Max16BitSampleValue = INT16_MAX;
 constexpr auto Min16BitSampleValue = INT16_MIN;
 
-static constexpr auto max_filter_order = 16;
+static constexpr auto MaxFilterOrder = 16;
 
-static constexpr auto millis_in_second   = 1000.0;
-static constexpr auto millis_in_second_f = 1000.0f;
+static constexpr auto MillisInSecond   = 1000.0;
+static constexpr auto MillisInSecondF = 1000.0f;
 
-static constexpr int use_mixer_rate = 0;
+static constexpr int UseMixerRate = 0;
 
 // Get a DOS-formatted silent-sample when there's a chance it will
 // be processed using AddSamples_nonnative()
@@ -370,13 +370,13 @@ private:
 
 	struct {
 		struct {
-			std::array<Iir::Butterworth::HighPass<max_filter_order>, 2> hpf = {};
+			std::array<Iir::Butterworth::HighPass<MaxFilterOrder>, 2> hpf = {};
 			int order          = 0;
 			int cutoff_freq_hz = 0;
 		} highpass = {};
 
 		struct {
-			std::array<Iir::Butterworth::LowPass<max_filter_order>, 2> lpf = {};
+			std::array<Iir::Butterworth::LowPass<MaxFilterOrder>, 2> lpf = {};
 			int order          = 0;
 			int cutoff_freq_hz = 0;
 		} lowpass = {};
@@ -406,7 +406,7 @@ private:
 	class Sleeper {
 	public:
 		Sleeper() = delete;
-		Sleeper(MixerChannel& c, const int sleep_after_ms = default_wait_ms);
+		Sleeper(MixerChannel& c, const int sleep_after_ms = DefaultWaitMs);
 		bool ConfigureFadeOut(const std::string& prefs);
 		AudioFrame MaybeFadeOrListen(const AudioFrame& frame);
 		void MaybeSleep();
@@ -418,9 +418,9 @@ private:
 		MixerChannel& channel;
 
 		// The wait before fading or sleeping is bound between:
-		static constexpr auto min_wait_ms     = 100;
-		static constexpr auto default_wait_ms = 500;
-		static constexpr auto max_wait_ms     = 5000;
+		static constexpr auto MinWaitMs     = 100;
+		static constexpr auto DefaultWaitMs = 500;
+		static constexpr auto MaxWaitMs     = 5000;
 
 		int64_t woken_at_ms            = {};
 		float fadeout_level            = {};

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -446,7 +446,7 @@ std::map<std::string, MixerChannelPtr>& MIXER_GetChannels();
 void MIXER_DeregisterChannel(MixerChannelPtr& channel);
 
 // Mixer configuration and initialization
-void MIXER_AddConfigSection(const config_ptr_t& conf);
+void MIXER_AddConfigSection(const ConfigPtr& conf);
 int MIXER_GetSampleRate();
 int MIXER_GetPreBufferMs();
 

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -413,7 +413,7 @@ private:
 		bool WakeUp();
 
 	private:
-		void DecrementFadeLevel(const int64_t awake_for_ms);
+		void DecrementFadeLevel(const int awake_for_ms);
 
 		MixerChannel& channel;
 

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -50,8 +50,8 @@ using MIXER_Handler = std::function<void(int frames)>;
 
 enum class MixerState { Uninitialized, NoSound, On, Muted };
 
-static constexpr int MixerBufferLength = {16 * 1024};
-static constexpr int MixerBufferMask   = {MixerBufferLength - 1};
+static constexpr int MixerBufferLength = 16 * 1024;
+static constexpr int MixerBufferMask   = MixerBufferLength - 1;
 
 // TODO This is hacky and should be removed. Only the PS1 Audio uses it.
 extern uint8_t MixTemp[MixerBufferLength];

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -286,9 +286,6 @@ private:
 
 	std::set<ChannelFeature> features = {};
 
-	// This gets added the frequency counter each mixer step
-	int freq_add = 0u;
-
 	// When this flows over a new sample needs to be read from the device
 	int freq_counter = 0u;
 

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -301,18 +301,18 @@ private:
 
 	int sample_rate_hz = 0u;
 
-	// Volume scalars
-	// ~~~~~~~~~~~~~~
+	// Volume gains
+	// ~~~~~!~~~~~~
 	// The user sets this via MIXER.COM, which lets them magnify or diminish
 	// the channel's volume relative to other adjustments, such as any
 	// adjustments done by the application at runtime.
-	AudioFrame user_volume_scalar = {1.0f, 1.0f};
+	AudioFrame user_volume_gain = {1.0f, 1.0f};
 
 	// The application (might) adjust a channel's volume programmatically at
 	// runtime via the Sound Blaster or ReelMagic control interfaces.
-	AudioFrame app_volume_scalar = {1.0f, 1.0f};
+	AudioFrame app_volume_gain = {1.0f, 1.0f};
 
-	// The 0 dB volume scalar is used to bring a channel to 0 dB in the
+	// The 0 dB volume gain is used to bring a channel to 0 dB in the
 	// signed 16-bit [-32k, +32k] range.
 	//
 	// Two examples:
@@ -323,13 +323,13 @@ private:
 	//  2. The GUS's simultaneous voices can accumulate to ~100%+RMS
 	//     above 0 dB, so for that channel we set this to RMS (sqrt of half).
 	//
-	float db0_volume_scalar = 1.0f;
+	float db0_volume_gain = 1.0f;
 
 	// All three of these are multiplied together to form the combined
-	// volume scalar. This means we can apply one float-multiply per sample
+	// volume gain. This means we can apply one float-multiply per sample
 	// and perform all three adjustments at once.
 	//
-	AudioFrame combined_volume_scalar = {1.0f, 1.0f};
+	AudioFrame combined_volume_gain = {1.0f, 1.0f};
 
 	// Defines the peak sample amplitude we can expect in this channel.
 	// Default to signed 16bit max, however channel's that know their own

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -293,13 +293,13 @@ private:
 	int freq_counter = 0u;
 
 	// Timing on how many samples were needed by the mixer
-	int frames_needed = 0u;
+	int frames_needed = 0;
 
 	// Previous and next sample fames
 	AudioFrame prev_frame = {};
 	AudioFrame next_frame = {};
 
-	int sample_rate_hz = 0u;
+	int sample_rate_hz = 0;
 
 	// Volume gains
 	// ~~~~~!~~~~~~

--- a/include/mouse.h
+++ b/include/mouse.h
@@ -33,7 +33,7 @@
 // ***************************************************************************
 
 void MOUSE_Init(Section *);
-void MOUSE_AddConfigSection(const config_ptr_t &);
+void MOUSE_AddConfigSection(const ConfigPtr &);
 
 // ***************************************************************************
 // Data types

--- a/include/mouse.h
+++ b/include/mouse.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2022-2023  The DOSBox Staging Team
+ *  Copyright (C) 2022-2024  The DOSBox Staging Team
  *  Copyright (C) 2002-2021  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/include/render.h
+++ b/include/render.h
@@ -188,7 +188,7 @@ extern ScalerLineHandler_t RENDER_DrawLine;
 void RENDER_Init(Section*);
 void RENDER_Reinit();
 
-void RENDER_AddConfigSection(const config_ptr_t& conf);
+void RENDER_AddConfigSection(const ConfigPtr& conf);
 
 AspectRatioCorrectionMode RENDER_GetAspectRatioCorrectionMode();
 

--- a/include/ring_buffer.h
+++ b/include/ring_buffer.h
@@ -1,0 +1,198 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2024-2024  The DOSBox Staging Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#ifndef DOSBOX_RING_BUFFER_H
+#define DOSBOX_RING_BUFFER_H
+
+#include <algorithm>
+#include <array>
+#include <bit>
+#include <cstdint>
+
+#include "math_utils.h"
+
+// Simple ring buffer implementation that basically wraps `std:array` and adds
+// iterators with "wrap-around" properties.
+//
+// Enforces power of two array sizes by default for efficiency reasons.
+//
+// Slightly adapted from:
+// https://gist.github.com/jhurliman/58b9ee8f52053a0e3dbbb45aad718457
+//
+#define POWER_OF_TWO_ARRAY_SIZE 1
+
+template <class T, size_t N>
+class RingBuffer {
+
+#if POWER_OF_TWO_ARRAY_SIZE
+	static_assert(std::has_single_bit(N), "RingBuffer size must be power of two");
+
+	static constexpr size_t IndexMask = (N - 1);
+#endif
+
+public:
+	RingBuffer() {}
+
+	RingBuffer(const T initValue)
+	{
+		std::fill_n(data_.begin(), data_.size(), initValue);
+	}
+
+	T at(size_t n)
+	{
+		return data_.at(n);
+	}
+
+	std::array<T, N>& data() const
+	{
+		return data_;
+	}
+
+	size_t size()
+	{
+		return data_.size();
+	}
+
+	class RingBufferIterator {
+		RingBuffer* array;
+		size_t index;
+
+	public:
+		using iterator_category = std::random_access_iterator_tag;
+		using value_type = T;
+		using difference_type = T;
+		using pointer = T*;
+		using reference = T&;
+
+		RingBufferIterator(RingBuffer& d, size_t idx) : array(&d), index(idx) {}
+
+		// Decrement operator
+		RingBufferIterator& operator--()
+		{
+			PrevIndex();
+			return *this;
+		}
+
+		RingBufferIterator operator--(int)
+		{
+			RingBufferIterator tmp(*array, index);
+			PrevIndex();
+			return tmp;
+		}
+
+		// Increment operator
+		RingBufferIterator& operator++()
+		{
+			NextIndex();
+			return *this;
+		}
+
+		RingBufferIterator operator++(int)
+		{
+			RingBufferIterator tmp(*array, index);
+			NextIndex();
+			return tmp;
+		}
+
+		// Addition (positive offset) operator
+		RingBufferIterator operator+(size_t off)
+		{
+			auto idx = (index + off);
+#if POWER_OF_TWO_ARRAY_SIZE
+			idx &= IndexMask;
+#else
+			idx %= array->size();
+#endif
+			return RingBufferIterator(*array, idx);
+		}
+
+		RingBufferIterator operator+=(size_t off)
+		{
+			*this = *this + off;
+			return *this;
+		}
+
+		// Subtraction (negative offset) operator
+		RingBufferIterator operator-(size_t off)
+		{
+			auto idx = index - off + array->size();
+#if POWER_OF_TWO_ARRAY_SIZE
+			idx &= IndexMask;
+#else
+			idx %= array->size();
+#endif
+			return RingBufferIterator(*array, idx);
+		}
+
+		RingBufferIterator operator-=(size_t off)
+		{
+			*this = *this - off;
+			return *this;
+		}
+
+		// Dereference operator
+		T& operator*() const
+		{
+			return (*array).data_[index];
+		}
+
+		// Equality operator
+		bool operator==(const RingBufferIterator& other) const
+		{
+			return index == other.index;
+		}
+
+	private:
+		void PrevIndex()
+		{
+#if POWER_OF_TWO_ARRAY_SIZE
+			--index;
+			index &= IndexMask;
+#else
+			--index;
+			if (index == array->size()) {
+				index = 0;
+			}
+#endif
+		}
+
+		void NextIndex()
+		{
+#if POWER_OF_TWO_ARRAY_SIZE
+			++index;
+			index &= IndexMask;
+#else
+			++index;
+			if (index == array->size()) {
+				index = 0;
+			}
+#endif
+		}
+	};
+
+	RingBufferIterator begin()
+	{
+		return RingBufferIterator(*this, 0);
+	}
+
+	std::array<T, N> data_ = {};
+};
+
+#endif // DOSBOX_RING_BUFFER_H

--- a/include/rwqueue.h
+++ b/include/rwqueue.h
@@ -1,7 +1,7 @@
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *
- *  Copyright (C) 2021-2023  The DOSBox Staging Team
+ *  Copyright (C) 2021-2024  The DOSBox Staging Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/meson.build
+++ b/meson.build
@@ -101,7 +101,6 @@ foreach flag : [
     '-Wduplicated-branches',
     '-Weffc++',
     '-Wextra-semi',
-    '-Wfloat-conversion',
     '-Wlogical-op',
     '-Wlogical-not-parentheses',
     '-Wredundant-decls',

--- a/src/capture/capture.cpp
+++ b/src/capture/capture.cpp
@@ -691,7 +691,7 @@ static void init_capture_dosbox_settings(Section_prop& secprop)
 	assert(str_prop);
 }
 
-void CAPTURE_AddConfigSection(const config_ptr_t& conf)
+void CAPTURE_AddConfigSection(const ConfigPtr& conf)
 {
 	assert(conf);
 

--- a/src/capture/capture.h
+++ b/src/capture/capture.h
@@ -43,7 +43,7 @@ enum class CaptureType {
 
 enum class CaptureState { Off, Pending, InProgress };
 
-void CAPTURE_AddConfigSection(const config_ptr_t& conf);
+void CAPTURE_AddConfigSection(const ConfigPtr& conf);
 
 // TODO move raw OPL and serial log capture into the capture module too
 

--- a/src/capture/capture.h
+++ b/src/capture/capture.h
@@ -1,7 +1,7 @@
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *
- *  Copyright (C) 2023-2023  The DOSBox Staging Team
+ *  Copyright (C) 2023-2024  The DOSBox Staging Team
  *  Copyright (C) 2002-2021  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/src/capture/image/image_capturer.cpp
+++ b/src/capture/image/image_capturer.cpp
@@ -1,7 +1,7 @@
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *
- *  Copyright (C) 2023-2023  The DOSBox Staging Team
+ *  Copyright (C) 2023-2024  The DOSBox Staging Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/dos/cdrom.h
+++ b/src/dos/cdrom.h
@@ -321,7 +321,7 @@ private:
 		uint32_t                 totalTrackFrames   = 0;
 		uint32_t                 startSector        = 0;
 		uint32_t                 totalRedbookFrames = 0;
-		int16_t buffer[MixerBufferLength * REDBOOK_CHANNELS] = {0};
+		int16_t buffer[MixerBufferByteSize * REDBOOK_CHANNELS] = {0};
 		bool                     isPlaying          = false;
 		bool                     isPaused           = false;
 	} player;

--- a/src/dos/cdrom.h
+++ b/src/dos/cdrom.h
@@ -316,7 +316,7 @@ private:
 		std::weak_ptr<TrackFile> trackFile = {};
 		mixer_channel_t channel = nullptr;
 		CDROM_Interface_Image    *cd                = nullptr;
-		void (MixerChannel::*addFrames)(uint16_t, const int16_t *) = nullptr;
+		void (MixerChannel::*addFrames)(int, const int16_t *) = nullptr;
 		uint32_t                 playedTrackFrames  = 0;
 		uint32_t                 totalTrackFrames   = 0;
 		uint32_t                 startSector        = 0;

--- a/src/dos/cdrom.h
+++ b/src/dos/cdrom.h
@@ -314,7 +314,7 @@ private:
 	static struct imagePlayer {
 		// Objects, pointers, and then scalars; in descending size-order.
 		std::weak_ptr<TrackFile> trackFile = {};
-		mixer_channel_t channel = nullptr;
+		MixerChannelPtr channel = nullptr;
 		CDROM_Interface_Image    *cd                = nullptr;
 		void (MixerChannel::*addFrames)(int, const int16_t *) = nullptr;
 		uint32_t                 playedTrackFrames  = 0;
@@ -370,7 +370,7 @@ private:
 	void CdAudioCallback(const uint16_t requested_frames);
 	void CdReaderLoop();
 
-	mixer_channel_t mixer_channel  = {};
+	MixerChannelPtr mixer_channel  = {};
 	std::thread thread             = {};
 	std::mutex mutex               = {};
 	std::condition_variable waiter = {};

--- a/src/dos/cdrom.h
+++ b/src/dos/cdrom.h
@@ -43,6 +43,7 @@
 // CDROM data and audio format constants
 #define BYTES_PER_RAW_REDBOOK_FRAME    2352u
 #define BYTES_PER_COOKED_REDBOOK_FRAME 2048u
+
 #define REDBOOK_FRAMES_PER_SECOND        75u
 #define REDBOOK_CHANNELS                  2u
 #define REDBOOK_BPS                       2u // bytes per sample
@@ -314,16 +315,29 @@ private:
 	static struct imagePlayer {
 		// Objects, pointers, and then scalars; in descending size-order.
 		std::weak_ptr<TrackFile> trackFile = {};
-		MixerChannelPtr channel = nullptr;
-		CDROM_Interface_Image    *cd                = nullptr;
-		void (MixerChannel::*addFrames)(int, const int16_t *) = nullptr;
-		uint32_t                 playedTrackFrames  = 0;
-		uint32_t                 totalTrackFrames   = 0;
-		uint32_t                 startSector        = 0;
-		uint32_t                 totalRedbookFrames = 0;
-		int16_t buffer[MixerBufferByteSize * REDBOOK_CHANNELS] = {0};
-		bool                     isPlaying          = false;
-		bool                     isPaused           = false;
+		MixerChannelPtr channel            = nullptr;
+		CDROM_Interface_Image* cd          = nullptr;
+
+		void (MixerChannel::*addFrames)(int, const int16_t*) = nullptr;
+
+		uint32_t playedTrackFrames  = 0;
+		uint32_t totalTrackFrames   = 0;
+		uint32_t startSector        = 0;
+		uint32_t totalRedbookFrames = 0;
+		bool isPlaying              = false;
+		bool isPaused               = false;
+
+		// TODO `MixerBufferByteSize` is hardcoded to 1024 * 16 bytes,
+		// so this buffer has been 32k long for a while now. There's
+		// potential for buffer overflows, though; the code that writes
+		// to the buffer asserts the max length of the writes, but
+		// allows lengths far greater than the 32k limit. So it kinda
+		// works, but by fluke.
+		//
+		// Probably the safest way going forward is to turn this into a
+		// `std::vector` and size it as needed at runtime.
+		//
+		int16_t buffer[MixerBufferByteSize * 2] = {};
 	} player;
 
 	// Private utility functions

--- a/src/dos/cdrom_image.cpp
+++ b/src/dos/cdrom_image.cpp
@@ -494,7 +494,7 @@ CDROM_Interface_Image::CDROM_Interface_Image(uint8_t sub_unit)
 			                                      this, std::placeholders::_1);
 
 			player.channel = MIXER_AddChannel(mixer_callback,
-			                                  use_mixer_rate,
+			                                  UseMixerRate,
 			                                  ChannelName::CdAudio,
 			                                  {ChannelFeature::Stereo,
 			                                   ChannelFeature::DigitalAudio});

--- a/src/dos/cdrom_image.cpp
+++ b/src/dos/cdrom_image.cpp
@@ -755,11 +755,13 @@ bool CDROM_Interface_Image::PlayAudioSector(uint32_t start, uint32_t len)
 
 	// Assign the mixer function associated with this track's content type
 	if (track_file->getEndian() == AUDIO_S16SYS) {
-		player.addFrames = track_channels ==  2  ? &MixerChannel::AddSamples_s16 \
-		                                         : &MixerChannel::AddSamples_m16;
+		player.addFrames = (track_channels == 2)
+		                         ? &MixerChannel::AddSamples_s16
+		                         : &MixerChannel::AddSamples_m16;
 	} else {
-		player.addFrames = track_channels ==  2  ? &MixerChannel::AddSamples_s16_nonnative \
-		                                         : &MixerChannel::AddSamples_m16_nonnative;
+		player.addFrames = (track_channels == 2)
+		                         ? &MixerChannel::AddSamples_s16_nonnative
+		                         : &MixerChannel::AddSamples_m16_nonnative;
 	}
 
 	/**

--- a/src/dos/drive_virtual.cpp
+++ b/src/dos/drive_virtual.cpp
@@ -572,14 +572,14 @@ bool Virtual_Drive::FindNext(DOS_DTA& dta)
 	                                                     pattern,
 	                                                     pos);
 	if (search_file) {
-		FatAttributeFlags attr = {FatAttributeFlags::ReadOnly};
-		attr.directory = search_file->isdir;
+		FatAttributeFlags search_attr = {FatAttributeFlags::ReadOnly};
+		search_attr.directory = search_file->isdir;
 
 		dta.SetResult(search_file->name.c_str(),
 		              search_file->data->size(),
 		              search_file->date,
 		              search_file->time,
-		              attr);
+		              search_attr);
 		search_file = search_file->next;
 		return true;
 	}

--- a/src/dos/program_mount_common.cpp
+++ b/src/dos/program_mount_common.cpp
@@ -1,7 +1,7 @@
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *
- *  Copyright (C) 2021-2023  The DOSBox Staging Team
+ *  Copyright (C) 2021-2024  The DOSBox Staging Team
  *  Copyright (C) 2002-2021  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -451,7 +451,7 @@ static void DOSBOX_RealInit(Section* sec)
 double DOSBOX_GetUptime()
 {
 	static auto start_ms = GetTicks();
-	return GetTicksSince(start_ms) / millis_in_second;
+	return GetTicksSince(start_ms) / MillisInSecond;
 }
 
 void DOSBOX_Init()

--- a/src/gui/gui_msgs.h
+++ b/src/gui/gui_msgs.h
@@ -1,7 +1,7 @@
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *
- *  Copyright (C) 2020-2023  The DOSBox Staging Team
+ *  Copyright (C) 2020-2024  The DOSBox Staging Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -1256,7 +1256,7 @@ static void decrease_viewport_stretch(const bool pressed)
 	}
 }
 
-void RENDER_AddConfigSection(const config_ptr_t& conf)
+void RENDER_AddConfigSection(const ConfigPtr& conf)
 {
 	assert(conf);
 

--- a/src/gui/shader_manager.h
+++ b/src/gui/shader_manager.h
@@ -1,7 +1,7 @@
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *
- *  Copyright (C) 2023-2023  The DOSBox Staging Team
+ *  Copyright (C) 2023-2024  The DOSBox Staging Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/hardware/adlib_gold.cpp
+++ b/src/hardware/adlib_gold.cpp
@@ -30,7 +30,7 @@ CHECK_NARROWING();
 // Yamaha YM7128B Surround Processor emulation
 // -------------------------------------------
 
-SurroundProcessor::SurroundProcessor(const uint16_t sample_rate_hz)
+SurroundProcessor::SurroundProcessor(const int sample_rate_hz)
 {
 	assert(sample_rate_hz >= 10);
 
@@ -104,7 +104,7 @@ AudioFrame SurroundProcessor::Process(const AudioFrame frame)
 // Philips Semiconductors TDA8425 hi-fi stereo audio processor emulation
 // ---------------------------------------------------------------------
 
-StereoProcessor::StereoProcessor(const uint16_t _sample_rate_hz)
+StereoProcessor::StereoProcessor(const int _sample_rate_hz)
         : sample_rate_hz(_sample_rate_hz)
 {
 	assert(sample_rate_hz > 0);
@@ -147,8 +147,10 @@ void StereoProcessor::Reset()
 	ControlWrite(StereoProcessorControlReg::Treble, shelf_filter_0db_value);
 
 	StereoProcessorSwitchFunctions sf = {};
-	sf.source_selector                = static_cast<uint8_t>(
-                StereoProcessorSourceSelector::Stereo1);
+
+	sf.source_selector = static_cast<uint8_t>(
+	        StereoProcessorSourceSelector::Stereo1);
+
 	sf.stereo_mode = static_cast<uint8_t>(StereoProcessorStereoMode::LinearStereo);
 
 	ControlWrite(StereoProcessorControlReg::SwitchFunctions, sf.data);
@@ -326,7 +328,7 @@ AudioFrame StereoProcessor::Process(const AudioFrame frame)
 // AdLib Gold module
 // -----------------
 
-AdlibGold::AdlibGold(const uint16_t sample_rate_hz)
+AdlibGold::AdlibGold(const int sample_rate_hz)
         : surround_processor(nullptr),
           stereo_processor(nullptr)
 {
@@ -347,7 +349,7 @@ void AdlibGold::SurroundControlWrite(const uint8_t val)
 	surround_processor->ControlWrite(val);
 }
 
-void AdlibGold::Process(const int16_t* in, const uint32_t frames, float* out)
+void AdlibGold::Process(const int16_t* in, const int frames, float* out)
 {
 	auto frames_remaining = frames;
 

--- a/src/hardware/adlib_gold.cpp
+++ b/src/hardware/adlib_gold.cpp
@@ -1,7 +1,7 @@
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *
- *  Copyright (C) 2022-2023  The DOSBox Staging Team
+ *  Copyright (C) 2022-2024  The DOSBox Staging Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/hardware/adlib_gold.h
+++ b/src/hardware/adlib_gold.h
@@ -30,7 +30,7 @@
 
 class SurroundProcessor {
 public:
-	SurroundProcessor(const uint16_t sample_rate_hz);
+	SurroundProcessor(const int sample_rate_hz);
 	~SurroundProcessor();
 
 	void ControlWrite(const uint8_t val);
@@ -86,7 +86,7 @@ enum class StereoProcessorStereoMode : uint8_t {
 
 class StereoProcessor {
 public:
-	StereoProcessor(const uint16_t sample_rate_hz);
+	StereoProcessor(const int sample_rate_hz);
 	~StereoProcessor();
 
 	void Reset();
@@ -102,7 +102,7 @@ public:
 	StereoProcessor& operator=(const StereoProcessor&) = delete;
 
 private:
-	uint16_t sample_rate_hz = 0;
+	int sample_rate_hz = 0;
 
 	AudioFrame gain = {};
 
@@ -123,14 +123,14 @@ private:
 
 class AdlibGold {
 public:
-	AdlibGold(const uint16_t sample_rate_hz);
+	AdlibGold(const int sample_rate_hz);
 	~AdlibGold();
 
 	void SurroundControlWrite(const uint8_t val);
 	void StereoControlWrite(const StereoProcessorControlReg reg,
 	                        const uint8_t data);
 
-	void Process(const int16_t* in, const uint32_t frames, float* out);
+	void Process(const int16_t* in, const int frames, float* out);
 
 private:
 	std::unique_ptr<SurroundProcessor> surround_processor = {};

--- a/src/hardware/adlib_gold.h
+++ b/src/hardware/adlib_gold.h
@@ -1,7 +1,7 @@
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *
- *  Copyright (C) 2022-2023  The DOSBox Staging Team
+ *  Copyright (C) 2022-2024  The DOSBox Staging Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/hardware/compressor.cpp
+++ b/src/hardware/compressor.cpp
@@ -58,11 +58,9 @@ void Compressor::Configure(const int _sample_rate_hz,
 	ratio           = _ratio;
 
 	attack_coeff = std::exp(-1.0f / (attack_time_ms * sample_rate_hz));
+	release_coeff = std::exp(-MillisInSecondF / (release_time_ms * sample_rate_hz));
 
-	release_coeff = std::exp(-millis_in_second_f /
-	                         (release_time_ms * sample_rate_hz));
-
-	rms_coeff = std::exp(-millis_in_second_f / (rms_window_ms * sample_rate_hz));
+	rms_coeff = std::exp(-MillisInSecondF / (rms_window_ms * sample_rate_hz));
 
 	Reset();
 }

--- a/src/hardware/compressor.cpp
+++ b/src/hardware/compressor.cpp
@@ -1,7 +1,7 @@
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *
- *  Copyright (C) 2022-2023  The DOSBox Staging Team
+ *  Copyright (C) 2022-2024  The DOSBox Staging Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/hardware/compressor.cpp
+++ b/src/hardware/compressor.cpp
@@ -37,7 +37,7 @@ Compressor::Compressor() = default;
 
 Compressor::~Compressor() = default;
 
-void Compressor::Configure(const uint16_t _sample_rate_hz,
+void Compressor::Configure(const int _sample_rate_hz,
                            const float _0dbfs_sample_value, const float threshold_db,
                            const float _ratio, const float attack_time_ms,
                            const float release_time_ms, const float rms_window_ms)
@@ -49,7 +49,7 @@ void Compressor::Configure(const uint16_t _sample_rate_hz,
 	assert(release_time_ms > 0.0f);
 	assert(rms_window_ms > 0.0f);
 
-	sample_rate_hz = _sample_rate_hz;
+	sample_rate_hz = static_cast<float>(_sample_rate_hz);
 
 	scale_in  = 1.0f / _0dbfs_sample_value;
 	scale_out = _0dbfs_sample_value;

--- a/src/hardware/compressor.h
+++ b/src/hardware/compressor.h
@@ -1,7 +1,7 @@
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *
- *  Copyright (C) 2022-2023  The DOSBox Staging Team
+ *  Copyright (C) 2022-2024  The DOSBox Staging Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/hardware/compressor.h
+++ b/src/hardware/compressor.h
@@ -79,7 +79,7 @@ public:
 	Compressor();
 	~Compressor();
 
-	void Configure(const uint16_t sample_rate_hz,
+	void Configure(const int sample_rate_hz,
 	               const float _0dbfs_sample_value, const float threshold_db,
 	               const float ratio, const float attack_time_ms,
 	               const float release_time_ms, const float rms_window_ms);
@@ -93,9 +93,9 @@ public:
 	Compressor &operator=(const Compressor &) = delete;
 
 private:
-	uint16_t sample_rate_hz = {};
-	float scale_in          = {};
-	float scale_out         = {};
+	float sample_rate_hz = {};
+	float scale_in       = {};
+	float scale_out      = {};
 
 	float threshold_value = {};
 	float ratio           = {};

--- a/src/hardware/covox.cpp
+++ b/src/hardware/covox.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2022-2023  The DOSBox Staging Team
+ *  Copyright (C) 2022-2024  The DOSBox Staging Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/hardware/covox.h
+++ b/src/hardware/covox.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2022-2023  The DOSBox Staging Team
+ *  Copyright (C) 2022-2024  The DOSBox Staging Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/hardware/covox.h
+++ b/src/hardware/covox.h
@@ -28,7 +28,7 @@
 
 class Covox final : public LptDac {
 public:
-	Covox() : LptDac(ChannelName::CovoxDac, use_mixer_rate) {}
+	Covox() : LptDac(ChannelName::CovoxDac, UseMixerRate) {}
 	void BindToPort(const io_port_t lpt_port) final;
 	void ConfigureFilters(const FilterState state) final;
 

--- a/src/hardware/disney.cpp
+++ b/src/hardware/disney.cpp
@@ -26,7 +26,7 @@
 
 CHECK_NARROWING();
 
-Disney::Disney() : LptDac(ChannelName::DisneySoundSourceDac, use_mixer_rate)
+Disney::Disney() : LptDac(ChannelName::DisneySoundSourceDac, UseMixerRate)
 {
 	// Prime the FIFO with a single silent sample
 	fifo.emplace(data_reg);
@@ -55,7 +55,7 @@ void Disney::ConfigureFilters(const FilterState state)
 
 	// Pull audio frames from the Disney DAC at 7 kHz
 	channel->SetSampleRate(dss_7khz_rate_hz);
-	ms_per_frame = millis_in_second / dss_7khz_rate_hz;
+	ms_per_frame = MillisInSecond / dss_7khz_rate_hz;
 
 	if (state == FilterState::On) {
 		// The filters are meant to emulate the Disney's bandwidth

--- a/src/hardware/disney.cpp
+++ b/src/hardware/disney.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2021-2023  The DOSBox Staging Team
+ *  Copyright (C) 2021-2024  The DOSBox Staging Team
  *  Copyright (C) 2002-2021  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/src/hardware/gameblaster.cpp
+++ b/src/hardware/gameblaster.cpp
@@ -85,7 +85,7 @@ void GameBlaster::Open(const int port_choice, const std::string &card_choice,
 	const auto audio_callback = std::bind(&GameBlaster::AudioCallback, this, _1);
 
 	channel = MIXER_AddChannel(audio_callback,
-	                           use_mixer_rate,
+	                           UseMixerRate,
 	                           ChannelName::Cms,
 	                           {ChannelFeature::Sleep,
 	                            ChannelFeature::Stereo,

--- a/src/hardware/gameblaster.h
+++ b/src/hardware/gameblaster.h
@@ -85,7 +85,7 @@ private:
 	static constexpr auto render_divisor = 32;
 	static constexpr auto render_rate_hz = ceil_sdivide(chip_clock,
 	                                                    render_divisor);
-	static constexpr auto ms_per_render  = millis_in_second / render_rate_hz;
+	static constexpr auto ms_per_render  = MillisInSecond / render_rate_hz;
 
 	// Runtime states
 	double last_rendered_ms        = 0;

--- a/src/hardware/gameblaster.h
+++ b/src/hardware/gameblaster.h
@@ -69,7 +69,7 @@ private:
 	const char *CardName() const;
 
 	// Managed objects
-	mixer_channel_t channel = nullptr;
+	MixerChannelPtr channel = nullptr;
 
 	IO_WriteHandleObject write_handlers[4]           = {};
 	IO_WriteHandleObject write_handler_for_detection = {};

--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -291,7 +291,7 @@ private:
 	// Playback related
 	double last_rendered_ms = 0.0;
 	double ms_per_render    = 0.0;
-	uint16_t sample_rate_hz = 0;
+	int sample_rate_hz      = 0;
 
 	uint8_t &adlib_command_reg = adlib_commandreg;
 
@@ -667,8 +667,7 @@ void Gus::ActivateVoices(uint8_t requested_voices)
 		// Gravis' calculation to convert from number of active voices
 		// to playback frame rate. Ref: UltraSound Lowlevel ToolKit
 		// v2.22 (21 December 1994), pp. 3 of 113.
-		sample_rate_hz = static_cast<uint16_t>(
-		        1000000.0 / (1.619695497 * active_voices));
+		sample_rate_hz = 1000000.0 / (1.619695497 * active_voices);
 
 		ms_per_render = millis_in_second / sample_rate_hz;
 

--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -60,7 +60,7 @@ constexpr uint32_t RAM_SIZE = 1024 * 1024; // 1 MB
 constexpr uint32_t BYTES_PER_DMA_XFER = 8 * 1024;         // 8 KB per transfer
 constexpr uint32_t ISA_BUS_THROUGHPUT = 32 * 1024 * 1024; // 32 MB/s
 constexpr uint16_t DMA_TRANSFERS_PER_S = ISA_BUS_THROUGHPUT / BYTES_PER_DMA_XFER;
-constexpr double MS_PER_DMA_XFER = millis_in_second / DMA_TRANSFERS_PER_S;
+constexpr double MS_PER_DMA_XFER = MillisInSecond / DMA_TRANSFERS_PER_S;
 
 // Voice-channel and state related constants
 constexpr uint8_t MAX_VOICES          = 32;
@@ -629,7 +629,7 @@ Gus::Gus(const io_port_t port_pref, const uint8_t dma_pref, const uint8_t irq_pr
 	                                      std::placeholders::_1);
 
 	audio_channel = MIXER_AddChannel(mixer_callback,
-	                                 use_mixer_rate,
+	                                 UseMixerRate,
 	                                 ChannelName::GravisUltrasound,
 	                                 {ChannelFeature::Sleep,
 	                                  ChannelFeature::Stereo,
@@ -656,7 +656,7 @@ Gus::Gus(const io_port_t port_pref, const uint8_t dma_pref, const uint8_t irq_pr
 		set_section_property_value("gus", "gus_filter", "off");
 	}
 
-	ms_per_render = millis_in_second / audio_channel->GetSampleRate();
+	ms_per_render = MillisInSecond / audio_channel->GetSampleRate();
 
 	UpdateDmaAddress(dma_pref);
 
@@ -681,7 +681,7 @@ void Gus::ActivateVoices(uint8_t requested_voices)
 		// v2.22 (21 December 1994), pp. 3 of 113.
 		sample_rate_hz = 1000000.0 / (1.619695497 * active_voices);
 
-		ms_per_render = millis_in_second / sample_rate_hz;
+		ms_per_render = MillisInSecond / sample_rate_hz;
 
 		audio_channel->SetSampleRate(sample_rate_hz);
 	}

--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -63,54 +63,54 @@ constexpr uint16_t DMA_TRANSFERS_PER_S = ISA_BUS_THROUGHPUT / BYTES_PER_DMA_XFER
 constexpr double MS_PER_DMA_XFER = millis_in_second / DMA_TRANSFERS_PER_S;
 
 // Voice-channel and state related constants
-constexpr uint8_t MAX_VOICES = 32u;
-constexpr uint8_t MIN_VOICES = 14u;
+constexpr uint8_t MAX_VOICES          = 32u;
+constexpr uint8_t MIN_VOICES          = 14u;
 constexpr uint8_t VOICE_DEFAULT_STATE = 3u;
 
 // DMA and IRQ extents and quantities
-constexpr uint8_t MIN_DMA_ADDRESS = 0u;
-constexpr uint8_t MAX_DMA_ADDRESS = 7u;
-constexpr uint8_t MIN_IRQ_ADDRESS = 0u;
-constexpr uint8_t MAX_IRQ_ADDRESS = 15u;
-constexpr uint8_t DMA_IRQ_ADDRESSES = 8u; // number of IRQ and DMA channels
+constexpr uint8_t MIN_DMA_ADDRESS        = 0u;
+constexpr uint8_t MAX_DMA_ADDRESS        = 7u;
+constexpr uint8_t MIN_IRQ_ADDRESS        = 0u;
+constexpr uint8_t MAX_IRQ_ADDRESS        = 15u;
+constexpr uint8_t DMA_IRQ_ADDRESSES      = 8u; // number of IRQ and DMA channels
 constexpr uint16_t DMA_TC_STATUS_BITMASK = 0b100000000; // Status in 9th bit
 
 // Pan position constants
 constexpr uint8_t PAN_DEFAULT_POSITION = 7u;
-constexpr uint8_t PAN_POSITIONS = 16u;  // 0: -45-deg, 7: centre, 15: +45-deg
+constexpr uint8_t PAN_POSITIONS = 16u; // 0: -45-deg, 7: centre, 15: +45-deg
 
 // Timer delay constants
 constexpr double TIMER_1_DEFAULT_DELAY = 0.080;
 constexpr double TIMER_2_DEFAULT_DELAY = 0.320;
 
 // Volume scaling and dampening constants
-constexpr auto DELTA_DB = 0.002709201;     // 0.0235 dB increments
+constexpr auto DELTA_DB             = 0.002709201; // 0.0235 dB increments
 constexpr int16_t VOLUME_INC_SCALAR = 512; // Volume index increment scalar
-constexpr uint16_t VOLUME_LEVELS = 4096u;
+constexpr uint16_t VOLUME_LEVELS    = 4096u;
 
 // Interwave addressing constant
 constexpr int16_t WAVE_WIDTH = 1 << 9; // Wave interpolation width (9 bits)
 
 // IO address quantities
-constexpr uint8_t READ_HANDLERS = 8u;
+constexpr uint8_t READ_HANDLERS  = 8u;
 constexpr uint8_t WRITE_HANDLERS = 9u;
 
 // A group of parameters defining the Gus's voice IRQ control that's also shared
 // (as a reference) into each instantiated voice.
 struct VoiceIrq {
-	uint32_t vol_state = 0u;
+	uint32_t vol_state  = 0u;
 	uint32_t wave_state = 0u;
-	uint8_t status = 0u;
+	uint8_t status      = 0u;
 };
 
 // A group of parameters used in the Voice class to track the Wave and Volume
 // controls.
 struct VoiceCtrl {
-	uint32_t &irq_state;
+	uint32_t& irq_state;
 	int32_t start = 0;
-	int32_t end = 0;
-	int32_t pos = 0;
-	int32_t inc = 0;
+	int32_t end   = 0;
+	int32_t pos   = 0;
+	int32_t inc   = 0;
 	uint16_t rate = 0;
 	uint8_t state = VOICE_DEFAULT_STATE;
 };
@@ -134,7 +134,7 @@ using write_io_array_t    = std::array<IO_WriteHandleObject, WRITE_HANDLERS>;
 //
 class Voice {
 public:
-	Voice(uint8_t num, VoiceIrq &irq) noexcept;
+	Voice(uint8_t num, VoiceIrq& irq) noexcept;
 	Voice(Voice&&) = default;
 
 	void RenderFrames(const ram_array_t& ram,
@@ -154,39 +154,39 @@ public:
 	VoiceCtrl vol_ctrl;
 	VoiceCtrl wave_ctrl;
 
-	uint32_t generated_8bit_ms = 0u;
+	uint32_t generated_8bit_ms  = 0u;
 	uint32_t generated_16bit_ms = 0u;
 
 private:
-	Voice() = delete;
-	Voice(const Voice &) = delete;            // prevent copying
-	Voice &operator=(const Voice &) = delete; // prevent assignment
+	Voice()                        = delete;
+	Voice(const Voice&)            = delete; // prevent copying
+	Voice& operator=(const Voice&) = delete; // prevent assignment
 	bool CheckWaveRolloverCondition() noexcept;
 	bool Is16Bit() const noexcept;
-	float GetVolScalar(const vol_scalars_array_t &vol_scalars);
-	float GetSample(const ram_array_t &ram) noexcept;
+	float GetVolScalar(const vol_scalars_array_t& vol_scalars);
+	float GetSample(const ram_array_t& ram) noexcept;
 	int32_t PopWavePos() noexcept;
-	float PopVolScalar(const vol_scalars_array_t &vol_scalars);
-	float Read8BitSample(const ram_array_t &ram, int32_t addr) const noexcept;
-	float Read16BitSample(const ram_array_t &ram, int32_t addr) const noexcept;
-	uint8_t ReadCtrlState(const VoiceCtrl &ctrl) const noexcept;
-	void IncrementCtrlPos(VoiceCtrl &ctrl, bool skip_loop) noexcept;
-	bool UpdateCtrlState(VoiceCtrl &ctrl, uint8_t state) noexcept;
+	float PopVolScalar(const vol_scalars_array_t& vol_scalars);
+	float Read8BitSample(const ram_array_t& ram, int32_t addr) const noexcept;
+	float Read16BitSample(const ram_array_t& ram, int32_t addr) const noexcept;
+	uint8_t ReadCtrlState(const VoiceCtrl& ctrl) const noexcept;
+	void IncrementCtrlPos(VoiceCtrl& ctrl, bool skip_loop) noexcept;
+	bool UpdateCtrlState(VoiceCtrl& ctrl, uint8_t state) noexcept;
 
 	// Control states
 	enum CTRL : uint8_t {
-		RESET = 0x01,
-		STOPPED = 0x02,
-		DISABLED = RESET | STOPPED,
-		BIT16 = 0x04,
-		LOOP = 0x08,
+		RESET         = 0x01,
+		STOPPED       = 0x02,
+		DISABLED      = RESET | STOPPED,
+		BIT16         = 0x04,
+		LOOP          = 0x08,
 		BIDIRECTIONAL = 0x10,
-		RAISEIRQ = 0x20,
-		DECREASING = 0x40,
+		RAISEIRQ      = 0x20,
+		DECREASING    = 0x40,
 	};
 
 	uint32_t irq_mask = 0u;
-	uint8_t &shared_irq_status;
+	uint8_t& shared_irq_status;
 	uint8_t pan_position = PAN_DEFAULT_POSITION;
 };
 
@@ -216,11 +216,11 @@ public:
 	void PrintStats();
 
 	struct Timer {
-		double delay = 0.0;
-		uint8_t value = 0xff;
-		bool has_expired = true;
+		double delay          = 0.0;
+		uint8_t value         = 0xff;
+		bool has_expired      = true;
 		bool is_counting_down = false;
-		bool is_masked = false;
+		bool is_masked        = false;
 		bool should_raise_irq = false;
 	};
 	Timer timer_one = {TIMER_1_DEFAULT_DELAY};
@@ -228,9 +228,9 @@ public:
 	bool PerformDmaTransfer();
 
 private:
-	Gus() = delete;
-	Gus(const Gus &) = delete;            // prevent copying
-	Gus &operator=(const Gus &) = delete; // prevent assignment
+	Gus()                      = delete;
+	Gus(const Gus&)            = delete; // prevent copying
+	Gus& operator=(const Gus&) = delete; // prevent assignment
 
 	void ActivateVoices(uint8_t requested_voices);
 	void AudioCallback(uint16_t requested_frames);
@@ -261,31 +261,33 @@ private:
 	void RenderUpToNow();
 	void StopPlayback();
 	void UpdateDmaAddress(uint8_t new_address);
-	void UpdateWaveMsw(int32_t &addr) const noexcept;
-	void UpdateWaveLsw(int32_t &addr) const noexcept;
+	void UpdateWaveMsw(int32_t& addr) const noexcept;
+	void UpdateWaveLsw(int32_t& addr) const noexcept;
 	void WriteToPort(io_port_t port, io_val_t value, io_width_t width);
 
 	void WriteToRegister();
 
 	// Collections
-	std::queue<AudioFrame> fifo     = {};
-	vol_scalars_array_t vol_scalars = {{}};
-	pan_scalars_array_t pan_scalars = {{}};
-	ram_array_t ram                 = {};
-	read_io_array_t read_handlers   = {};
-	write_io_array_t write_handlers = {};
-	std::vector<Voice> voices       = {};
+	std::queue<AudioFrame> fifo             = {};
+	vol_scalars_array_t vol_scalars         = {{}};
+	pan_scalars_array_t pan_scalars         = {{}};
+	ram_array_t ram                         = {};
+	read_io_array_t read_handlers           = {};
+	write_io_array_t write_handlers         = {};
+	std::vector<Voice> voices               = {};
 	std::vector<AudioFrame> rendered_frames = {};
 
 	const address_array_t dma_addresses = {
-	        {MIN_DMA_ADDRESS, 1, 3, 5, 6, MAX_IRQ_ADDRESS, 0, 0}};
+	        {MIN_DMA_ADDRESS, 1, 3, 5, 6, MAX_IRQ_ADDRESS, 0, 0}
+        };
 	const address_array_t irq_addresses = {
-	        {MIN_IRQ_ADDRESS, 2, 5, 3, 7, 11, 12, MAX_IRQ_ADDRESS}};
+	        {MIN_IRQ_ADDRESS, 2, 5, 3, 7, 11, 12, MAX_IRQ_ADDRESS}
+        };
 
 	// Struct and pointer members
-	VoiceIrq voice_irq = {};
-	Voice *target_voice = nullptr;
-	DmaChannel *dma_channel = nullptr;
+	VoiceIrq voice_irq            = {};
+	Voice* target_voice           = nullptr;
+	DmaChannel* dma_channel       = nullptr;
 	mixer_channel_t audio_channel = nullptr;
 
 	// Playback related
@@ -293,45 +295,45 @@ private:
 	double ms_per_render    = 0.0;
 	int sample_rate_hz      = 0;
 
-	uint8_t &adlib_command_reg = adlib_commandreg;
+	uint8_t& adlib_command_reg = adlib_commandreg;
 
 	// Port address
 	io_port_t port_base = 0u;
 
 	// Voice states
 	uint32_t active_voice_mask = 0u;
-	uint16_t voice_index = 0u;
-	uint8_t active_voices = 0u;
+	uint16_t voice_index       = 0u;
+	uint8_t active_voices      = 0u;
 	uint8_t prev_logged_voices = 0u;
 
-	// RAM and register data 
-	uint32_t dram_addr = 0u;
-	uint16_t register_data = 0u;
+	// RAM and register data
+	uint32_t dram_addr        = 0u;
+	uint16_t register_data    = 0u;
 	uint8_t selected_register = 0u;
 
 	// Control states
-	uint8_t mix_ctrl = 0x0b; // latches enabled, LINEs disabled
+	uint8_t mix_ctrl    = 0x0b; // latches enabled, LINEs disabled
 	uint8_t sample_ctrl = 0u;
-	uint8_t timer_ctrl = 0u;
+	uint8_t timer_ctrl  = 0u;
 
 	// DMA states
-	uint16_t dma_addr = 0u;
+	uint16_t dma_addr       = 0u;
 	uint8_t dma_addr_nibble = 0u;
 	// dma_ctrl would normally be a uint8_t as real hardware uses 8 bits,
 	// but we store the DMA terminal count status in the 9th bit
 	uint16_t dma_ctrl = 0u;
-	uint8_t dma1 = 0u; // playback DMA
-	uint8_t dma2 = 0u; // recording DMA
+	uint8_t dma1      = 0u; // playback DMA
+	uint8_t dma2      = 0u; // recording DMA
 
 	// IRQ states
-	uint8_t irq1 = 0u; // playback IRQ
-	uint8_t irq2 = 0u; // MIDI IRQ
+	uint8_t irq1       = 0u; // playback IRQ
+	uint8_t irq2       = 0u; // MIDI IRQ
 	uint8_t irq_status = 0u;
 
-	bool dac_enabled = false;
-	bool irq_enabled = false;
+	bool dac_enabled                = false;
+	bool irq_enabled                = false;
 	bool irq_previously_interrupted = false;
-	bool is_running = false;
+	bool is_running                 = false;
 	bool should_change_irq_dma      = false;
 };
 
@@ -340,7 +342,7 @@ uint8_t adlib_commandreg = ADLIB_CMD_DEFAULT;
 
 static std::unique_ptr<Gus> gus = nullptr;
 
-Voice::Voice(uint8_t num, VoiceIrq &irq) noexcept
+Voice::Voice(uint8_t num, VoiceIrq& irq) noexcept
         : vol_ctrl{irq.vol_state},
           wave_ctrl{irq.wave_state},
           irq_mask(1 << num),
@@ -349,36 +351,37 @@ Voice::Voice(uint8_t num, VoiceIrq &irq) noexcept
 
 /*
 Gravis SDK, Section 3.11. Rollover feature:
-	Each voice has a 'rollover' feature that allows an application to be notified
-	when a voice's playback position passes over a particular place in DRAM.  This
-	is very useful for getting seamless digital audio playback.  Basically, the GF1
-	will generate an IRQ when a voice's current position is  equal to the end
-	position.  However, instead of stopping or looping back to the start position,
-	the voice will continue playing in the same direction.  This means that there
-	will be no pause (or gap) in the playback.
+        Each voice has a 'rollover' feature that allows an application to be
+notified when a voice's playback position passes over a particular place in
+DRAM.  This is very useful for getting seamless digital audio playback.
+Basically, the GF1 will generate an IRQ when a voice's current position is equal
+to the end position.  However, instead of stopping or looping back to the start
+position, the voice will continue playing in the same direction.  This means
+that there will be no pause (or gap) in the playback.
 
-	Note that this feature is enabled/disabled through the voice's VOLUME control
-	register (since there are no more bits available in the voice control
-	registers).   A voice's loop enable bit takes precedence over the rollover. This
-	means that if a voice's loop enable is on, it will loop when it hits the end
-	position, regardless of the state of the rollover enable.
+        Note that this feature is enabled/disabled through the voice's VOLUME
+control register (since there are no more bits available in the voice control
+        registers).   A voice's loop enable bit takes precedence over the
+rollover. This means that if a voice's loop enable is on, it will loop when it
+hits the end position, regardless of the state of the rollover enable.
 ---
 Joh Campbell, maintainer of DOSox-X:
-	Despite the confusing description above, that means that looping takes
-	precedence over rollover. If not looping, then rollover means to fire the IRQ
-	but keep moving. If looping, then fire IRQ and carry out loop behavior. Gravis
-	Ultrasound Windows 3.1 drivers expect this behavior, else Windows WAVE output
-	will not work correctly.
+        Despite the confusing description above, that means that looping takes
+        precedence over rollover. If not looping, then rollover means to fire
+the IRQ but keep moving. If looping, then fire IRQ and carry out loop behavior.
+Gravis Ultrasound Windows 3.1 drivers expect this behavior, else Windows WAVE
+output will not work correctly.
 */
 bool Voice::CheckWaveRolloverCondition() noexcept
 {
 	return (vol_ctrl.state & CTRL::BIT16) && !(wave_ctrl.state & CTRL::LOOP);
 }
 
-void Voice::IncrementCtrlPos(VoiceCtrl &ctrl, bool dont_loop_or_restart) noexcept
+void Voice::IncrementCtrlPos(VoiceCtrl& ctrl, bool dont_loop_or_restart) noexcept
 {
-	if (ctrl.state & CTRL::DISABLED)
+	if (ctrl.state & CTRL::DISABLED) {
 		return;
+	}
 	int32_t remaining = 0;
 	if (ctrl.state & CTRL::DECREASING) {
 		ctrl.pos -= ctrl.inc;
@@ -388,8 +391,9 @@ void Voice::IncrementCtrlPos(VoiceCtrl &ctrl, bool dont_loop_or_restart) noexcep
 		remaining = ctrl.pos - ctrl.end;
 	}
 	// Not yet reaching a boundary
-	if (remaining < 0)
+	if (remaining < 0) {
 		return;
+	}
 
 	// Generate an IRQ if requested
 	if (ctrl.state & CTRL::RAISEIRQ) {
@@ -397,17 +401,19 @@ void Voice::IncrementCtrlPos(VoiceCtrl &ctrl, bool dont_loop_or_restart) noexcep
 	}
 
 	// Allow the current position to move beyond its limit
-	if (dont_loop_or_restart)
+	if (dont_loop_or_restart) {
 		return;
+	}
 
 	// Should we loop?
 	if (ctrl.state & CTRL::LOOP) {
 		/* Bi-directional looping */
-		if (ctrl.state & CTRL::BIDIRECTIONAL)
+		if (ctrl.state & CTRL::BIDIRECTIONAL) {
 			ctrl.state ^= CTRL::DECREASING;
+		}
 		ctrl.pos = (ctrl.state & CTRL::DECREASING)
-		                   ? ctrl.end - remaining
-		                   : ctrl.start + remaining;
+		                 ? ctrl.end - remaining
+		                 : ctrl.start + remaining;
 	}
 	// Otherwise, restart the position back to its start or end
 	else {
@@ -422,19 +428,20 @@ bool Voice::Is16Bit() const noexcept
 	return (wave_ctrl.state & CTRL::BIT16);
 }
 
-float Voice::GetSample(const ram_array_t &ram) noexcept
+float Voice::GetSample(const ram_array_t& ram) noexcept
 {
-	const int32_t pos = PopWavePos();
-	const auto addr = pos / WAVE_WIDTH;
-	const auto fraction = pos & (WAVE_WIDTH - 1);
+	const int32_t pos             = PopWavePos();
+	const auto addr               = pos / WAVE_WIDTH;
+	const auto fraction           = pos & (WAVE_WIDTH - 1);
 	const bool should_interpolate = wave_ctrl.inc < WAVE_WIDTH && fraction;
-	const auto is_16bit = Is16Bit();
-	float sample = is_16bit ? Read16BitSample(ram, addr)
-	                        : Read8BitSample(ram, addr);
+	const auto is_16bit           = Is16Bit();
+	float sample                  = is_16bit ? Read16BitSample(ram, addr)
+	                                         : Read8BitSample(ram, addr);
 	if (should_interpolate) {
-		const auto next_addr = addr + 1;
-		const float next_sample = is_16bit ? Read16BitSample(ram, next_addr)
-		                                   : Read8BitSample(ram, next_addr);
+		const auto next_addr           = addr + 1;
+		const float next_sample        = is_16bit
+		                                       ? Read16BitSample(ram, next_addr)
+		                                       : Read8BitSample(ram, next_addr);
 		constexpr float WAVE_WIDTH_INV = 1.0 / WAVE_WIDTH;
 		sample += (next_sample - sample) *
 		          static_cast<float>(fraction) * WAVE_WIDTH_INV;
@@ -449,8 +456,9 @@ void Voice::RenderFrames(const ram_array_t& ram,
                          const pan_scalars_array_t& pan_scalars,
                          std::vector<AudioFrame>& frames)
 {
-	if (vol_ctrl.state & wave_ctrl.state & CTRL::DISABLED)
+	if (vol_ctrl.state & wave_ctrl.state & CTRL::DISABLED) {
 		return;
+	}
 
 	const auto pan_scalar = pan_scalars.at(pan_position);
 
@@ -475,7 +483,7 @@ int32_t Voice::PopWavePos() noexcept
 }
 
 // Returns the current vol scalar and increments the volume control's position.
-float Voice::PopVolScalar(const vol_scalars_array_t &vol_scalars)
+float Voice::PopVolScalar(const vol_scalars_array_t& vol_scalars)
 {
 	// transform the current position into an index into the volume array
 	const auto i = ceil_sdivide(vol_ctrl.pos, VOLUME_INC_SCALAR);
@@ -484,29 +492,30 @@ float Voice::PopVolScalar(const vol_scalars_array_t &vol_scalars)
 }
 
 // Read an 8-bit sample scaled into the 16-bit range, returned as a float
-float Voice::Read8BitSample(const ram_array_t &ram, const int32_t addr) const noexcept
+float Voice::Read8BitSample(const ram_array_t& ram, const int32_t addr) const noexcept
 {
-	const auto i = static_cast<size_t>(addr) & 0xfffffu;
-	constexpr auto bits_in_16 = std::numeric_limits<int16_t>::digits;
-	constexpr auto bits_in_8 = std::numeric_limits<int8_t>::digits;
+	const auto i                   = static_cast<size_t>(addr) & 0xfffffu;
+	constexpr auto bits_in_16      = std::numeric_limits<int16_t>::digits;
+	constexpr auto bits_in_8       = std::numeric_limits<int8_t>::digits;
 	constexpr float to_16bit_range = 1 << (bits_in_16 - bits_in_8);
 	return static_cast<int8_t>(ram.at(i)) * to_16bit_range;
 }
 
 // Read a 16-bit sample returned as a float
-float Voice::Read16BitSample(const ram_array_t &ram, const int32_t addr) const noexcept
+float Voice::Read16BitSample(const ram_array_t& ram, const int32_t addr) const noexcept
 {
 	const auto upper = addr & 0b1100'0000'0000'0000'0000;
 	const auto lower = addr & 0b0001'1111'1111'1111'1111;
-	const auto i = static_cast<uint32_t>(upper | (lower << 1));
+	const auto i     = static_cast<uint32_t>(upper | (lower << 1));
 	return static_cast<int16_t>(host_readw(&ram.at(i)));
 }
 
-uint8_t Voice::ReadCtrlState(const VoiceCtrl &ctrl) const noexcept
+uint8_t Voice::ReadCtrlState(const VoiceCtrl& ctrl) const noexcept
 {
 	uint8_t state = ctrl.state;
-	if (ctrl.irq_state & irq_mask)
+	if (ctrl.irq_state & irq_mask) {
 		state |= 0x80;
+	}
 	return state;
 }
 
@@ -528,14 +537,15 @@ void Voice::ResetCtrls() noexcept
 	WritePanPot(PAN_DEFAULT_POSITION);
 }
 
-bool Voice::UpdateCtrlState(VoiceCtrl &ctrl, uint8_t state) noexcept
+bool Voice::UpdateCtrlState(VoiceCtrl& ctrl, uint8_t state) noexcept
 {
 	const uint32_t orig_irq_state = ctrl.irq_state;
 	// Manually set the irq
-	if ((state & 0xa0) == 0xa0)
+	if ((state & 0xa0) == 0xa0) {
 		ctrl.irq_state |= irq_mask;
-	else
+	} else {
 		ctrl.irq_state &= ~irq_mask;
+	}
 
 	// Always update the state
 	ctrl.state = state & 0x7f;
@@ -557,7 +567,7 @@ bool Voice::UpdateWaveState(uint8_t state) noexcept
 void Voice::WritePanPot(uint8_t pos) noexcept
 {
 	constexpr uint8_t max_pos = PAN_POSITIONS - 1;
-	pan_position = std::min(pos, max_pos);
+	pan_position              = std::min(pos, max_pos);
 }
 
 // Four volume-index-rate "banks" are available that define the number of
@@ -578,10 +588,10 @@ void Voice::WritePanPot(uint8_t pos) noexcept
 // at the time of sample population.
 void Voice::WriteVolRate(uint16_t val) noexcept
 {
-	vol_ctrl.rate = val;
+	vol_ctrl.rate                  = val;
 	constexpr uint8_t bank_lengths = 63u;
-	const int pos_in_bank = val & bank_lengths;
-	const int decimator = 1 << (3 * (val >> 6));
+	const int pos_in_bank          = val & bank_lengths;
+	const int decimator            = 1 << (3 * (val >> 6));
 	vol_ctrl.inc = ceil_sdivide(pos_in_bank * VOLUME_INC_SCALAR, decimator);
 
 	// Sanity check the bounds of the incrementer
@@ -591,7 +601,7 @@ void Voice::WriteVolRate(uint16_t val) noexcept
 void Voice::WriteWaveRate(uint16_t val) noexcept
 {
 	wave_ctrl.rate = val;
-	wave_ctrl.inc = ceil_udivide(val, 2u);
+	wave_ctrl.inc  = ceil_udivide(val, 2u);
 }
 
 Gus::Gus(const io_port_t port_pref, const uint8_t dma_pref, const uint8_t irq_pref,
@@ -603,7 +613,7 @@ Gus::Gus(const io_port_t port_pref, const uint8_t dma_pref, const uint8_t irq_pr
 {
 	// port operations are "zero-based" from the datum to the user's port
 	constexpr io_port_t port_datum = 0x200;
-	port_base = port_pref - port_datum;
+	port_base                      = port_pref - port_datum;
 
 	// Create the internal voice channels
 	for (uint8_t i = 0; i < MAX_VOICES; ++i) {
@@ -614,7 +624,8 @@ Gus::Gus(const io_port_t port_pref, const uint8_t dma_pref, const uint8_t irq_pr
 	RegisterIoHandlers();
 
 	// Register the Audio and DMA channels
-	const auto mixer_callback = std::bind(&Gus::AudioCallback, this,
+	const auto mixer_callback = std::bind(&Gus::AudioCallback,
+	                                      this,
 	                                      std::placeholders::_1);
 
 	audio_channel = MIXER_AddChannel(mixer_callback,
@@ -634,9 +645,10 @@ Gus::Gus(const io_port_t port_pref, const uint8_t dma_pref, const uint8_t irq_pr
 	audio_channel->Set0dbScalar(rms_squared);
 
 	if (!audio_channel->TryParseAndSetCustomFilter(filter_prefs)) {
-		if (filter_prefs != "off")
+		if (filter_prefs != "off") {
 			LOG_WARNING("GUS: Invalid 'gus_filter' setting: '%s', using 'off'",
 			            filter_prefs.c_str());
+		}
 
 		audio_channel->SetHighPassFilter(FilterState::Off);
 		audio_channel->SetLowPassFilter(FilterState::Off);
@@ -684,7 +696,7 @@ const std::vector<AudioFrame>& Gus::RenderFrames(const int num_requested_frames)
 	}
 
 	if (dac_enabled) {
-		auto voice = voices.begin();
+		auto voice            = voices.begin();
 		const auto last_voice = voice + active_voices;
 		while (voice < last_voice) {
 			// Render all of the requested frames from each voice
@@ -776,11 +788,12 @@ void Gus::BeginPlayback()
 void Gus::CheckIrq()
 {
 	const bool should_interrupt = irq_status & (irq_enabled ? 0xff : 0x9f);
-	const bool lines_enabled = mix_ctrl & 0x08;
-	if (should_interrupt && lines_enabled)
+	const bool lines_enabled    = mix_ctrl & 0x08;
+	if (should_interrupt && lines_enabled) {
 		PIC_ActivateIRQ(irq1);
-	else if (irq_previously_interrupted)
+	} else if (irq_previously_interrupted) {
 		PIC_DeActivateIRQ(irq1);
+	}
 
 #if LOG_GUS
 	const auto state_str = should_interrupt && lines_enabled ? "activated"
@@ -797,9 +810,10 @@ void Gus::CheckIrq()
 
 bool Gus::CheckTimer(const size_t t)
 {
-	auto &timer = t == 0 ? timer_one : timer_two;
-	if (!timer.is_masked)
+	auto& timer = t == 0 ? timer_one : timer_two;
+	if (!timer.is_masked) {
 		timer.has_expired = true;
+	}
 	if (timer.should_raise_irq) {
 		irq_status |= 0x4 << t;
 		CheckIrq();
@@ -816,15 +830,18 @@ void Gus::CheckVoiceIrq()
 		CheckIrq();
 		return;
 	}
-	if (voice_irq.vol_state)
+	if (voice_irq.vol_state) {
 		irq_status |= 0x40;
-	if (voice_irq.wave_state)
+	}
+	if (voice_irq.wave_state) {
 		irq_status |= 0x20;
+	}
 	CheckIrq();
 	while (!(totalmask & 1ULL << voice_irq.status)) {
 		voice_irq.status++;
-		if (voice_irq.status >= active_voices)
+		if (voice_irq.status >= active_voices) {
 			voice_irq.status = 0;
+		}
 	}
 }
 
@@ -834,12 +851,11 @@ void Gus::CheckVoiceIrq()
 uint32_t Gus::GetDmaOffset() noexcept
 {
 	uint32_t adjusted;
-	if(IsDmaXfer16Bit()) {
+	if (IsDmaXfer16Bit()) {
 		const auto upper = dma_addr & 0b1100'0000'0000'0000;
 		const auto lower = dma_addr & 0b0001'1111'1111'1111;
-		adjusted = static_cast<uint32_t>(upper | (lower << 1));
-	}
-	else {
+		adjusted         = static_cast<uint32_t>(upper | (lower << 1));
+	} else {
 		adjusted = dma_addr;
 	}
 	return check_cast<uint32_t>(adjusted << 4) + dma_addr_nibble;
@@ -852,9 +868,8 @@ void Gus::UpdateDmaAddr(uint32_t offset) noexcept
 	if (IsDmaXfer16Bit()) {
 		const auto upper = offset & 0b1100'0000'0000'0000'0000;
 		const auto lower = offset & 0b0011'1111'1111'1111'1110;
-		adjusted = upper | (lower >> 1);
-	}
-	else {
+		adjusted         = upper | (lower >> 1);
+	} else {
 		// Take the top 16 bits from the 20 bit address
 		adjusted = offset & 0b1111'1111'1111'1111'0000;
 	}
@@ -904,12 +919,13 @@ bool Gus::PerformDmaTransfer()
 
 	// If requested, invert the loaded samples' most-significant bits
 	if (is_reading && dma_ctrl & 0x80) {
-		auto ram_pos = ram.begin() + offset;
+		auto ram_pos           = ram.begin() + offset;
 		const auto ram_pos_end = ram_pos + bytes_transfered;
 		// adjust our start and skip size if handling 16-bit PCM samples
 		ram_pos += IsDmaPcm16Bit() ? 1u : 0u;
 		const auto skip = IsDmaPcm16Bit() ? 2u : 1u;
-		assert(ram_pos >= ram.begin() && ram_pos <= ram_pos_end && ram_pos_end <= ram.end());
+		assert(ram_pos >= ram.begin() && ram_pos <= ram_pos_end &&
+		       ram_pos_end <= ram.end());
 		while (ram_pos < ram_pos_end) {
 			*ram_pos ^= 0x80;
 			ram_pos += skip;
@@ -946,8 +962,9 @@ bool Gus::IsDmaXfer16Bit() noexcept
 
 static void GUS_DMA_Event(uint32_t)
 {
-	if (gus->PerformDmaTransfer())
+	if (gus->PerformDmaTransfer()) {
 		PIC_AddEvent(GUS_DMA_Event, MS_PER_DMA_XFER);
+	}
 }
 
 void Gus::StartDmaTransfers()
@@ -957,8 +974,9 @@ void Gus::StartDmaTransfers()
 
 void Gus::DmaCallback(const DmaChannel*, DMAEvent event)
 {
-	if (event == DMA_UNMASKED)
+	if (event == DMA_UNMASKED) {
 		StartDmaTransfers();
+	}
 }
 
 void Gus::SetupEnvironment(uint16_t port, const char* ultradir_env_val)
@@ -995,8 +1013,8 @@ void Gus::ClearEnvironment()
 void Gus::PopulateVolScalars() noexcept
 {
 	constexpr auto VOLUME_LEVEL_DIVISOR = 1.0 + DELTA_DB;
-	double scalar = 1.0;
-	auto volume = vol_scalars.end();
+	double scalar                       = 1.0;
+	auto volume                         = vol_scalars.end();
 	// The last element starts at 1.0 and we divide downward to
 	// the first element that holds zero, which is directly assigned
 	// after the loop.
@@ -1015,48 +1033,48 @@ with 0 representing the full-left rotation, 7 being the mid-point,
 and 15 being the full-right rotation.  The SDK also describes
 that output power is held constant through this range.
 
-	#!/usr/bin/env python3
-	import math
-	print(f'Left-scalar  Pot Norm.   Right-scalar | Power')
-	print(f'-----------  --- -----   ------------ | -----')
-	for pot in range(16):
-		norm = (pot - 7.) / (7.0 if pot < 7 else 8.0)
-		direction = math.pi * (norm + 1.0 ) / 4.0
-		lscale = math.cos(direction)
-		rscale = math.sin(direction)
-		power = lscale * lscale + rscale * rscale
-		print(f'{lscale:.5f} <~~~ {pot:2} ({norm:6.3f})'\
-		      f' ~~~> {rscale:.5f} | {power:.3f}')
+        #!/usr/bin/env python3
+        import math
+        print(f'Left-scalar  Pot Norm.   Right-scalar | Power')
+        print(f'-----------  --- -----   ------------ | -----')
+        for pot in range(16):
+                norm = (pot - 7.) / (7.0 if pot < 7 else 8.0)
+                direction = math.pi * (norm + 1.0 ) / 4.0
+                lscale = math.cos(direction)
+                rscale = math.sin(direction)
+                power = lscale * lscale + rscale * rscale
+                print(f'{lscale:.5f} <~~~ {pot:2} ({norm:6.3f})'\
+                      f' ~~~> {rscale:.5f} | {power:.3f}')
 
-	Left-scalar  Pot Norm.   Right-scalar | Power
-	-----------  --- -----   ------------ | -----
-	1.00000 <~~~  0 (-1.000) ~~~> 0.00000 | 1.000
-	0.99371 <~~~  1 (-0.857) ~~~> 0.11196 | 1.000
-	0.97493 <~~~  2 (-0.714) ~~~> 0.22252 | 1.000
-	0.94388 <~~~  3 (-0.571) ~~~> 0.33028 | 1.000
-	0.90097 <~~~  4 (-0.429) ~~~> 0.43388 | 1.000
-	0.84672 <~~~  5 (-0.286) ~~~> 0.53203 | 1.000
-	0.78183 <~~~  6 (-0.143) ~~~> 0.62349 | 1.000
-	0.70711 <~~~  7 ( 0.000) ~~~> 0.70711 | 1.000
-	0.63439 <~~~  8 ( 0.125) ~~~> 0.77301 | 1.000
-	0.55557 <~~~  9 ( 0.250) ~~~> 0.83147 | 1.000
-	0.47140 <~~~ 10 ( 0.375) ~~~> 0.88192 | 1.000
-	0.38268 <~~~ 11 ( 0.500) ~~~> 0.92388 | 1.000
-	0.29028 <~~~ 12 ( 0.625) ~~~> 0.95694 | 1.000
-	0.19509 <~~~ 13 ( 0.750) ~~~> 0.98079 | 1.000
-	0.09802 <~~~ 14 ( 0.875) ~~~> 0.99518 | 1.000
-	0.00000 <~~~ 15 ( 1.000) ~~~> 1.00000 | 1.000
+        Left-scalar  Pot Norm.   Right-scalar | Power
+        -----------  --- -----   ------------ | -----
+        1.00000 <~~~  0 (-1.000) ~~~> 0.00000 | 1.000
+        0.99371 <~~~  1 (-0.857) ~~~> 0.11196 | 1.000
+        0.97493 <~~~  2 (-0.714) ~~~> 0.22252 | 1.000
+        0.94388 <~~~  3 (-0.571) ~~~> 0.33028 | 1.000
+        0.90097 <~~~  4 (-0.429) ~~~> 0.43388 | 1.000
+        0.84672 <~~~  5 (-0.286) ~~~> 0.53203 | 1.000
+        0.78183 <~~~  6 (-0.143) ~~~> 0.62349 | 1.000
+        0.70711 <~~~  7 ( 0.000) ~~~> 0.70711 | 1.000
+        0.63439 <~~~  8 ( 0.125) ~~~> 0.77301 | 1.000
+        0.55557 <~~~  9 ( 0.250) ~~~> 0.83147 | 1.000
+        0.47140 <~~~ 10 ( 0.375) ~~~> 0.88192 | 1.000
+        0.38268 <~~~ 11 ( 0.500) ~~~> 0.92388 | 1.000
+        0.29028 <~~~ 12 ( 0.625) ~~~> 0.95694 | 1.000
+        0.19509 <~~~ 13 ( 0.750) ~~~> 0.98079 | 1.000
+        0.09802 <~~~ 14 ( 0.875) ~~~> 0.99518 | 1.000
+        0.00000 <~~~ 15 ( 1.000) ~~~> 1.00000 | 1.000
 */
 void Gus::PopulatePanScalars() noexcept
 {
-	int i = 0;
+	int i           = 0;
 	auto pan_scalar = pan_scalars.begin();
 	while (pan_scalar != pan_scalars.end()) {
 		// Normalize absolute range [0, 15] to [-1.0, 1.0]
 		const auto norm = (i - 7.0) / (i < 7 ? 7 : 8);
 		// Convert to an angle between 0 and 90-degree, in radians
-		const auto angle = (norm + 1) * M_PI / 4;
-		pan_scalar->left = static_cast<float>(cos(angle));
+		const auto angle  = (norm + 1) * M_PI / 4;
+		pan_scalar->left  = static_cast<float>(cos(angle));
 		pan_scalar->right = static_cast<float>(sin(angle));
 		++pan_scalar;
 		++i;
@@ -1071,8 +1089,9 @@ void Gus::PopulatePanScalars() noexcept
 void Gus::PrepareForPlayback() noexcept
 {
 	// Initialize the voice states
-	for (auto &voice : voices)
+	for (auto& voice : voices) {
 		voice.ResetCtrls();
+	}
 
 	// Initialize the OPL emulator state
 	adlib_command_reg = ADLIB_CMD_DEFAULT;
@@ -1083,18 +1102,18 @@ void Gus::PrepareForPlayback() noexcept
 
 	if (!is_running) {
 		register_data = 0x100; // DAC/IRQ disabled
-		is_running = true;
+		is_running    = true;
 	}
 }
 
 void Gus::PrintStats()
 {
 	// Aggregate stats from all voices
-	uint32_t combined_8bit_ms = 0u;
+	uint32_t combined_8bit_ms  = 0u;
 	uint32_t combined_16bit_ms = 0u;
-	uint32_t used_8bit_voices = 0u;
+	uint32_t used_8bit_voices  = 0u;
 	uint32_t used_16bit_voices = 0u;
-	for (const auto &voice : voices) {
+	for (const auto& voice : voices) {
 		if (voice.generated_8bit_ms) {
 			combined_8bit_ms += voice.generated_8bit_ms;
 			used_8bit_voices++;
@@ -1107,24 +1126,27 @@ void Gus::PrintStats()
 	const uint32_t combined_ms = combined_8bit_ms + combined_16bit_ms;
 
 	// Is there enough information to be meaningful?
-	if (combined_ms < 10000u || !(used_8bit_voices + used_16bit_voices))
+	if (combined_ms < 10000u || !(used_8bit_voices + used_16bit_voices)) {
 		return;
+	}
 
 	// Print info about the type of audio and voices used
-	if (used_16bit_voices == 0u)
+	if (used_16bit_voices == 0u) {
 		LOG_MSG("GUS: Audio comprised of 8-bit samples from %u voices",
 		        used_8bit_voices);
-	else if (used_8bit_voices == 0u)
+	} else if (used_8bit_voices == 0u) {
 		LOG_MSG("GUS: Audio comprised of 16-bit samples from %u voices",
 		        used_16bit_voices);
-	else {
-		const auto ratio_8bit = ceil_udivide(100u * combined_8bit_ms,
-		                                     combined_ms);
+	} else {
+		const auto ratio_8bit  = ceil_udivide(100u * combined_8bit_ms,
+                                                     combined_ms);
 		const auto ratio_16bit = ceil_udivide(100u * combined_16bit_ms,
 		                                      combined_ms);
 		LOG_MSG("GUS: Audio was made up of %u%% 8-bit %u-voice and "
 		        "%u%% 16-bit %u-voice samples",
-		        ratio_8bit, used_8bit_voices, ratio_16bit,
+		        ratio_8bit,
+		        used_8bit_voices,
+		        ratio_16bit,
 		        used_16bit_voices);
 	}
 }
@@ -1137,28 +1159,33 @@ uint16_t Gus::ReadFromPort(const io_port_t port, io_width_t width)
 	case 0x208:
 		uint8_t time;
 		time = 0u;
-		if (timer_one.has_expired)
+		if (timer_one.has_expired) {
 			time |= (1 << 6);
-		if (timer_two.has_expired)
+		}
+		if (timer_two.has_expired) {
 			time |= 1 << 5;
-		if (time & 0x60)
+		}
+		if (time & 0x60) {
 			time |= 1 << 7;
-		if (irq_status & 0x04)
+		}
+		if (irq_status & 0x04) {
 			time |= 1 << 2;
-		if (irq_status & 0x08)
+		}
+		if (irq_status & 0x08) {
 			time |= 1 << 1;
+		}
 		return time;
 	case 0x20a: return adlib_command_reg;
 	case 0x302: return static_cast<uint8_t>(voice_index);
 	case 0x303: return selected_register;
 	case 0x304:
-		if (width == io_width_t::word)
+		if (width == io_width_t::word) {
 			return ReadFromRegister() & 0xffff;
-		else
+		} else {
 			return ReadFromRegister() & 0xff;
+		}
 	case 0x305: return ReadFromRegister() >> 8;
-	case 0x307:
-		return dram_addr < ram.size() ? ram.at(dram_addr) : 0;
+	case 0x307: return dram_addr < ram.size() ? ram.at(dram_addr) : 0;
 	default:
 #if LOG_GUS
 		LOG_MSG("GUS: Read at port %#x", port);
@@ -1194,19 +1221,23 @@ uint16_t Gus::ReadFromRegister()
 		return static_cast<uint16_t>(reg << 8);
 	case 0x4c: // Reset register
 		reg = is_running ? 1 : 0;
-		if (dac_enabled)
+		if (dac_enabled) {
 			reg |= 2;
-		if (irq_enabled)
+		}
+		if (irq_enabled) {
 			reg |= 4;
+		}
 		return static_cast<uint16_t>(reg << 8);
 	case 0x8f: // General voice IRQ status register
 		reg = voice_irq.status | 0x20;
 		uint32_t mask;
 		mask = 1 << voice_irq.status;
-		if (!(voice_irq.vol_state & mask))
+		if (!(voice_irq.vol_state & mask)) {
 			reg |= 0x40;
-		if (!(voice_irq.wave_state & mask))
+		}
+		if (!(voice_irq.wave_state & mask)) {
 			reg |= 0x80;
+		}
 		voice_irq.vol_state &= ~mask;
 		voice_irq.wave_state &= ~mask;
 		CheckVoiceIrq();
@@ -1217,10 +1248,11 @@ uint16_t Gus::ReadFromRegister()
 		// to the voice-specific register switch below.
 	}
 
-	if (!target_voice)
+	if (!target_voice) {
 		return (selected_register == 0x80 || selected_register == 0x8d)
-		               ? 0x0300
-		               : 0u;
+		             ? 0x0300
+		             : 0u;
+	}
 
 	// Registers that read from from the current voice
 	switch (selected_register) {
@@ -1256,7 +1288,7 @@ uint16_t Gus::ReadFromRegister()
 void Gus::RegisterIoHandlers()
 {
 	using namespace std::placeholders;
-	
+
 	// Register the IO read addresses
 	assert(read_handlers.size() > 7);
 	const auto read_from = std::bind(&Gus::ReadFromPort, this, _1, _2);
@@ -1293,24 +1325,24 @@ void Gus::StopPlayback()
 	// Halt playback before altering the DSP state
 	audio_channel->Enable(false);
 
-	dac_enabled = false;
-	irq_enabled = false;
-	irq_status = 0;
+	dac_enabled                = false;
+	irq_enabled                = false;
+	irq_status                 = 0;
 	irq_previously_interrupted = false;
 
-	dma_ctrl = 0u;
-	mix_ctrl = 0xb; // latches enabled, LINEs disabled
-	timer_ctrl = 0u;
+	dma_ctrl    = 0u;
+	mix_ctrl    = 0xb; // latches enabled, LINEs disabled
+	timer_ctrl  = 0u;
 	sample_ctrl = 0u;
 
-	target_voice = nullptr;
-	voice_index = 0u;
+	target_voice  = nullptr;
+	voice_index   = 0u;
 	active_voices = 0u;
 
 	UpdateDmaAddr(0);
-	dram_addr = 0u;
-	register_data = 0u;
-	selected_register = 0u;
+	dram_addr             = 0u;
+	register_data         = 0u;
+	selected_register     = 0u;
 	should_change_irq_dma = false;
 	PIC_RemoveEvents(GUS_TimerEvent);
 	is_running = false;
@@ -1319,7 +1351,7 @@ void Gus::StopPlayback()
 static void GUS_TimerEvent(uint32_t t)
 {
 	if (gus->CheckTimer(t)) {
-		const auto &timer = t == 0 ? gus->timer_one : gus->timer_two;
+		const auto& timer = t == 0 ? gus->timer_one : gus->timer_two;
 		PIC_AddEvent(GUS_TimerEvent, timer.delay, t);
 	}
 }
@@ -1341,7 +1373,7 @@ void Gus::UpdateDmaAddress(const uint8_t new_address)
 	}
 
 	// Update the address, channel, and callback
-	dma1 = new_address;
+	dma1        = new_address;
 	dma_channel = DMA_GetChannel(dma1);
 	assert(dma_channel);
 	dma_channel->ReserveFor(ChannelName::GravisUltrasound, gus_destroy);
@@ -1360,7 +1392,7 @@ void Gus::WriteToPort(io_port_t port, io_val_t value, io_width_t width)
 	//	LOG_MSG("GUS: Write to port %x val %x", port, val);
 	switch (port - port_base) {
 	case 0x200:
-		mix_ctrl = static_cast<uint8_t>(val);
+		mix_ctrl              = static_cast<uint8_t>(val);
 		should_change_irq_dma = true;
 		return;
 	case 0x208: adlib_command_reg = static_cast<uint8_t>(val); break;
@@ -1379,53 +1411,59 @@ void Gus::WriteToPort(io_port_t port, io_val_t value, io_width_t width)
 				PIC_AddEvent(GUS_TimerEvent, timer_one.delay, 0);
 				timer_one.is_counting_down = true;
 			}
-		} else
+		} else {
 			timer_one.is_counting_down = false;
+		}
 		if (val & 0x2) {
 			if (!timer_two.is_counting_down) {
 				PIC_AddEvent(GUS_TimerEvent, timer_two.delay, 1);
 				timer_two.is_counting_down = true;
 			}
-		} else
+		} else {
 			timer_two.is_counting_down = false;
+		}
 		break;
 		// TODO Check if 0x20a register is also available on the gus
 		// like on the interwave
 	case 0x20b:
-		if (!should_change_irq_dma)
+		if (!should_change_irq_dma) {
 			break;
+		}
 		should_change_irq_dma = false;
 		if (mix_ctrl & 0x40) {
 			// IRQ configuration, only use low bits for irq 1
-			const auto i = val & 7u;
-			const auto &address = irq_addresses.at(i);
-			if (address)
+			const auto i        = val & 7u;
+			const auto& address = irq_addresses.at(i);
+			if (address) {
 				irq1 = address;
+			}
 #if LOG_GUS
 			LOG_MSG("GUS: Assigned IRQ1 to %d", irq1);
 #endif
 		} else {
 			// DMA configuration, only use low bits for dma 1
-			const uint8_t i = val & 0x7;
+			const uint8_t i    = val & 0x7;
 			const auto address = dma_addresses.at(i);
-			if (address)
+			if (address) {
 				UpdateDmaAddress(address);
+			}
 		}
 		break;
 	case 0x302:
-		voice_index = val & 31;
+		voice_index  = val & 31;
 		target_voice = &voices.at(voice_index);
 		break;
 	case 0x303:
 		selected_register = static_cast<uint8_t>(val);
-		register_data = 0;
+		register_data     = 0;
 		break;
 	case 0x304:
 		if (width == io_width_t::word) {
 			register_data = val;
 			WriteToRegister();
-		} else
+		} else {
 			register_data = val;
+		}
 		break;
 	case 0x305:
 		register_data = static_cast<uint16_t>((0x00ff & register_data) |
@@ -1433,8 +1471,9 @@ void Gus::WriteToPort(io_port_t port, io_val_t value, io_width_t width)
 		WriteToRegister();
 		break;
 	case 0x307:
-		if (dram_addr < ram.size())
+		if (dram_addr < ram.size()) {
 			ram.at(dram_addr) = static_cast<uint8_t>(val);
+		}
 		break;
 	default:
 #if LOG_GUS
@@ -1444,19 +1483,19 @@ void Gus::WriteToPort(io_port_t port, io_val_t value, io_width_t width)
 	}
 }
 
-void Gus::UpdateWaveLsw(int32_t &addr) const noexcept
+void Gus::UpdateWaveLsw(int32_t& addr) const noexcept
 {
 	constexpr auto WAVE_LSW_MASK = ~((1 << 16) - 1); // Lower wave mask
-	const auto lower = addr & WAVE_LSW_MASK;
-	addr = lower | register_data;
+	const auto lower             = addr & WAVE_LSW_MASK;
+	addr                         = lower | register_data;
 }
 
-void Gus::UpdateWaveMsw(int32_t &addr) const noexcept
+void Gus::UpdateWaveMsw(int32_t& addr) const noexcept
 {
 	constexpr auto WAVE_MSW_MASK = (1 << 16) - 1; // Upper wave mask
-	const auto upper = register_data & 0x1fff;
-	const auto lower = addr & WAVE_MSW_MASK;
-	addr = lower | (upper << 16);
+	const auto upper             = register_data & 0x1fff;
+	const auto lower             = addr & WAVE_MSW_MASK;
+	addr                         = lower | (upper << 16);
 }
 
 void Gus::WriteToRegister()
@@ -1466,7 +1505,8 @@ void Gus::WriteToRegister()
 	// Registers that write to the general DSP
 	switch (selected_register) {
 	case 0xe: // Set number of active voices
-		selected_register = register_data >> 8; // Jazz Jackrabbit needs this
+		selected_register = register_data >> 8; // Jazz Jackrabbit needs
+		                                        // this
 		{
 			const uint8_t num_voices = 1 + ((register_data >> 8) & 31);
 			ActivateVoices(num_voices);
@@ -1479,11 +1519,12 @@ void Gus::WriteToRegister()
 		// lower bits with reg's top 8 bits
 		dma_ctrl &= DMA_TC_STATUS_BITMASK;
 		dma_ctrl |= register_data >> 8;
-		if (dma_ctrl & 1)
+		if (dma_ctrl & 1) {
 			StartDmaTransfers();
+		}
 		return;
 	case 0x42: // Gravis DRAM DMA address register
-		dma_addr = register_data;
+		dma_addr        = register_data;
 		dma_addr_nibble = 0u; // invalidate the nibble
 		return;
 	case 0x43: // LSW Peek/poke DRAM position
@@ -1497,13 +1538,16 @@ void Gus::WriteToRegister()
 	case 0x45: // Timer control register.  Identical in operation to Adlib's
 		timer_ctrl = static_cast<uint8_t>(register_data >> 8);
 		timer_one.should_raise_irq = (timer_ctrl & 0x04) > 0;
-		if (!timer_one.should_raise_irq)
+		if (!timer_one.should_raise_irq) {
 			irq_status &= ~0x04;
+		}
 		timer_two.should_raise_irq = (timer_ctrl & 0x08) > 0;
-		if (!timer_two.should_raise_irq)
+		if (!timer_two.should_raise_irq) {
 			irq_status &= ~0x08;
-		if (!timer_one.should_raise_irq && !timer_two.should_raise_irq)
+		}
+		if (!timer_one.should_raise_irq && !timer_two.should_raise_irq) {
 			CheckIrq();
+		}
 		return;
 	case 0x46: // Timer 1 control
 		timer_one.value = static_cast<uint8_t>(register_data >> 8);
@@ -1515,19 +1559,21 @@ void Gus::WriteToRegister()
 		return;
 	case 0x49: // DMA sampling control register
 		sample_ctrl = static_cast<uint8_t>(register_data >> 8);
-		if (sample_ctrl & 1)
+		if (sample_ctrl & 1) {
 			StartDmaTransfers();
+		}
 		return;
 	case 0x4c: // Runtime control
-		{
-			const auto state = (register_data >> 8) & 7;
-			if (state == 0)
-				StopPlayback();
-			else if (state == 1)
-				PrepareForPlayback();
-			else if (active_voices)
-				BeginPlayback();
+	{
+		const auto state = (register_data >> 8) & 7;
+		if (state == 0) {
+			StopPlayback();
+		} else if (state == 1) {
+			PrepareForPlayback();
+		} else if (active_voices) {
+			BeginPlayback();
 		}
+	}
 		return;
 	default:
 		break;
@@ -1536,15 +1582,17 @@ void Gus::WriteToRegister()
 	}
 
 	// All the registers below operated on the target voice
-	if (!target_voice)
+	if (!target_voice) {
 		return;
+	}
 
 	uint8_t data = 0;
 	// Registers that write to the current voice
 	switch (selected_register) {
 	case 0x0: // Voice wave control register
-		if (target_voice->UpdateWaveState(register_data >> 8))
+		if (target_voice->UpdateWaveState(register_data >> 8)) {
 			CheckVoiceIrq();
+		}
 		break;
 	case 0x1: // Voice rate control register
 		target_voice->WriteWaveRate(register_data);
@@ -1592,8 +1640,9 @@ void Gus::WriteToRegister()
 		target_voice->WritePanPot(register_data >> 8);
 		break;
 	case 0xd: // Voice volume control register
-		if (target_voice->UpdateVolState(register_data >> 8))
+		if (target_voice->UpdateVolState(register_data >> 8)) {
 			CheckVoiceIrq();
+		}
 		break;
 	default:
 #if LOG_GUS
@@ -1614,10 +1663,12 @@ Gus::~Gus()
 	ClearEnvironment();
 
 	// Stop the game from accessing the IO ports
-	for (auto &rh : read_handlers)
+	for (auto& rh : read_handlers) {
 		rh.Uninstall();
-	for (auto &wh : write_handlers)
+	}
+	for (auto& wh : write_handlers) {
 		wh.Uninstall();
+	}
 
 	// Deregister the mixer channel, after which it's cleaned up
 	assert(audio_channel);
@@ -1630,7 +1681,7 @@ Gus::~Gus()
 	}
 }
 
-static void gus_destroy([[maybe_unused]] Section *sec)
+static void gus_destroy([[maybe_unused]] Section* sec)
 {
 	// GUS destroy is run when the user wants to deactivate the GUS:
 	// C:\> config -set gus=false
@@ -1643,12 +1694,13 @@ static void gus_destroy([[maybe_unused]] Section *sec)
 	}
 }
 
-static void gus_init(Section *sec)
+static void gus_init(Section* sec)
 {
 	assert(sec);
-	const Section_prop *conf = dynamic_cast<Section_prop *>(sec);
-	if (!conf || !conf->Get_bool("gus"))
+	const Section_prop* conf = dynamic_cast<Section_prop*>(sec);
+	if (!conf || !conf->Get_bool("gus")) {
 		return;
+	}
 
 	// Read the GUS config settings
 	const auto port = static_cast<uint16_t>(conf->Get_hex("gusbase"));
@@ -1672,11 +1724,11 @@ static void gus_init(Section *sec)
 	sec->AddDestroyFunction(&gus_destroy, changeable_at_runtime);
 }
 
-void init_gus_dosbox_settings(Section_prop &secprop)
+void init_gus_dosbox_settings(Section_prop& secprop)
 {
 	constexpr auto when_idle = Property::Changeable::WhenIdle;
 
-	auto *bool_prop = secprop.Add_bool("gus", when_idle, false);
+	auto* bool_prop = secprop.Add_bool("gus", when_idle, false);
 	assert(bool_prop);
 	bool_prop->Set_help(
 	        "Enable Gravis UltraSound emulation (disabled by default).\n"
@@ -1685,13 +1737,13 @@ void init_gus_dosbox_settings(Section_prop &secprop)
 	        "majority of programs, but some games and demos expect the GUS factory\n"
 	        "defaults of base address 220, IRQ 11, and DMA 1.");
 
-	auto *hex_prop = secprop.Add_hex("gusbase", when_idle, 0x240);
+	auto* hex_prop = secprop.Add_hex("gusbase", when_idle, 0x240);
 	assert(hex_prop);
-	hex_prop->Set_values(
-	        {"240", "220", "260", "280", "2a0", "2c0", "2e0", "300"});
-	hex_prop->Set_help("The IO base address of the Gravis UltraSound (240 by default).");
+	hex_prop->Set_values({"240", "220", "260", "280", "2a0", "2c0", "2e0", "300"});
+	hex_prop->Set_help(
+	        "The IO base address of the Gravis UltraSound (240 by default).");
 
-	auto *int_prop = secprop.Add_int("gusirq", when_idle, 5);
+	auto* int_prop = secprop.Add_int("gusirq", when_idle, 5);
 	assert(int_prop);
 	int_prop->Set_values({"3", "5", "7", "9", "10", "11", "12"});
 	int_prop->Set_help("The IRQ number of the Gravis UltraSound (5 by default).");

--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -47,7 +47,7 @@
 // ----------------
 
 // AdLib emulation state constant
-constexpr uint8_t ADLIB_CMD_DEFAULT = 85u;
+constexpr uint8_t ADLIB_CMD_DEFAULT = 85;
 
 // Environment variable names
 const auto ultrasnd_env_name = "ULTRASND";
@@ -63,21 +63,21 @@ constexpr uint16_t DMA_TRANSFERS_PER_S = ISA_BUS_THROUGHPUT / BYTES_PER_DMA_XFER
 constexpr double MS_PER_DMA_XFER = millis_in_second / DMA_TRANSFERS_PER_S;
 
 // Voice-channel and state related constants
-constexpr uint8_t MAX_VOICES          = 32u;
-constexpr uint8_t MIN_VOICES          = 14u;
-constexpr uint8_t VOICE_DEFAULT_STATE = 3u;
+constexpr uint8_t MAX_VOICES          = 32;
+constexpr uint8_t MIN_VOICES          = 14;
+constexpr uint8_t VOICE_DEFAULT_STATE = 3;
 
 // DMA and IRQ extents and quantities
-constexpr uint8_t MIN_DMA_ADDRESS        = 0u;
-constexpr uint8_t MAX_DMA_ADDRESS        = 7u;
-constexpr uint8_t MIN_IRQ_ADDRESS        = 0u;
-constexpr uint8_t MAX_IRQ_ADDRESS        = 15u;
-constexpr uint8_t DMA_IRQ_ADDRESSES      = 8u; // number of IRQ and DMA channels
+constexpr uint8_t MIN_DMA_ADDRESS        = 0;
+constexpr uint8_t MAX_DMA_ADDRESS        = 7;
+constexpr uint8_t MIN_IRQ_ADDRESS        = 0;
+constexpr uint8_t MAX_IRQ_ADDRESS        = 15;
+constexpr uint8_t DMA_IRQ_ADDRESSES      = 8; // number of IRQ and DMA channels
 constexpr uint16_t DMA_TC_STATUS_BITMASK = 0b100000000; // Status in 9th bit
 
 // Pan position constants
-constexpr uint8_t PAN_DEFAULT_POSITION = 7u;
-constexpr uint8_t PAN_POSITIONS = 16u; // 0: -45-deg, 7: centre, 15: +45-deg
+constexpr uint8_t PAN_DEFAULT_POSITION = 7;
+constexpr uint8_t PAN_POSITIONS = 16; // 0: -45-deg, 7: centre, 15: +45-deg
 
 // Timer delay constants
 constexpr double TIMER_1_DEFAULT_DELAY = 0.080;
@@ -86,21 +86,21 @@ constexpr double TIMER_2_DEFAULT_DELAY = 0.320;
 // Volume scaling and dampening constants
 constexpr auto DELTA_DB             = 0.002709201; // 0.0235 dB increments
 constexpr int16_t VOLUME_INC_SCALAR = 512; // Volume index increment scalar
-constexpr uint16_t VOLUME_LEVELS    = 4096u;
+constexpr uint16_t VOLUME_LEVELS    = 4096;
 
 // Interwave addressing constant
 constexpr int16_t WAVE_WIDTH = 1 << 9; // Wave interpolation width (9 bits)
 
 // IO address quantities
-constexpr uint8_t READ_HANDLERS  = 8u;
-constexpr uint8_t WRITE_HANDLERS = 9u;
+constexpr uint8_t READ_HANDLERS  = 8;
+constexpr uint8_t WRITE_HANDLERS = 9;
 
 // A group of parameters defining the Gus's voice IRQ control that's also shared
 // (as a reference) into each instantiated voice.
 struct VoiceIrq {
-	uint32_t vol_state  = 0u;
-	uint32_t wave_state = 0u;
-	uint8_t status      = 0u;
+	uint32_t vol_state  = 0;
+	uint32_t wave_state = 0;
+	uint8_t status      = 0;
 };
 
 // A group of parameters used in the Voice class to track the Wave and Volume
@@ -154,8 +154,8 @@ public:
 	VoiceCtrl vol_ctrl;
 	VoiceCtrl wave_ctrl;
 
-	uint32_t generated_8bit_ms  = 0u;
-	uint32_t generated_16bit_ms = 0u;
+	uint32_t generated_8bit_ms  = 0;
+	uint32_t generated_16bit_ms = 0;
 
 private:
 	Voice()                        = delete;
@@ -185,7 +185,7 @@ private:
 		DECREASING    = 0x40,
 	};
 
-	uint32_t irq_mask = 0u;
+	uint32_t irq_mask = 0;
 	uint8_t& shared_irq_status;
 	uint8_t pan_position = PAN_DEFAULT_POSITION;
 };
@@ -298,37 +298,37 @@ private:
 	uint8_t& adlib_command_reg = adlib_commandreg;
 
 	// Port address
-	io_port_t port_base = 0u;
+	io_port_t port_base = 0;
 
 	// Voice states
-	uint32_t active_voice_mask = 0u;
-	uint16_t voice_index       = 0u;
-	uint8_t active_voices      = 0u;
-	uint8_t prev_logged_voices = 0u;
+	uint32_t active_voice_mask = 0;
+	uint16_t voice_index       = 0;
+	uint8_t active_voices      = 0;
+	uint8_t prev_logged_voices = 0;
 
 	// RAM and register data
-	uint32_t dram_addr        = 0u;
-	uint16_t register_data    = 0u;
-	uint8_t selected_register = 0u;
+	uint32_t dram_addr        = 0;
+	uint16_t register_data    = 0;
+	uint8_t selected_register = 0;
 
 	// Control states
 	uint8_t mix_ctrl    = 0x0b; // latches enabled, LINEs disabled
-	uint8_t sample_ctrl = 0u;
-	uint8_t timer_ctrl  = 0u;
+	uint8_t sample_ctrl = 0;
+	uint8_t timer_ctrl  = 0;
 
 	// DMA states
-	uint16_t dma_addr       = 0u;
-	uint8_t dma_addr_nibble = 0u;
+	uint16_t dma_addr       = 0;
+	uint8_t dma_addr_nibble = 0;
 	// dma_ctrl would normally be a uint8_t as real hardware uses 8 bits,
 	// but we store the DMA terminal count status in the 9th bit
-	uint16_t dma_ctrl = 0u;
-	uint8_t dma1      = 0u; // playback DMA
-	uint8_t dma2      = 0u; // recording DMA
+	uint16_t dma_ctrl = 0;
+	uint8_t dma1      = 0; // playback DMA
+	uint8_t dma2      = 0; // recording DMA
 
 	// IRQ states
-	uint8_t irq1       = 0u; // playback IRQ
-	uint8_t irq2       = 0u; // MIDI IRQ
-	uint8_t irq_status = 0u;
+	uint8_t irq1       = 0; // playback IRQ
+	uint8_t irq2       = 0; // MIDI IRQ
+	uint8_t irq_status = 0;
 
 	bool dac_enabled                = false;
 	bool irq_enabled                = false;
@@ -494,7 +494,7 @@ float Voice::PopVolScalar(const vol_scalars_array_t& vol_scalars)
 // Read an 8-bit sample scaled into the 16-bit range, returned as a float
 float Voice::Read8BitSample(const ram_array_t& ram, const int32_t addr) const noexcept
 {
-	const auto i                   = static_cast<size_t>(addr) & 0xfffffu;
+	const auto i                   = static_cast<size_t>(addr) & 0xfffff;
 	constexpr auto bits_in_16      = std::numeric_limits<int16_t>::digits;
 	constexpr auto bits_in_8       = std::numeric_limits<int8_t>::digits;
 	constexpr float to_16bit_range = 1 << (bits_in_16 - bits_in_8);
@@ -531,7 +531,7 @@ uint8_t Voice::ReadWaveState() const noexcept
 
 void Voice::ResetCtrls() noexcept
 {
-	vol_ctrl.pos = 0u;
+	vol_ctrl.pos = 0;
 	UpdateVolState(0x1);
 	UpdateWaveState(0x1);
 	WritePanPot(PAN_DEFAULT_POSITION);
@@ -589,7 +589,7 @@ void Voice::WritePanPot(uint8_t pos) noexcept
 void Voice::WriteVolRate(uint16_t val) noexcept
 {
 	vol_ctrl.rate                  = val;
-	constexpr uint8_t bank_lengths = 63u;
+	constexpr uint8_t bank_lengths = 63;
 	const int pos_in_bank          = val & bank_lengths;
 	const int decimator            = 1 << (3 * (val >> 6));
 	vol_ctrl.inc = ceil_sdivide(pos_in_bank * VOLUME_INC_SCALAR, decimator);
@@ -922,8 +922,8 @@ bool Gus::PerformDmaTransfer()
 		auto ram_pos           = ram.begin() + offset;
 		const auto ram_pos_end = ram_pos + bytes_transfered;
 		// adjust our start and skip size if handling 16-bit PCM samples
-		ram_pos += IsDmaPcm16Bit() ? 1u : 0u;
-		const auto skip = IsDmaPcm16Bit() ? 2u : 1u;
+		ram_pos += IsDmaPcm16Bit() ? 1 : 0;
+		const auto skip = IsDmaPcm16Bit() ? 2 : 1;
 		assert(ram_pos >= ram.begin() && ram_pos <= ram_pos_end &&
 		       ram_pos_end <= ram.end());
 		while (ram_pos < ram_pos_end) {
@@ -1109,10 +1109,10 @@ void Gus::PrepareForPlayback() noexcept
 void Gus::PrintStats()
 {
 	// Aggregate stats from all voices
-	uint32_t combined_8bit_ms  = 0u;
-	uint32_t combined_16bit_ms = 0u;
-	uint32_t used_8bit_voices  = 0u;
-	uint32_t used_16bit_voices = 0u;
+	uint32_t combined_8bit_ms  = 0;
+	uint32_t combined_16bit_ms = 0;
+	uint32_t used_8bit_voices  = 0;
+	uint32_t used_16bit_voices = 0;
 	for (const auto& voice : voices) {
 		if (voice.generated_8bit_ms) {
 			combined_8bit_ms += voice.generated_8bit_ms;
@@ -1158,7 +1158,7 @@ uint16_t Gus::ReadFromPort(const io_port_t port, io_width_t width)
 	case 0x206: return irq_status;
 	case 0x208:
 		uint8_t time;
-		time = 0u;
+		time = 0;
 		if (timer_one.has_expired) {
 			time |= (1 << 6);
 		}
@@ -1251,7 +1251,7 @@ uint16_t Gus::ReadFromRegister()
 	if (!target_voice) {
 		return (selected_register == 0x80 || selected_register == 0x8d)
 		             ? 0x0300
-		             : 0u;
+		             : 0;
 	}
 
 	// Registers that read from from the current voice
@@ -1330,19 +1330,19 @@ void Gus::StopPlayback()
 	irq_status                 = 0;
 	irq_previously_interrupted = false;
 
-	dma_ctrl    = 0u;
+	dma_ctrl    = 0;
 	mix_ctrl    = 0xb; // latches enabled, LINEs disabled
-	timer_ctrl  = 0u;
-	sample_ctrl = 0u;
+	timer_ctrl  = 0;
+	sample_ctrl = 0;
 
 	target_voice  = nullptr;
-	voice_index   = 0u;
-	active_voices = 0u;
+	voice_index   = 0;
+	active_voices = 0;
 
 	UpdateDmaAddr(0);
-	dram_addr             = 0u;
-	register_data         = 0u;
-	selected_register     = 0u;
+	dram_addr             = 0;
+	register_data         = 0;
+	selected_register     = 0;
 	should_change_irq_dma = false;
 	PIC_RemoveEvents(GUS_TimerEvent);
 	is_running = false;
@@ -1432,7 +1432,7 @@ void Gus::WriteToPort(io_port_t port, io_val_t value, io_width_t width)
 		should_change_irq_dma = false;
 		if (mix_ctrl & 0x40) {
 			// IRQ configuration, only use low bits for irq 1
-			const auto i        = val & 7u;
+			const auto i        = val & 7;
 			const auto& address = irq_addresses.at(i);
 			if (address) {
 				irq1 = address;
@@ -1525,7 +1525,7 @@ void Gus::WriteToRegister()
 		return;
 	case 0x42: // Gravis DRAM DMA address register
 		dma_addr        = register_data;
-		dma_addr_nibble = 0u; // invalidate the nibble
+		dma_addr_nibble = 0; // invalidate the nibble
 		return;
 	case 0x43: // LSW Peek/poke DRAM position
 		dram_addr = (0xf0000 & dram_addr) |

--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -1768,7 +1768,7 @@ void init_gus_dosbox_settings(Section_prop& secprop)
 	        "  <custom>:  Custom filter definition; see 'sb_filter' for details.");
 }
 
-void GUS_AddConfigSection(const config_ptr_t& conf)
+void GUS_AddConfigSection(const ConfigPtr& conf)
 {
 	assert(conf);
 

--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -288,7 +288,7 @@ private:
 	VoiceIrq voice_irq            = {};
 	Voice* target_voice           = nullptr;
 	DmaChannel* dma_channel       = nullptr;
-	mixer_channel_t audio_channel = nullptr;
+	MixerChannelPtr audio_channel = nullptr;
 
 	// Playback related
 	double last_rendered_ms = 0.0;

--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -679,7 +679,7 @@ void Gus::ActivateVoices(uint8_t requested_voices)
 		// Gravis' calculation to convert from number of active voices
 		// to playback frame rate. Ref: UltraSound Lowlevel ToolKit
 		// v2.22 (21 December 1994), pp. 3 of 113.
-		sample_rate_hz = 1000000.0 / (1.619695497 * active_voices);
+		sample_rate_hz = ifloor(1000000.0 / (1.619695497 * active_voices));
 
 		ms_per_render = MillisInSecond / sample_rate_hz;
 

--- a/src/hardware/imfc.cpp
+++ b/src/hardware/imfc.cpp
@@ -13469,7 +13469,7 @@ void init_imfc_dosbox_settings(Section_prop& secprop)
 	        "  <custom>:  Custom filter definition; see 'sb_filter' for details.");
 }
 
-void IMFC_AddConfigSection(const config_ptr_t& conf)
+void IMFC_AddConfigSection(const ConfigPtr& conf)
 {
 	assert(conf);
 

--- a/src/hardware/imfc.cpp
+++ b/src/hardware/imfc.cpp
@@ -3108,7 +3108,7 @@ constexpr auto EG_OFF = 0;
 class ym2151_device {
 public:
 	// construction/destruction
-	explicit ym2151_device(mixer_channel_t&& channel);
+	explicit ym2151_device(MixerChannelPtr&& channel);
 	~ym2151_device();
 
 	// configuration helpers
@@ -3164,7 +3164,7 @@ private:
 	};
 
 	// Playback related
-	mixer_channel_t audio_channel = nullptr;
+	MixerChannelPtr audio_channel = nullptr;
 	std::queue<AudioFrame> fifo   = {};
 	double last_rendered_ms       = 0.0;
 	double ms_per_render          = 0.0;
@@ -4835,7 +4835,7 @@ void ym2151_device::advance()
 //  ym2151_device - constructor
 //-------------------------------------------------
 
-ym2151_device::ym2151_device(mixer_channel_t&& channel)
+ym2151_device::ym2151_device(MixerChannelPtr&& channel)
         : audio_channel(std::move(channel))
 {
 	device_start();
@@ -12865,7 +12865,7 @@ public:
 	MusicFeatureCard(const MusicFeatureCard&)            = delete;
 	MusicFeatureCard& operator=(const MusicFeatureCard&) = delete;
 
-	MusicFeatureCard(mixer_channel_t&& audio_channel, const io_port_t port,
+	MusicFeatureCard(MixerChannelPtr&& audio_channel, const io_port_t port,
 	                 const uint8_t irq)
 	        : m_ya2151(std::move(audio_channel)),
 	          // create all the instances

--- a/src/hardware/imfc.cpp
+++ b/src/hardware/imfc.cpp
@@ -4843,7 +4843,7 @@ ym2151_device::ym2151_device(mixer_channel_t&& channel)
 	device_reset();
 
 	assert(audio_channel);
-	ms_per_render = millis_in_second / audio_channel->GetSampleRate();
+	ms_per_render = MillisInSecond / audio_channel->GetSampleRate();
 	audio_channel->Enable(true);
 }
 

--- a/src/hardware/innovation.cpp
+++ b/src/hardware/innovation.cpp
@@ -328,7 +328,7 @@ static void init_innovation_dosbox_settings(Section_prop& sec_prop)
 	        "  <custom>:  Custom filter definition; see 'sb_filter' for details.");
 }
 
-void INNOVATION_AddConfigSection(const config_ptr_t& conf)
+void INNOVATION_AddConfigSection(const ConfigPtr& conf)
 {
 	assert(conf);
 

--- a/src/hardware/innovation.cpp
+++ b/src/hardware/innovation.cpp
@@ -75,13 +75,14 @@ void Innovation::Open(const std::string_view model_choice,
 	else if (clock_choice == "hardsid")
 		chip_clock = 1000000.0;
 	assert(chip_clock);
-	ms_per_clock = millis_in_second / chip_clock;
+
+	ms_per_clock = MillisInSecond / chip_clock;
 
 	// Setup the mixer and get it's sampling rate
 	const auto mixer_callback = std::bind(&Innovation::AudioCallback, this, _1);
 
 	auto mixer_channel = MIXER_AddChannel(mixer_callback,
-	                                      use_mixer_rate,
+	                                      UseMixerRate,
 	                                      ChannelName::InnovationSsi2001,
 	                                      {ChannelFeature::Sleep,
 	                                       ChannelFeature::ReverbSend,

--- a/src/hardware/innovation.h
+++ b/src/hardware/innovation.h
@@ -54,7 +54,7 @@ private:
 	void WriteToPort(io_port_t port, io_val_t value, io_width_t width);
 
 	// Managed objects
-	mixer_channel_t channel               = nullptr;
+	MixerChannelPtr channel               = nullptr;
 	IO_ReadHandleObject read_handler      = {};
 	IO_WriteHandleObject write_handler    = {};
 	std::unique_ptr<reSIDfp::SID> service = {};

--- a/src/hardware/input/mouse_config.cpp
+++ b/src/hardware/input/mouse_config.cpp
@@ -454,7 +454,7 @@ static void config_init(Section_prop &secprop)
 	                    "Note: Requires PS/2 mouse to be enabled.");
 }
 
-void MOUSE_AddConfigSection(const config_ptr_t& conf)
+void MOUSE_AddConfigSection(const ConfigPtr& conf)
 {
 	assert(conf);
 

--- a/src/hardware/lpt_dac.cpp
+++ b/src/hardware/lpt_dac.cpp
@@ -53,7 +53,7 @@ LptDac::LptDac(const std::string_view name, const uint16_t channel_rate_hz,
 	                           dac_name.c_str(),
 	                           features);
 
-	ms_per_frame = millis_in_second / channel->GetSampleRate();
+	ms_per_frame = MillisInSecond / channel->GetSampleRate();
 
 	// Update our status to indicate we're ready
 	status_reg.error = false;

--- a/src/hardware/lpt_dac.h
+++ b/src/hardware/lpt_dac.h
@@ -60,7 +60,7 @@ protected:
 	void AudioCallback(const uint16_t requested_frames);
 	std::queue<AudioFrame> render_queue = {};
 
-	mixer_channel_t channel = {};
+	MixerChannelPtr channel = {};
 
 	double last_rendered_ms = 0.0;
 	double ms_per_frame     = 0.0;

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -56,7 +56,7 @@
 
 CHECK_NARROWING();
 
-//#define DEBUG_MIXER
+// #define DEBUG_MIXER
 
 constexpr auto MixerFrameSize = 4;
 
@@ -187,7 +187,7 @@ struct MixerSettings {
 	std::atomic<int> sample_rate_hz = 0;
 
 	// Matches SDL AudioSpec.samples type
-	int blocksize = 0;
+	int blocksize    = 0;
 	int prebuffer_ms = 25;
 
 	SDL_AudioDeviceID sdldevice = 0;
@@ -330,7 +330,8 @@ static CrossfeedPreset crossfeed_pref_to_preset(const std::string& pref)
 {
 	const auto pref_has_bool = parse_bool_setting(pref);
 	if (pref_has_bool) {
-		return *pref_has_bool ? DefaultCrossfeedPreset : CrossfeedPreset::None;
+		return *pref_has_bool ? DefaultCrossfeedPreset
+		                      : CrossfeedPreset::None;
 	}
 	if (pref == "light") {
 		return CrossfeedPreset::Light;
@@ -401,7 +402,8 @@ void MIXER_SetCrossfeedPreset(const CrossfeedPreset new_preset)
 	sync_crossfeed_setting(c.preset);
 
 	if (mixer.do_crossfeed) {
-		LOG_MSG("MIXER: Crossfeed enabled ('%s' preset)", to_string(c.preset));
+		LOG_MSG("MIXER: Crossfeed enabled ('%s' preset)",
+		        to_string(c.preset));
 	} else {
 		LOG_MSG("MIXER: Crossfeed disabled");
 	}
@@ -702,15 +704,17 @@ mixer_channel_t MIXER_FindChannel(const char* name)
 	if (it == mixer.channels.end()) {
 		// Deprecated alias SPKR to PCSPEAKER
 		if (std::string_view(name) == "SPKR") {
-			LOG_WARNING("MIXER: 'SPKR' is deprecated due to inconsistent "
-			            "naming, please use 'PCSPEAKER' instead");
+			LOG_WARNING(
+			        "MIXER: 'SPKR' is deprecated due to inconsistent "
+			        "naming, please use 'PCSPEAKER' instead");
 			it = mixer.channels.find(ChannelName::PcSpeaker);
 
 			// Deprecated alias FM to OPL
 		} else if (std::string_view(name) == "FM") {
-			LOG_WARNING("MIXER: 'FM' is deprecated due to inconsistent "
-			            "naming, please use '%s' instead",
-			            ChannelName::Opl);
+			LOG_WARNING(
+			        "MIXER: 'FM' is deprecated due to inconsistent "
+			        "naming, please use '%s' instead",
+			        ChannelName::Opl);
 			it = mixer.channels.find(ChannelName::Opl);
 		}
 	}
@@ -785,7 +789,7 @@ void MixerChannel::SetAppVolume(const AudioFrame volume)
 	        name,
 	        static_cast<double>(left),
 	        static_cast<double>(right),
-	        static_cast<double>(app_volume_scalar.left * 100.0f),
+	        static_cast<double>(app_volume_scalar.left  * 100.0f),
 	        static_cast<double>(app_volume_scalar.right * 100.0f));
 #endif
 }
@@ -1187,8 +1191,7 @@ static int clamp_filter_cutoff_freq([[maybe_unused]] const std::string& channel_
 	}
 }
 
-void MixerChannel::ConfigureHighPassFilter(const int order,
-                                           const int _cutoff_freq_hz)
+void MixerChannel::ConfigureHighPassFilter(const int order, const int _cutoff_freq_hz)
 {
 	const auto cutoff_freq_hz = clamp_filter_cutoff_freq(name, _cutoff_freq_hz);
 
@@ -1201,8 +1204,7 @@ void MixerChannel::ConfigureHighPassFilter(const int order,
 	filters.highpass.cutoff_freq_hz = cutoff_freq_hz;
 }
 
-void MixerChannel::ConfigureLowPassFilter(const int order,
-                                          const int _cutoff_freq_hz)
+void MixerChannel::ConfigureLowPassFilter(const int order, const int _cutoff_freq_hz)
 {
 	const auto cutoff_freq_hz = clamp_filter_cutoff_freq(name, _cutoff_freq_hz);
 
@@ -1233,10 +1235,11 @@ bool MixerChannel::TryParseAndSetCustomFilter(const std::string& filter_prefs)
 	const auto dual_filter   = (parts.size() == 6);
 
 	if (!(single_filter || dual_filter)) {
-		LOG_WARNING("%s: Invalid custom filter definition: '%s'. Must be "
-		            "specified in \"lfp|hpf ORDER CUTOFF_FREQUENCY\" format",
-		            name.c_str(),
-		            filter_prefs.c_str());
+		LOG_WARNING(
+		        "%s: Invalid custom filter definition: '%s'. Must be "
+		        "specified in \"lfp|hpf ORDER CUTOFF_FREQUENCY\" format",
+		        name.c_str(),
+		        filter_prefs.c_str());
 		return false;
 	}
 
@@ -1276,8 +1279,7 @@ bool MixerChannel::TryParseAndSetCustomFilter(const std::string& filter_prefs)
 			SetLowPassFilter(FilterState::On);
 
 		} else if (type_pref == "hpf") {
-			ConfigureHighPassFilter(order,
-			                        cutoff_freq_hz);
+			ConfigureHighPassFilter(order, cutoff_freq_hz);
 			SetHighPassFilter(FilterState::On);
 
 		} else {
@@ -1309,10 +1311,11 @@ bool MixerChannel::TryParseAndSetCustomFilter(const std::string& filter_prefs)
 		const auto filter2_cutoff_freq_hz = parts[i++];
 
 		if (filter1_type == filter2_type) {
-			LOG_WARNING("%s: Invalid custom filter definition: '%s'. "
-			            "The two filters must be of different types.",
-			            name.c_str(),
-			            filter_prefs.c_str());
+			LOG_WARNING(
+			        "%s: Invalid custom filter definition: '%s'. "
+			        "The two filters must be of different types.",
+			        name.c_str(),
+			        filter_prefs.c_str());
 			return false;
 		}
 
@@ -1539,6 +1542,7 @@ AudioFrame MixerChannel::ConvertNextFrame(const Type* data, const int pos)
 					        data + left_pos);
 					auto host_pt1 = reinterpret_cast<const uint8_t* const>(
 					        data + right_pos);
+
 					if (sizeof(Type) == 2) {
 						frame[0] = (int16_t)host_readw(host_pt0);
 						frame[1] = (int16_t)host_readw(host_pt1);
@@ -1555,6 +1559,7 @@ AudioFrame MixerChannel::ConvertNextFrame(const Type* data, const int pos)
 				} else {
 					auto host_pt = reinterpret_cast<const uint8_t* const>(
 					        data + pos);
+
 					if (sizeof(Type) == 2) {
 						frame[0] = (int16_t)host_readw(host_pt);
 					} else {
@@ -1578,6 +1583,7 @@ AudioFrame MixerChannel::ConvertNextFrame(const Type* data, const int pos)
 					        data + left_pos);
 					auto host_pt1 = reinterpret_cast<const uint8_t* const>(
 					        data + right_pos);
+
 					if (sizeof(Type) == 2) {
 						frame[0] = static_cast<float>(
 						        static_cast<int>(host_readw(
@@ -1605,6 +1611,7 @@ AudioFrame MixerChannel::ConvertNextFrame(const Type* data, const int pos)
 				} else {
 					auto host_pt = reinterpret_cast<const uint8_t* const>(
 					        data + pos);
+
 					if (sizeof(Type) == 2) {
 						frame[0] = static_cast<float>(
 						        static_cast<int>(host_readw(
@@ -1670,7 +1677,7 @@ void MixerChannel::ConvertSamples(const Type* data, const int frames,
 		envelope.Process(stereo, frame_with_gain);
 
 		out_frame = {0.0f, 0.0f};
-		out_frame[mapped_output_left] += frame_with_gain.left;
+		out_frame[mapped_output_left]  += frame_with_gain.left;
 		out_frame[mapped_output_right] += frame_with_gain.right;
 
 		out.emplace_back(out_frame[0]);
@@ -1709,7 +1716,7 @@ AudioFrame MixerChannel::ApplyCrossfeed(const AudioFrame frame) const
 	auto pan = [](const float sample, const float pan) -> AudioFrame {
 		return {(1.0f - pan) * sample, pan * sample};
 	};
-	const auto a = pan(frame.left, crossfeed.pan_left);
+	const auto a = pan(frame.left,  crossfeed.pan_left);
 	const auto b = pan(frame.right, crossfeed.pan_right);
 	return {a.left + b.left, a.right + b.right};
 }
@@ -1768,16 +1775,17 @@ bool MixerChannel::Sleeper::ConfigureFadeOut(const std::string& prefs)
 		}
 	}
 	// Otherwise inform the user and disable the fade
-	LOG_WARNING("%s: Invalid custom fade-out definition: '%s'. Must be "
-	            "specified in \"WAIT FADE\" format where WAIT is between "
-	            "%d and %d (in milliseconds) and FADE is between %d and "
-	            "%d (in milliseconds); using 'off'.",
-	            channel.GetName().c_str(),
-	            prefs.c_str(),
-	            min_wait_ms,
-	            max_wait_ms,
-	            min_fade_ms,
-	            max_fade_ms);
+	LOG_WARNING(
+	        "%s: Invalid custom fade-out definition: '%s'. Must be "
+	        "specified in \"WAIT FADE\" format where WAIT is between "
+	        "%d and %d (in milliseconds) and FADE is between %d and "
+	        "%d (in milliseconds); using 'off'.",
+	        channel.GetName().c_str(),
+	        prefs.c_str(),
+	        min_wait_ms,
+	        max_wait_ms,
+	        min_fade_ms,
+	        max_fade_ms);
 
 	wants_fadeout = false;
 	return false;
@@ -1815,7 +1823,7 @@ AudioFrame MixerChannel::Sleeper::MaybeFadeOrListen(const AudioFrame& frame)
 	if (!had_signal) {
 		// Otherwise, we simply passively listen for signal
 		constexpr auto silence_threshold = 1.0f;
-		had_signal = fabsf(frame.left) > silence_threshold ||
+		had_signal = fabsf(frame.left)  > silence_threshold ||
 		             fabsf(frame.right) > silence_threshold;
 	}
 	return frame;
@@ -1847,7 +1855,7 @@ void MixerChannel::Sleeper::MaybeSleep()
 bool MixerChannel::Sleeper::WakeUp()
 {
 	// Always reset for another round of awakeness
-	woken_at_ms = GetTicks();
+	woken_at_ms   = GetTicks();
 	fadeout_level = 1.0f;
 	had_signal    = false;
 
@@ -1904,17 +1912,18 @@ void MixerChannel::AddSamples(const int frames, const Type* data)
 				s.pos += s.step;
 
 #ifdef DEBUG_MIXER
-				LOG_DEBUG("%s: AddSamples last %.1f:%.1f curr %.1f:%.1f"
-				          " -> out %.1f:%.1f, pos=%.2f, step=%.2f",
-				          name.c_str(),
-				          s.last_frame.left,
-				          s.last_frame.right,
-				          curr_frame.left,
-				          curr_frame.right,
-				          out_left,
-				          out_right,
-				          s.pos,
-				          s.step);
+				LOG_DEBUG(
+				        "%s: AddSamples last %.1f:%.1f curr %.1f:%.1f"
+				        " -> out %.1f:%.1f, pos=%.2f, step=%.2f",
+				        name.c_str(),
+				        s.last_frame.left,
+				        s.last_frame.right,
+				        curr_frame.left,
+				        curr_frame.right,
+				        out_left,
+				        out_right,
+				        s.pos,
+				        s.step);
 #endif
 
 				if (s.pos > 1.0f) {
@@ -1972,11 +1981,11 @@ void MixerChannel::AddSamples(const int frames, const Type* data)
 		AudioFrame frame = {*pos++, *pos++};
 
 		if (do_highpass_filter) {
-			frame.left = filters.highpass.hpf[0].filter(frame.left);
+			frame.left  = filters.highpass.hpf[0].filter(frame.left);
 			frame.right = filters.highpass.hpf[1].filter(frame.right);
 		}
 		if (do_lowpass_filter) {
-			frame.left = filters.lowpass.lpf[0].filter(frame.left);
+			frame.left  = filters.lowpass.lpf[0].filter(frame.left);
 			frame.right = filters.lowpass.lpf[1].filter(frame.right);
 		}
 		if (do_crossfeed) {
@@ -2061,7 +2070,7 @@ void MixerChannel::AddStretched(const int len, int16_t* data)
 			frame_with_gain = sleeper.MaybeFadeOrListen(frame_with_gain);
 		}
 
-		mixer.work[mixpos][mapped_output_left] += frame_with_gain.left;
+		mixer.work[mixpos][mapped_output_left]  += frame_with_gain.left;
 		mixer.work[mixpos][mapped_output_right] += frame_with_gain.right;
 
 		mixpos = (mixpos + 1) & MixerBufferMask;
@@ -2314,7 +2323,7 @@ static void mix_samples(const int frames_requested)
 		for (auto i = 0; i < frames_added; ++i) {
 			for (auto ch = 0; ch < 2; ++ch) {
 				mixer.work[pos][ch] = mixer.highpass_filter[ch].filter(
-						mixer.work[pos][ch]);
+				        mixer.work[pos][ch]);
 			}
 			pos = (pos + 1) & MixerBufferMask;
 		}
@@ -2461,8 +2470,8 @@ static void SDLCALL mixer_callback([[maybe_unused]] void* userdata,
 				                     : frames_needed) -
 				            frames_remaining;
 
-				mixer.tick_add = calc_tickadd(mixer.sample_rate_hz +
-				                              (diff * 3));
+				mixer.tick_add = calc_tickadd(
+				        mixer.sample_rate_hz + (diff * 3));
 				frames_remaining = 0; // No stretching as we
 				                      // compensate with the
 				                      // tick_add value
@@ -2502,13 +2511,13 @@ static void SDLCALL mixer_callback([[maybe_unused]] void* userdata,
 			}
 
 			if (diff > (mixer.min_frames_needed >> 1)) {
-				mixer.tick_add = calc_tickadd(mixer.sample_rate_hz -
-				                              (diff / 5));
+				mixer.tick_add = calc_tickadd(
+				        mixer.sample_rate_hz - (diff / 5));
 			}
 
 			else if (diff > (mixer.min_frames_needed >> 2)) {
-				mixer.tick_add = calc_tickadd(mixer.sample_rate_hz -
-				                              (diff >> 3));
+				mixer.tick_add = calc_tickadd(
+				        mixer.sample_rate_hz - (diff >> 3));
 			} else {
 				mixer.tick_add = calc_tickadd(mixer.sample_rate_hz);
 			}
@@ -2802,7 +2811,7 @@ void MIXER_Init(Section* sec)
 	assert(section);
 
 	mixer.sample_rate_hz = section->Get_int("rate");
-	mixer.blocksize = section->Get_int("blocksize");
+	mixer.blocksize      = section->Get_int("blocksize");
 
 	const auto configured_state = section->Get_bool("nosound")
 	                                    ? MixerState::NoSound
@@ -2831,9 +2840,9 @@ void MIXER_Init(Section* sec)
 	const auto prebuffer_frames = (mixer.sample_rate_hz * mixer.prebuffer_ms) /
 	                              1000;
 
-	mixer.pos           = 0;
-	mixer.frames_done   = 0;
-	mixer.frames_needed = mixer.min_frames_needed + 1;
+	mixer.pos               = 0;
+	mixer.frames_done       = 0;
+	mixer.frames_needed     = mixer.min_frames_needed + 1;
 	mixer.min_frames_needed = 0;
 	mixer.max_frames_needed = mixer.blocksize * 2 + 2 * prebuffer_frames;
 
@@ -2918,15 +2927,15 @@ void init_mixer_dosbox_settings(Section_prop& sec_prop)
 	constexpr auto default_sample_rate_hz = 48000;
 #if defined(WIN32)
 	// Longstanding known-good defaults for Windows
-	constexpr auto default_blocksize    = 1024;
-	constexpr auto default_prebuffer_ms = 25;
-	constexpr bool default_allow_negotiate  = false;
+	constexpr auto default_blocksize       = 1024;
+	constexpr auto default_prebuffer_ms    = 25;
+	constexpr bool default_allow_negotiate = false;
 
 #else
 	// Non-Windows platforms tolerate slightly lower latency
-	constexpr auto default_blocksize    = 512;
-	constexpr auto default_prebuffer_ms = 20;
-	constexpr bool default_allow_negotiate  = true;
+	constexpr auto default_blocksize       = 512;
+	constexpr auto default_prebuffer_ms    = 20;
+	constexpr bool default_allow_negotiate = true;
 #endif
 
 	constexpr auto always        = Property::Changeable::Always;
@@ -2946,8 +2955,7 @@ void init_mixer_dosbox_settings(Section_prop& sec_prop)
 	int_prop->Set_help("Mixer sample rate in Hz (%s by default).");
 
 	int_prop = sec_prop.Add_int("blocksize", only_at_start, default_blocksize);
-	int_prop->Set_values(
-	        {"128", "256", "512", "1024", "2048", "4096", "8192"});
+	int_prop->Set_values({"128", "256", "512", "1024", "2048", "4096", "8192"});
 	int_prop->Set_help(
 	        "Mixer block size in sample frames (%s by default). Larger values might help\n"
 	        "with sound stuttering but the sound will also be more lagged.");
@@ -2966,10 +2974,11 @@ void init_mixer_dosbox_settings(Section_prop& sec_prop)
 
 	const auto default_on = true;
 	bool_prop = sec_prop.Add_bool("compressor", when_idle, default_on);
-	bool_prop->Set_help("Enable the auto-leveling compressor on the master channel to prevent clipping\n"
-	                    "of the audio output:\n"
-	                    "  off:  Disable compressor.\n"
-	                    "  on:   Enable compressor (default).");
+	bool_prop->Set_help(
+	        "Enable the auto-leveling compressor on the master channel to prevent clipping\n"
+	        "of the audio output:\n"
+	        "  off:  Disable compressor.\n"
+	        "  on:   Enable compressor (default).");
 
 	auto string_prop = sec_prop.Add_string("crossfeed", when_idle, "off");
 	string_prop->Set_help(

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -1095,7 +1095,7 @@ void MixerChannel::AddSilence()
 					if (prev_frame[ch] > f) {
 						next_frame[ch] = prev_frame[ch] - f;
 					} else if (prev_frame[ch] < -f) {
-						next_frame[ch] = prev_frame[0] + f;
+						next_frame[ch] = prev_frame[ch] + f;
 					} else {
 						next_frame[ch] = 0.0f;
 					}

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -169,7 +169,7 @@ struct MixerSettings {
 
 	AudioFrame master_volume = {1.0f, 1.0f};
 
-	std::map<std::string, mixer_channel_t> channels = {};
+	std::map<std::string, MixerChannelPtr> channels = {};
 
 	std::map<std::string, MixerChannelSettings> channel_settings_cache = {};
 
@@ -287,7 +287,7 @@ bool StereoLine::operator==(const StereoLine other) const
 	return left == other.left && right == other.right;
 }
 
-static void set_global_crossfeed(const mixer_channel_t& channel)
+static void set_global_crossfeed(const MixerChannelPtr& channel)
 {
 	assert(channel);
 
@@ -298,7 +298,7 @@ static void set_global_crossfeed(const mixer_channel_t& channel)
 	}
 }
 
-static void set_global_reverb(const mixer_channel_t& channel)
+static void set_global_reverb(const MixerChannelPtr& channel)
 {
 	assert(channel);
 
@@ -313,7 +313,7 @@ static void set_global_reverb(const mixer_channel_t& channel)
 	}
 }
 
-static void set_global_chorus(const mixer_channel_t& channel)
+static void set_global_chorus(const MixerChannelPtr& channel)
 {
 	assert(channel);
 
@@ -624,7 +624,7 @@ static void init_compressor(const bool compressor_enabled)
 	LOG_MSG("MIXER: Master compressor enabled");
 }
 
-void MIXER_DeregisterChannel(mixer_channel_t& channel_to_remove)
+void MIXER_DeregisterChannel(MixerChannelPtr& channel_to_remove)
 {
 	if (!channel_to_remove) {
 		return;
@@ -652,7 +652,7 @@ void MIXER_DeregisterChannel(mixer_channel_t& channel_to_remove)
 	MIXER_UnlockAudioDevice();
 }
 
-mixer_channel_t MIXER_AddChannel(MIXER_Handler handler,
+MixerChannelPtr MIXER_AddChannel(MIXER_Handler handler,
                                  const int sample_rate_hz, const char* name,
                                  const std::set<ChannelFeature>& features)
 {
@@ -700,7 +700,7 @@ mixer_channel_t MIXER_AddChannel(MIXER_Handler handler,
 	return chan;
 }
 
-mixer_channel_t MIXER_FindChannel(const char* name)
+MixerChannelPtr MIXER_FindChannel(const char* name)
 {
 	MIXER_LockAudioDevice();
 
@@ -731,7 +731,7 @@ mixer_channel_t MIXER_FindChannel(const char* name)
 	return chan;
 }
 
-std::map<std::string, mixer_channel_t>& MIXER_GetChannels()
+std::map<std::string, MixerChannelPtr>& MIXER_GetChannels()
 {
 	return mixer.channels;
 }

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -1088,7 +1088,7 @@ void MixerChannel::AddSilence()
 	MIXER_LockAudioDevice();
 
 	if (frames_done < frames_needed) {
-		if (prev_frame[0] == 0.0f && prev_frame[1] == 0.0f) {
+		if (prev_frame.left == 0.0f && prev_frame.right == 0.0f) {
 			frames_done = frames_needed;
 			// Make sure the next samples are zero when they get
 			// switched to prev
@@ -1544,19 +1544,19 @@ AudioFrame MixerChannel::ConvertNextFrame(const Type* data, const int pos)
 		// unsigned 8-bit
 		if (!signeddata) {
 			if (stereo) {
-				frame[0] = lut_u8to16[static_cast<uint8_t>(data[left_pos])];
-				frame[1] = lut_u8to16[static_cast<uint8_t>(data[right_pos])];
+				frame.left  = lut_u8to16[static_cast<uint8_t>(data[left_pos])];
+				frame.right = lut_u8to16[static_cast<uint8_t>(data[right_pos])];
 			} else {
-				frame[0] = lut_u8to16[static_cast<uint8_t>(data[pos])];
+				frame.left = lut_u8to16[static_cast<uint8_t>(data[pos])];
 			}
 		}
 		// signed 8-bit
 		else {
 			if (stereo) {
-				frame[0] = lut_s8to16[static_cast<int8_t>(data[left_pos])];
-				frame[1] = lut_s8to16[static_cast<int8_t>(data[right_pos])];
+				frame.left  = lut_s8to16[static_cast<int8_t>(data[left_pos])];
+				frame.right = lut_s8to16[static_cast<int8_t>(data[right_pos])];
 			} else {
-				frame[0] = lut_s8to16[static_cast<int8_t>(data[pos])];
+				frame.left = lut_s8to16[static_cast<int8_t>(data[pos])];
 			}
 		}
 	} else {
@@ -1564,8 +1564,8 @@ AudioFrame MixerChannel::ConvertNextFrame(const Type* data, const int pos)
 		if (signeddata) {
 			if (stereo) {
 				if (nativeorder) {
-					frame[0] = static_cast<float>(data[left_pos]);
-					frame[1] = static_cast<float>(data[right_pos]);
+					frame.left  = static_cast<float>(data[left_pos]);
+					frame.right = static_cast<float>(data[right_pos]);
 				} else {
 					auto host_pt0 = reinterpret_cast<const uint8_t* const>(
 					        data + left_pos);
@@ -1573,26 +1573,26 @@ AudioFrame MixerChannel::ConvertNextFrame(const Type* data, const int pos)
 					        data + right_pos);
 
 					if (sizeof(Type) == 2) {
-						frame[0] = (int16_t)host_readw(host_pt0);
-						frame[1] = (int16_t)host_readw(host_pt1);
+						frame.left  = (int16_t)host_readw(host_pt0);
+						frame.right = (int16_t)host_readw(host_pt1);
 					} else {
-						frame[0] = static_cast<float>(
+						frame.left = static_cast<float>(
 						        (int32_t)host_readd(host_pt0));
-						frame[1] = static_cast<float>(
+						frame.right = static_cast<float>(
 						        (int32_t)host_readd(host_pt1));
 					}
 				}
 			} else { // mono
 				if (nativeorder) {
-					frame[0] = static_cast<float>(data[pos]);
+					frame.left = static_cast<float>(data[pos]);
 				} else {
 					auto host_pt = reinterpret_cast<const uint8_t* const>(
 					        data + pos);
 
 					if (sizeof(Type) == 2) {
-						frame[0] = (int16_t)host_readw(host_pt);
+						frame.left = (int16_t)host_readw(host_pt);
 					} else {
-						frame[0] = static_cast<float>(
+						frame.left = static_cast<float>(
 						        (int32_t)host_readd(host_pt));
 					}
 				}
@@ -1601,10 +1601,10 @@ AudioFrame MixerChannel::ConvertNextFrame(const Type* data, const int pos)
 			const auto offs = 32768;
 			if (stereo) {
 				if (nativeorder) {
-					frame[0] = static_cast<float>(
+					frame.left = static_cast<float>(
 					        static_cast<int>(data[left_pos]) -
 					        offs);
-					frame[1] = static_cast<float>(
+					frame.right = static_cast<float>(
 					        static_cast<int>(data[right_pos]) -
 					        offs);
 				} else {
@@ -1614,20 +1614,20 @@ AudioFrame MixerChannel::ConvertNextFrame(const Type* data, const int pos)
 					        data + right_pos);
 
 					if (sizeof(Type) == 2) {
-						frame[0] = static_cast<float>(
+						frame.left = static_cast<float>(
 						        static_cast<int>(host_readw(
 						                host_pt0)) -
 						        offs);
-						frame[1] = static_cast<float>(
+						frame.right = static_cast<float>(
 						        static_cast<int>(host_readw(
 						                host_pt1)) -
 						        offs);
 					} else {
-						frame[0] = static_cast<float>(
+						frame.left = static_cast<float>(
 						        static_cast<int>(host_readd(
 						                host_pt0)) -
 						        offs);
-						frame[1] = static_cast<float>(
+						frame.right = static_cast<float>(
 						        static_cast<int>(host_readd(
 						                host_pt1)) -
 						        offs);
@@ -1635,19 +1635,19 @@ AudioFrame MixerChannel::ConvertNextFrame(const Type* data, const int pos)
 				}
 			} else { // mono
 				if (nativeorder) {
-					frame[0] = static_cast<float>(
+					frame.left = static_cast<float>(
 					        static_cast<int>(data[pos]) - offs);
 				} else {
 					auto host_pt = reinterpret_cast<const uint8_t* const>(
 					        data + pos);
 
 					if (sizeof(Type) == 2) {
-						frame[0] = static_cast<float>(
+						frame.left = static_cast<float>(
 						        static_cast<int>(host_readw(
 						                host_pt)) -
 						        offs);
 					} else {
-						frame[0] = static_cast<float>(
+						frame.left = static_cast<float>(
 						        static_cast<int>(host_readd(
 						                host_pt)) -
 						        offs);
@@ -1675,8 +1675,8 @@ void MixerChannel::ConvertSamples(const Type* data, const int frames,
 	const auto mapped_channel_left  = channel_map.left;
 	const auto mapped_channel_right = channel_map.right;
 
-	auto pos = 0;
-	std::array<float, 2> out_frame;
+	auto pos             = 0;
+	AudioFrame out_frame = {};
 
 	out.resize(0);
 
@@ -1711,8 +1711,8 @@ void MixerChannel::ConvertSamples(const Type* data, const int frames,
 		out_frame[mapped_output_left]  += frame_with_gain.left;
 		out_frame[mapped_output_right] += frame_with_gain.right;
 
-		out.emplace_back(out_frame[0]);
-		out.emplace_back(out_frame[1]);
+		out.emplace_back(out_frame.left);
+		out.emplace_back(out_frame.right);
 
 		if (do_zoh_upsample) {
 			zoh_upsampler.pos += zoh_upsampler.step;
@@ -2313,10 +2313,8 @@ static void mix_samples(const int frames_requested)
 			                    mixer.aux_reverb[pos][1]};
 
 			// High-pass filter the reverb input
-			for (auto ch = 0; ch < 2; ++ch) {
-				frame[ch] = mixer.reverb.highpass_filter[ch].filter(
-				        frame[ch]);
-			}
+			frame.left  = mixer.reverb.highpass_filter[0].filter(frame.left);
+			frame.right = mixer.reverb.highpass_filter[1].filter( frame.right);
 
 			// MVerb operates on two non-interleaved sample streams
 			static float in_left[1]     = {};

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -752,11 +752,8 @@ void MixerChannel::Set0dbScalar(const float scalar)
 
 void MixerChannel::RecalcCombinedVolume()
 {
-	combined_volume_gain.left = user_volume_gain.left * app_volume_gain.left *
-	                            mixer.master_volume.left * db0_volume_gain;
-
-	combined_volume_gain.right = user_volume_gain.right * app_volume_gain.right *
-	                             mixer.master_volume.right * db0_volume_gain;
+	combined_volume_gain = user_volume_gain * app_volume_gain *
+	                       mixer.master_volume * db0_volume_gain;
 }
 
 const AudioFrame MixerChannel::GetUserVolume() const
@@ -1704,7 +1701,7 @@ void MixerChannel::ConvertSamples(const Type* data, const int frames,
 		// prevent severe clicks and pops. Becomes a no-op when done.
 		envelope.Process(stereo, frame_with_gain);
 
-		out_frame = {0.0f, 0.0f};
+		out_frame = {};
 		out_frame[mapped_output_left]  += frame_with_gain.left;
 		out_frame[mapped_output_right] += frame_with_gain.right;
 
@@ -2093,8 +2090,8 @@ void MixerChannel::AddStretched(const int len, int16_t* data)
 		auto sample = prev_frame.left +
 		              static_cast<float>((diff * diff_mul) >> FreqShift);
 
-		AudioFrame frame_with_gain = {sample * combined_volume_gain.left,
-		                              sample * combined_volume_gain.right};
+		AudioFrame frame     = {sample, sample};
+		auto frame_with_gain = frame * combined_volume_gain;
 
 		if (do_sleep) {
 			frame_with_gain = sleeper.MaybeFadeOrListen(frame_with_gain);

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -2015,12 +2015,12 @@ void MixerChannel::AddSamples(const int frames, const Type* data)
 		AudioFrame frame = {*pos++, *pos++};
 
 		if (do_highpass_filter) {
-			frame.left  = filters.highpass.hpf[0].filter(frame.left);
-			frame.right = filters.highpass.hpf[1].filter(frame.right);
+			frame = {filters.highpass.hpf[0].filter(frame.left),
+			         filters.highpass.hpf[1].filter(frame.right)};
 		}
 		if (do_lowpass_filter) {
-			frame.left  = filters.lowpass.lpf[0].filter(frame.left);
-			frame.right = filters.lowpass.lpf[1].filter(frame.right);
+			frame = {filters.lowpass.lpf[0].filter(frame.left),
+			         filters.lowpass.lpf[1].filter(frame.right)};
 		}
 		if (do_crossfeed) {
 			frame = ApplyCrossfeed(frame);
@@ -2355,11 +2355,10 @@ static void mix_samples(const int frames_requested)
 		auto pos = start_pos;
 
 		for (auto i = 0; i < frames_added; ++i) {
-			mixer.work[pos].left = mixer.highpass_filter[0].filter(
-			        mixer.work[pos].left);
+			auto& hpf = mixer.highpass_filter;
 
-			mixer.work[pos].right = mixer.highpass_filter[1].filter(
-			        mixer.work[pos].right);
+			mixer.work[pos] = {hpf[0].filter(mixer.work[pos].left),
+			                   hpf[1].filter(mixer.work[pos].right)};
 
 			pos = (pos + 1) & MixerBufferMask;
 		}

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -2289,7 +2289,7 @@ static constexpr float calc_frames_per_tick(const int freq_hz)
 	assert(freq_hz > 0);
 
 	constexpr auto MillisecondsPerTick = 1000;
-	return freq_hz / MillisecondsPerTick;
+	return static_cast<float>(freq_hz) / MillisecondsPerTick;
 }
 
 // Mix a certain amount of new sample frames

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -2612,13 +2612,13 @@ static void SDLCALL mixer_callback([[maybe_unused]] void* userdata,
 
 static void stop_mixer([[maybe_unused]] Section* sec) {}
 
-[[maybe_unused]] static const char* MixerStateToString(const MixerState s)
+[[maybe_unused]] static const char* to_string(const MixerState s)
 {
 	switch (s) {
-	case MixerState::Uninitialized: return "uninitialized";
-	case MixerState::NoSound: return "no sound";
-	case MixerState::On: return "on";
-	case MixerState::Muted: return "mute";
+	case MixerState::Uninitialized: return "Uninitialized";
+	case MixerState::NoSound: return "No sound";
+	case MixerState::On: return "On";
+	case MixerState::Muted: return "Mute";
 	}
 	return "unknown!";
 }
@@ -2641,25 +2641,35 @@ static void set_mixer_state(const MixerState requested)
 
 	if (mixer.state == new_state) {
 		// Nothing to do.
-		// LOG_MSG("MIXER: Is already %s, skipping",
-		// MixerStateToString(mixer.state));
+#ifdef DEBUG_MIXER
+		LOG_MSG("MIXER: Already in '%s' state, skipping",
+		        to_string(mixer.state));
+#endif
 
 	} else if (mixer.state == MixerState::On && new_state != MixerState::On) {
 		TIMER_DelTickHandler(handle_mix_samples);
 		TIMER_AddTickHandler(handle_mix_no_sound);
-		// LOG_MSG("MIXER: Changed from on to %s",
-		// MixerStateToString(new_state));
+#ifdef DEBUG_MIXER
+		LOG_MSG("MIXER: Changed mixer state from on to '%s'",
+		        to_string(new_state));
+#endif
 
 	} else if (mixer.state != MixerState::On && new_state == MixerState::On) {
 		TIMER_DelTickHandler(handle_mix_no_sound);
 		TIMER_AddTickHandler(handle_mix_samples);
-		// LOG_MSG("MIXER: Changed from %s to on",
-		// MixerStateToString(mixer.state));
+#ifdef DEBUG_MIXER
+		LOG_MSG("MIXER: Changed mixer state from '%s' to on",
+		        to_string(mixer.state));
+#endif
 
 	} else {
 		// Nothing to do.
-		// LOG_MSG("MIXER: Skipping unecessary change from %s to %s",
-		// MixerStateToString(mixer.state), MixerStateToString(new_state));
+#ifdef DEBUG_MIXER
+		LOG_MSG("MIXER: Skipping unnecessary mixer state change change "
+		        "from '%s' to '%s'",
+		        to_string(mixer.state),
+		        to_string(new_state));
+#endif
 	}
 	mixer.state = new_state;
 

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -3027,7 +3027,7 @@ static void init_mixer_dosbox_settings(Section_prop& sec_prop)
 	MAPPER_AddHandler(handle_toggle_mute, SDL_SCANCODE_F8, PRIMARY_MOD, "mute", "Mute");
 }
 
-void MIXER_AddConfigSection(const config_ptr_t& conf)
+void MIXER_AddConfigSection(const ConfigPtr& conf)
 {
 	assert(conf);
 

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -1506,7 +1506,7 @@ float MixerChannel::GetChorusLevel() const
 
 // Floating-point conversion from unsigned 8-bit to signed 16-bit.
 // This is only used to populate a lookup table that's 20-fold faster.
-constexpr int16_t u8to16(const int u_val)
+static constexpr int16_t u8to16(const int u_val)
 {
 	assert(u_val >= 0 && u_val <= UINT8_MAX);
 	const auto s_val = u_val - 128;
@@ -1519,9 +1519,10 @@ constexpr int16_t u8to16(const int u_val)
 
 // 8-bit to 16-bit lookup tables
 int16_t lut_u8to16[UINT8_MAX + 1] = {};
-constexpr int16_t* lut_s8to16     = lut_u8to16 + 128;
 
-constexpr void fill_8to16_lut()
+static constexpr int16_t* lut_s8to16 = lut_u8to16 + 128;
+
+static constexpr void fill_8to16_lut()
 {
 	for (int i = 0; i <= UINT8_MAX; ++i) {
 		lut_u8to16[i] = u8to16(i);
@@ -1725,8 +1726,8 @@ void MixerChannel::ConvertSamples(const Type* data, const int frames,
 	}
 }
 
-spx_uint32_t estimate_max_out_frames(SpeexResamplerState* resampler_state,
-                                     const spx_uint32_t in_frames)
+static spx_uint32_t estimate_max_out_frames(SpeexResamplerState* resampler_state,
+                                            const spx_uint32_t in_frames)
 {
 	assert(resampler_state);
 	assert(in_frames);
@@ -2965,7 +2966,7 @@ static void handle_toggle_mute(const bool was_pressed)
 	};
 }
 
-void init_mixer_dosbox_settings(Section_prop& sec_prop)
+static void init_mixer_dosbox_settings(Section_prop& sec_prop)
 {
 	constexpr auto DefaultSampleRateHz = 48000;
 #if defined(WIN32)

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -2089,7 +2089,7 @@ void MixerChannel::AddStretched(const int len, int16_t* data)
 	while (frames_remaining--) {
 		auto prev_sample = prev_frame.left;
 		auto curr_sample = static_cast<float>(*data);
-		float out_sample = {};
+		float out_sample = 0;
 
 		switch (resample_method) {
 		case ResampleMethod::LinearInterpolation:
@@ -2464,6 +2464,8 @@ static void handle_mix_no_sound()
 static void SDLCALL mixer_callback([[maybe_unused]] void* userdata,
                                    Uint8* stream, int bytes_requested)
 {
+	assert(bytes_requested >= 0);
+
 	ZoneScoped;
 	memset(stream, 0, static_cast<size_t>(bytes_requested));
 
@@ -2475,8 +2477,8 @@ static void SDLCALL mixer_callback([[maybe_unused]] void* userdata,
 	auto reduce_frames = 0;
 
 	// Used for time-stretching the audio in the buffer overrun scenario.
-	float index     = {};
-	float index_add = {};
+	float index     = 0;
+	float index_add = 0;
 
 	if (mixer.frames_done < frames_requested) {
 		// Buffer underrun

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -2485,17 +2485,7 @@ static void SDLCALL mixer_callback([[maybe_unused]] void* userdata,
 		            mixer.min_frames_needed.load());
 #endif
 
-		if ((frames_requested - mixer.frames_done) >
-		    (frames_requested >> 7)) {
-			// Max 1 percent stretch.
-			LOG_WARNING("MIXER:     Stretch more than 1 percent");
-			return;
-		}
 		reduce_frames = mixer.frames_done;
-		index_add = (reduce_frames << IndexShiftLocal) / frames_requested;
-
-		mixer.tick_add = calc_tickadd(mixer.sample_rate_hz +
-		                              mixer.min_frames_needed);
 
 	} else if (mixer.frames_done < mixer.max_frames_needed) {
 		auto frames_remaining = mixer.frames_done - frames_requested;
@@ -2535,7 +2525,7 @@ static void SDLCALL mixer_callback([[maybe_unused]] void* userdata,
 			            frames_requested;
 		} else {
 			reduce_frames = frames_requested;
-#if 1
+#if 0
 			LOG_MSG("MIXER: Regular run requested %d, have %d, min %d, remaining %d",
 			        frames_requested,
 			        mixer.frames_done.load(),

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -117,9 +117,12 @@ struct ReverbSettings {
 		mverb.setParameter(EmVerb::BANDWIDTHFREQ, bandwidth_freq_hz);
 		mverb.setParameter(EmVerb::DECAY, decay);
 		mverb.setParameter(EmVerb::DAMPINGFREQ, dampening_freq_hz);
-		mverb.setParameter(EmVerb::GAIN, 1.0f); // Always max gain (no
-		                                        // attenuation)
-		mverb.setParameter(EmVerb::MIX, 1.0f); // Always 100% wet signal
+
+		// Always max gain (no attenuation)
+		mverb.setParameter(EmVerb::GAIN, 1.0f);
+
+		// Always 100% wet output signal
+		mverb.setParameter(EmVerb::MIX, 1.0f);
 
 		mverb.setSampleRate(static_cast<float>(sample_rate_hz));
 
@@ -149,6 +152,9 @@ struct ChorusSettings {
 		constexpr auto Chorus1Enabled  = true;
 		constexpr auto Chorus2Disabled = false;
 		chorus_engine.setEnablesChorus(Chorus1Enabled, Chorus2Disabled);
+
+		// The chorus effect can only operates in 100% wet output mode,
+		// so we don't need to configure it for that.
 	}
 };
 

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -2560,7 +2560,8 @@ static void SDLCALL mixer_callback([[maybe_unused]] void* userdata,
 	mixer.pos = (mixer.pos + reduce_frames) & MixerBufferMask;
 
 	if (frames_requested != reduce_frames) {
-		while (frames_requested--) {
+		auto frames = std::min(reduce_frames, frames_requested);
+		while (frames--) {
 			const auto i = (pos + (index >> IndexShiftLocal)) &
 			               MixerBufferMask;
 			index += index_add;

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -160,9 +160,9 @@ struct ChorusSettings {
 };
 
 struct MixerSettings {
-	std::array<AudioFrame, MixerBufferLength> work       = {};
-	std::array<AudioFrame, MixerBufferLength> aux_reverb = {};
-	std::array<AudioFrame, MixerBufferLength> aux_chorus = {};
+	std::array<AudioFrame, MixerBufferByteSize> work       = {};
+	std::array<AudioFrame, MixerBufferByteSize> aux_reverb = {};
+	std::array<AudioFrame, MixerBufferByteSize> aux_chorus = {};
 
 	std::vector<float> resample_temp = {};
 	std::vector<float> resample_out  = {};
@@ -215,7 +215,7 @@ struct MixerSettings {
 static struct MixerSettings mixer = {};
 
 // TODO This is hacky and should be removed. Only the PS1 Audio uses it.
-alignas(sizeof(float)) uint8_t MixTemp[MixerBufferLength] = {};
+alignas(sizeof(float)) uint8_t MixTemp[MixerBufferByteSize] = {};
 
 void MixerChannel::SetLineoutMap(const StereoLine map)
 {
@@ -1065,7 +1065,7 @@ void MixerChannel::Mix(const int frames_requested)
 			break;
 		}
 		// avoid overflow
-		frames_remaining = std::min(frames_remaining, MixerBufferLength);
+		frames_remaining = std::min(frames_remaining, MixerBufferByteSize);
 
 		handler(frames_remaining);
 	}
@@ -2201,7 +2201,7 @@ void MixerChannel::FillUp()
 	auto frames_remaining = static_cast<int>(index * mixer.frames_needed);
 	while (frames_remaining > 0) {
 		const auto frames_to_mix = std::clamp(
-		        frames_remaining, 0, static_cast<int>(MixerBufferLength));
+		        frames_remaining, 0, static_cast<int>(MixerBufferByteSize));
 
 		MIXER_LockAudioDevice();
 		Mix(frames_to_mix);
@@ -2542,8 +2542,8 @@ static void SDLCALL mixer_callback([[maybe_unused]] void* userdata,
 		            mixer.frames_done.load(),
 		            mixer.min_frames_needed.load());
 #endif
-		if (mixer.frames_done > MixerBufferLength) {
-			index_add = MixerBufferLength - 2 * mixer.min_frames_needed;
+		if (mixer.frames_done > MixerBufferByteSize) {
+			index_add = MixerBufferByteSize - 2 * mixer.min_frames_needed;
 		} else {
 			index_add = mixer.frames_done - 2 * mixer.min_frames_needed;
 		}

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -2478,12 +2478,17 @@ static void SDLCALL mixer_callback([[maybe_unused]] void* userdata,
 
 	/* Enough room in the buffer ? */
 	if (mixer.frames_done < frames_requested) {
-		//		LOG_WARNING("Full underrun requested %d, have
-		//%d, min %d", frames_requested, mixer.frames_done.load(),
-		// mixer.min_frames_needed.load());
+#if 1
+		LOG_WARNING("MIXER: Full underrun requested %d, have %d, min %d",
+		            frames_requested,
+		            mixer.frames_done.load(),
+		            mixer.min_frames_needed.load());
+#endif
+
 		if ((frames_requested - mixer.frames_done) >
-		    (frames_requested >> 7)) { // Max 1 percent
-			                       // stretch.
+		    (frames_requested >> 7)) {
+			// Max 1 percent stretch.
+			LOG_WARNING("MIXER:     Stretch more than 1 percent");
 			return;
 		}
 		reduce_frames = mixer.frames_done;
@@ -2517,20 +2522,26 @@ static void SDLCALL mixer_callback([[maybe_unused]] void* userdata,
 				frames_remaining = 1 + (2 * frames_remaining) /
 				                               mixer.min_frames_needed; // frames_remaining=1,2,3
 			}
-			//			LOG_WARNING("needed underrun
-			// requested %d, have %d, min %d, frames_remaining %d",
-			// frames_requested, mixer.frames_done.load(),
-			// mixer.min_frames_needed.load(), frames_remaining);
+#if 1
+			LOG_WARNING("MIXER: Needed underrun requested %d, have %d, min %d, remaining %d",
+			            frames_requested,
+			            mixer.frames_done.load(),
+			            mixer.min_frames_needed.load(),
+			            frames_remaining);
+#endif
 			reduce_frames = frames_requested - frames_remaining;
 
 			index_add = (reduce_frames << IndexShiftLocal) /
 			            frames_requested;
 		} else {
 			reduce_frames = frames_requested;
-			//			LOG_MSG("regular run requested
-			//%d, have %d, min %d, frames_remaining %d",
-			// frames_requested, mixer.frames_done.load(),
-			// mixer.min_frames_needed.load(), frames_remaining);
+#if 1
+			LOG_MSG("MIXER: Regular run requested %d, have %d, min %d, remaining %d",
+			        frames_requested,
+			        mixer.frames_done.load(),
+			        mixer.min_frames_needed.load(),
+			        frames_remaining);
+#endif
 
 			/* Mixer tick value being updated:
 			 * 3 cases:
@@ -2559,7 +2570,7 @@ static void SDLCALL mixer_callback([[maybe_unused]] void* userdata,
 		}
 	} else {
 		// There is way too much data in the buffer
-#ifdef DEBUG_MIXER
+#if 1
 		LOG_WARNING("MIXER: Overflow run requested %d, have %d, min % d ",
 		            frames_requested,
 		            mixer.frames_done.load(),

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -2484,7 +2484,7 @@ static void SDLCALL mixer_callback([[maybe_unused]] void* userdata,
 
 	if (mixer.frames_done < frames_requested) {
 		// Buffer underrun
-#if 1
+#if 0
 		LOG_WARNING("MIXER: Full underrun requested %d, have %d, min %d",
 		            frames_requested,
 		            mixer.frames_done.load(),
@@ -2501,7 +2501,7 @@ static void SDLCALL mixer_callback([[maybe_unused]] void* userdata,
 
 			frames_remaining = 1 + (2 * frames_remaining) /
 			                               mixer.min_frames_needed;
-#if 1
+#if 0
 			LOG_WARNING("MIXER: Needed underrun requested %d, have %d, min %d, remaining %d",
 			            frames_requested,
 			            mixer.frames_done.load(),
@@ -2523,7 +2523,7 @@ static void SDLCALL mixer_callback([[maybe_unused]] void* userdata,
 
 	} else {
 		// Buffer overrun -- this usually happens in fast-forward mode.
-#if 1
+#if 0
 		LOG_WARNING("MIXER: Overflow run requested %d, have %d, min % d ",
 		            frames_requested,
 		            mixer.frames_done.load(),

--- a/src/hardware/opl.cpp
+++ b/src/hardware/opl.cpp
@@ -985,7 +985,7 @@ void OPL_Init(Section* sec, const OplMode oplmode)
 }
 
 // Must be called after SB_AddConfigSection
-void OPL_AddConfigSettings(const config_ptr_t& conf)
+void OPL_AddConfigSettings(const ConfigPtr& conf)
 {
 	assert(conf);
 	auto secprop = static_cast<Section_prop*>(conf->GetSection("sblaster"));

--- a/src/hardware/opl.cpp
+++ b/src/hardware/opl.cpp
@@ -228,7 +228,7 @@ void Opl::Init()
 		OPL3_Reset(&opl.chip, OplSampleRateHz);
 	}
 
-	ms_per_frame = millis_in_second / OplSampleRateHz;
+	ms_per_frame = MillisInSecond / OplSampleRateHz;
 
 	memset(cache, 0, ARRAY_LEN(cache));
 

--- a/src/hardware/opl.cpp
+++ b/src/hardware/opl.cpp
@@ -57,7 +57,7 @@ static const char* to_string(const OplMode opl_mode)
 	// clang-format on
 }
 
-Timer::Timer(int16_t micros)
+Timer::Timer(const int micros)
         : clock_interval(micros * 0.001) // interval in milliseconds
 {
 	SetCounter(0);
@@ -307,11 +307,11 @@ int16_t remove_dc_bias(const int16_t back_sample)
 {
 	// Calculate the number of samples we need average across to maintain
 	// the lowest frequency given an assumed playback rate.
-	constexpr int16_t PcmPlaybackRateHz      = 16000;
-	constexpr int16_t LowestFreqToMaintainHz = 200;
-	constexpr int16_t NumToAverage = PcmPlaybackRateHz / LowestFreqToMaintainHz;
+	constexpr auto PcmPlaybackRateHz      = 16000;
+	constexpr auto LowestFreqToMaintainHz = 200;
+	constexpr auto NumToAverage = PcmPlaybackRateHz / LowestFreqToMaintainHz;
 
-	static int32_t sum = 0;
+	static int sum = 0;
 
 	static std::queue<int16_t> samples = {};
 
@@ -390,7 +390,7 @@ void Opl::RenderUpToNow()
 	}
 }
 
-void Opl::AudioCallback(const uint16_t requested_frames)
+void Opl::AudioCallback(const int requested_frames)
 {
 	assert(channel);
 #if 0

--- a/src/hardware/opl.h
+++ b/src/hardware/opl.h
@@ -37,7 +37,7 @@
 
 class Timer {
 public:
-	Timer(int16_t micros);
+	Timer(const int micros);
 
 	bool Update(const double time);
 	void Reset();
@@ -159,7 +159,7 @@ private:
 
 	void Init();
 
-	void AudioCallback(const uint16_t frames);
+	void AudioCallback(const int frames);
 	AudioFrame RenderFrame();
 	void RenderUpToNow();
 

--- a/src/hardware/opl.h
+++ b/src/hardware/opl.h
@@ -99,7 +99,7 @@ enum class EsfmMode { Legacy, Native };
 
 class Opl {
 public:
-	mixer_channel_t channel = {};
+	MixerChannelPtr channel = {};
 
 	OplRegisterCache cache = {};
 

--- a/src/hardware/pcspeaker_discrete.cpp
+++ b/src/hardware/pcspeaker_discrete.cpp
@@ -471,7 +471,7 @@ PcSpeakerDiscrete::PcSpeakerDiscrete()
 	                                std::placeholders::_1);
 
 	channel = MIXER_AddChannel(callback,
-	                           use_mixer_rate,
+	                           UseMixerRate,
 	                           device_name,
 	                           {ChannelFeature::Sleep,
 	                            ChannelFeature::ChorusSend,

--- a/src/hardware/pcspeaker_discrete.h
+++ b/src/hardware/pcspeaker_discrete.h
@@ -71,7 +71,7 @@ private:
 
 	std::queue<DelayEntry> entries = {};
 
-	mixer_channel_t channel = nullptr;
+	MixerChannelPtr channel = nullptr;
 
 	PpiPortB port_b      = {};
 	PpiPortB prev_port_b = {};

--- a/src/hardware/pcspeaker_impulse.cpp
+++ b/src/hardware/pcspeaker_impulse.cpp
@@ -425,7 +425,7 @@ void PcSpeakerImpulse::AddImpulse(float index, const int16_t amplitude)
 
 #else
 	// Mathematically intensive reference implementation
-	const auto portion_of_ms = static_cast <double>(index) / millis_in_second;
+	const auto portion_of_ms = static_cast <double>(index) / MillisInSecond;
 	for (size_t i = 0; i < waveform_deque.size(); ++i) {
 		const auto impulse_time = static_cast<double>(i) / sample_rate_hz -
 		                          portion_of_ms;

--- a/src/hardware/pcspeaker_impulse.cpp
+++ b/src/hardware/pcspeaker_impulse.cpp
@@ -415,7 +415,7 @@ void PcSpeakerImpulse::AddImpulse(float index, const int16_t amplitude)
 		phase = sinc_oversampling_factor - phase;
 	}
 
-	for (uint16_t i = 0; i < sinc_filter_quality; ++i) {
+	for (auto i = 0; i < sinc_filter_quality; ++i) {
 		const auto wave_i    = check_cast<uint16_t>(offset + i);
 		const auto impulse_i = check_cast<uint16_t>(
 		        phase + i * sinc_oversampling_factor);
@@ -435,7 +435,7 @@ void PcSpeakerImpulse::AddImpulse(float index, const int16_t amplitude)
 }
 #endif
 
-void PcSpeakerImpulse::ChannelCallback(uint16_t requested_frames)
+void PcSpeakerImpulse::ChannelCallback(int requested_frames)
 {
 	ForwardPIT(1.0f);
 	pit.last_index = 0;
@@ -545,7 +545,7 @@ PcSpeakerImpulse::PcSpeakerImpulse()
 
 	LOG_MSG("%s: Initialised %s model", device_name, model_name);
 
-	channel->SetPeakAmplitude(static_cast<uint32_t>(positive_amplitude));
+	channel->SetPeakAmplitude(positive_amplitude);
 }
 
 PcSpeakerImpulse::~PcSpeakerImpulse()

--- a/src/hardware/pcspeaker_impulse.h
+++ b/src/hardware/pcspeaker_impulse.h
@@ -114,7 +114,7 @@ private:
 
 	std::array<float, sinc_filter_width> impulse_lut = {};
 
-	mixer_channel_t channel = nullptr;
+	MixerChannelPtr channel = nullptr;
 
 	PpiPortB prev_port_b = {};
 

--- a/src/hardware/pcspeaker_impulse.h
+++ b/src/hardware/pcspeaker_impulse.h
@@ -44,7 +44,7 @@ public:
 private:
 	void AddImpulse(float index, const int16_t amplitude);
 	void AddPITOutput(const float index);
-	void ChannelCallback(uint16_t requested_frames);
+	void ChannelCallback(int requested_frames);
 	void ForwardPIT(const float new_index);
 	float CalcImpulse(const double t) const;
 	void InitializeImpulseLUT();
@@ -69,8 +69,8 @@ private:
 	static constexpr float ms_per_pit_tick = 1000.0f / PIT_TICK_RATE;
 
 	// Mixer channel constants
-	static constexpr uint16_t sample_rate_hz     = 32000;
-	static constexpr uint16_t sample_rate_per_ms = sample_rate_hz / 1000;
+	static constexpr auto sample_rate_hz     = 32000;
+	static constexpr auto sample_rate_per_ms = sample_rate_hz / 1000;
 
 	static constexpr auto minimum_counter = 2 * PIT_TICK_RATE / sample_rate_hz;
 
@@ -78,11 +78,12 @@ private:
 	static constexpr float cutoff_margin = 0.2f;
 
 	// Should be selected based on sampling rate
-	static constexpr float sinc_amplitude_fade         = 0.999f;
-	static constexpr uint16_t sinc_filter_quality      = 100;
-	static constexpr uint16_t sinc_oversampling_factor = 32;
-	static constexpr uint16_t sinc_filter_width = sinc_filter_quality *
-	                                              sinc_oversampling_factor;
+	static constexpr float sinc_amplitude_fade     = 0.999f;
+	static constexpr auto sinc_filter_quality      = 100;
+	static constexpr auto sinc_oversampling_factor = 32;
+
+	static constexpr auto sinc_filter_width = sinc_filter_quality *
+	                                          sinc_oversampling_factor;
 
 	static constexpr float max_possible_pit_ms = 1320000.0f / PIT_TICK_RATE;
 

--- a/src/hardware/ps1audio.cpp
+++ b/src/hardware/ps1audio.cpp
@@ -85,7 +85,7 @@ private:
 	static constexpr auto bytes_pending_limit =  fifo_size << frac_shift;
 
 	// Managed objects
-	mixer_channel_t channel = nullptr;
+	MixerChannelPtr channel = nullptr;
 	IO_ReadHandleObject read_handlers[5] = {};
 	IO_WriteHandleObject write_handlers[4] = {};
 	Ps1Registers regs = {};
@@ -107,7 +107,7 @@ private:
 	bool can_trigger_irq = false;
 };
 
-static void setup_filter(mixer_channel_t& channel, const bool filter_enabled)
+static void setup_filter(MixerChannelPtr& channel, const bool filter_enabled)
 {
 	if (filter_enabled) {
 		constexpr auto HpfOrder        = 3;
@@ -397,7 +397,7 @@ private:
 	void WriteSoundGeneratorPort205(io_port_t port, io_val_t, io_width_t);
 
 	// Managed objects
-	mixer_channel_t channel = nullptr;
+	MixerChannelPtr channel = nullptr;
 	IO_WriteHandleObject write_handler = {};
 	sn76496_device device;
 	std::unique_ptr<reSIDfp::TwoPassSincResampler> resampler = {};

--- a/src/hardware/ps1audio.cpp
+++ b/src/hardware/ps1audio.cpp
@@ -132,7 +132,7 @@ Ps1Dac::Ps1Dac(const std::string& filter_choice)
 	const auto callback = std::bind(&Ps1Dac::Update, this, _1);
 
 	channel = MIXER_AddChannel(callback,
-	                           use_mixer_rate,
+	                           UseMixerRate,
 	                           ChannelName::Ps1AudioCardDac,
 	                           {ChannelFeature::Sleep,
 	                            ChannelFeature::ReverbSend,
@@ -408,7 +408,7 @@ private:
 	static constexpr auto render_divisor   = 16;
 	static constexpr auto render_rate_hz   = ceil_sdivide(ps1_psg_clock_hz,
                                                             render_divisor);
-	static constexpr auto ms_per_render    = millis_in_second / render_rate_hz;
+	static constexpr auto ms_per_render    = MillisInSecond / render_rate_hz;
 
 	// Runtime states
 	device_sound_interface *dsi = static_cast<sn76496_base_device *>(&device);
@@ -423,7 +423,7 @@ Ps1Synth::Ps1Synth(const std::string& filter_choice)
 	const auto callback = std::bind(&Ps1Synth::AudioCallback, this, _1);
 
 	channel = MIXER_AddChannel(callback,
-	                           use_mixer_rate,
+	                           UseMixerRate,
 	                           ChannelName::Ps1AudioCardPsg,
 	                           {ChannelFeature::Sleep,
 	                            ChannelFeature::ReverbSend,

--- a/src/hardware/reelmagic/player.cpp
+++ b/src/hardware/reelmagic/player.cpp
@@ -788,7 +788,7 @@ void ReelMagic_EnableAudioChannel(const bool should_enable)
 	}
 
 	mixer_channel = MIXER_AddChannel(&RMMixerChannelCallback,
-	                                 use_mixer_rate,
+	                                 UseMixerRate,
 	                                 ChannelName::ReelMagic,
 	                                 {// ChannelFeature::Sleep,
 	                                  ChannelFeature::Stereo,

--- a/src/hardware/reelmagic/player.cpp
+++ b/src/hardware/reelmagic/player.cpp
@@ -736,7 +736,7 @@ void ReelMagic_DeleteAllPlayers()
 //
 // audio stuff begins here...
 //
-mixer_channel_t mixer_channel = nullptr;
+MixerChannelPtr mixer_channel = nullptr;
 static AudioFifo* active_fifo = nullptr;
 
 static void ActivatePlayerAudioFifo(AudioFifo& audio_fifo)

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -223,7 +223,7 @@ struct SbInfo {
 		uint32_t count = 0;
 	} e2 = {};
 
-	mixer_channel_t chan = nullptr;
+	MixerChannelPtr chan = nullptr;
 };
 
 static SbInfo sb = {};
@@ -418,7 +418,7 @@ struct FilterConfig {
 	uint16_t zoh_rate_hz           = {};
 };
 
-static void set_filter(mixer_channel_t channel, const FilterConfig& config)
+static void set_filter(MixerChannelPtr channel, const FilterConfig& config)
 {
 	if (config.hpf_state == FilterState::On ||
 	    config.hpf_state == FilterState::ForcedOn) {
@@ -481,7 +481,7 @@ static std::optional<FilterType> determine_filter_type(const std::string& filter
 	return {};
 }
 
-static void configure_sb_filter_for_model(mixer_channel_t channel,
+static void configure_sb_filter_for_model(MixerChannelPtr channel,
                                           const std::string& filter_prefs,
                                           const bool filter_always_on,
                                           const SbType sb_type)
@@ -560,7 +560,7 @@ static void configure_sb_filter_for_model(mixer_channel_t channel,
 	set_filter(channel, config);
 }
 
-static void configure_sb_filter(mixer_channel_t channel,
+static void configure_sb_filter(MixerChannelPtr channel,
                                 const std::string& filter_prefs,
                                 const bool filter_always_on, const SbType sb_type)
 {
@@ -580,7 +580,7 @@ static void configure_sb_filter(mixer_channel_t channel,
 	}
 }
 
-static void configure_opl_filter_for_model(mixer_channel_t opl_channel,
+static void configure_opl_filter_for_model(MixerChannelPtr opl_channel,
                                            const std::string& filter_prefs,
                                            const SbType sb_type)
 {
@@ -641,7 +641,7 @@ static void configure_opl_filter_for_model(mixer_channel_t opl_channel,
 	set_filter(opl_channel, config);
 }
 
-static void configure_opl_filter(mixer_channel_t opl_channel,
+static void configure_opl_filter(MixerChannelPtr opl_channel,
                                  const std::string& filter_prefs, const SbType sb_type)
 {
 	assert(opl_channel);

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -3304,7 +3304,7 @@ void shutdown_sblaster(Section* /*sec*/) {
 	sblaster = {};
 }
 
-void SB_AddConfigSection(const config_ptr_t& conf)
+void SB_AddConfigSection(const ConfigPtr& conf)
 {
 	constexpr auto changeable_at_runtime = true;
 

--- a/src/hardware/tandy_sound.cpp
+++ b/src/hardware/tandy_sound.cpp
@@ -120,7 +120,7 @@ private:
 	DMA dma = {};
 
 	// Managed objects
-	mixer_channel_t channel = nullptr;
+	MixerChannelPtr channel = nullptr;
 	IO_ReadHandleObject read_handler = {};
 	IO_WriteHandleObject write_handlers[2] = {};
 
@@ -148,7 +148,7 @@ private:
 	void WriteToPort(io_port_t, io_val_t value, io_width_t);
 
 	// Managed objects
-	mixer_channel_t channel                                  = nullptr;
+	MixerChannelPtr channel                                  = nullptr;
 	IO_WriteHandleObject write_handlers[2]                   = {};
 	std::unique_ptr<sn76496_base_device> device              = {};
 	std::unique_ptr<reSIDfp::TwoPassSincResampler> resampler = {};
@@ -165,7 +165,7 @@ private:
 	double last_rendered_ms           = 0.0;
 };
 
-static void setup_filter(mixer_channel_t& channel, const bool filter_enabled)
+static void setup_filter(MixerChannelPtr& channel, const bool filter_enabled)
 {
 	// The filters are meant to emulate the bandwidth limited sound of the
 	// small integrated speaker of the Tandy. This more accurately

--- a/src/hardware/tandy_sound.cpp
+++ b/src/hardware/tandy_sound.cpp
@@ -158,7 +158,7 @@ private:
 	static constexpr auto render_divisor = 16;
 	static constexpr auto render_rate_hz = ceil_sdivide(tandy_psg_clock_hz,
 	                                                    render_divisor);
-	static constexpr auto ms_per_render  = millis_in_second / render_rate_hz;
+	static constexpr auto ms_per_render  = MillisInSecond / render_rate_hz;
 
 	// Runtime states
 	device_sound_interface *dsi       = nullptr;
@@ -199,7 +199,7 @@ TandyDAC::TandyDAC(const ConfigProfile config_profile,
 	const auto callback = std::bind(&TandyDAC::AudioCallback, this, _1);
 
 	channel = MIXER_AddChannel(callback,
-	                           use_mixer_rate,
+	                           UseMixerRate,
 	                           ChannelName::TandyDac,
 	                           {ChannelFeature::Sleep,
 	                            ChannelFeature::ChorusSend,
@@ -477,7 +477,7 @@ TandyPSG::TandyPSG(const ConfigProfile config_profile, const bool is_dac_enabled
 	const auto callback = std::bind(&TandyPSG::AudioCallback, this, _1);
 
 	channel = MIXER_AddChannel(callback,
-	                           use_mixer_rate,
+	                           UseMixerRate,
 	                           ChannelName::TandyPsg,
 	                           {ChannelFeature::Sleep,
 	                            ChannelFeature::FadeOut,

--- a/src/midi/midi.cpp
+++ b/src/midi/midi.cpp
@@ -829,7 +829,7 @@ void init_midi_dosbox_settings(Section_prop& secprop)
 	        "applications, or when debugging MIDI issues.");
 }
 
-void MIDI_AddConfigSection(const config_ptr_t& conf)
+void MIDI_AddConfigSection(const ConfigPtr& conf)
 {
 	assert(conf);
 

--- a/src/midi/midi_fluidsynth.cpp
+++ b/src/midi/midi_fluidsynth.cpp
@@ -931,7 +931,7 @@ MIDI_RC MidiHandlerFluidsynth::ListAll(Program* caller)
 
 static void fluid_init([[maybe_unused]] Section* sec) {}
 
-void FLUID_AddConfigSection(const config_ptr_t& conf)
+void FLUID_AddConfigSection(const ConfigPtr& conf)
 {
 	assert(conf);
 	Section_prop* sec = conf->AddSection_prop("fluidsynth", &fluid_init);

--- a/src/midi/midi_fluidsynth.cpp
+++ b/src/midi/midi_fluidsynth.cpp
@@ -240,7 +240,7 @@ bool MidiHandlerFluidsynth::Open([[maybe_unused]] const char* conf)
 {
 	Close();
 
-	fluid_settings_ptr_t fluid_settings(new_fluid_settings(),
+	FluidSynthSettingsPtr fluid_settings(new_fluid_settings(),
 	                                    delete_fluid_settings);
 	if (!fluid_settings) {
 		LOG_WARNING("FSYNTH: new_fluid_settings failed");

--- a/src/midi/midi_fluidsynth.cpp
+++ b/src/midi/midi_fluidsynth.cpp
@@ -257,7 +257,7 @@ bool MidiHandlerFluidsynth::Open([[maybe_unused]] const char* conf)
 	// settings used to instantiate the synth, so we use the mixer's native
 	// rate to configure FluidSynth.
 	const auto sample_rate_hz = MIXER_GetSampleRate();
-	ms_per_audio_frame        = millis_in_second / sample_rate_hz;
+	ms_per_audio_frame        = MillisInSecond / sample_rate_hz;
 
 	fluid_settings_setnum(fluid_settings.get(),
 	                      "synth.sample-rate",
@@ -531,7 +531,7 @@ bool MidiHandlerFluidsynth::Open([[maybe_unused]] const char* conf)
 	// Size the out-bound audio frame FIFO
 	assertm(sample_rate_hz >= 8000, "Sample rate must be at least 8 kHz");
 
-	const auto audio_frames_per_ms = iround(sample_rate_hz / millis_in_second);
+	const auto audio_frames_per_ms = iround(sample_rate_hz / MillisInSecond);
 	audio_frame_fifo.Resize(
 	        check_cast<size_t>(render_ahead_ms * audio_frames_per_ms));
 

--- a/src/midi/midi_fluidsynth.cpp
+++ b/src/midi/midi_fluidsynth.cpp
@@ -263,7 +263,7 @@ bool MidiHandlerFluidsynth::Open([[maybe_unused]] const char* conf)
 	                      "synth.sample-rate",
 	                      sample_rate_hz);
 
-	fsynth_ptr_t fluid_synth(new_fluid_synth(fluid_settings.get()),
+	FluidSynthPtr fluid_synth(new_fluid_synth(fluid_settings.get()),
 	                         delete_fluid_synth);
 	if (!fluid_synth) {
 		LOG_WARNING("FSYNTH: Failed to create the FluidSynth synthesizer.");

--- a/src/midi/midi_fluidsynth.h
+++ b/src/midi/midi_fluidsynth.h
@@ -68,10 +68,10 @@ private:
 
 	using FluidSynthSettingsPtr =
 	        std::unique_ptr<fluid_settings_t, decltype(&delete_fluid_settings)>;
-	using fsynth_ptr_t = std::unique_ptr<fluid_synth_t, decltype(&delete_fluid_synth)>;
+	using FluidSynthPtr = std::unique_ptr<fluid_synth_t, decltype(&delete_fluid_synth)>;
 
 	FluidSynthSettingsPtr settings{nullptr, &delete_fluid_settings};
-	fsynth_ptr_t synth{nullptr, &delete_fluid_synth};
+	FluidSynthPtr synth{nullptr, &delete_fluid_synth};
 
 	MixerChannelPtr mixer_channel = nullptr;
 	RWQueue<AudioFrame> audio_frame_fifo{1};

--- a/src/midi/midi_fluidsynth.h
+++ b/src/midi/midi_fluidsynth.h
@@ -66,11 +66,11 @@ private:
 	void RenderAudioFramesToFifo(const uint16_t num_audio_frames = 1);
 	void Render();
 
-	using fluid_settings_ptr_t =
+	using FluidSynthSettingsPtr =
 	        std::unique_ptr<fluid_settings_t, decltype(&delete_fluid_settings)>;
 	using fsynth_ptr_t = std::unique_ptr<fluid_synth_t, decltype(&delete_fluid_synth)>;
 
-	fluid_settings_ptr_t settings{nullptr, &delete_fluid_settings};
+	FluidSynthSettingsPtr settings{nullptr, &delete_fluid_settings};
 	fsynth_ptr_t synth{nullptr, &delete_fluid_synth};
 
 	MixerChannelPtr mixer_channel = nullptr;

--- a/src/midi/midi_fluidsynth.h
+++ b/src/midi/midi_fluidsynth.h
@@ -73,7 +73,7 @@ private:
 	fluid_settings_ptr_t settings{nullptr, &delete_fluid_settings};
 	fsynth_ptr_t synth{nullptr, &delete_fluid_synth};
 
-	mixer_channel_t mixer_channel = nullptr;
+	MixerChannelPtr mixer_channel = nullptr;
 	RWQueue<AudioFrame> audio_frame_fifo{1};
 	RWQueue<MidiWork> work_fifo{1};
 	std::thread renderer = {};

--- a/src/midi/midi_lasynth_model.cpp
+++ b/src/midi/midi_lasynth_model.cpp
@@ -50,7 +50,7 @@ LASynthModel::LASynthModel(const std::string &rom_name,
 	assert(ctrl_full || (ctrl_a && ctrl_b));
 }
 
-std::optional<std_fs::path> LASynthModel::find_rom(const service_t& service,
+std::optional<std_fs::path> LASynthModel::find_rom(const Mt32ServicePtr& service,
                                                    const std_fs::path& dir,
                                                    const Rom* rom)
 {
@@ -95,7 +95,7 @@ std::optional<std_fs::path> LASynthModel::find_rom(const service_t& service,
 }
 
 // Checks if its ROMs can be positively found in the provided directory
-bool LASynthModel::InDir(const service_t& service, const std_fs::path& dir) const
+bool LASynthModel::InDir(const Mt32ServicePtr& service, const std_fs::path& dir) const
 {
 	assert(service);
 
@@ -109,7 +109,7 @@ bool LASynthModel::InDir(const service_t& service, const std_fs::path& dir) cons
 }
 
 // If present, loads either the full or partial ROMs from the provided directory
-bool LASynthModel::Load(const service_t& service, const std_fs::path& dir) const
+bool LASynthModel::Load(const Mt32ServicePtr& service, const std_fs::path& dir) const
 {
 	if (!service) {
 		return false;

--- a/src/midi/midi_lasynth_model.h
+++ b/src/midi/midi_lasynth_model.h
@@ -1,7 +1,7 @@
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *
- *  Copyright (C) 2021-2023  The DOSBox Staging Team
+ *  Copyright (C) 2021-2024  The DOSBox Staging Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/midi/midi_lasynth_model.h
+++ b/src/midi/midi_lasynth_model.h
@@ -69,13 +69,13 @@ public:
 	// Returns true if the model has a matches that provided "mt32" or "cm32l".
 	bool Matches(const std::string &model_name) const;
 
-	using service_t = std::unique_ptr<MT32Emu::Service>;
-	bool InDir(const service_t& service, const std_fs::path& dir) const;
-	bool Load(const service_t& service, const std_fs::path& dir) const;
+	using Mt32ServicePtr = std::unique_ptr<MT32Emu::Service>;
+	bool InDir(const Mt32ServicePtr& service, const std_fs::path& dir) const;
+	bool Load(const Mt32ServicePtr& service, const std_fs::path& dir) const;
 
 private:
 	size_t SetVersion();
-	static std::optional<std_fs::path> find_rom(const service_t& service,
+	static std::optional<std_fs::path> find_rom(const Mt32ServicePtr& service,
 	                                            const std_fs::path& dir,
 	                                            const Rom* rom);
 

--- a/src/midi/midi_mt32.cpp
+++ b/src/midi/midi_mt32.cpp
@@ -774,7 +774,7 @@ bool MidiHandler_mt32::Open([[maybe_unused]] const char* conf)
 
 	const auto sample_rate_hz = MIXER_GetSampleRate();
 
-	ms_per_audio_frame = millis_in_second / sample_rate_hz;
+	ms_per_audio_frame = MillisInSecond / sample_rate_hz;
 
 	mt32_service->setAnalogOutputMode(AnalogMode);
 	mt32_service->selectRendererType(RenderingType);
@@ -832,7 +832,7 @@ bool MidiHandler_mt32::Open([[maybe_unused]] const char* conf)
 	// Size the out-bound audio frame FIFO
 	assertm(sample_rate_hz >= 8000, "Sample rate must be at least 8 kHz");
 
-	const auto audio_frames_per_ms = iround(sample_rate_hz / millis_in_second);
+	const auto audio_frames_per_ms = iround(sample_rate_hz / MillisInSecond);
 	audio_frame_fifo.Resize(
 	        check_cast<size_t>(render_ahead_ms * audio_frames_per_ms));
 

--- a/src/midi/midi_mt32.cpp
+++ b/src/midi/midi_mt32.cpp
@@ -449,7 +449,7 @@ static std::string get_model_setting()
 	return section->Get_string("model");
 }
 
-static std::set<const LASynthModel*> find_models(const MidiHandler_mt32::service_t& service,
+static std::set<const LASynthModel*> find_models(const Mt32ServicePtr& service,
                                                  const std_fs::path& dir)
 {
 	std::set<const LASynthModel*> models = {};
@@ -461,7 +461,7 @@ static std::set<const LASynthModel*> find_models(const MidiHandler_mt32::service
 	return models;
 }
 
-static std::optional<ModelAndDir> load_model(const MidiHandler_mt32::service_t& service,
+static std::optional<ModelAndDir> load_model(const Mt32ServicePtr& service,
                                              const std::string& wanted_model_name,
                                              const std::deque<std_fs::path>& rom_dirs)
 {
@@ -576,10 +576,10 @@ static mt32emu_report_handler_i get_report_handler_interface()
 	return REPORT_HANDLER_I;
 }
 
-MidiHandler_mt32::service_t MidiHandler_mt32::GetService()
+Mt32ServicePtr MidiHandler_mt32::GetService()
 {
 	const std::lock_guard<std::mutex> lock(service_mutex);
-	service_t mt32_service = std::make_unique<MT32Emu::Service>();
+	Mt32ServicePtr mt32_service = std::make_unique<MT32Emu::Service>();
 	// Has libmt32emu already created a context?
 	if (!mt32_service->getContext()) {
 		mt32_service->createContext(get_report_handler_interface(), this);
@@ -609,7 +609,7 @@ static size_t get_max_dir_width(const char* indent, const char* column_delim)
 using DirsWithModels = std::map<std_fs::path, std::set<const LASynthModel*>>;
 
 static std::set<const LASynthModel*> populate_available_models(
-        const MidiHandler_mt32::service_t& service, DirsWithModels& dirs_with_models)
+        const Mt32ServicePtr& service, DirsWithModels& dirs_with_models)
 {
 	std::set<const LASynthModel*> available_models;
 

--- a/src/midi/midi_mt32.cpp
+++ b/src/midi/midi_mt32.cpp
@@ -1062,7 +1062,7 @@ void MidiHandler_mt32::Render()
 
 static void mt32_init([[maybe_unused]] Section* sec) {}
 
-void MT32_AddConfigSection(const config_ptr_t& conf)
+void MT32_AddConfigSection(const ConfigPtr& conf)
 {
 	assert(conf);
 	Section_prop* sec_prop = conf->AddSection_prop("mt32", &mt32_init);

--- a/src/midi/midi_mt32.h
+++ b/src/midi/midi_mt32.h
@@ -84,7 +84,7 @@ private:
 	void Render();
 
 	// Managed objects
-	mixer_channel_t channel = nullptr;
+	MixerChannelPtr channel = nullptr;
 	RWQueue<AudioFrame> audio_frame_fifo{1};
 	RWQueue<MidiWork> work_fifo{1};
 

--- a/src/midi/midi_mt32.h
+++ b/src/midi/midi_mt32.h
@@ -50,10 +50,10 @@ static_assert(MT32EMU_VERSION_MAJOR > 2 ||
                       (MT32EMU_VERSION_MAJOR == 2 && MT32EMU_VERSION_MINOR >= 5),
               "libmt32emu >= 2.5.0 required (using " MT32EMU_VERSION ")");
 
+using Mt32ServicePtr = std::unique_ptr<MT32Emu::Service>;
+
 class MidiHandler_mt32 final : public MidiHandler {
 public:
-	using service_t = std::unique_ptr<MT32Emu::Service>;
-
 	MidiHandler_mt32() = default;
 	~MidiHandler_mt32() override;
 	void Close() override;
@@ -75,7 +75,7 @@ public:
 	void PrintStats();
 
 private:
-	service_t GetService();
+	Mt32ServicePtr GetService();
 	void MixerCallBack(uint16_t len);
 	void ProcessWorkFromFifo();
 
@@ -89,7 +89,7 @@ private:
 	RWQueue<MidiWork> work_fifo{1};
 
 	std::mutex service_mutex = {};
-	service_t service        = {};
+	Mt32ServicePtr service   = {};
 	std::thread renderer     = {};
 
 	std::optional<ModelAndDir> model_and_dir = {};

--- a/src/misc/rwqueue.cpp
+++ b/src/misc/rwqueue.cpp
@@ -1,7 +1,7 @@
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *
- *  Copyright (C) 2021-2023  The DOSBox Staging Team
+ *  Copyright (C) 2021-2024  The DOSBox Staging Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/tests/dosbox_test_fixture.h
+++ b/tests/dosbox_test_fixture.h
@@ -52,7 +52,7 @@ private:
 	char const *arg_c_str;
 	const char *argv[1];
 	CommandLine com_line;
-	config_ptr_t config;
+	ConfigPtr config;
 	// Only init these sections for our tests
 	std::vector<std::string> sections{"dosbox", "cpu",      "mixer",
 	                                  "midi",   "sblaster", "speaker",

--- a/tests/fs_utils_tests.cpp
+++ b/tests/fs_utils_tests.cpp
@@ -1,7 +1,7 @@
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *
- *  Copyright (C) 2020-2022  The DOSBox Staging Team
+ *  Copyright (C) 2020-2024  The DOSBox Staging Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/tests/math_utils_tests.cpp
+++ b/tests/math_utils_tests.cpp
@@ -1,7 +1,7 @@
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *
- *  Copyright (C) 2020-2023  The DOSBox Staging Team
+ *  Copyright (C) 2020-2024  The DOSBox Staging Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -93,6 +93,7 @@ unit_tests = [
     {'name': 'math_utils', 'deps': [libmisc_stubs_dep, libshell_stubs_dep]},
     {'name': 'mixer', 'deps': [dosbox_dep, libiir_dep], 'extra_cpp': []},
     {'name': 'rect', 'deps': []},
+    {'name': 'ring_buffer', 'deps': []},
     {'name': 'rgb', 'deps': []},
     {'name': 'rwqueue', 'deps': [libmisc_stubs_dep, libshell_stubs_dep]},
     {'name': 'semaphore_internal', 'deps': [dosbox_dep]},

--- a/tests/ring_buffer_tests.cpp
+++ b/tests/ring_buffer_tests.cpp
@@ -1,0 +1,168 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2024-2024  The DOSBox Staging Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#include <cstdio>
+
+#include "ring_buffer.h"
+
+#include <gtest/gtest.h>
+
+constexpr auto BufSize = 16;
+
+RingBuffer<int, BufSize> buf = {};
+
+void init_buf(int num_items = BufSize)
+{
+	auto it = buf.begin();
+	for (auto i = 0; i < num_items; ++i) {
+		*it++ = i;
+	}
+}
+
+TEST(RingBuffer, read)
+{
+	init_buf();
+
+	auto it = buf.begin();
+	for (auto i = 0; i < BufSize; ++i) {
+		EXPECT_EQ(*it, i);
+		++it;
+	}
+}
+
+TEST(RingBuffer, read_wraparound)
+{
+	init_buf();
+
+	// read with wraparound 5 times
+	auto it = buf.begin();
+	for (auto i = 0; i < BufSize * 5; ++i) {
+		EXPECT_EQ(*it, i % BufSize);
+		++it;
+	}
+}
+
+TEST(RingBuffer, write_wraparound)
+{
+	init_buf(BufSize + 3);
+
+	auto it = buf.begin();
+	EXPECT_EQ(*it++, BufSize);
+	EXPECT_EQ(*it++, BufSize + 1);
+	EXPECT_EQ(*it++, BufSize + 2);
+
+	for (auto i = 3; i < BufSize; ++i) {
+		EXPECT_EQ(*it, i);
+		++it;
+	}
+}
+
+TEST(RingBuffer, iterator_add)
+{
+	init_buf();
+
+	auto it = buf.begin();
+	EXPECT_EQ(*(it + 5), 5);
+
+	it += 4;
+	EXPECT_EQ(*it, 4);
+	++it;
+	EXPECT_EQ(*it, 5);
+}
+
+TEST(RingBuffer, iterator_add_wraparound)
+{
+	init_buf();
+
+	auto it = buf.begin();
+	EXPECT_EQ(*(it + 5), 5);
+	EXPECT_EQ(*(it + 5 + BufSize - 1), 4);
+	EXPECT_EQ(*(it + 5 + BufSize), 5);
+
+	it += 5;
+	EXPECT_EQ(*it, 5);
+	it += BufSize - 1;
+	EXPECT_EQ(*it, 4);
+	++it;
+	EXPECT_EQ(*it, 5);
+
+	it = buf.begin() + BufSize - 1;
+	EXPECT_EQ(*it, BufSize - 1);
+	++it;
+	EXPECT_EQ(*it, 0);
+}
+
+TEST(RingBuffer, iterator_sub)
+{
+	init_buf();
+
+	auto it = buf.begin() + 5;
+	EXPECT_EQ(*it, 5);
+
+	EXPECT_EQ(*(it - 3), 2);
+	it -= 2;
+	EXPECT_EQ(*it, 3);
+	--it;
+	EXPECT_EQ(*it, 2);
+}
+
+TEST(RingBuffer, iterator_sub_wraparound)
+{
+	init_buf();
+
+	auto it = buf.begin();
+	EXPECT_EQ(*it, 0);
+
+	EXPECT_EQ(*(it - 1), BufSize - 1);
+	EXPECT_EQ(*(it - 2), BufSize - 2);
+
+	--it;
+	EXPECT_EQ(*it, BufSize - 1);
+
+	it = buf.begin();
+	it -= 5;
+	EXPECT_EQ(*it, BufSize - 5);
+}
+
+TEST(RingBuffer, iterator_equality)
+{
+	init_buf();
+
+	auto it = buf.begin();
+	EXPECT_TRUE(it == buf.begin());
+	EXPECT_FALSE(it == (buf.begin() + 1));
+
+	++it;
+	EXPECT_FALSE(it == buf.begin());
+	EXPECT_TRUE((it - 1) == buf.begin());
+}
+
+TEST(RingBuffer, iterator_inequality)
+{
+	init_buf();
+
+	auto it = buf.begin();
+	EXPECT_FALSE(it != buf.begin());
+	EXPECT_TRUE(it != (buf.begin() + 1));
+
+	++it;
+	EXPECT_TRUE(it != buf.begin());
+	EXPECT_FALSE((it - 1) != buf.begin());
+}


### PR DESCRIPTION
# Description

This is about refactoring the mixer code _aggressively_ to bring it into the 21st century, kicking and screaming 🙀 The mixer was full of old-school stuff that probably made sense in the very early 2000s but not so much anymore (e.g., fixed-point math stuff).

We've been eyeing the mixer with kcgen for a while now, so it definitely had it coming 😎 I'm far from being done with it yet, but this is more than enough for a single mega PR 😅 

Main changes:

- Disable `-Wsign-conversion`, now with feeling 😎 🤘🏻 (https://github.com/dosbox-staging/dosbox-staging/pull/3650/commits/b28919685b6ff4674130235288885b1025813c21; my [first attempt ](https://github.com/dosbox-staging/dosbox-staging/pull/3631)was only partially successful)
- De-uint the mixer (use plain `int`s everywhere where it makes sense)
- De-uint the AdLib Gold, GUS, OPL, PC Speaker Impulse audio devices
- Replace fixed-point math in the mixer with proper float calculations
- Replace the ad-hoc ring buffer implementation in the mixer with a re-usable `RingBuffer` container that wraps `std::array` (see what I did there?! 😆)
- Use iterators in the mixer as much as possible, replacing for loops with manually maintained indices (improves readability and less error-prone)
- Extend `AudioFrame` with operators and use these in the mixer as much as possible (improves readability and less error-prone)
- Remove some time-stretching trickery from the mixer that attempts to handle buffer underruns, but in practice, makes zero difference (this simplifies the code somewhat)
- Remove some really weird "non-accurate rendering mode" from the mixer that was always activate _except_ when audio capturing was enabled; it attempted to minimise dropouts but I have no idea how... Basically, it did nothing useful.
- Remove lots of weird "magical" heuristic stuff that I just don't see how it can do anything of value. These are separate commits for easy bisecting, but it's good to get rid of cruft that doesn't seem to do anything useful...
- Fix OPL fade-out bug (https://github.com/dosbox-staging/dosbox-staging/pull/3650/commits/642d3870d586fc4d790f057402e9aa63aafb4598)
- Lots of shadowing warning fixes (less error-prone)
- And many small things and improvements—see the individual commits for details

Fixes https://github.com/dosbox-staging/dosbox-staging/issues/2704 and similar debug build only crashes. E.g., when you put your machine to sleep then wake it up, usually you'll get a crash with the debug builds, at least on macOS, but release builds are fine. Same deal when plugging in your headphones on macOS—yep, that caused the debug build to crash 😐 (I think some of the ridiculous fixed-point math stuff caused it, some counter got "too big" and tripped some asserts or something).

Anyway, all these debug-mode-special crashes are now gone.


## Related issues

- https://github.com/dosbox-staging/dosbox-staging/pull/3631
- https://github.com/dosbox-staging/dosbox-staging/issues/2704

# Manual testing

Lots of regression testing 😄 I'll test it more during the next few weeks until it gets reviewed (I'm assuming it won't go quickly). 

Testing tips:

- Test with chorus & reverb enabled.
- Test using the fast-forward hotkey to make sure we're still getting the sped-up tape "chipmunk" effect 😎 
- Test Direct DAC by configuring **Alone in the Dark** for the "Sound Blaster (no DMA)" option
- Test buffer underrun situations haven't regressed by setting `blocksize = 128` and `prebuffer = 5` or something low enough.
- Test the `reverse` mixer command still does its thing.
- Test setting the gain on different mixer channels and the master channel still works.
- Smoke test some AdLib, AdLib Gold (**Dune** is the only game to test), GUS, PS1 Audio, PC Speaker, Tandy & Game Blaster games—make sure there is sound and it's not distorted or anything.
- Test with `sbfilter = modern` (legacy linear interpolation) and `sbfilter = auto` and different SB models (Speex resampling and/or zero-order-hold upsampling, dependent on the SB model).
- Confirm audio capturing still works.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

