### PR TITLE
Fix switch to dynamic core warning edge case

### DIFF
--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -195,7 +195,7 @@ static bool maybe_display_switch_to_dynamic_core_warning(const int cycles)
 		LOG_WARNING(
 		        "CPU: Setting fixed %d cycles. Try setting 'core = dynamic' "
 		        "for increased performance if you need more than %d cycles.",
-		        CPU_CycleMax,
+		        cycles,
 		        CyclesThreshold);
 		return true;
 

--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -3154,12 +3154,18 @@ public:
 
 	bool Configure(Section* sec)
 	{
-		Section_prop* secprop = static_cast<Section_prop*>(sec);
-
 		// TODO needed?
 		// CPU_CycleLeft = 0;
 		CPU_Cycles          = 0;
 		auto_determine_mode = {};
+
+		Section_prop* secprop = static_cast<Section_prop*>(sec);
+
+		const std::string cpu_core = secprop->Get_string("core");
+		const std::string cpu_type = secprop->Get_string("cputype");
+
+		ConfigureCpuCore(cpu_core);
+		ConfigureCpuType(cpu_core, cpu_type);
 
 		auto cycles_pref = secprop->Get_string("cycles");
 		trim(cycles_pref);
@@ -3189,12 +3195,6 @@ public:
 			ConfigureCyclesModern(secprop);
 			set_modern_cycles_config(CpuMode::Real);
 		}
-
-		const std::string cpu_core = secprop->Get_string("core");
-		const std::string cpu_type = secprop->Get_string("cputype");
-
-		ConfigureCpuCore(cpu_core);
-		ConfigureCpuType(cpu_core, cpu_type);
 
 		cpu_cycle_up   = secprop->Get_int("cycleup");
 		cpu_cycle_down = secprop->Get_int("cycledown");


### PR DESCRIPTION
# Description

This config triggered the switch to dynamic core warning. Well, no longer 😎 

```ini
[cpu]
core = dynamic
cpu_cycles = 30000
cpu_cycles_protected = auto
```

Setting the same settings manually from the CLI did not trigger the warning, that's why I missed it.

# Manual testing

Tested the above config and regression tested Tomb Raider Gold with the below config settings:

```ini
cycles = max
```
```ini
cycles = auto 3000 max 100% limit 200000
```
```ini
cycles = max limit 200000
```

```ini
cpu_cycles_protected = 200000
cpu_throttle = on
```

```ini
core = dynamic
cpu_cycles_protected = 200000
cpu_throttle = on
```


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

