### PR TITLE
fix msys2 compilation error with cdrom_win32.cpp

### DIFF
--- a/src/dos/cdrom_win32.cpp
+++ b/src/dos/cdrom_win32.cpp
@@ -298,7 +298,7 @@ bool CDROM_Interface_Win32::LoadUnloadMedia(bool unload)
 		return false;
 	}
 	DWORD control_code       = unload ? IOCTL_STORAGE_EJECT_MEDIA
-	                                  : IOCTL_CDROM_LOAD_MEDIA;
+	                                  : IOCTL_DISK_LOAD_MEDIA;
 	LPVOID input_buffer      = NULL;
 	DWORD input_buffer_size  = 0;
 	LPVOID output_buffer     = NULL;

--- a/src/dos/cdrom_win32.cpp
+++ b/src/dos/cdrom_win32.cpp
@@ -298,7 +298,7 @@ bool CDROM_Interface_Win32::LoadUnloadMedia(bool unload)
 		return false;
 	}
 	DWORD control_code       = unload ? IOCTL_STORAGE_EJECT_MEDIA
-	                                  : IOCTL_DISK_LOAD_MEDIA;
+	                                  : IOCTL_STORAGE_LOAD_MEDIA;
 	LPVOID input_buffer      = NULL;
 	DWORD input_buffer_size  = 0;
 	LPVOID output_buffer     = NULL;


### PR DESCRIPTION
in msys2 it would through undefined when declaring IOCTL_CDROM_LOAD_MEDIA so i change it to IOCTL_DISK_LOAD_MEDIA this fixed compilation and i have had no issues testing the build that it produced.
I have ran all TESTs and asan build there has been no breaking issues on mys2
