### PR TITLE
Move System File Table memory location

### DIFF
--- a/include/dos_inc.h
+++ b/include/dos_inc.h
@@ -231,6 +231,7 @@ bool DOS_ResizeMemory(uint16_t segment,uint16_t * blocks);
 bool DOS_FreeMemory(uint16_t segment);
 void DOS_FreeProcessMemory(uint16_t pspseg);
 uint16_t DOS_GetMemory(uint16_t pages);
+void DOS_FreeTableMemory();
 bool DOS_SetMemAllocStrategy(uint16_t strat);
 void DOS_SetMcbFaultStrategy(const char *mcb_fault_strategy_pref);
 uint16_t DOS_GetMemAllocStrategy(void);

--- a/include/dos_inc.h
+++ b/include/dos_inc.h
@@ -99,6 +99,10 @@ enum { RETURN_EXIT=0,RETURN_CTRLC=1,RETURN_ABORT=2,RETURN_TSR=3};
 #define DOS_PRIVATE_SEGMENT 0xc800
 #define DOS_PRIVATE_SEGMENT_END 0xd000
 
+constexpr int SftHeaderSize = 6;
+constexpr int SftEntrySize = 59;
+constexpr int SftNumEntries = 16;
+
 /* internal Dos Tables */
 
 extern DOS_File * Files[DOS_FILES];

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -1526,6 +1526,8 @@ public:
 		// without throwing an inevitable `DOS: Too many devices added`
 		// exception
 		DOS_ShutDownDevices();
+
+		DOS_FreeTableMemory();
 	}
 };
 

--- a/src/dos/dos_misc.cpp
+++ b/src/dos/dos_misc.cpp
@@ -69,10 +69,10 @@ static bool DOS_MultiplexFunctions(void) {
 		LOG(LOG_DOSMISC,LOG_ERROR)("Some BAD filetable call used bx=%X",reg_bx);
 		if(reg_bx <= DOS_FILES) CALLBACK_SCF(false);
 		else CALLBACK_SCF(true);
-		if (reg_bx<16) {
+		if (reg_bx < SftNumEntries) {
 			RealPt sftrealpt=mem_readd(RealToPhysical(dos_infoblock.GetPointer())+4);
 			PhysPt sftptr=RealToPhysical(sftrealpt);
-			Bitu sftofs=0x06+reg_bx*0x3b;
+			Bitu sftofs= SftHeaderSize + reg_bx * SftEntrySize;
 
 			if (Files[reg_bx]) mem_writeb(sftptr+sftofs,Files[reg_bx]->refCtr);
 			else mem_writeb(sftptr+sftofs,0);

--- a/src/dos/dos_tables.cpp
+++ b/src/dos/dos_tables.cpp
@@ -51,6 +51,11 @@ uint16_t DOS_GetMemory(uint16_t pages) {
 	return page;
 }
 
+void DOS_FreeTableMemory()
+{
+	dos_memseg = DOS_PRIVATE_SEGMENT;
+}
+
 static Bitu DOS_CaseMapFunc(void) {
 	//LOG(LOG_DOSMISC,LOG_ERROR)("Case map routine called : %c",reg_al);
 	return CBRET_NONE;


### PR DESCRIPTION
# Description

The System File Table (SFT) was being faked and did not have enough memory allocated for it. This caused issues with Dunkle Schatten 2.

The game was making an INT 2F call that requests a pointer to an SFT entry. This interrupt handler writes into SFT memory which was overlapping with the DOS Device Chain, causing a hang.

To fix, actually allocate enough memory to store 100 file handles and set the pointer to firstFileTable to reflect the new location.

## Related issues

Fixes #3668


# Manual testing

The game doesn't crash anymore :smile: 


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

