### PR TITLE
Various MT-32 improvements & fix Bumpy's Arcade Fantasy intro tune

### DIFF
--- a/src/midi/midi_mt32.cpp
+++ b/src/midi/midi_mt32.cpp
@@ -60,10 +60,11 @@ constexpr auto AnalogMode = MT32Emu::AnalogOutputMode_ACCURATE;
 // within range) Higher quality than the real devices
 constexpr auto DacEmulationMode = MT32Emu::DACInputMode_NICE;
 
-// Analog rendering types: int16_t, FLOAT
-// Use float samples in the renderer and simplified wave generator model.
-// Maximum output quality and minimum noise.
-constexpr auto RenderingType = MT32Emu::RendererType_FLOAT;
+// Analog rendering types: BIT16S, FLOAT
+// Use 16-bit signed samples in the renderer and the accurate wave generator
+// model based on logarithmic fixed-point computations and LUTs. Maximum
+// emulation accuracy and speed (it's a lot faster than the FLOAT renderer).
+constexpr auto RenderingType = MT32Emu::RendererType_BIT16S;
 
 // Sample rate conversion quality: FASTEST, FAST, GOOD, BEST
 constexpr auto ResamplingQuality = MT32Emu::SamplerateConversionQuality_BEST;

--- a/src/midi/midi_mt32.cpp
+++ b/src/midi/midi_mt32.cpp
@@ -82,9 +82,9 @@ constexpr bool UseNiceRamp = true;
 // possible on the real hardwre).
 constexpr bool UseNicePanning = true;
 
-// Prefer not forcing always in-phase partial mixing (this is more authentic
-// sounding).
-constexpr bool UseNicePartialMixing = false;
+// Force always in-phase partial mixing to avoid the sometimes out-of-phase
+// partials of the original units which can result in phasing artifacts.
+constexpr bool UseNicePartialMixing = true;
 
 // Do not attempt to emulate delays introduced by the slow MIDI transfer
 // protocol.

--- a/src/midi/midi_mt32.cpp
+++ b/src/midi/midi_mt32.cpp
@@ -81,6 +81,28 @@ constexpr bool UseNicePanning = true;
 // sounding).
 constexpr bool UseNicePartialMixing = false;
 
+// Do not attempt to emulate delays introduced by the slow MIDI transfer
+// protocol.
+//
+// Enabling delay emulation could result in missed MIDI events if the MT-32
+// receives a large number of events in quick bursts, causing its internal
+// ring buffers to overflow. This can be heard as missed notes and
+// wrong sounding instrument (e.g., in the intro tune of Bumpy's Arcade
+// Fantasy).
+//
+// Emulating MIDI protocol induced micro-delays are neither musically
+// significant nor desirable. Most importantly, these odd up to 1-3 ms delays
+// on some events are not noticeable. Losing MIDI events that potentially set
+// up the correct sounds when the game starts is a much more important concern.
+//
+// While such transfer bursts are most likely an MPU-401 intelligent mode
+// emulation bug in DOSBox, disabling the delay mode emulation in libmt32
+// effectively fixes the problem and makes the resulting music sound closer to
+// the composer's intentions.
+//
+//
+constexpr auto MidiDelayMode = MT32Emu::MIDIDelayMode_IMMEDIATE;
+
 using Rom = LASynthModel::Rom;
 
 // MT-32
@@ -784,6 +806,7 @@ bool MidiHandler_mt32::Open([[maybe_unused]] const char* conf)
 	mt32_service->setNiceAmpRampEnabled(UseNiceRamp);
 	mt32_service->setNicePanningEnabled(UseNicePanning);
 	mt32_service->setNicePartialMixingEnabled(UseNicePartialMixing);
+	mt32_service->setMIDIDelayMode(MidiDelayMode);
 
 	const auto rc = mt32_service->openSynth();
 	if (rc != MT32EMU_RC_OK) {

--- a/src/midi/midi_mt32.cpp
+++ b/src/midi/midi_mt32.cpp
@@ -62,28 +62,38 @@ constexpr auto AccurateAnalogModeSampleRateHz = 48'000;
 
 // DAC Emulation modes: NICE, PURE, GENERATION1, and GENERATION2
 //
-// Produce samples at double the volume, without tricks.
-// Nicer overdrive characteristics than the DAC hacks (it simply clips samples
-// within range) Higher quality than the real devices
+// "Nice" mode produces samples at double the volume, without tricks, and
+// results in nicer overdrive characteristics than the DAC hacks (it simply
+// clips samples within range). Higher quality than the real devices.
 constexpr auto DacEmulationMode = MT32Emu::DACInputMode_NICE;
 
 // Analog rendering types: BIT16S, FLOAT
+//
 // Use 16-bit signed samples in the renderer and the accurate wave generator
 // model based on logarithmic fixed-point computations and LUTs. Maximum
 // emulation accuracy and speed (it's a lot faster than the FLOAT renderer).
 constexpr auto RenderingType = MT32Emu::RendererType_BIT16S;
 
-// Prefer amp ramp interpolation to avoid clicks (the hardware doesn't
-// always interpolate).
+// In this mode, we want to ensure that amp ramp never jumps to the target
+// value and always gradually increases or decreases. It seems that real units
+// do not bother to always check if a newly started ramp leads to a jump.
+// We also prefer the quality improvement over the emulation accuracy,
+// so this mode is enabled by default.
 constexpr bool UseNiceRamp = true;
 
-// Prefer higher panning resolution over the coarser positions used by the
-// hardware (this allows for "true center" pan positions which is not
-// possible on the real hardwre).
+// Despite the Roland's manual specifies allowed panpot values in range 0-14,
+// the LA-32 only receives 3-bit pan setting in fact. In particular, this
+// makes it impossible to set the "middle" panning for a single partial.
+// In the NicePanning mode, we enlarge the pan setting accuracy to 4 bits
+// making it smoother thus sacrificing the emulation accuracy.
 constexpr bool UseNicePanning = true;
 
-// Force always in-phase partial mixing to avoid the sometimes out-of-phase
-// partials of the original units which can result in phasing artifacts.
+// LA-32 is known to mix partials either in-phase (so that they are added)
+// or in counter-phase (so that they are subtracted instead).
+// In some cases, this quirk isn't highly desired because a pair of closely
+// sounding partials may occasionally cancel out.
+// In the NicePartialMixing mode, the mixing is always performed in-phase,
+// thus making the behaviour more predictable.
 constexpr bool UseNicePartialMixing = true;
 
 // Do not attempt to emulate delays introduced by the slow MIDI transfer
@@ -104,7 +114,6 @@ constexpr bool UseNicePartialMixing = true;
 // emulation bug in DOSBox, disabling the delay mode emulation in libmt32
 // effectively fixes the problem and makes the resulting music sound closer to
 // the composer's intentions.
-//
 //
 constexpr auto MidiDelayMode = MT32Emu::MIDIDelayMode_IMMEDIATE;
 


### PR DESCRIPTION
# Description

## Summary

This changes a couple of things in our libmt32 config:

- Turn off MIDI delay emulation (see reasoning below). This fixes the intro tune in **Bumpy's Arcade Fantasy**, and probably other game startup scenarios. Thanks to @madbrain76 for raising this 🎉 
- Use 16-bit integer rendering mode which is more accurate to the real hardware _and_ a lot faster (I couldn't hear any difference, but the performance matters). This resolves https://github.com/dosbox-staging/dosbox-staging/issues/3594.
- Use "nice" partials mode (this skips the emulation of a quirk that results in weird-sounding notes under some conditions; it's hard to imagine this is a desirable thing to emulate)

## Details

Enabling delay emulation could result in missed MIDI events if the MT-32 receives a large number of events in quick bursts, causing its internal ring buffers to overflow. This can be heard as missed notes and wrong sounding instruments (e.g., in the intro tune of Bumpy's Arcade Fantasy).

Emulating MIDI protocol induced micro-delays are neither musically significant nor desirable. Most importantly, these odd up to 1-3 ms delays on some events are not noticeable. Losing MIDI events that potentially set up the correct sounds when the game starts is a much more important concern.

While such transfer bursts are most likely an MPU-401 intelligent mode emulation bug in DOSBox, disabling the delay mode emulation in libmt32 effectively fixes the problem and makes the resulting music sound closer to the composer's intentions.

# Related discussion

- https://github.com/munt/munt/issues/119

# Manual testing

- Confirmed **Bumpy's Arcade Fantasy** plays _more correctly_ now, and less notes are cut off from the start of the intro tune. Also, the instrument sounds are now close to the Amiga soundtrack:
https://www.youtube.com/watch?v=hju8oJdzvo8

   @Python-Exoproject ☝🏻 This might be relevant to your interests 😎 

- Tested a few other MT-32 games (Eric the Unready, Space Quest 3, Spellcasting 101). All sound fine.


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

