### PR TITLE
Clarify build instructions for low memory targets

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -174,7 +174,11 @@ when the option supports multiple values.
    with `meson subprojects update --reset name-of-subpackage`. For example,
    to reset FluidSynth: `meson subprojects update --reset fluidsynth`.
 
-5. If that doesn't help, try resetting your build area with:
+5. If Meson hangs due to low memory availability, make sure to pass
+   `-j1` to the `meson compile` command, to limit parallel jobs. This is
+   usefully when compiling on Raspberry Pi like system with only 1GB of memory.
+
+6. If that doesn't help, try resetting your build area with:
 
     ``` shell
     git checkout -f main

--- a/BUILD.md
+++ b/BUILD.md
@@ -175,8 +175,8 @@ when the option supports multiple values.
    to reset FluidSynth: `meson subprojects update --reset fluidsynth`.
 
 5. If Meson hangs due to low memory availability, make sure to pass
-   `-j1` to the `meson compile` command, to limit parallel jobs. This is
-   usefully when compiling on Raspberry Pi like system with only 1GB of memory.
+   `-j1` to the `meson compile` command to limit parallel jobs. This is
+   useful when compiling on Raspberry Pi like system with only 1GB of memory.
 
 6. If that doesn't help, try resetting your build area with:
 


### PR DESCRIPTION
# Description

When building DosBOX Staging on the Raspberry Pi 3B+, the build will hang due to the RPI running out of memory. The 3B+ has only 1GB of memory.

Passing `-j1` to meson will limit the parallel jobs, decrease memory consumption and thus lead to a successful build.

## Related issues

#3638

# Manual testing

-

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [ ] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [ ] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [ ] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [x] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [x] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

