### PR TITLE
Fix warning when using a high cycles value on a non-dynamic core

### DIFF
--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -1776,6 +1776,17 @@ void CPU_SET_CRX(Bitu cr, Bitu value)
 				break;
 			}
 
+#if C_DYNAMIC_X86
+			if (auto_determine_mode.auto_core) {
+				CPU_Core_Dyn_X86_Cache_Init(true);
+				cpudecoder = &CPU_Core_Dyn_X86_Run;
+			}
+#elif C_DYNREC
+			if (auto_determine_mode.auto_core) {
+				CPU_Core_Dynrec_Cache_Init(true);
+				cpudecoder = &CPU_Core_Dynrec_Run;
+			}
+#endif
 			if (legacy_cycles_mode) {
 				if (auto_determine_mode.auto_cycles) {
 					CPU_CycleAutoAdjust = true;
@@ -1798,17 +1809,6 @@ void CPU_SET_CRX(Bitu cr, Bitu value)
 				}
 			}
 
-#if C_DYNAMIC_X86
-			if (auto_determine_mode.auto_core) {
-				CPU_Core_Dyn_X86_Cache_Init(true);
-				cpudecoder = &CPU_Core_Dyn_X86_Run;
-			}
-#elif C_DYNREC
-			if (auto_determine_mode.auto_core) {
-				CPU_Core_Dynrec_Cache_Init(true);
-				cpudecoder = &CPU_Core_Dynrec_Run;
-			}
-#endif
 			last_auto_determine_mode = auto_determine_mode;
 			auto_determine_mode      = {};
 


### PR DESCRIPTION
# Description

Fixes https://github.com/dosbox-staging/dosbox-staging/issues/3710

It's a rather innocent looking change and it seems to work. Hopefully I haven't broken anything horribly 😆  


# Manual testing

- Increased the cycles at the DOS prompt at startup until the warning appeared.
- Ran Fasttracker II with the defaults and confirmed the warning didn't appear.
- Set `core = normal`, started FT2, and confirmed the warning appeared.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

