### PR TITLE
Fix ESS mixer volume handling

### DIFF
--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -1436,7 +1436,7 @@ void MixerChannel::SetReverbLevel(const float level)
 
 	const auto level_db = remap(LevelMin, LevelMax, LevelMinDb, LevelMaxDb, level);
 
-	reverb.send_gain = static_cast<float>(decibel_to_gain(level_db));
+	reverb.send_gain = decibel_to_gain(level_db);
 
 #ifdef DEBUG_MIXER
 	LOG_DEBUG("%s: Reverb send is on: level: %4.2f, level_db: %6.2f, gain: %4.2f",
@@ -1477,7 +1477,7 @@ void MixerChannel::SetChorusLevel(const float level)
 
 	const auto level_db = remap(LevelMin, LevelMax, LevelMinDb, LevelMaxDb, level);
 
-	chorus.send_gain = static_cast<float>(decibel_to_gain(level_db));
+	chorus.send_gain = decibel_to_gain(level_db);
 
 #ifdef DEBUG_MIXER
 	LOG_DEBUG("%s: Chorus send is on: level: %4.2f, level_db: %6.2f, gain: %4.2f",

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -191,15 +191,17 @@ struct SbInfo {
 
 	struct {
 		uint8_t index     = 0;
+
 		uint8_t dac[2]    = {};
 		uint8_t fm[2]     = {};
 		uint8_t cda[2]    = {};
 		uint8_t master[2] = {};
 		uint8_t lin[2]    = {};
 		uint8_t mic       = 0;
-		bool stereo       = false;
-		bool enabled      = false;
-		bool filtered     = false;
+
+		bool stereo   = false;
+		bool enabled  = false;
+		bool filtered = false;
 
 		uint8_t unhandled[0x48] = {};
 
@@ -2197,13 +2199,13 @@ static void ctmixer_reset()
 	ctmixer_update_volumes();
 }
 
-static void set_sb_pro_volume(uint8_t* dest, const uint8_t value)
+static void write_sb_pro_volume(uint8_t* dest, const uint8_t value)
 {
 	dest[0] = ((((value)&0xf0) >> 3) | (sb.type == SbType::SB16 ? 1 : 3));
 	dest[1] = ((((value)&0x0f) << 1) | (sb.type == SbType::SB16 ? 1 : 3));
 }
 
-static uint8_t make_sb_pro_volume(const uint8_t* src)
+static uint8_t read_sb_pro_volume(const uint8_t* src)
 {
 	return ((((src[0] & 0x1e) << 3) | ((src[1] & 0x1e) >> 1)) |
 	        ((sb.type == SbType::SBPro1 || sb.type == SbType::SBPro2) ? 0x11 : 0));
@@ -2275,19 +2277,19 @@ static void ctmixer_write(const uint8_t val)
 		break;
 
 	case 0x02: // Master Volume (SB2 Only)
-		set_sb_pro_volume(sb.mixer.master, (val & 0xf) | (val << 4));
+		write_sb_pro_volume(sb.mixer.master, (val & 0xf) | (val << 4));
 		ctmixer_update_volumes();
 		break;
 
 	case 0x04: // DAC Volume (SBPRO)
-		set_sb_pro_volume(sb.mixer.dac, val);
+		write_sb_pro_volume(sb.mixer.dac, val);
 		ctmixer_update_volumes();
 		break;
 
 	case 0x06: { // FM output selection
 		// Somewhat obsolete with dual OPL SBpro + FM volume (SB2 Only)
 		// volume controls both channels
-		set_sb_pro_volume(sb.mixer.fm, (val & 0xf) | (val << 4));
+		write_sb_pro_volume(sb.mixer.fm, (val & 0xf) | (val << 4));
 
 		ctmixer_update_volumes();
 
@@ -2299,7 +2301,7 @@ static void ctmixer_write(const uint8_t val)
 	} break;
 
 	case 0x08: // CDA Volume (SB2 Only)
-		set_sb_pro_volume(sb.mixer.cda, (val & 0xf) | (val << 4));
+		write_sb_pro_volume(sb.mixer.cda, (val & 0xf) | (val << 4));
 		ctmixer_update_volumes();
 		break;
 
@@ -2338,22 +2340,22 @@ static void ctmixer_write(const uint8_t val)
 		break;
 
 	case 0x22: // Master Volume (SBPRO)
-		set_sb_pro_volume(sb.mixer.master, val);
+		write_sb_pro_volume(sb.mixer.master, val);
 		ctmixer_update_volumes();
 		break;
 
 	case 0x26: // FM Volume (SBPRO)
-		set_sb_pro_volume(sb.mixer.fm, val);
+		write_sb_pro_volume(sb.mixer.fm, val);
 		ctmixer_update_volumes();
 		break;
 
 	case 0x28: // CD Audio Volume (SBPRO)
-		set_sb_pro_volume(sb.mixer.cda, val);
+		write_sb_pro_volume(sb.mixer.cda, val);
 		ctmixer_update_volumes();
 		break;
 
 	case 0x2e: // Line-in Volume (SBPRO)
-		set_sb_pro_volume(sb.mixer.lin, val);
+		write_sb_pro_volume(sb.mixer.lin, val);
 		break;
 
 	// case 0x20: // Master Volume Left (SBPRO) ?
@@ -2526,10 +2528,10 @@ static uint8_t ctmixer_read()
 		break;
 
 	case 0x22: // Master Volume (SB Pro)
-		return make_sb_pro_volume(sb.mixer.master);
+		return read_sb_pro_volume(sb.mixer.master);
 
 	case 0x04: // DAC Volume (SB Pro)
-		return make_sb_pro_volume(sb.mixer.dac);
+		return read_sb_pro_volume(sb.mixer.dac);
 
 	case 0x06: // FM Volume (SB2 only) + FM output selection
 		return ((sb.mixer.fm[1] >> 1) & 0xe);
@@ -2549,13 +2551,13 @@ static uint8_t ctmixer_read()
 		       (sb.mixer.filtered ? 0x20 : 0x00);
 
 	case 0x26: // FM Volume (SB Pro)
-		return make_sb_pro_volume(sb.mixer.fm);
+		return read_sb_pro_volume(sb.mixer.fm);
 
 	case 0x28: // CD Audio Volume (SB Pro)
-		return make_sb_pro_volume(sb.mixer.cda);
+		return read_sb_pro_volume(sb.mixer.cda);
 
 	case 0x2e: // Line-in Volume (SB Pro)
-		return make_sb_pro_volume(sb.mixer.lin);
+		return read_sb_pro_volume(sb.mixer.lin);
 
 	case 0x30: // Master Volume Left (SB16)
 		if (sb.type == SbType::SB16) {

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -2590,12 +2590,8 @@ static uint8_t ctmixer_read()
 
 	case 0x34:
 		// FM Volume Left (SB16)
-		// FM Volume (ESS)
 		if (sb.type == SbType::SB16) {
 			return sb.mixer.fm[0] << 3;
-		}
-		if (sb.ess_type != EssType::None) {
-			return map_5bit_to_nibble_stereo(sb.mixer.fm);
 		}
 		ret = 0xa;
 		break;
@@ -2607,9 +2603,14 @@ static uint8_t ctmixer_read()
 		ret = 0xa;
 		break;
 
-	case 0x36: // CD Volume Left (SB16)
+	case 0x36:
+		// CD Volume Left (SB16)
+		// FM Volume (ESS)
 		if (sb.type == SbType::SB16) {
 			return sb.mixer.cda[0] << 3;
+		}
+		if (sb.ess_type != EssType::None) {
+			return map_5bit_to_nibble_stereo(sb.mixer.fm);
 		}
 		ret = 0xa;
 		break;

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -857,7 +857,7 @@ static const T* maybe_silence(const uint32_t num_samples, const T* buffer)
 		return buffer;
 	}
 
-	static std::vector<T> quiet_buffer;
+	static std::vector<T> quiet_buffer = {};
 	constexpr auto Silent = Mixer_GetSilentDOSSample<T>();
 
 	if (quiet_buffer.size() < num_samples) {


### PR DESCRIPTION
# Description

Fixes issue reported in https://github.com/dosbox-staging/dosbox-staging/issues/3700#issuecomment-2132240735.

86box seems to have a more correct ESS mixer implementation, although it's unclear whether that's accurate to the real hardware or they just guessed the values.

https://github.com/86Box/86Box/blob/e61c6205584e4414fc4a64494be5c6f1aab3e6ff/src/sound/snd_sb.c#L93

In any case, reconciling the ESS and SB-specific mixer volume handling would take some non-trivial effort, and I'm not going to complicate our Sound Blaster code with that for the sake of a single 2024 demo. All in all, it's a rather insignificant detail to get the volume curve _exactly_ right.

# Manual testing

Now you can set the audio volume with the `+` and `-` keys in koolnESS: https://www.pouet.net/prod.php?which=96920

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

