### PR TITLE
Remove hard-coded version string from MSVC CI

### DIFF
--- a/.github/workflows/windows-msvc.yml
+++ b/.github/workflows/windows-msvc.yml
@@ -178,10 +178,19 @@ jobs:
         run: |
           # Construct VC_REDIST_DIR
           readonly VC_REDIST_BASE="C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Redist/MSVC"
-          readonly VC_REDIST_VERSION="14.38.33135"
           readonly VC_REDIST_CRT_VERSION="Microsoft.VC143.CRT"
-          export VC_REDIST_DIR="$VC_REDIST_BASE/$VC_REDIST_VERSION/${{ matrix.conf.arch }}/$VC_REDIST_CRT_VERSION"
-          find "$VC_REDIST_BASE" -maxdepth 3 -type d
+          for ENTRY in "$VC_REDIST_BASE"/*
+          do
+              ENTRY=$ENTRY/${{ matrix.conf.arch }}/$VC_REDIST_CRT_VERSION
+              if [ -d "$ENTRY" ]; then
+                  export VC_REDIST_DIR=$ENTRY
+                  break
+              fi
+          done
+          if [ ! -d "$VC_REDIST_DIR" ]; then
+              echo "Failed to find MSVC Redistributable"
+              exit 1
+          fi
 
           # Package
           ./scripts/create-package.sh \


### PR DESCRIPTION
# Description

`VC_REDIST_VERSION` gets changed every couple of months when GitHub pushes an update to the runners.  The other strings in this path should be stable until a major MSVC version release (ex. Visual Studio 2026 or whatever comes next).

I believe there's only ever a single MSVC redist version in the image so I took a shortcut of finding the first matching path instead of trying to parse version numbers.

## Related issues

Fixes #3735


# Manual testing

If CI passes, we should be good.


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

