### PR TITLE
Kill `openglnb` with fire 🔥🔥🔥🔥🔥

### DIFF
--- a/contrib/resources/glshaders/interpolation/catmull-rom.glsl
+++ b/contrib/resources/glshaders/interpolation/catmull-rom.glsl
@@ -101,26 +101,30 @@ COMPAT_VARYING vec2 vTexCoord;
 
 void main()
 {
-	// We're going to sample a a 4x4 grid of texels surrounding the target UV coordinate. We'll do this by rounding
-	// down the sample location to get the exact center of our "starting" texel. The starting texel will be at
-	// location [1, 1] in the grid, where [0, 0] is the top left corner.
+	// We're going to sample a a 4x4 grid of texels surrounding the target
+	// UV coordinate. We'll do this by rounding down the sample location to
+	// get the exact center of our "starting" texel. The starting texel will
+	// be at location [1, 1] in the grid, where [0, 0] is the top left corner.
 	vec2 samplePos = vTexCoord * rubyTextureSize;
 	vec2 texCoord1 = floor(samplePos - 0.5) + 0.5;
 
-	// Compute the fractional offset from our starting texel to our original sample location, which we'll
-	// feed into the Catmull-Rom spline function to get our filter weights.
+	// Compute the fractional offset from our starting texel to our original
+	// sample location, which we'll feed into the Catmull-Rom spline
+	// function to get our filter weights.
 	vec2 f = samplePos - texCoord1;
 
-	// Compute the Catmull-Rom weights using the fractional offset that we calculated earlier.
-	// These equations are pre-expanded based on our knowledge of where the texels will be located,
-	// which lets us avoid having to evaluate a piece-wise function.
+	// Compute the Catmull-Rom weights using the fractional offset that we
+	// calculated earlier. These equations are pre-expanded based on our
+	// knowledge of where the texels will be located, which lets us avoid
+	// having to evaluate a piece-wise function.
 	vec2 w0 = f * (-0.5 + f * (1.0 - 0.5 * f));
 	vec2 w1 = 1.0 + f * f * (-2.5 + 1.5 * f);
 	vec2 w2 = f * (0.5 + f * (2.0 - 1.5 * f));
 	vec2 w3 = f * f * (-0.5 + 0.5 * f);
 
-	// Work out weighting factors and sampling offsets that will let us use bilinear filtering to
-	// simultaneously evaluate the middle 2 samples from the 4x4 grid.
+	// Work out weighting factors and sampling offsets that will let us use
+	// bilinear filtering to simultaneously evaluate the middle 2 samples
+	// from the 4x4 grid.
 	vec2 w12 = w1 + w2;
 	vec2 offset12 = w2 / (w1 + w2);
 

--- a/contrib/resources/glshaders/interpolation/catmull-rom.glsl
+++ b/contrib/resources/glshaders/interpolation/catmull-rom.glsl
@@ -97,59 +97,6 @@ precision mediump float;
 uniform vec2 rubyTextureSize;
 uniform sampler2D rubyTexture;
 
-/*
-	The following code allows the shader to override any texture filtering
-	configured in DOSBox. if 'output' is set to 'opengl', bilinear filtering
-	will be enabled and OPENGLNB will not be defined, if 'output' is set to
-	'openglnb', nearest neighbour filtering will be enabled and OPENGLNB will
-	be defined.
-
-	If you wish to use the default filtering method that is currently enabled
-	in DOSBox, use COMPAT_TEXTURE to lookup a texel from the input texture.
-
-	If you wish to force nearest-neighbor interpolation use NN_TEXTURE.
-
-	If you wish to force bilinear interpolation use BL_TEXTURE.
-
-	If DOSBox is configured to use the filtering method that is being forced,
-	the default hardware implementation will be used, otherwise the custom
-	implementations below will be used instead.
-
-	These custom implemenations rely on the `rubyTextureSize` uniform variable.
-	The code could calculate the texture size from the sampler using the
-	textureSize() GLSL function, but this would require a minimum of GLSL
-	version 130, which may prevent the shader from working on older systems.
-*/
-
-#if defined(OPENGLNB)
-#define NN_TEXTURE COMPAT_TEXTURE
-#define BL_TEXTURE blTexture
-vec4 blTexture(in sampler2D sampler, in vec2 uv)
-{
-	// subtract 0.5 here and add it again after the floor to centre the texel
-	vec2 texCoord = uv * rubyTextureSize - vec2(0.5);
-	vec2 s0t0 = floor(texCoord) + vec2(0.5);
-	vec2 s0t1 = s0t0 + vec2(0.0, 1.0);
-	vec2 s1t0 = s0t0 + vec2(1.0, 0.0);
-	vec2 s1t1 = s0t0 + vec2(1.0);
-
-	vec2 invTexSize = 1.0 / rubyTextureSize;
-	vec4 c_s0t0 = COMPAT_TEXTURE(sampler, s0t0 * invTexSize);
-	vec4 c_s0t1 = COMPAT_TEXTURE(sampler, s0t1 * invTexSize);
-	vec4 c_s1t0 = COMPAT_TEXTURE(sampler, s1t0 * invTexSize);
-	vec4 c_s1t1 = COMPAT_TEXTURE(sampler, s1t1 * invTexSize);
-
-	vec2 weight = fract(texCoord);
-
-	vec4 c0 = c_s0t0 + (c_s1t0 - c_s0t0) * weight.x;
-	vec4 c1 = c_s0t1 + (c_s1t1 - c_s0t1) * weight.x;
-
-	return (c0 + (c1 - c0) * weight.y);
-}
-#else
-#define BL_TEXTURE COMPAT_TEXTURE
-#endif
-
 COMPAT_VARYING vec2 vTexCoord;
 
 void main()
@@ -186,17 +133,17 @@ void main()
 	texCoord3 /= rubyTextureSize;
 	texCoord12 /= rubyTextureSize;
 
-	FragColor = BL_TEXTURE(rubyTexture, vec2(texCoord0.x, texCoord0.y)) * w0.x * w0.y
-		+ BL_TEXTURE(rubyTexture, vec2(texCoord12.x, texCoord0.y)) * w12.x * w0.y
-		+ BL_TEXTURE(rubyTexture, vec2(texCoord3.x, texCoord0.y)) * w3.x * w0.y
+	FragColor = COMPAT_TEXTURE(rubyTexture, vec2(texCoord0.x, texCoord0.y)) * w0.x * w0.y
+		+ COMPAT_TEXTURE(rubyTexture, vec2(texCoord12.x, texCoord0.y)) * w12.x * w0.y
+		+ COMPAT_TEXTURE(rubyTexture, vec2(texCoord3.x, texCoord0.y)) * w3.x * w0.y
 
-		+ BL_TEXTURE(rubyTexture, vec2(texCoord0.x, texCoord12.y)) * w0.x * w12.y
-		+ BL_TEXTURE(rubyTexture, vec2(texCoord12.x, texCoord12.y)) * w12.x * w12.y
-		+ BL_TEXTURE(rubyTexture, vec2(texCoord3.x, texCoord12.y)) * w3.x * w12.y
+		+ COMPAT_TEXTURE(rubyTexture, vec2(texCoord0.x, texCoord12.y)) * w0.x * w12.y
+		+ COMPAT_TEXTURE(rubyTexture, vec2(texCoord12.x, texCoord12.y)) * w12.x * w12.y
+		+ COMPAT_TEXTURE(rubyTexture, vec2(texCoord3.x, texCoord12.y)) * w3.x * w12.y
 
-		+ BL_TEXTURE(rubyTexture, vec2(texCoord0.x, texCoord3.y)) * w0.x * w3.y
-		+ BL_TEXTURE(rubyTexture, vec2(texCoord12.x, texCoord3.y)) * w12.x * w3.y
-		+ BL_TEXTURE(rubyTexture, vec2(texCoord3.x, texCoord3.y)) * w3.x * w3.y;
+		+ COMPAT_TEXTURE(rubyTexture, vec2(texCoord0.x, texCoord3.y)) * w0.x * w3.y
+		+ COMPAT_TEXTURE(rubyTexture, vec2(texCoord12.x, texCoord3.y)) * w12.x * w3.y
+		+ COMPAT_TEXTURE(rubyTexture, vec2(texCoord3.x, texCoord3.y)) * w3.x * w3.y;
 }
 
 #endif

--- a/contrib/resources/glshaders/scaler/advinterp2x.glsl
+++ b/contrib/resources/glshaders/scaler/advinterp2x.glsl
@@ -83,9 +83,6 @@ vec3 getadvinterp2xtexel(vec2 coord)
 void main()
 {
 	vec2 coord = v_texCoord;
-#if defined(OPENGLNB)
-	gl_FragColor = vec4(getadvinterp2xtexel(coord), 1.0);
-#else
 	coord -= 0.5;
 	vec3 c0 = getadvinterp2xtexel(coord);
 	vec3 c1 = getadvinterp2xtexel(coord + vec2(1.0, 0.0));
@@ -94,6 +91,5 @@ void main()
 
 	coord = fract(max(coord, 0.0));
 	gl_FragColor = vec4(mix(mix(c0, c1, coord.x), mix(c2, c3, coord.x), coord.y), 1.0);
-#endif
 }
 #endif

--- a/contrib/resources/glshaders/scaler/advinterp3x.glsl
+++ b/contrib/resources/glshaders/scaler/advinterp3x.glsl
@@ -98,9 +98,6 @@ vec3 getadvinterp3xtexel(vec2 coord)
 void main()
 {
 	vec2 coord = v_texCoord;
-#if defined(OPENGLNB)
-	gl_FragColor = vec4(getadvinterp3xtexel(coord), 1.0);
-#else
 	coord -= 0.5;
 	vec3 c0 = getadvinterp3xtexel(coord);
 	vec3 c1 = getadvinterp3xtexel(coord + vec2(1.0, 0.0));
@@ -109,6 +106,5 @@ void main()
 
 	coord = fract(max(coord, 0.0));
 	gl_FragColor = vec4(mix(mix(c0, c1, coord.x), mix(c2, c3, coord.x), coord.y), 1.0);
-#endif
 }
 #endif

--- a/contrib/resources/glshaders/scaler/advmame2x.glsl
+++ b/contrib/resources/glshaders/scaler/advmame2x.glsl
@@ -83,9 +83,6 @@ vec3 getadvmame2xtexel(vec2 coord)
 void main()
 {
 	vec2 coord = v_texCoord;
-#if defined(OPENGLNB)
-	gl_FragColor = vec4(getadvmame2xtexel(coord), 1.0);
-#else
 	coord -= 0.5;
 	vec3 c0 = getadvmame2xtexel(coord);
 	vec3 c1 = getadvmame2xtexel(coord + vec2(1.0, 0.0));
@@ -94,6 +91,5 @@ void main()
 
 	coord = fract(max(coord, 0.0));
 	gl_FragColor = vec4(mix(mix(c0, c1, coord.x), mix(c2, c3, coord.x), coord.y), 1.0);
-#endif
 }
 #endif

--- a/contrib/resources/glshaders/scaler/advmame3x.glsl
+++ b/contrib/resources/glshaders/scaler/advmame3x.glsl
@@ -87,9 +87,6 @@ vec3 getadvmame3xtexel(vec2 coord)
 void main()
 {
 	vec2 coord = v_texCoord;
-#if defined(OPENGLNB)
-	gl_FragColor = vec4(getadvmame3xtexel(coord), 1.0);
-#else
 	coord -= 0.5;
 	vec3 c0 = getadvmame3xtexel(coord);
 	vec3 c1 = getadvmame3xtexel(coord + vec2(1.0, 0.0));
@@ -98,6 +95,5 @@ void main()
 
 	coord = fract(max(coord, 0.0));
 	gl_FragColor = vec4(mix(mix(c0, c1, coord.x), mix(c2, c3, coord.x), coord.y), 1.0);
-#endif
 }
 #endif

--- a/contrib/resources/glshaders/scaler/rgb2x.glsl
+++ b/contrib/resources/glshaders/scaler/rgb2x.glsl
@@ -66,9 +66,6 @@ vec4 getRGB2xtexel(vec2 coord)
 void main()
 {
 	vec2 coord = v_texCoord;
-#if defined(OPENGLNB)
-	gl_FragColor = getRGB2xtexel(coord);
-#else
 	coord -= 0.5;
 	vec4 c0 = getRGB2xtexel(coord);
 	vec4 c1 = getRGB2xtexel(coord + vec2(1.0, 0.0));
@@ -77,6 +74,5 @@ void main()
 
 	coord = fract(max(coord, 0.0));
 	gl_FragColor = mix(mix(c0, c1, coord.x), mix(c2, c3, coord.x), coord.y);
-#endif
 }
 #endif

--- a/contrib/resources/glshaders/scaler/rgb3x.glsl
+++ b/contrib/resources/glshaders/scaler/rgb3x.glsl
@@ -70,9 +70,6 @@ vec4 getRGB3xtexel(vec2 coord)
 void main()
 {
 	vec2 coord = v_texCoord;
-#if defined(OPENGLNB)
-	gl_FragColor = getRGB3xtexel(coord);
-#else
 	coord -= 0.5;
 	vec4 c0 = getRGB3xtexel(coord);
 	vec4 c1 = getRGB3xtexel(coord + vec2(1.0, 0.0));
@@ -81,6 +78,5 @@ void main()
 
 	coord = fract(max(coord, 0.0));
 	gl_FragColor = mix(mix(c0, c1, coord.x), mix(c2, c3, coord.x), coord.y);
-#endif
 }
 #endif

--- a/include/sdlmain.h
+++ b/include/sdlmain.h
@@ -269,7 +269,6 @@ struct SDL_Block {
 		GLuint texture;
 		GLuint displaylist;
 		GLint max_texsize;
-		bool bilinear;
 		bool npot_textures_supported = false;
 		bool use_shader;
 		bool framebuffer_is_srgb_encoded;

--- a/include/sdlmain.h
+++ b/include/sdlmain.h
@@ -191,7 +191,6 @@ struct SDL_Block {
 	RenderingBackend rendering_backend      = RenderingBackend::Texture;
 	RenderingBackend want_rendering_backend = RenderingBackend::Texture;
 
-	InterpolationMode interpolation_mode    = InterpolationMode::Bilinear;
 	IntegerScalingMode integer_scaling_mode = IntegerScalingMode::Off;
 
 	struct {
@@ -307,6 +306,8 @@ struct SDL_Block {
 		SDL_Surface* input_surface   = nullptr;
 		SDL_Texture* texture         = nullptr;
 		SDL_PixelFormat* pixelFormat = nullptr;
+
+		InterpolationMode interpolation_mode = InterpolationMode::Bilinear;
 	} texture = {};
 
 	struct {

--- a/include/video.h
+++ b/include/video.h
@@ -383,7 +383,7 @@ void GFX_SetShader(const ShaderInfo& shader_info, const std::string& shader_sour
 void GFX_SetIntegerScalingMode(const IntegerScalingMode mode);
 IntegerScalingMode GFX_GetIntegerScalingMode();
 
-InterpolationMode GFX_GetInterpolationMode();
+InterpolationMode GFX_GetTextureInterpolationMode();
 
 struct VideoMode;
 class Fraction;

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -556,21 +556,19 @@ static bool force_no_pixel_doubling = false;
 //
 static void setup_scan_and_pixel_doubling()
 {
-	const auto nearest_neighbour_on = (GFX_GetInterpolationMode() ==
-	                                   InterpolationMode::NearestNeighbour);
-
 	switch (GFX_GetRenderingBackend()) {
-	case RenderingBackend::Texture:
+	case RenderingBackend::Texture: {
+		const auto nearest_neighbour_on = (GFX_GetTextureInterpolationMode() ==
+		                                   InterpolationMode::NearestNeighbour);
+
 		force_vga_single_scan   = nearest_neighbour_on;
 		force_no_pixel_doubling = nearest_neighbour_on;
-		break;
+	} break;
 
 	case RenderingBackend::OpenGl: {
 		const auto shader_info = get_shader_manager().GetCurrentShaderInfo();
 		const auto none_shader_active = (shader_info.name == NoneShaderName);
-
-		const auto double_scan_enabled = (nearest_neighbour_on &&
-		                                  none_shader_active);
+		const auto double_scan_enabled = none_shader_active;
 
 		force_vga_single_scan = (shader_info.settings.force_single_scan ||
 		                         double_scan_enabled);

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -4344,10 +4344,10 @@ static void config_add_sdl()
 #else
 		"texture_default",
 #endif
-		        "texture", "texturenb",
 #if C_OPENGL
-		        "opengl"
+		        "opengl",
 #endif
+		        "texture", "texturenb",
 	});
 
 	pstring = sdl_sec->Add_string("texture_renderer", always, "auto");

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3022,8 +3022,7 @@ static void setup_window_sizes_from_conf(const char* windowresolution_val,
 	save_window_size(refined_size.x, refined_size.y);
 
 	// Let the user know the resulting window properties
-	// TODO pixels or logical unit?
-	LOG_MSG("DISPLAY: Initialised %dx%d windowed mode on display-%d",
+	LOG_MSG("DISPLAY: Using %dx%d window size in windowed mode on display-%d",
 	        refined_size.x,
 	        refined_size.y,
 	        sdl.display_number);


### PR DESCRIPTION
# Description

Welcome to the second episode of our popular ["kill X with fire" series](https://github.com/dosbox-staging/dosbox-staging/issues/2448)! 😎 In this installment, the ghastly "non-bilinear" OpenGL mode (`output = openglnb`) goes the way of the Dodo bird! 🐦🥳 🎊 *

### TL;DR for the impatient

- The `openglnb` output option is a relic from the past, born out of necessity in the early 2000s, and carried forward by not keeping up with the times and adopting more advanced image processing techniques in DOSBox land. There is simply zero reason for its continued existence, given we have the far superior `sharp` shader and `integer_scaling` options.

- The `glshader = sharp` + `output = opengl`  combo is superior to `openglnb` as it strikes a balance between _pixel-evenness_ and _sharpness_, which is super important with aspect-ratio correction enabled.

- The `openglnb` (nearest-neighbour, no bilinear) option, however, which is the most primitive form of upscaling an image, prioritises _sharpness_ and totally ignores pixel-evenness, which results in ghastly looking interference artifacts (moire patterns). This is easy to notice on checkerboard dither patterns and on text. It's less easy to notice on 256-colour VGA graphics with lots of smooth gradients, but, of course, the issue is always there.

Thanks to  @Python-Exoproject for drawing my attention to the issue (I almost never use `openglnb` these days, except for testing stuff).

_* No endangered species have been harmed during this exercise._ 😎 

## Related issues

This makes https://github.com/dosbox-staging/dosbox-staging/issues/3627 redundant (we'll just leave `texture` and `texturenb` as is).

## Summary

- `openglnb` performs nearest-neighbour image interpolation; this has no place in quality image processing in 2024 (and it was a very bad and obsolete technique even 20-25 years ago).
- Most shaders yield identical output with both `openglnb` (nearest-neighbour interpolation) and `opengl` (bilinear interpolation). E.g., the new CRT shaders don't care which output mode you choose; they will yield 100% identical output with both (because they do their own interpolation in the shader code).
- The `sharp` shader, however, which is our "sharp crisp pixels" option, takes advantage of the hardware accelerated bilinear interpolation of modern GPUs. Thereforce, if you force-disable bilinear texture interpolation by setting `output = openglnb`, you effectively negate the advantages of the `sharp` shader and get plain old (and bad) nearest-neighbour interpolation. This is bad. Very bad.
- Another issue is that the `crt-auto` shaders revert to the `sharp` shader when there isn't enough resolution to do proper CRT shading. Therefore, the CRT shaders appear to be "fine" with `openglnb`--until you start using small window sizes and/or high-resolution DOS video modes, in which case you'll effectively get nearest-neighbour.
- Arguably, the `openglnb` output should have been removed the moment Staging introduced the `sharp` shader years ago.
- `openglnb` has no performance or compatibility advantages over `opengl` whatsoever.
- The `texturenb` output mode stays as that is our only option for the fallback SDL texture renderer to achieve "sharp" pixels (at the cost of pixel evenness, as we'll see below).

## Historical context

- Although pixel shaders were introduced into common GPUs in 2001, and games like Morrowind used pixel shaders to very good effect, the adoption in emulation circles was slow due to whatever reasons. OpenGL drivers in the early to mid 2000s were not that great either, so maybe that played a role in that too.
- In any case, when DOSBox added its `opengl` output mode, that upscaled the framebuffer via bilinear interpolation, resulting in a blurry image most people absolutely hate and for good reasons. So, the guys thought, okay, let's add an option then to turn off bilinear interpolation, and `openglnb` (nb = no bilinear) was born. In this mode, the hardware-accelerated bilinear interpolation of the GPU is turned off, so you get "sharp" pixels with no fuzzy interpolation artifacts.
- With 2x, 3x, 4x, etc. integer scaling `openglnb` gives perfect results _if_the emulated video mode has square pixels (1:1 pixel aspect ratio). For example, 640x480 is such a mode. With `openglnb` and 2x scaling, you get 1280x960 with perfectly sharp pixels. So far so good.
- But 320x200, 640x350, 720x400, and many other video modes feature non-square pixels. In all these screen modes, the nearest-neighbour interpolation performed by the `openglnb` mode will result in quite ghastly looking, uneven scaling artifacts. Still, this was seen as the lesser evil as the other alternative DOSBox provided was bilinear interpolation via `opengl` which blurred the image.
- Probably a sad side-effect of this situation was that people kinda preferred to turn off aspect ratio correction, because with that off, you were always dealing with square pixels. So `openglnb` with 2x or 3x scaling and `aspect = off` still yielded perfectly sharp pixels for 320x200 content -- but in the _wrong aspect ratio_, so the graphics appeared ~20% squashed vertically.
- Fast forward to recent times... Because DOSBox development had essentially stopped around ~2010, even though other DOSBox forks started adding shader support, somehow using `openglnb` as the "best" option for sharp pixels became common knowledge.
- Not sure when, probably around 2010-2015 or so, the "sharp bilinear" upscaling technique has started becoming popular (e.g., ScummVM added support for it even in its 100% software-rendered mode quite early on). This is what our `sharp` shader does by taking advantage of GPU hardware-acceleration, so it's very fast even on low-end hardware like the Raspberry Pi or old computers from around 2010-2012.
- The `sharp`  shader is superior to `openglnb` as it strikes a balance between _pixel -evenness_ and _sharpness_. The nearest-neighbour option, however, which is the most primitive form of upscaling an image, prioritises _sharpness_ and totally ignores pixel-evenness, which results in ghastly looking interference artifacts (moire patterns). This is easy to notice on checkerboard dither patterns and on text. It's less easy to notice on VGA graphics with lots of smooth gradients, but of course the issue is always there.
- All in all, the `openglnb` option is a relic from the past, born out of necessity, and carried forward by not keeping up with the times and adopting more advanced image processing techniques in DOSBox land. There is simply no reason for its continued existence, given we have the superior `sharp` shader.
- For the SDL texture output, we need to keep the `texturenb` option. Note `texture` and `texturenb` arebasically for people who by some bad luck happen to be on hardware that does not have functioning OpenGL drivers. This is extremely rare nowadays, and it was extremely rare 10-15 years ago... Nevertheless, these people can experience bad nearest-neighbour interpolation with the `texturenb` output mode as their "crisp pixel" option, just like in the early days of DOSBox 😎 (Because shaders are not supported in the texture output modes).

Yes, I am passionate about bad image scaling 😅 Looking at nearest-neighbour interpolated output gets me in a really bad mood, no kidding 🥶 

## Example images

All images were captured straight from DOSBox on a 1080p monitor. On 4k screens, the ugly nearest-neighbour scaling artifacts are much less noticeable. Still, that's not a reason for keeping `openglnb`.

For each game, the first image is `openglnb` output (bad), the second `opengl` + the `sharp` shader (good).

---

**This is super important:** You _must_ view all example images at 100% magnification (with 1:1 pixel mapping), otherwise your browser or image viewer _will_ introduce extra unwanted scaling artifacts, rendering the whole comparison completely pointless!

One good way to do that is to open the images in separate browser tabs, ensure they're displayed at 100% magnification, then switch back and forth between the image-pairs with Ctrl+Tab / Ctrl+Shift+Tab to appreciate the differences.

**Double or triple check you're indeed the images at 100% magnification.** If you hover over the image in the new brower tab and cursor turns into a magnifying glass, you need to press the left mouse button to zoom the image to 100% zoom! You need to do this _every time_ you open a new image in a new tab!

---

### Wonderland

Let's start with a super obvious example to train our eyes a little 😄 This is a 800x600 game scaled to fullscreen with a non-integer scaling ratio. Note how the text is extremely hard to read in the `openglnb` output, and there are extra [moire patterns](https://en.wikipedia.org/wiki/Moir%C3%A9_pattern) forming in the checkerboard background pattern due to extreme aliasing.

![image](https://github.com/dosbox-staging/dosbox-staging/assets/698770/56e19d22-67c6-49fc-885e-537715a16e97)

![image](https://github.com/dosbox-staging/dosbox-staging/assets/698770/ee02cc81-5b39-429d-bea2-609700659eb1)

### DOS prompt

Note how uneven the lines making up the letters are on the `openglnb` image.

![image](https://github.com/dosbox-staging/dosbox-staging/assets/698770/57720dc8-065f-4dc8-9377-05c33d638b5e)

![image](https://github.com/dosbox-staging/dosbox-staging/assets/698770/ffe66da5-0e3b-493b-8d86-1b7f734a0974)

### Leisure Suit Larry 3 (1)

Again, the unevenness is very easy to see on the `openglnb` output and it's very jarring. Note this is a 320x200 game!

![image](https://github.com/dosbox-staging/dosbox-staging/assets/698770/cd54d665-ecbe-4e7f-a4b2-7e8cb765162f)

![image](https://github.com/dosbox-staging/dosbox-staging/assets/698770/e1f4b887-4bc7-49f8-abfb-4f13846b922d)

### Leisure Suit Larry 3 (2)

Note there is mild to moderate moire interference (depending on your sensitivity 😄) on the checkerboard dither pattern in the sky. All EGA games featuring checkerboard dither are highly problematic with `openglnb`.

Note it is impossible _not_ to have moire with 320x200 games with aspect ratio correction on as the pixels are not squares. Then if you add non-integer image scaling to the mix, the results can get really bad.

![image](https://github.com/dosbox-staging/dosbox-staging/assets/698770/815187d4-a36c-4cb8-80e8-02cf81f013a8)

![image](https://github.com/dosbox-staging/dosbox-staging/assets/698770/805373aa-17cc-47ec-9ab4-9384daaa4b9a)

# Manual testing

- Tested that `openglnb` is still accepted but a warning is logged and the output is switched to `opengl`.
- Tested that all shaders still work as before.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

