### PR TITLE
Implement File Locking

### DIFF
--- a/include/dos_inc.h
+++ b/include/dos_inc.h
@@ -198,6 +198,8 @@ bool DOS_Canonicalize(const char* const name, char* const canonicalized);
 std::string DOS_Canonicalize(const char* const name);
 bool DOS_CreateTempFile(char* const name, uint16_t* entry);
 bool DOS_FileExists(const char* const name);
+bool DOS_LockFile(const uint16_t entry, const uint32_t pos, const uint32_t len);
+bool DOS_UnlockFile(const uint16_t entry, const uint32_t pos, const uint32_t len);
 
 /* Helper Functions */
 bool DOS_MakeName(const char* const name, char* const fullname, uint8_t* drive);
@@ -312,6 +314,7 @@ static inline uint16_t long2para(uint32_t size) {
 #define DOSERR_REMOVE_CURRENT_DIRECTORY 16
 #define DOSERR_NOT_SAME_DEVICE 17
 #define DOSERR_NO_MORE_FILES 18
+#define DOSERR_LOCK_VIOLATION 33
 #define DOSERR_FILE_ALREADY_EXISTS 80
 
 /* Wait/check user input */

--- a/include/dos_system.h
+++ b/include/dos_system.h
@@ -345,7 +345,7 @@ public:
 	DOS_Drive();
 	virtual ~DOS_Drive() = default;
 
-	virtual bool FileOpen(DOS_File** file, char* name, uint32_t flags) = 0;
+	virtual bool FileOpen(DOS_File** file, char* name, uint8_t flags) = 0;
 	virtual bool FileCreate(DOS_File** file, char* name,
 	                        FatAttributeFlags attributes) = 0;
 	virtual bool FileUnlink(char* _name)=0;

--- a/include/dos_system.h
+++ b/include/dos_system.h
@@ -129,7 +129,7 @@ public:
 
 	void SetDrive(uint8_t drv) { hdrive=drv;}
 	uint8_t GetDrive(void) { return hdrive;}
-	uint32_t flags   = 0;
+	uint8_t flags    = 0;
 	uint16_t time    = 0;
 	uint16_t date    = 0;
 	FatAttributeFlags attr = {};

--- a/include/dos_system.h
+++ b/include/dos_system.h
@@ -98,6 +98,11 @@ struct DosFilename {
 	std::string ext  = {};
 };
 
+struct FileRegionLock {
+	uint32_t pos = 0;
+	uint32_t len = 0;
+};
+
 class DOS_File {
 public:
 	DOS_File() = default;
@@ -137,6 +142,7 @@ public:
 	bool open        = false;
 	std::string name = {};
 	bool newtime     = false;
+	std::vector<FileRegionLock> region_locks = {};
 	/* Some Device Specific Stuff */
 private:
 	uint8_t hdrive = 0xff;

--- a/include/drives.h
+++ b/include/drives.h
@@ -88,7 +88,7 @@ public:
 	           uint8_t _sectors_cluster, uint16_t _total_clusters,
 	           uint16_t _free_clusters, uint8_t _mediaid,
 	           bool _always_open_ro_files = false);
-	bool FileOpen(DOS_File** file, char* name, uint32_t flags) override;
+	bool FileOpen(DOS_File** file, char* name, uint8_t flags) override;
 	virtual FILE* GetSystemFilePtr(const char* const name, const char* const type);
 	virtual bool GetSystemFilename(char* sysName, const char* const dosName);
 	bool FileCreate(DOS_File** file, char* name,
@@ -200,7 +200,7 @@ public:
 	         bool roflag);
 	fatDrive(const fatDrive&)            = delete; // prevent copying
 	fatDrive& operator=(const fatDrive&) = delete; // prevent assignment
-	bool FileOpen(DOS_File** file, char* name, uint32_t flags) override;
+	bool FileOpen(DOS_File** file, char* name, uint8_t flags) override;
 	bool FileCreate(DOS_File** file, char* name,
 	                FatAttributeFlags attributes) override;
 	bool FileUnlink(char* name) override;
@@ -276,7 +276,7 @@ public:
 	           uint16_t _bytes_sector, uint8_t _sectors_cluster,
 	           uint16_t _total_clusters, uint16_t _free_clusters,
 	           uint8_t _mediaid, int& error);
-	bool FileOpen(DOS_File** file, char* name, uint32_t flags) override;
+	bool FileOpen(DOS_File** file, char* name, uint8_t flags) override;
 	bool FileCreate(DOS_File** file, char* name,
 	                FatAttributeFlags attributes) override;
 	bool FileUnlink(char* name) override;
@@ -377,7 +377,7 @@ public:
 	isoDrive(char driveLetter, const char* device_name, uint8_t mediaid,
 	         int& error);
 	~isoDrive() override;
-	bool FileOpen(DOS_File** file, char* name, uint32_t flags) override;
+	bool FileOpen(DOS_File** file, char* name, uint8_t flags) override;
 	bool FileCreate(DOS_File** file, char* name,
 	                FatAttributeFlags attributes) override;
 	bool FileUnlink(char* name) override;
@@ -449,7 +449,7 @@ using vfile_block_t = std::shared_ptr<VFILE_Block>;
 class Virtual_Drive final : public DOS_Drive {
 public:
 	Virtual_Drive();
-	bool FileOpen(DOS_File** file, char* name, uint32_t flags) override;
+	bool FileOpen(DOS_File** file, char* name, uint8_t flags) override;
 	bool FileCreate(DOS_File** file, char* name,
 	                FatAttributeFlags attributes) override;
 	bool FileUnlink(char* name) override;
@@ -494,7 +494,7 @@ public:
 	              uint8_t _mediaid,
 	              uint8_t &error);
 
-	bool FileOpen(DOS_File** file, char* name, uint32_t flags) override;
+	bool FileOpen(DOS_File** file, char* name, uint8_t flags) override;
 	bool FileCreate(DOS_File** file, char* name,
 	                FatAttributeFlags attributes) override;
 	bool FindFirst(char* _dir, DOS_DTA& dta, bool fcb_findfirst) override;

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -1059,14 +1059,11 @@ static Bitu DOS_21Handler(void) {
 		{
 			MEM_StrCopy(SegPhys(ds)+reg_dx,name1,DOSNAMEBUF);
 			uint16_t handle;
-			if (DOS_OpenFile(name1,0,&handle)) {
-				DOS_CloseFile(handle);
+			if (DOS_FileExists(name1)) {
 				DOS_SetError(DOSERR_FILE_ALREADY_EXISTS);
 				reg_ax=dos.errorcode;
 				CALLBACK_SCF(true);
-				break;
-			}
-			if (DOS_CreateFile(name1, reg_cl, &handle)) {
+			} else if (DOS_CreateFile(name1, reg_cl, &handle)) {
 				reg_ax=handle;
 				CALLBACK_SCF(false);
 			} else {

--- a/src/dos/dos_misc.cpp
+++ b/src/dos/dos_misc.cpp
@@ -63,6 +63,10 @@ static Bitu INT2A_Handler(void) {
 
 static bool DOS_MultiplexFunctions(void) {
 	switch (reg_ax) {
+	case 0x1000:
+		// Report that SHARE.EXE is installed
+		reg_al = 0xff;
+		return true;
 	case 0x1216:	/* GET ADDRESS OF SYSTEM FILE TABLE ENTRY */
 		// reg_bx is a system file table entry, should coincide with
 		// the file handle so just use that

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -1125,7 +1125,7 @@ bool fatDrive::FileExists(const char *name) {
 	return found;
 }
 
-bool fatDrive::FileOpen(DOS_File **file, char *name, uint32_t flags) {
+bool fatDrive::FileOpen(DOS_File **file, char *name, uint8_t flags) {
 	direntry fileEntry;
 	uint32_t dirClust, subEntry;
 	if (!getFileDirEntry(name, &fileEntry, &dirClust, &subEntry)) {

--- a/src/dos/drive_iso.cpp
+++ b/src/dos/drive_iso.cpp
@@ -208,7 +208,7 @@ void isoDrive::Activate(void) {
 	UpdateMscdex(driveLetter, fileName, subUnit);
 }
 
-bool isoDrive::FileOpen(DOS_File **file, char *name, uint32_t flags) {
+bool isoDrive::FileOpen(DOS_File **file, char *name, uint8_t flags) {
 	if ((flags & 0x0f) == OPEN_WRITE) {
 		DOS_SetError(DOSERR_ACCESS_DENIED);
 		return false;

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -123,7 +123,7 @@ DOS_File *FindOpenFile(const DOS_Drive *drive, const char *name)
 	return nullptr;
 }
 
-bool localDrive::FileOpen(DOS_File **file, char *name, uint32_t flags)
+bool localDrive::FileOpen(DOS_File **file, char *name, uint8_t flags)
 {
 	const char *type = nullptr;
 	switch (flags&0xf) {
@@ -955,7 +955,7 @@ cdromDrive::cdromDrive(const char _driveLetter,
 	if (MSCDEX_GetVolumeName(subUnit,name)) dirCache.SetLabel(name,true,true);
 }
 
-bool cdromDrive::FileOpen(DOS_File** file, char* name, uint32_t flags)
+bool cdromDrive::FileOpen(DOS_File** file, char* name, uint8_t flags)
 {
 	if ((flags & 0xf) == OPEN_READWRITE) {
 		flags &= ~static_cast<unsigned>(OPEN_READWRITE);

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -713,7 +713,7 @@ bool localFile::Read(uint8_t *data, uint16_t *size)
 
 bool localFile::Write(uint8_t *data, uint16_t *size)
 {
-	uint32_t lastflags = this->flags & 0xf;
+	uint8_t lastflags = this->flags & 0xf;
 	if (lastflags == OPEN_READ || lastflags == OPEN_READ_NO_MOD) {	// check if file opened in read-only mode
 		DOS_SetError(DOSERR_ACCESS_DENIED);
 		return false;

--- a/src/dos/drive_overlay.cpp
+++ b/src/dos/drive_overlay.cpp
@@ -460,7 +460,7 @@ void Overlay_Drive::convert_overlay_to_DOSname_in_base(char* dirname )
 	}
 }
 
-bool Overlay_Drive::FileOpen(DOS_File * * file,char * name,uint32_t flags) {
+bool Overlay_Drive::FileOpen(DOS_File** file, char* name, uint8_t flags) {
 	const char* type;
 	switch (flags&0xf) {
 	case OPEN_READ:        type = "rb" ; break;

--- a/src/dos/drive_overlay.cpp
+++ b/src/dos/drive_overlay.cpp
@@ -215,8 +215,8 @@ public:
 			LOG_MSG("constructing OverlayFile: %s", name);
 	}
 
-	bool Write(uint8_t * data,uint16_t * size) override {
-		uint32_t f = flags&0xf;
+	bool Write(uint8_t* data, uint16_t* size) override {
+		uint8_t f = flags & 0xf;
 		if (!overlay_active && (f == OPEN_READWRITE || f == OPEN_WRITE)) {
 			if (logoverlay) LOG_MSG("write detected, switching file for %s",GetName());
 			if (*data == 0) {

--- a/src/dos/drive_virtual.cpp
+++ b/src/dos/drive_virtual.cpp
@@ -418,7 +418,7 @@ Virtual_Drive::Virtual_Drive() : search_file()
 		parent_dir = std::make_shared<VFILE_Block>();
 }
 
-bool Virtual_Drive::FileOpen(DOS_File * * file,char * name,uint32_t flags) {
+bool Virtual_Drive::FileOpen(DOS_File** file, char* name, uint8_t flags) {
 	assert(name);
 	if (*name == 0) {
 		DOS_SetError(DOSERR_ACCESS_DENIED);


### PR DESCRIPTION
# Description

I've implemented locking the entire file with sharing bits in `DOS_OpenFile` and `DOS_CreateFile`.

There is another (completely independent from sharing bits) method that lock regions of a file.  This is done through INT 21 AH = 0x5c.  This requires performing a check on `DOS_ReadFile` and `DOS_WriteFile` to check if the region a process is attempting to read/write to has been locked by another process.

Many of the games I've tested require Win32s (who's installer does a `SHARE.EXE` check).  This check failed for me on both DOSBox-X and using `FAKESHR.COM` so we are doing better than them now :smile: 


## Related issues

Fixes #1489

# Manual testing

- 3-D Ultra Pinball
- Comix Zone
- Microsoft Flight Simulator 5 - ATC Workshop
- AFL Finals Fever
- Mind Grid - Install errors but probably not related to this PR (also producible on main see #3703)
- Microsoft Word 6.1 for Windows


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

