### PR TITLE
Map 'Capture MIDI action' to Ctrl+Alt+F6 (Cmd+Opt+F6) by default

### DIFF
--- a/src/capture/capture.cpp
+++ b/src/capture/capture.cpp
@@ -617,8 +617,8 @@ static void init_key_mappings()
 	                  "Rec. Audio");
 
 	MAPPER_AddHandler(handle_capture_midi_event,
-	                  SDL_SCANCODE_UNKNOWN,
-	                  0,
+	                  SDL_SCANCODE_F6,
+	                  PRIMARY_MOD | MMOD2,
 	                  "caprawmidi",
 	                  "Rec. MIDI");
 


### PR DESCRIPTION
# Description

What the title says—pretty uncontroversial, I hope. I've been on the fence about adding this mapping by default, but I see no harm in it, so doing it because it came up a few times lately.

Addresses https://github.com/dosbox-staging/dosbox-staging/issues/1099

# Manual testing

The capture MIDI hotkey is mapped by default to Ctrl+Alt+F6 (Cmd+Opt+F6) and it does its job 😄 

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

