### PR TITLE
Allow loadfix to execute batch files

### DIFF
--- a/src/dos/program_loadfix.cpp
+++ b/src/dos/program_loadfix.cpp
@@ -76,7 +76,10 @@ void LOADFIX::Run(void)
 			}
 			// Use shell to start program
 			DOS_Shell shell;
+			// If it's a batch file, this call places it into an internal data structure.
 			shell.ExecuteProgram(filename, args);
+			// Actually run the batch file. This is a no-op if it's an executable.
+			shell.RunBatchFile();
 			DOS_FreeMemory(segment);
 			WriteOut(MSG_Get("PROGRAM_LOADFIX_DEALLOC"),kb);
 		}


### PR DESCRIPTION
# Description

`shell.ExecuteProgram()` has code to detect if the filename is a batch file and, if so, appends it to a `batchfiles` data structure but it doesn't actually execute the batch file.  Make a call to `shell.RunBatchFile()` to run the batch file.  This call does nothing if the filename was an executable.


## Related issues

Fixes #3655


# Manual testing

Tested with a test batch file and with Sim City 2000 batch file and direct executable.


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

