### PR TITLE
Fix broken shell_history_file config option (global object version)

### DIFF
--- a/include/shell.h
+++ b/include/shell.h
@@ -90,20 +90,16 @@ class ShellHistory {
 public:
 	std::vector<std::string> GetCommands(uint16_t code_page) const;
 	void Append(std::string command, uint16_t code_page);
-
-	ShellHistory();
-	~ShellHistory();
-	ShellHistory(const ShellHistory&)            = delete;
-	ShellHistory& operator=(const ShellHistory&) = delete;
-	ShellHistory(ShellHistory&&)                 = delete;
-	ShellHistory& operator=(ShellHistory&&)      = delete;
+	void SetPathFromConfig();
+	void ReadHistoryFromFile();
+	void WriteHistoryToFile();
 
 private:
-	std::vector<std::string> commands{};
-	std_fs::path path;
+	std::vector<std::string> commands = {};
+	std_fs::path path = {};
 };
 
-extern std::unique_ptr<ShellHistory> global_shell_history;
+extern ShellHistory global_shell_history;
 
 class DOS_Shell : public Program {
 private:
@@ -116,7 +112,6 @@ private:
 
 	friend class AutoexecEditor;
 
-	ShellHistory& history                  = *global_shell_history;
 	std::stack<BatchFile> batchfiles       = {};
 	uint16_t input_handle                  = STDIN;
 	bool call                              = false;

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -1109,7 +1109,6 @@ void DOSBOX_Init()
 	pstring = secprop->Add_path("shell_history_file",
 	                            only_at_start,
 	                            "shell_history.txt");
-	global_shell_history = std::make_unique<ShellHistory>();
 
 	pstring->Set_help(
 	        "File containing persistent command line history ('shell_history.txt'\n"

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -42,7 +42,7 @@ callback_number_t call_shellstop = 0;
 /* Larger scope so shell_del autoexec can use it to
  * remove things from the environment */
 DOS_Shell *first_shell = nullptr;
-std::unique_ptr<ShellHistory> global_shell_history;
+ShellHistory global_shell_history = {};
 
 static Bitu shellstop_handler()
 {
@@ -1366,12 +1366,15 @@ void SHELL_Init() {
 	// Load SETVER fake version table from external file
 	SETVER::LoadTableFromFile();
 
+	global_shell_history.SetPathFromConfig();
+	global_shell_history.ReadHistoryFromFile();
+
 	// first_shell is only setup here, so may as well invoke
 	// it's constructor directly
 	first_shell = new DOS_Shell;
 	first_shell->Run();
 	delete first_shell;
 	first_shell = nullptr; // Make clear that it shouldn't be used anymore
-	
-	global_shell_history.reset();
+
+	global_shell_history.WriteHistoryToFile();
 }

--- a/src/shell/shell_history.cpp
+++ b/src/shell/shell_history.cpp
@@ -31,7 +31,6 @@ CHECK_NARROWING();
 static constexpr int HistoryMaxLineLength = 256;
 static constexpr int HistoryMaxNumLines   = 500;
 
-static std_fs::path get_shell_history_path();
 static bool command_is_exit(std::string_view command);
 
 void ShellHistory::Append(std::string command, uint16_t code_page)
@@ -69,7 +68,7 @@ std::vector<std::string> ShellHistory::GetCommands(uint16_t code_page) const
 	return dos_encoded_commands;
 }
 
-ShellHistory::ShellHistory() : path(get_shell_history_path())
+void ShellHistory::ReadHistoryFromFile()
 {
 	// Must check arguments directly as control->SwitchToSecureMode()
 	// will not be called until the first shell is run
@@ -99,7 +98,7 @@ ShellHistory::ShellHistory() : path(get_shell_history_path())
 	}
 }
 
-ShellHistory::~ShellHistory()
+void ShellHistory::WriteHistoryToFile()
 {
 	// Secure mode can be enabled from the shell during runtime.
 	// On exit, we must check this value instead.
@@ -125,17 +124,15 @@ ShellHistory::~ShellHistory()
 	}
 }
 
-static std_fs::path get_shell_history_path()
+void ShellHistory::SetPathFromConfig()
 {
 	const auto* section = dynamic_cast<Section_prop*>(control->GetSection("dos"));
 	assert(section);
 
-	const auto* path = section->Get_path("shell_history_file"); //-V522
-	if (path == nullptr) {
-		return {};
+	const auto* config_path = section->Get_path("shell_history_file"); //-V522
+	if (config_path) {
+		path = config_path->realpath;
 	}
-
-	return path->realpath;
 }
 
 static bool command_is_exit(std::string_view command)

--- a/src/shell/shell_misc.cpp
+++ b/src/shell/shell_misc.cpp
@@ -78,7 +78,7 @@ void DOS_Shell::InputCommand(char* line)
 {
 	std::string command = ReadCommand();
 
-	history.Append(command, get_utf8_code_page());
+	global_shell_history.Append(command, get_utf8_code_page());
 
 	const auto* const dos_section = dynamic_cast<Section_prop*>(
 	        control->GetSection("dos"));
@@ -104,7 +104,7 @@ void DOS_Shell::InputCommand(char* line)
 
 std::string DOS_Shell::ReadCommand()
 {
-	std::vector<std::string> history_clone = history.GetCommands(
+	std::vector<std::string> history_clone = global_shell_history.GetCommands(
 	        get_utf8_code_page());
 	const auto last_command = [&history_clone]() -> std::string {
 		if (history_clone.empty()) {


### PR DESCRIPTION
# Description

The issue is that the `global_shell_history` object was being constructed before the config file was parsed.  Previously, it was reading the config and the shell history file during object creation, which was happening at the incorrect time (too early in the init process).

In this PR, I made it more explicit when the shell history gets read and written.  Constructors and destructors have been removed and the object is now a real global instead of the weird reference to `unique_ptr` that was going on before.

## Related issues

Fixes #3661

# Manual testing

- Setting `shell_history_file` to empty disables reading and writing shell history entirely
- Removing the `shell_history_file` line entirely falls back to the default of `shell_history.txt`
- Setting `shell_history_file` to an arbitrary file name works as expected
- If `shell_history_file` is not empty and does not exist, a new file is created

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

