### PR TITLE
Cleanup some leaked file handles

### DIFF
--- a/include/shell.h
+++ b/include/shell.h
@@ -57,9 +57,9 @@ public:
 	BatchFile& operator=(const BatchFile&) = delete;
 	BatchFile(BatchFile&&)                 = delete;
 	BatchFile& operator=(BatchFile&&)      = delete;
-	virtual ~BatchFile()                   = default;
+	~BatchFile()                           = default;
 
-	virtual bool ReadLine(char* line);
+	bool ReadLine(char* line);
 	bool Goto(std::string_view label);
 	void Shift();
 	void SetEcho(bool echo_on);

--- a/src/shell/file_reader.cpp
+++ b/src/shell/file_reader.cpp
@@ -20,7 +20,7 @@
 
 #include "file_reader.h"
 
-std::optional<FileReader> FileReader::GetFileReader(const std::string& filename)
+std::unique_ptr<FileReader> FileReader::GetFileReader(const std::string& filename)
 {
 	auto fullname = DOS_Canonicalize(filename.c_str());
 
@@ -29,7 +29,7 @@ std::optional<FileReader> FileReader::GetFileReader(const std::string& filename)
 		return {};
 	}
 	DOS_CloseFile(handle);
-	return FileReader(std::move(fullname));
+	return std::unique_ptr<FileReader>(new FileReader(std::move(fullname)));
 }
 
 FileReader::FileReader(std::string filename)

--- a/src/shell/file_reader.cpp
+++ b/src/shell/file_reader.cpp
@@ -28,6 +28,7 @@ std::optional<FileReader> FileReader::GetFileReader(const std::string& filename)
 	if (!DOS_OpenFile(fullname.c_str(), (DOS_NOT_INHERIT | OPEN_READ), &handle)) {
 		return {};
 	}
+	DOS_CloseFile(handle);
 	return FileReader(std::move(fullname));
 }
 

--- a/src/shell/file_reader.h
+++ b/src/shell/file_reader.h
@@ -28,7 +28,7 @@
 
 class FileReader final : public LineReader {
 public:
-	static std::optional<FileReader> GetFileReader(const std::string& file);
+	static std::unique_ptr<FileReader> GetFileReader(const std::string& file);
 
 	void Reset() final;
 	std::optional<std::string> Read() final;

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -203,6 +203,11 @@ uint16_t get_tick_random_number() {
 	return (uint16_t)(GetTicks() % random_uplimit);
 }
 
+// Disable PVS warning 1020 for this function.
+// It's a false positive about needing to call DOS_CloseFile()
+#pragma pvs(push)
+#pragma pvs(disable: 1020)
+
 void DOS_Shell::ParseLine(char *line)
 {
 	LOG(LOG_EXEC, LOG_ERROR)("Parsing command line: %s", line);
@@ -331,6 +336,8 @@ void DOS_Shell::ParseLine(char *line)
 		}
 	}
 }
+
+#pragma pvs(pop)
 
 void DOS_Shell::RunBatchFile()
 {

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -203,6 +203,11 @@ uint16_t get_tick_random_number() {
 	return (uint16_t)(GetTicks() % random_uplimit);
 }
 
+// Yo dawg MSVC-Clang likes to complain about pragmas
+// So here's a pragma so you stop complaining about pragmas
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunknown-pragmas"
+
 // Disable PVS warning 1020 for this function.
 // It's a false positive about needing to call DOS_CloseFile()
 #pragma pvs(push)
@@ -338,6 +343,8 @@ void DOS_Shell::ParseLine(char *line)
 }
 
 #pragma pvs(pop)
+
+#pragma clang diagnostic pop
 
 void DOS_Shell::RunBatchFile()
 {

--- a/src/shell/shell_misc.cpp
+++ b/src/shell/shell_misc.cpp
@@ -476,8 +476,7 @@ bool DOS_Shell::ExecuteProgram(std::string_view name, std::string_view args)
 
 		if (auto reader = FileReader::GetFileReader(fullname)) {
 			batchfiles.emplace(*psp,
-			                   std::make_unique<FileReader>(
-			                           std::move(*reader)),
+			                   std::move(reader),
 			                   name,
 			                   args,
 			                   current_echo);


### PR DESCRIPTION
# Description

This allows Dunkle Schatten 2 to load and past the first couple of screens before it freezes.  For some reason, it's very sensitive to extra files being created.  It's kind of like a DOS Valgrind because it helped me clean up some leaks.

Once it gets past a certain number of files, it stomps on our device chain and then spins forever in this loop:

https://github.com/dosbox-staging/dosbox-staging/blob/ffea16b2a60dbcb545654246e1d67d7af9eb55aa/src/dos/dos_devices.cpp#L238-L257

I haven't fixed the root problem yet but it lead me to some buggy code I could fix regardless.

## Related issues

#3668


# Manual testing

- Output redirection works `dir > test.txt`
- Pipe works `dir | more`
- Input redirection works `test.txt < more`

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

