### PR TITLE
Set CMOS_Destroy not changeable at runtime

### DIFF
--- a/src/hardware/cmos.cpp
+++ b/src/hardware/cmos.cpp
@@ -387,6 +387,6 @@ void CMOS_Init(Section* sec)
 
 	test = new CMOS(sec);
 
-	constexpr auto changeable_at_runtime = true;
+	constexpr auto changeable_at_runtime = false;
 	sec->AddDestroyFunction(&CMOS_Destroy, changeable_at_runtime);
 }


### PR DESCRIPTION
# Description

CMOS_Init was marked not changeable but CMOS_Destroy was. This led to the CMOS object being destroyed on config changes and not being re-created.

## Related issues

Fixes #3721

# Manual testing

Changing [dosbox] config settings at runtime no longer causes Horde to hang on start-up.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

