### PR TITLE
Allow running the `INTRO` built-in from subshells

### DIFF
--- a/src/dos/program_intro.cpp
+++ b/src/dos/program_intro.cpp
@@ -75,8 +75,6 @@ void INTRO::Run(void) {
 		output.Display();
 		return;
 	}
-    /* Only run if called from the first shell (Xcom TFTD runs any intro file in the path) */
-    if (DOS_PSP(dos.psp()).GetParent() != DOS_PSP(DOS_PSP(dos.psp()).GetParent()).GetParent()) return;
     if (cmd->FindExist("cdrom",false)) {
 #ifdef WIN32
         WriteOut(MSG_Get("PROGRAM_INTRO_CDROM_WINDOWS"));


### PR DESCRIPTION
# Description

Fixes https://github.com/dosbox-staging/dosbox-staging/issues/3550

@weirddan455 found the line, I'm deleting it. Teamwork! 😎 

# Manual testing

1. `INTRO` can be run from subshell (when you launch another `COMMAND.COM`).
2. **XCOM – Terror From the Deep** runs fine (the hack was supposedly put in to fix that game).

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

