### PR TITLE
Fix broken shell_history_file config option (std::weak_ptr version)

### DIFF
--- a/include/shell.h
+++ b/include/shell.h
@@ -103,8 +103,6 @@ private:
 	std_fs::path path;
 };
 
-extern std::unique_ptr<ShellHistory> global_shell_history;
-
 class DOS_Shell : public Program {
 private:
 	void PrintHelpForCommands(MoreOutputStrings& output, HELP_Filter req_filter);
@@ -116,7 +114,7 @@ private:
 
 	friend class AutoexecEditor;
 
-	ShellHistory& history                  = *global_shell_history;
+	std::shared_ptr<ShellHistory> history  = {};
 	std::stack<BatchFile> batchfiles       = {};
 	uint16_t input_handle                  = STDIN;
 	bool call                              = false;

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -1109,7 +1109,6 @@ void DOSBOX_Init()
 	pstring = secprop->Add_path("shell_history_file",
 	                            only_at_start,
 	                            "shell_history.txt");
-	global_shell_history = std::make_unique<ShellHistory>();
 
 	pstring->Set_help(
 	        "File containing persistent command line history ('shell_history.txt'\n"

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -42,7 +42,6 @@ callback_number_t call_shellstop = 0;
 /* Larger scope so shell_del autoexec can use it to
  * remove things from the environment */
 DOS_Shell *first_shell = nullptr;
-std::unique_ptr<ShellHistory> global_shell_history;
 
 static Bitu shellstop_handler()
 {
@@ -60,6 +59,13 @@ DOS_Shell::DOS_Shell()
 	               HELP_Category::Misc,
 	               HELP_CmdType::Program,
 	               "COMMAND"};
+
+	static std::weak_ptr<ShellHistory> global_shell_history = {};
+	history = global_shell_history.lock();
+	if (!history) {
+		history = std::make_shared<ShellHistory>();
+		global_shell_history = history;
+	}
 }
 
 void DOS_Shell::GetRedirection(char *line,
@@ -1372,6 +1378,4 @@ void SHELL_Init() {
 	first_shell->Run();
 	delete first_shell;
 	first_shell = nullptr; // Make clear that it shouldn't be used anymore
-	
-	global_shell_history.reset();
 }

--- a/src/shell/shell_misc.cpp
+++ b/src/shell/shell_misc.cpp
@@ -78,7 +78,7 @@ void DOS_Shell::InputCommand(char* line)
 {
 	std::string command = ReadCommand();
 
-	history.Append(command, get_utf8_code_page());
+	history->Append(command, get_utf8_code_page());
 
 	const auto* const dos_section = dynamic_cast<Section_prop*>(
 	        control->GetSection("dos"));
@@ -104,7 +104,7 @@ void DOS_Shell::InputCommand(char* line)
 
 std::string DOS_Shell::ReadCommand()
 {
-	std::vector<std::string> history_clone = history.GetCommands(
+	std::vector<std::string> history_clone = history->GetCommands(
 	        get_utf8_code_page());
 	const auto last_command = [&history_clone]() -> std::string {
 		if (history_clone.empty()) {


### PR DESCRIPTION
# Description

This PR solves the same problem as #3663 but is more minimal with changes.  It retains RAII (reading the file on construction and writing on destruction) but uses `std::shared_ptr` and `std::weak_ptr` for proper smart point usage.  `global_shell_history` now gets created during construction of the first `DOS_Shell` object and destroyed after the destruction of the last `DOS_Shell object`.

`std::weak_ptr` is a non-owning reference to a `std::shared_ptr`.  weak_ptr's `.lock()` function atomically checks if the reference is still valid and, if so, returns a `std::shared_ptr` object.  We use this as our global object so that it does not hold a reference count and keep `global_shell_history` alive until some undetermined point when global objects get destroyed.  Instead, it will get destroyed when the last `std::shared_ptr` goes out of scope (which is when the last `DOS_Shell` object gets destroyed).

## Related issues

Fixes #3661

Previous PR using a global object #3663

# Manual testing

Functionally the same as the previous PR.  The same tests all work.

- Setting `shell_history_file` to empty disables reading and writing shell history entirely
- Removing the `shell_history_file` line entirely falls back to the default of `shell_history.txt`
- Setting `shell_history_file` to an arbitrary file name works as expected
- If `shell_history_file` is not empty and does not exist, a new file is created

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

