### PR TITLE
Make parameter addresses properly sized in ppc64le dynrec (fixes #3686)

### DIFF
--- a/src/cpu/core_dynrec/risc_ppc64le.h
+++ b/src/cpu/core_dynrec/risc_ppc64le.h
@@ -564,10 +564,11 @@ static void inline gen_load_param_imm(Bitu imm, Bitu param)
 }
 
 // load an address as param'th function parameter
-// 32-bit
+// can be 64-bit, especially in PIE code
 static void inline gen_load_param_addr(Bitu addr, Bitu param)
 {
-	gen_load_param_imm(addr, param);
+	// "gen_mov_qword_to_reg"
+	gen_mov_qword_to_reg_imm(RegParams[param],(uint64_t)addr);
 }
 
 // load a host-register as param'th function parameter


### PR DESCRIPTION
# Description

Fixes #3686 

The `ppc64le` dynrec erroneously clamps address parameters in function calls to 32-bit because I missed that call when rewriting it from the 32-bit PowerPC dynrec. This caused no problems previously because it was never built with PIE and was unlikely to be passed a 64-bit address, but that's not true for PIE.

This bug is obviously not in the 32-bit PowerPC JIT and does not affect other platforms, nor does the fix affect other platforms (entirely within the `ppc64le` dynrec). There is no detectable impact to performance.

# Manual testing

Tested in both debug and release builds against my usual suite of benchmarks, Doom, Descent and Duke Nukem 3D. No other platforms are touched by this code.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [X] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [X] performed a self-review of my code.
- [X] commented on the particularly hard-to-understand areas of my code.
- [X] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [X] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [X] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [X] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [X] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [X] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [X] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

