### PR TITLE
Add support for ESS mixer registers

### DIFF
--- a/include/math_utils.h
+++ b/include/math_utils.h
@@ -252,14 +252,14 @@ constexpr uint32_t clamp_to_uint32(const T val)
 	return static_cast<uint32_t>(std::clamp(val, min_val, max_val));
 }
 
-constexpr uint8_t read_low_nibble(const uint8_t byte)
+constexpr uint8_t low_nibble(const uint8_t byte)
 {
-	return static_cast<uint8_t>(byte & 0x0f);
+	return byte & 0x0f;
 }
 
-constexpr uint8_t read_high_nibble(const uint8_t byte)
+constexpr uint8_t high_nibble(const uint8_t byte)
 {
-	return static_cast<uint8_t>(byte >> 4);
+	return (byte & 0xf0) >> 4;
 }
 
 inline float decibel_to_gain(const float decibel)

--- a/src/hardware/input/mouseif_dos_driver.cpp
+++ b/src/hardware/input/mouseif_dos_driver.cpp
@@ -1871,27 +1871,26 @@ static void prepare_driver_info()
 
 	const std::string str_copyright = DOSBOX_COPYRIGHT;
 
-	auto read_low_nibble_str = [&](const uint8_t byte) {
-		return std::to_string(static_cast<int>(read_low_nibble(byte)));
+	auto low_nibble_str = [&](const uint8_t byte) {
+		return std::to_string(low_nibble(byte));
 	};
-	auto read_high_nibble_str = [&](const uint8_t byte) {
-		return std::to_string(static_cast<int>(read_high_nibble(byte)));
+	auto high_nibble_str = [&](const uint8_t byte) {
+		return std::to_string(high_nibble(byte));
 	};
 
-	static_assert(read_low_nibble(driver_version_minor) <= 9);
-	static_assert(read_low_nibble(driver_version_major) <= 9);
-	static_assert(read_high_nibble(driver_version_minor) <= 9);
-	static_assert(read_high_nibble(driver_version_major) <= 9);
+	static_assert(low_nibble(driver_version_minor) <= 9);
+	static_assert(low_nibble(driver_version_major) <= 9);
+	static_assert(high_nibble(driver_version_minor) <= 9);
+	static_assert(high_nibble(driver_version_major) <= 9);
 
 	std::string str_version = "version ";
-	if (read_high_nibble(driver_version_major) > 0) {
-		str_version = str_version + read_high_nibble_str(driver_version_major);
+	if (high_nibble(driver_version_major) > 0) {
+		str_version = str_version + high_nibble_str(driver_version_major);
 	}
 
-	str_version = str_version +
-	              read_low_nibble_str(driver_version_major) + std::string(".") +
-	              read_high_nibble_str(driver_version_minor) +
-	              read_low_nibble_str(driver_version_minor);
+	str_version = str_version + low_nibble_str(driver_version_major) +
+	              std::string(".") + high_nibble_str(driver_version_minor) +
+	              low_nibble_str(driver_version_minor);
 
 	const size_t length_bytes = (str_version.length() + 1) +
 	                            (str_copyright.length() + 1);


### PR DESCRIPTION
# Description

This PR ports over the ESS-specific mixer regusters from DOSBox-X to read/write the mixer volume levels.

Fixes https://github.com/dosbox-staging/dosbox-staging/issues/3700

# Manual testing

Run **koolnESS** referenced in the above ticket, and confirm the music fades out when switching between tunes.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

