### PR TITLE
Make GCC 11 / Ubuntu 22.04 the minimum build target

### DIFF
--- a/.github/meson/native-clang-12.ini
+++ b/.github/meson/native-clang-12.ini
@@ -1,3 +1,0 @@
-[binaries]
-c = ['ccache', 'clang-12']
-cpp = ['ccache', 'clang++-12']

--- a/.github/meson/native-clang-14.ini
+++ b/.github/meson/native-clang-14.ini
@@ -1,3 +1,0 @@
-[binaries]
-c = ['ccache', 'clang-14']
-cpp = ['ccache', 'clang++-14']

--- a/.github/meson/native-gcc-10.ini
+++ b/.github/meson/native-gcc-10.ini
@@ -1,3 +1,0 @@
-[binaries]
-c = ['ccache', 'gcc-10']
-cpp = ['ccache', 'g++-10']

--- a/.github/meson/native-gcc-7.ini
+++ b/.github/meson/native-gcc-7.ini
@@ -1,3 +1,0 @@
-[binaries]
-c = ['ccache', 'gcc-7']
-cpp = ['ccache', 'g++-7']

--- a/.github/meson/native-gcc-9.ini
+++ b/.github/meson/native-gcc-9.ini
@@ -1,3 +1,0 @@
-[binaries]
-c = ['ccache', 'gcc-9']
-cpp = ['ccache', 'g++-9']

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -89,7 +89,7 @@ jobs:
       matrix:
         conf:
 
-          - name: GCC 10, Ubuntu 22.04
+          - name: GCC 12, Ubuntu 22.04
             os: ubuntu-22.04
             packages: g++-12
             build_flags: -Dbuildtype=debug --native-file=.github/meson/native-gcc-12.ini
@@ -105,7 +105,7 @@ jobs:
             needs_all_deps: true
             run_tests: true
 
-          - name: GCC 12, +debugger
+          - name: GCC 12, Ubuntu 22.04, debugger build
             os: ubuntu-22.04
             packages: g++-12
             build_flags: -Denable_debugger=heavy --native-file=.github/meson/native-gcc-12.ini
@@ -126,7 +126,7 @@ jobs:
             needs_min_deps: true
             max_warnings: -1
 
-          - name: GCC, Debian 11, ARMv7
+          - name: GCC 11, Debian 11, ARMv7
             os: ubuntu-20.04
             build_flags: -Dbuildtype=debug -Duse_zlib_ng=false --cross-file dosbox-cross
             max_warnings: 0
@@ -136,7 +136,7 @@ jobs:
             deb_vers: 11
             needs_min_deps: false
 
-          - name: GCC, Debian 11, aarch64
+          - name: GCC 11, Debian 11, aarch64
             os: ubuntu-20.04
             build_flags: -Dbuildtype=debug --cross-file dosbox-cross
             max_warnings: 0
@@ -146,7 +146,7 @@ jobs:
             deb_vers: 11
             needs_min_deps: false
 
-          - name: GCC, Debian 11, ppc64le
+          - name: GCC 11, Debian 11, ppc64le
             os: ubuntu-20.04
             build_flags: -Dbuildtype=debug --cross-file dosbox-cross
             max_warnings: 21

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -267,7 +267,7 @@ jobs:
 
   build_linux_release:
     name: Release build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     needs: cache_subprojects
     steps:
@@ -281,7 +281,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get install -y tree \
-            $(cat packages/ubuntu-20.04-apt.txt)
+            $(cat packages/ubuntu-22.04-apt.txt)
           sudo pip3 install --upgrade meson ninja
 
       - name: Restore subprojects cache
@@ -329,7 +329,6 @@ jobs:
             -Ddefault_library=static \
             --wrap-mode=forcefallback \
             -Db_lto=true -Db_lto_threads=$(nproc) \
-            --native-file=.github/meson/native-gcc-9.ini \
             build \
           || ( cat build/meson-logs/meson-log.txt ; exit 1 )
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -127,7 +127,7 @@ jobs:
             max_warnings: -1
 
           - name: GCC 11, Debian 11, ARMv7
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             build_flags: -Dbuildtype=debug -Duse_zlib_ng=false --cross-file dosbox-cross
             max_warnings: 0
             run_tests: true
@@ -137,7 +137,7 @@ jobs:
             needs_min_deps: false
 
           - name: GCC 11, Debian 11, aarch64
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             build_flags: -Dbuildtype=debug --cross-file dosbox-cross
             max_warnings: 0
             run_tests: true
@@ -147,7 +147,7 @@ jobs:
             needs_min_deps: false
 
           - name: GCC 11, Debian 11, ppc64le
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             build_flags: -Dbuildtype=debug --cross-file dosbox-cross
             max_warnings: 21
             run_tests: true

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -112,6 +112,20 @@ jobs:
             max_warnings: 0
             needs_all_deps: true
 
+          - name: GCC 11, Ubuntu 22.04, minimal build
+            os: ubuntu-22.04
+            build_flags: >-
+              -Dbuildtype=minsize
+              -Dunit_tests=disabled
+              -Duse_alsa=false
+              -Duse_fluidsynth=false
+              -Duse_mt32emu=false
+              -Duse_opengl=false
+              -Duse_sdl2_net=false
+              -Duse_slirp=false
+            needs_min_deps: true
+            max_warnings: -1
+
           - name: GCC, Debian 11, ARMv7
             os: ubuntu-20.04
             build_flags: -Dbuildtype=debug -Duse_zlib_ng=false --cross-file dosbox-cross
@@ -141,22 +155,6 @@ jobs:
             arch: ppc64el
             deb_vers: 11
             needs_min_deps: false
-
-          - name: GCC 9, minimum build
-            os: ubuntu-20.04
-            packages: g++-9
-            build_flags: >-
-              -Dbuildtype=minsize
-              -Dunit_tests=disabled
-              -Duse_alsa=false
-              -Duse_fluidsynth=false
-              -Duse_mt32emu=false
-              -Duse_opengl=false
-              -Duse_sdl2_net=false
-              -Duse_slirp=false
-              --native-file=.github/meson/native-gcc-9.ini
-            needs_min_deps: true
-            max_warnings: -1
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
# Description

As we discussed today, let's move the minimum GCC version forward to 11 on Linux. That means bumping the GCC version of the "minimal build" target from 9 to 11. Staying on 9 just makes it a lot harder to use the nice new C++20 features. Supporting the last 2 Ubuntu LTS releases seems like a good approach; 3 is perhaps pushing it a little bit.

People who desire to compile Staging on legacy systems are welcome to check out an earlier release tag; those will still build with GCC 9, 10, etc.

Some notes:

- The ARMv7, ppc64 and aarch64 targets seem to use some custom Docker image created by kcgen if I'm not mistaken to cross-compile Staging for those platforms. I haven't touched those, neither am I going to. Feel free to tinker with them or maintain them if they're important for you, otherwise they will be disabled / removed the first time they cause a nuissance.
- We should eventually add a new 24.04 target; Linux guys, please step forward 😎 

# Relates issues

The below PR can only go in after this because of some C++20 features that are unsupported on GCC 9:

- https://github.com/dosbox-staging/dosbox-staging/pull/3650

# Manual testing

None.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

