### PR TITLE
Improve the `core` and `cputype` setting descriptions

### DIFF
--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -3240,21 +3240,59 @@ void init_cpu_dosbox_settings(Section_prop& secprop)
 	pstring->Set_values({
 		"auto",
 #if C_DYNAMIC_X86 || C_DYNREC
-		        "dynamic",
+		"dynamic",
 #endif
-		        "normal", "simple"
+		"normal", "simple"
 	});
+
 	pstring->Set_help(
-	        "CPU core used in emulation ('auto' by default). 'auto' will switch to dynamic\n"
-	        "if available and appropriate.");
+	        "Type of CPU emulation core to use ('auto' by default).\n"
+	        "  auto:     'normal' core for real mode programs, 'dynamic' core for protected\n"
+	        "            mode programs (default). Most programs will run correctly with this\n"
+	        "            setting.\n"
+	        "  normal:   The DOS program is interpreted instruction by instruction. This\n"
+	        "            yields the most accurate timings, but puts 3-5 times more load on\n"
+	        "            the host CPU compared to the 'dynamic' core. Therefore, it's\n"
+	        "            generally only recommended for real mode programs that don't need\n"
+	        "            a fast emulated CPU or are timing-sensitive. The 'normal' core is\n"
+	        "            also necessary for programs that self-modify their code.\n"
+	        "  simple:   The 'normal' core optimised for old real mode programs; it might\n"
+	        "            give you slightly better compatibility with older games. Auto-\n"
+	        "            switches to the 'normal' core in protected mode.\n"
+	        "  dynamic:  The instructions of the DOS program are translated to host CPU\n"
+	        "            instructions in blocks and are then executed directly. This puts\n"
+	        "            3-5 times less load on the host CPU compared to the 'normal' core,\n"
+	        "            but the timings might be less accurate. The 'dynamic' core is a\n"
+	        "            necessity for demanding DOS programs (e.g., 3D SVGA games).\n"
+	        "            Programs that self-modify their code might misbehave or crash on\n"
+	        "            the 'dynamic' core; use the 'normal' core for such programs.");
 
 	pstring = secprop.Add_string("cputype", Always, "auto");
 	pstring->Set_values(
 	        {"auto", "386", "386_fast", "386_prefetch", "486", "pentium", "pentium_mmx"});
 
 	pstring->Set_help(
-	        "CPU type used in emulation ('auto' by default). 'auto' is the fastest choice.\n"
-	        "Prefetch variant emulates the prefetch queue and requires the 'normal' core.");
+	        "CPU type to emulate ('auto' by default).\n"
+	        "You should only change this if the program doesn't run correctly on 'auto'.\n"
+	        "  auto:          The fastest and most compatible setting (default).\n"
+	        "                 Technically, this is '386_fast' plus 486 CPUID, 486 CR\n"
+	        "                 register behaviour, and extra 486 instructions.\n"
+	        "  386:           386 CPUID and 386 specific page access level calculation.\n"
+	        "  386_fast:      Same as '386' but with loose page privilege checks which is\n"
+	        "                 much faster.\n"
+	        "  386_prefetch:  Same as '386_fast' plus accurate CPU prefetch queue emulation.\n"
+	        "                 This is necessary for programs that self-modify their code or\n"
+	        "                 employ anti-debugging tricks. Games that require '386_prefetch'\n"
+	        "                 include Contra, FIFA International Soccer (1994), Terminator 1,\n"
+	        "                 and X-Men: Madness in The Murderworld.\n"
+	        "  486:           486 CPUID, 486+ specific page access level calculation, 486 CR\n"
+	        "                 register behaviour, and extra 486 instructions.\n"
+	        "  pentium:       Same as '486' but with Pentium CPUID, Pentium CR register\n"
+	        "                 behaviour, and RDTSC instruction support. Recommended for\n"
+	        "                 Windows 3.x games (e.g., Betrayal in Antara).\n"
+	        "  pentium_mmx:   Same as 'pentium' plus MMX instruction set support. Very few\n"
+	        "                 games use MMX instructions; it's mostly only useful for\n"
+	        "                 demoscene productions.");
 
 	pstring->SetDeprecatedWithAlternateValue("386_slow", "386");
 	pstring->SetDeprecatedWithAlternateValue("486_slow", "486");

--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -3078,21 +3078,26 @@ public:
 		} else if (cpu_type == "386_prefetch") {
 			CPU_ArchitectureType = ArchitectureType::Intel386Fast;
 
-			if (cpu_core == "normal") {
-				cpudecoder = &CPU_Core_Prefetch_Run;
-
-				CPU_PrefetchQueueSize = 16;
-
-			} else if (cpu_core == "auto") {
+			if (cpu_core == "auto") {
 				cpudecoder = &CPU_Core_Prefetch_Run;
 
 				CPU_PrefetchQueueSize         = 16;
 				auto_determine_mode.auto_core = false;
 
 			} else {
-				// TODO Should be a warning and the relevant settings should
-				// be automatically set instead of of hard quitting.
-				E_Exit("prefetch queue emulation requires the normal core setting.");
+				if (cpu_core != "normal") {
+					LOG_WARNING(
+					        "CPU: 'core = 386_prefetch' requires the 'normal' "
+					        "core, using 'core = normal'");
+
+					set_section_property_value("cpu",
+					                           "core",
+					                           "normal");
+				}
+
+				cpudecoder = &CPU_Core_Prefetch_Run;
+
+				CPU_PrefetchQueueSize = 16;
 			}
 
 		} else if (cpu_type == "386") {
@@ -3104,19 +3109,26 @@ public:
 		} else if (cpu_type == "486_prefetch") {
 			CPU_ArchitectureType = ArchitectureType::Intel486NewSlow;
 
-			if (cpu_core == "normal") {
+			if (cpu_core == "auto") {
 				cpudecoder = &CPU_Core_Prefetch_Run;
 
-				CPU_PrefetchQueueSize = 32;
-
-			} else if (cpu_core == "auto") {
-				cpudecoder = &CPU_Core_Prefetch_Run;
-
-				CPU_PrefetchQueueSize           = 32;
+				CPU_PrefetchQueueSize         = 32;
 				auto_determine_mode.auto_core = false;
 
 			} else {
-				E_Exit("prefetch queue emulation requires the normal core setting.");
+				if (cpu_core != "normal") {
+					LOG_WARNING(
+					        "CPU: 'core = 486_prefetch' requires the 'normal' "
+					        "core, using 'core = normal'");
+
+					set_section_property_value("cpu",
+					                           "core",
+					                           "normal");
+				}
+
+				cpudecoder = &CPU_Core_Prefetch_Run;
+
+				CPU_PrefetchQueueSize = 32;
 			}
 
 		} else if (cpu_type == "pentium") {


### PR DESCRIPTION
# Description

Also, revert `core` to `normal` if needed for `cputype = 386_prefetch`. Previously, the `core = dynamic` and `cputype = 386_prefetch` combo resulted in a hard exit, which is not exactly great behaviour...

It took me quite a bit of research to find out all these details, and I'm quite confident I got everything right 😎 

### References

- [DOSBox-X Wiki — Differences in emulated CPU types](https://github.com/joncampbell123/dosbox-x/wiki/Guide:CPU-settings-in-DOSBox%E2%80%90X#differences-in-emulated-cpu-types)
- [VOGONS — CPU type options](https://www.vogons.org/viewtopic.php?p=186286#p186286)
- [VOGONS — Games that requires specific cputype settings](https://www.vogons.org/viewtopic.php?p=161679#p161679)
- [VOGONS — `cputype` feature matrix](https://www.vogons.org/viewtopic.php?p=905713#p905713)

The feature matrix is pretty handy, so here it is for posterity:

![image](https://github.com/dosbox-staging/dosbox-staging/assets/698770/30329c2f-02d3-4422-b3ba-7368a14170f6)

# Manual testing

<img width="1005" alt="image" src="https://github.com/dosbox-staging/dosbox-staging/assets/698770/1d3786ae-9151-4c71-9382-663592c1986c">

<img width="995" alt="image" src="https://github.com/dosbox-staging/dosbox-staging/assets/698770/a15b66b6-7c7f-462b-883b-12326bee984e">


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

