### PR TITLE
Fix Reboot Handler crash

### DIFF
--- a/include/control.h
+++ b/include/control.h
@@ -159,4 +159,7 @@ public:
 	Verbosity GetStartupVerbosity() const;
 };
 
+using ConfigPtr = std::unique_ptr<Config>;
+extern ConfigPtr control;
+
 #endif

--- a/include/control.h
+++ b/include/control.h
@@ -162,4 +162,6 @@ public:
 using ConfigPtr = std::unique_ptr<Config>;
 extern ConfigPtr control;
 
+void restart_dosbox(std::vector<std::string> &parameters = control->startup_params);
+
 #endif

--- a/include/dosbox.h
+++ b/include/dosbox.h
@@ -74,10 +74,6 @@ void DOSBOX_Init(void);
 
 void DOSBOX_SetMachineTypeFromConfig(Section_prop* section);
 
-class Config;
-using ConfigPtr = std::unique_ptr<Config>;
-extern ConfigPtr control;
-
 enum SVGACards {
 	SVGA_None,
 	SVGA_S3Trio,

--- a/include/hardware.h
+++ b/include/hardware.h
@@ -27,6 +27,8 @@
 #include <cstdio>
 #include <string>
 
+#include "control.h"
+
 class Section;
 
 enum class OplMode { None, Opl2, DualOpl2, Opl3, Opl3Gold, Esfm };

--- a/include/midi.h
+++ b/include/midi.h
@@ -27,6 +27,7 @@
 #include <array>
 #include <cassert>
 
+#include "control.h"
 #include "setup.h"
 
 class Program;

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -36,6 +36,7 @@
 
 #include "../src/hardware/compressor.h"
 #include "audio_frame.h"
+#include "control.h"
 #include "envelope.h"
 
 #include <Iir.h>

--- a/include/mouse.h
+++ b/include/mouse.h
@@ -26,6 +26,7 @@
 #include <string>
 #include <vector>
 
+#include "control.h"
 #include "rect.h"
 
 // ***************************************************************************

--- a/src/dos/cdrom_win32.cpp
+++ b/src/dos/cdrom_win32.cpp
@@ -23,6 +23,7 @@
 
 #if defined(WIN32)
 
+#include <devioctl.h>
 #include <ntddcdrm.h>
 #include <windows.h>
 

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3284,7 +3284,6 @@ static void set_output(Section* sec, const bool wants_aspect_ratio_correction)
 }
 
 // extern void UI_Run(bool);
-void Restart(bool pressed);
 
 static void apply_active_settings()
 {
@@ -3336,6 +3335,11 @@ static void set_priority_levels(const std::string& active_pref,
 
 	sdl.priority.active   = to_level(active_pref);
 	sdl.priority.inactive = to_level(inactive_pref);
+}
+
+static void restart_hotkey_handler([[maybe_unused]] bool pressed)
+{
+	restart_dosbox();
 }
 
 static void read_gui_config(Section* sec)
@@ -3446,7 +3450,7 @@ static void read_gui_config(Section* sec)
 	                  "shutdown", "Shutdown");
 
 	MAPPER_AddHandler(switch_fullscreen, SDL_SCANCODE_RETURN, MMOD2, "fullscr", "Fullscreen");
-	MAPPER_AddHandler(Restart, SDL_SCANCODE_HOME, PRIMARY_MOD | MMOD2, "restart", "Restart");
+	MAPPER_AddHandler(restart_hotkey_handler, SDL_SCANCODE_HOME, PRIMARY_MOD | MMOD2, "restart", "Restart");
 	MAPPER_AddHandler(MOUSE_ToggleUserCapture,
 	                  SDL_SCANCODE_F10,
 	                  PRIMARY_MOD,
@@ -4512,11 +4516,6 @@ void restart_dosbox(std::vector<std::string> &parameters) {
 	}
 	delete [] newargs;
 #endif // WIN32
-}
-
-void Restart(bool pressed) { // mapper handler
-	(void) pressed; // deliberately unused but required for API compliance
-	restart_dosbox();
 }
 
 static void list_glshaders()

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -4430,7 +4430,7 @@ extern void DEBUG_ShutDown(Section * /*sec*/);
 
 void MIXER_CloseAudioDevice(void);
 
-void restart_program(std::vector<std::string> & parameters) {
+void restart_dosbox(std::vector<std::string> &parameters) {
 #ifdef WIN32
 	std::string command_line = {};
 	bool first = true;
@@ -4516,7 +4516,7 @@ void restart_program(std::vector<std::string> & parameters) {
 
 void Restart(bool pressed) { // mapper handler
 	(void) pressed; // deliberately unused but required for API compliance
-	restart_program(control->startup_params);
+	restart_dosbox();
 }
 
 static void list_glshaders()

--- a/src/hardware/input/intel8042.cpp
+++ b/src/hardware/input/intel8042.cpp
@@ -26,6 +26,7 @@
 #include "bitops.h"
 #include "checks.h"
 #include "config.h"
+#include "control.h"
 #include "inout.h"
 #include "mem.h"
 #include "pic.h"
@@ -673,8 +674,7 @@ static bool is_cmd_vendor_lines(const Command command)
 
 static void request_system_reset()
 {
-	E_Exit("I8042: System reset requested");
-	// TODO: we need a proper reset implementation
+	restart_dosbox();
 }
 
 static void execute_command(const Command command)

--- a/src/ints/bios.cpp
+++ b/src/ints/bios.cpp
@@ -1026,7 +1026,7 @@ static Bitu Reboot_Handler(void) {
 	const auto start = PIC_FullIndex();
 	while ((PIC_FullIndex() - start) < 3000.0)
 		CALLBACK_Idle();
-	throw 1;
+	restart_dosbox();
 	return CBRET_NONE;
 }
 

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -292,7 +292,6 @@ void Program::AddToHelpList()
 }
 
 bool MSG_Write(const char*);
-void restart_program(std::vector<std::string>& parameters);
 
 class CONFIG final : public Program {
 public:
@@ -376,7 +375,7 @@ void CONFIG::Run(void)
 				return;
 			}
 			if (pvars.size() == 0) {
-				restart_program(control->startup_params);
+				restart_dosbox();
 			} else {
 				std::vector<std::string> restart_params;
 				restart_params.push_back(
@@ -389,7 +388,7 @@ void CONFIG::Run(void)
 				                      remaining_args.begin(),
 				                      remaining_args.end());
 
-				restart_program(restart_params);
+				restart_dosbox(restart_params);
 			}
 			return;
 

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -44,7 +44,7 @@ extern char** environ;
 #endif
 
 // Commonly accessed global that holds configuration records
-std::unique_ptr<Config> control = {};
+ConfigPtr control = {};
 
 // Set by parseconfigfile so Prop_path can use it to construct the realpath
 static std_fs::path current_config_dir;


### PR DESCRIPTION
# Description

Previously, this was doing `throw 1;` for some reason.  Not exactly sure what the end result of that was supposed to be.  I assume it would exit the program and throw an error since I don't know if we actually handle that exception anywhere.

Changed this to use the same restart function that is used by the restart hotkey as well as `config -r`.  This simply reloads DOSBox which is probably the result that we want here.

## Related issues

Fixes #3682

# Manual testing

Found a Space Quest 1 floppy image that is non-bootable.  Ran `boot sq1.img`.  This displayes a non-system disk error and, after pressing Enter, calls into the Restart Handler.  The Restart Handler now restarts DOSBox correctly instead of crashing.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

