### PR TITLE
Minor `vga_draw.cpp` refactor

### DIFF
--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -2180,7 +2180,7 @@ ImageInfo setup_drawing()
 		video_mode.graphics_standard = GraphicsStandard::Vga;
 		video_mode.color_depth       = ColorDepth::IndexedColor256;
 
-		const bool num_scanline_repeats = vga.crtc.maximum_scan_line.maximum_scan_line;
+		const auto num_scanline_repeats = vga.crtc.maximum_scan_line.maximum_scan_line;
 
 		// We assume the two scanline doubling methods cannot be stacked, but
 		// not sure if this is true.
@@ -2305,7 +2305,7 @@ ImageInfo setup_drawing()
 			// double-scan" on VGA (render single-scanned, then double the
 			// image vertically with a scaler).
 			//
-			const bool num_scanline_repeats =
+			const auto num_scanline_repeats =
 			        vga.crtc.maximum_scan_line.maximum_scan_line;
 
 			// We assume the two scanline doubling methods cannot be


### PR DESCRIPTION
# Description

Addresses https://github.com/dosbox-staging/dosbox-staging/issues/3733. It wasn't an actual bug because the numbers are just used in greater-than-zero checks a few lines further down, so the boolean did the job fine. But it's cleaner this way, of course.

Thanks for raising it @Arcnor 👍🏻 


# Manual testing

None! I'm living dangerously today! 😎 

(It's a trivial fix, there's not much to test)

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

