### PR TITLE
Fix Sound Blaster programmatic low-pass filter toggling behaviour

### DIFF
--- a/include/mixer.h
+++ b/include/mixer.h
@@ -209,6 +209,8 @@ public:
 
 	void SetHighPassFilter(const FilterState state);
 	void SetLowPassFilter(const FilterState state);
+	FilterState GetHighPassFilterState() const;
+	FilterState GetLowPassFilterState() const;
 	void ConfigureHighPassFilter(const int order, const int cutoff_freq_hz);
 	void ConfigureLowPassFilter(const int order, const int cutoff_freq_hz);
 	bool TryParseAndSetCustomFilter(const std::string& filter_prefs);

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -368,19 +368,19 @@ private:
 
 	struct {
 		struct {
+			FilterState state = FilterState::Off;
 			std::array<Iir::Butterworth::HighPass<MaxFilterOrder>, 2> hpf = {};
 			int order          = 0;
 			int cutoff_freq_hz = 0;
 		} highpass = {};
 
 		struct {
+			FilterState state = FilterState::Off;
 			std::array<Iir::Butterworth::LowPass<MaxFilterOrder>, 2> lpf = {};
 			int order          = 0;
 			int cutoff_freq_hz = 0;
 		} lowpass = {};
 	} filters               = {};
-	bool do_highpass_filter = false;
-	bool do_lowpass_filter  = false;
 
 	struct {
 		float strength  = 0.0f;

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -125,7 +125,7 @@ enum class ChannelFeature {
 	Synthesizer,
 };
 
-enum class FilterState { Off, On, ForcedOn };
+enum class FilterState { Off, On };
 
 struct MixerChannelSettings {
 	bool is_enabled          = {};

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -183,11 +183,22 @@ public:
 	int GetSampleRate() const;
 
 	void Set0dbScalar(const float f);
-	void RecalcCombinedVolume();
+	void UpdateCombinedVolume();
 
+	// The "user volume" is the volume level of the built-in DOSBox mixer
+	// (MIXER command)
 	const AudioFrame GetUserVolume() const;
 	void SetUserVolume(const AudioFrame volume);
 
+	// The "app volume" is the volume level set programmatically by DOS
+	// programs (on audio devices that support that, e.g., the Sound
+	// Blaster mixer, or the CD Audio volume level).
+	//
+	// For example, if you set the volume level of the CDAUDIO channel to 50%
+	// in the mixer via `MIXER CDAUDIO 50`, then you also set the CD audio
+	// music level in a game to "half volume", the final volume will be around
+	// 25%.
+	//
 	const AudioFrame GetAppVolume() const;
 	void SetAppVolume(const AudioFrame volume);
 

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -1172,6 +1172,16 @@ void MixerChannel::SetLowPassFilter(const FilterState state)
 	}
 }
 
+FilterState MixerChannel::GetHighPassFilterState() const
+{
+	return filters.highpass.state;
+}
+
+FilterState MixerChannel::GetLowPassFilterState() const
+{
+	return filters.lowpass.state;
+}
+
 static int clamp_filter_cutoff_freq([[maybe_unused]] const std::string& channel_name,
                                     const int cutoff_freq_hz)
 {

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -1136,14 +1136,12 @@ static void log_filter_settings(const std::string& channel_name,
 
 	// we programmatically expect only 'on' and 'forced-on' states:
 	assert(state != FilterState::Off);
-	assert(state == FilterState::On || state == FilterState::ForcedOn);
 
 	constexpr auto DbPerOrder = 6;
 
-	LOG_MSG("%s: %s filter enabled%s (%d dB/oct at %d Hz)",
+	LOG_MSG("%s: %s filter enabled (%d dB/oct at %d Hz)",
 	        channel_name.c_str(),
 	        filter_name.c_str(),
-	        state == FilterState::ForcedOn ? " (forced)" : "",
 	        order * DbPerOrder,
 	        cutoff_freq_hz);
 }

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -739,11 +739,13 @@ void MixerChannel::Set0dbScalar(const float scalar)
 
 	db0_volume_gain = scalar;
 
-	RecalcCombinedVolume();
+	UpdateCombinedVolume();
 }
 
-void MixerChannel::RecalcCombinedVolume()
+void MixerChannel::UpdateCombinedVolume()
 {
+	// TODO Now that we use floats, we should apply the master volume at the
+	// very end as it has no risk of overloading the 16-bit range
 	combined_volume_gain = user_volume_gain * app_volume_gain *
 	                       mixer.master_volume * db0_volume_gain;
 }
@@ -757,7 +759,7 @@ void MixerChannel::SetUserVolume(const AudioFrame volume)
 {
 	// Allow unconstrained user-defined values
 	user_volume_gain = volume;
-	RecalcCombinedVolume();
+	UpdateCombinedVolume();
 }
 
 const AudioFrame MixerChannel::GetAppVolume() const
@@ -775,7 +777,7 @@ void MixerChannel::SetAppVolume(const AudioFrame volume)
 	};
 	app_volume_gain = {clamp_to_unity(volume.left),
 	                   clamp_to_unity(volume.right)};
-	RecalcCombinedVolume();
+	UpdateCombinedVolume();
 
 #ifdef DEBUG
 	LOG_MSG("MIXER: %-7s channel: application requested volume "
@@ -798,7 +800,7 @@ void MIXER_SetMasterVolume(const AudioFrame volume)
 	mixer.master_volume = volume;
 
 	for (const auto& [_, channel] : mixer.channels) {
-		channel->RecalcCombinedVolume();
+		channel->UpdateCombinedVolume();
 	}
 }
 

--- a/src/hardware/opl.cpp
+++ b/src/hardware/opl.cpp
@@ -950,8 +950,8 @@ static void init_opl_dosbox_settings(Section_prop& secprop)
 
 	pbool = secprop.Add_bool("sb_filter_always_on", when_idle, false);
 	pbool->Set_help(
-	        "Force the Sound Blaster filter to be always on\n"
-	        "(disallow programs from turning the filter off; disabled by default).");
+	        "Force the Sound Blaster Pro 2 filter to be always on (disabled by default).\n"
+	        "Other Sound Blaster models don't allow toggling the filter in software.");
 
 	pstring = secprop.Add_string("opl_filter", when_idle, "auto");
 	pstring->Set_help(

--- a/src/hardware/opl.cpp
+++ b/src/hardware/opl.cpp
@@ -489,7 +489,7 @@ void Opl::AdlibGoldControlWrite(const uint8_t val)
 		ctrl.rvol = val;
 
 	setvol:
-		if (ctrl.mixer) {
+		if (ctrl.mixer_enabled) {
 			// Dune CD version uses 32 volume steps in an apparent
 			// mistake, should be 128
 			channel->SetAppVolume(
@@ -769,7 +769,7 @@ Opl::Opl(Section* configuration, const OplMode _opl_mode)
 	Section_prop* section = static_cast<Section_prop*>(configuration);
 	const auto base = static_cast<uint16_t>(section->Get_hex("sbbase"));
 
-	ctrl.mixer = section->Get_bool("sbmixer");
+	ctrl.mixer_enabled = section->Get_bool("sbmixer");
 
 	std::set channel_features = {ChannelFeature::Sleep,
 	                             ChannelFeature::FadeOut,

--- a/src/hardware/opl.cpp
+++ b/src/hardware/opl.cpp
@@ -930,29 +930,6 @@ static void init_opl_dosbox_settings(Section_prop& secprop)
 	pstring = secprop.Add_string("oplemu", deprecated, "");
 	pstring->Set_help("Only 'nuked' OPL emulation is supported now.");
 
-	pstring = secprop.Add_string("sb_filter", when_idle, "modern");
-	pstring->Set_help(
-	        "Type of filter to emulate for the Sound Blaster digital sound output:\n"
-	        "  auto:      Use the appropriate filter determined by 'sbtype'.\n"
-	        "  sb1, sb2, sbpro1, sbpro2, sb16:\n"
-	        "             Use the filter of this Sound Blaster model.\n"
-	        "  modern:    Use linear interpolation upsampling that acts as a low-pass\n"
-	        "             filter; this is the legacy DOSBox behaviour (default).\n"
-	        "  off:       Don't filter the output.\n"
-	        "  <custom>:  One or two custom filters in the following format:\n"
-	        "               TYPE ORDER FREQ\n"
-	        "             Where TYPE can be 'hpf' (high-pass) or 'lpf' (low-pass),\n"
-	        "             ORDER is the order of the filter from 1 to 16\n"
-	        "             (1st order = 6dB/oct slope, 2nd order = 12dB/oct, etc.),\n"
-	        "             and FREQ is the cutoff frequency in Hz. Examples:\n"
-	        "                lpf 2 12000\n"
-	        "                hpf 3 120 lfp 1 6500");
-
-	pbool = secprop.Add_bool("sb_filter_always_on", when_idle, false);
-	pbool->Set_help(
-	        "Force the Sound Blaster Pro 2 filter to be always on (disabled by default).\n"
-	        "Other Sound Blaster models don't allow toggling the filter in software.");
-
 	pstring = secprop.Add_string("opl_filter", when_idle, "auto");
 	pstring->Set_help(
 	        "Type of filter to emulate for the Sound Blaster OPL output:\n"

--- a/src/hardware/opl.h
+++ b/src/hardware/opl.h
@@ -151,8 +151,8 @@ private:
 		uint8_t lvol  = default_volume;
 		uint8_t rvol  = default_volume;
 
-		bool active = false;
-		bool mixer  = false;
+		bool active        = false;
+		bool mixer_enabled = false;
 
 		bool wants_dc_bias_removed = false;
 	} ctrl = {};

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -413,16 +413,16 @@ static void log_filter_config(const char* channel_name, const char* output_type,
 }
 
 struct FilterConfig {
-	FilterState hpf_state       = FilterState::Off;
-	uint8_t hpf_order           = {};
-	uint16_t hpf_cutoff_freq_hz = {};
+	FilterState hpf_state  = FilterState::Off;
+	int hpf_order          = {};
+	int hpf_cutoff_freq_hz = {};
 
-	FilterState lpf_state       = FilterState::Off;
-	uint8_t lpf_order           = {};
-	uint16_t lpf_cutoff_freq_hz = {};
+	FilterState lpf_state  = FilterState::Off;
+	int lpf_order          = {};
+	int lpf_cutoff_freq_hz = {};
 
 	ResampleMethod resample_method = {};
-	uint16_t zoh_rate_hz           = {};
+	int zoh_rate_hz                = {};
 };
 
 static void set_filter(MixerChannelPtr channel, const FilterConfig& config)
@@ -498,7 +498,7 @@ static void configure_sb_filter_for_model(MixerChannelPtr channel,
 
 	FilterConfig config = {};
 
-	auto enable_lpf = [&](const uint8_t order, const uint16_t cutoff_freq_hz) {
+	auto enable_lpf = [&](const int order, const int cutoff_freq_hz) {
 		config.lpf_state          = FilterState::On;
 		config.lpf_order          = order;
 		config.lpf_cutoff_freq_hz = cutoff_freq_hz;
@@ -598,7 +598,7 @@ static void configure_opl_filter_for_model(MixerChannelPtr opl_channel,
 	FilterConfig config    = {};
 	config.resample_method = ResampleMethod::Resample;
 
-	auto enable_lpf = [&](const uint8_t order, const uint16_t cutoff_freq_hz) {
+	auto enable_lpf = [&](const int order, const int cutoff_freq_hz) {
 		config.lpf_state          = FilterState::On;
 		config.lpf_order          = order;
 		config.lpf_cutoff_freq_hz = cutoff_freq_hz;
@@ -1229,7 +1229,7 @@ static void flush_remainig_dma_transfer()
 	}
 }
 
-static void set_channel_rate_hz(const uint32_t requested_rate_hz)
+static void set_channel_rate_hz(const int requested_rate_hz)
 {
 	// The official guide states the following:
 	// "Valid output rates range from 5000 to 45 000 Hz, inclusive."
@@ -1250,9 +1250,7 @@ static void set_channel_rate_hz(const uint32_t requested_rate_hz)
 	//
 	constexpr int MinRateHz = 5000;
 
-	const auto rate_hz = std::clamp(static_cast<int>(requested_rate_hz),
-	                                MinRateHz,
-	                                NativeDacRateHz);
+	const auto rate_hz = std::clamp(requested_rate_hz, MinRateHz, NativeDacRateHz);
 
 	assert(sb.chan);
 	if (sb.chan->GetSampleRate() != rate_hz) {

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -569,9 +569,13 @@ static void configure_sb_filter(MixerChannelPtr channel,
                                 const std::string& filter_prefs,
                                 const bool filter_always_on, const SbType sb_type)
 {
-	// A bit unfortunate, but we need to enable the ZOH upsampler and the
-	// correct upsample rate first for the filter cutoff frequency
-	// validation to work correctly.
+	// When a custom filter is set, we're doing zero-order-hold upsampling to
+	// the native Sound Blaster DAC rate, apply the custom filter, then
+	// resample to the host rate.
+	//
+	// We need to enable the ZOH upsampler and the correct upsample rate first
+	// for the filter cutoff frequency validation to work correctly.
+	//
 	channel->SetZeroOrderHoldUpsamplerTargetRate(NativeDacRateHz);
 	channel->SetResampleMethod(ResampleMethod::ZeroOrderHoldAndResample);
 

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -141,10 +141,6 @@ struct SbInfo {
 	// ESS chipset emulation, to be set only for SbType::SBPro2
 	EssType ess_type = EssType::None;
 
-	FilterType sb_filter_type   = FilterType::None;
-	FilterType opl_filter_type  = FilterType::None;
-	FilterState sb_filter_state = FilterState::Off;
-
 	struct {
 		bool pending_8bit;
 		bool pending_16bit;

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -198,8 +198,9 @@ struct SbInfo {
 		bool stereo   = false;
 		bool enabled  = false;
 
-		bool filtered         = false;
-		bool filter_always_on = false;
+		bool filtered          = false;
+		bool filter_configured = false;
+		bool filter_always_on  = false;
 
 		uint8_t unhandled[0x48] = {};
 
@@ -579,6 +580,9 @@ static void configure_sb_filter(MixerChannelPtr channel,
 		// model-specific setting.
 		configure_sb_filter_for_model(channel, filter_prefs, sb_type);
 	}
+
+	sb.mixer.filter_configured = (channel->GetLowPassFilterState() ==
+	                              FilterState::On);
 }
 
 static void configure_opl_filter_for_model(MixerChannelPtr opl_channel,
@@ -2316,7 +2320,7 @@ static void ctmixer_write(const uint8_t val)
 
 		// Disallow toggling the filter programmatically if 'filter_always_on'
 		// is set
-		if (!sb.mixer.filter_always_on) {
+		if (sb.mixer.filter_configured && !sb.mixer.filter_always_on) {
 			sb.chan->SetLowPassFilter(sb.mixer.filtered
 			                                  ? FilterState::On
 			                                  : FilterState::Off);

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -3432,6 +3432,29 @@ void init_sblaster_dosbox_settings(Section_prop& secprop)
 	        "(100 by default). This mitigates pops heard when starting many SB-based games.\n"
 	        "Reduce this if you notice intial playback is missing audio.");
 	pint->SetMinMax(0, 100);
+
+	pstring = secprop.Add_string("sb_filter", when_idle, "modern");
+	pstring->Set_help(
+	        "Type of filter to emulate for the Sound Blaster digital sound output:\n"
+	        "  auto:      Use the appropriate filter determined by 'sbtype'.\n"
+	        "  sb1, sb2, sbpro1, sbpro2, sb16:\n"
+	        "             Use the filter of this Sound Blaster model.\n"
+	        "  modern:    Use linear interpolation upsampling that acts as a low-pass\n"
+	        "             filter; this is the legacy DOSBox behaviour (default).\n"
+	        "  off:       Don't filter the output.\n"
+	        "  <custom>:  One or two custom filters in the following format:\n"
+	        "               TYPE ORDER FREQ\n"
+	        "             Where TYPE can be 'hpf' (high-pass) or 'lpf' (low-pass),\n"
+	        "             ORDER is the order of the filter from 1 to 16\n"
+	        "             (1st order = 6dB/oct slope, 2nd order = 12dB/oct, etc.),\n"
+	        "             and FREQ is the cutoff frequency in Hz. Examples:\n"
+	        "                lpf 2 12000\n"
+	        "                hpf 3 120 lfp 1 6500");
+
+	pbool = secprop.Add_bool("sb_filter_always_on", when_idle, false);
+	pbool->Set_help(
+	        "Force the Sound Blaster Pro 2 filter to be always on (disabled by default).\n"
+	        "Other Sound Blaster models don't allow toggling the filter in software.");
 }
 
 static std::unique_ptr<SBLASTER> sblaster = {};

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -186,16 +186,28 @@ struct SbInfo {
 	} dac = {};
 
 	struct {
-		uint8_t index     = 0;
+		uint8_t index = 0;
 
-		uint8_t dac[2]    = {};
-		uint8_t fm[2]     = {};
-		uint8_t cda[2]    = {};
+		// If true, DOS software can programmatically change the Sound
+		// Blaster mixer's volume levels on SB Pro 1 and later card for
+		// the SB (DAC), OPL (FM) and CDAUDIO channels. These are called
+		// "app levels". The final output level is the "user level" set
+		// in the DOSBox mixer multiplied with the "app level" for these
+		// channels.
+		//
+		// If the Sound Blaster mixer is disabled, the "app levels"
+		// default to unity gain.
+		//
+		bool enabled = false;
+
+		uint8_t dac[2] = {}; // can be controlled programmatically
+		uint8_t fm[2]  = {}; // can be controlled programmatically
+		uint8_t cda[2] = {}; // can be controlled programmatically
+
 		uint8_t master[2] = {};
 		uint8_t lin[2]    = {};
 		uint8_t mic       = 0;
 
-		bool enabled  = false;
 		bool stereo_enabled = false;
 
 		bool filter_enabled    = false;
@@ -3380,7 +3392,17 @@ void init_sblaster_dosbox_settings(Section_prop& secprop)
 	pint->Set_help("The High DMA channel of the Sound Blaster 16 (5 by default).");
 
 	auto pbool = secprop.Add_bool("sbmixer", when_idle, true);
-	pbool->Set_help("Allow the Sound Blaster mixer to modify the DOSBox mixer (enabled by default).");
+	pbool->Set_help(
+	        "Allow the Sound Blaster mixer to modify volume levels (enabled by default).\n"
+	        "Sound Blaster Pro 1 and later cards allow programs to set the volume of the\n"
+	        "digital audio (DAC), FM synth, and CD Audio output. These correspond to the\n"
+	        "SB, OPL, and CDAUDIO DOSBox mixer channels, respectively.\n"
+	        "  on:   The final level of the above channels is a combination of the volume\n"
+	        "        set by the program, and the volume set in the DOSBox mixer.\n"
+	        "  off:  Only the DOSBox mixer determines the volume of these channels.\n"
+	        "Note: Some games change the volume levels dynamically (e.g., lower the FM music\n"
+	        "      volume when speech is playing); it's best to leave 'sbmixer' enabled for\n"
+	        "      such games.");
 
 	pint = secprop.Add_int("sbwarmup", when_idle, 100);
 	pint->Set_help(


### PR DESCRIPTION
# Description

Fixes https://github.com/dosbox-staging/dosbox-staging/issues/3709

Technically, this wasn't introduced by the mixer refactors, just an extra assert I added during the refactors uncovered a pre-existing issue.

Other than fixing the tripped assert and the usual refactorings, this also corrects the filter toggling behaviour. See code comments for further details.

# Manual testing

DOOM doesn't trip the assert on exit in debug mode with `sbtype = sb16` configured.

DOOM is kinda interesting because it does not mess around with the state of the low-pass filter on startup, _but_ it enables it on exit.

I've also tested with the following setting combo permutations:

```ini
[sblaster]
sbtype = sb16 | sbpro 1 | sbpro2
sb_filter = none | auto | modern
sb_filter_always_on = yes | no
```

An interesting combo is `sbpro2` plus `sb_filter = none` (which could be assert-tripping-prone without the fix). It's a bit hard to hear the effects of the filter or whether it's on or off unless you really know what to listen for, so I've added debug logging around the filter state setting logic.


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

