### PR TITLE
Fix Windows 3.1 regression from SFT change

### DIFF
--- a/include/dos_inc.h
+++ b/include/dos_inc.h
@@ -107,7 +107,6 @@ enum class DosReturnMode : uint8_t {
 
 constexpr int SftHeaderSize = 6;
 constexpr int SftEntrySize = 59;
-constexpr int SftNumEntries = 16;
 
 constexpr uint32_t SftEndPointer = 0xffffffff;
 constexpr uint16_t SftNextTableOffset = 0x0;
@@ -115,6 +114,7 @@ constexpr uint16_t SftNumberOfFilesOffset = 0x04;
 
 // Fake SFT table for use by DOS_MultiplexFunctions() ax = 0x1216
 extern RealPt fake_sft_table;
+constexpr int FakeSftEntries = 16;
 
 /* internal Dos Tables */
 

--- a/include/dos_inc.h
+++ b/include/dos_inc.h
@@ -109,6 +109,13 @@ constexpr int SftHeaderSize = 6;
 constexpr int SftEntrySize = 59;
 constexpr int SftNumEntries = 16;
 
+constexpr uint32_t SftEndPointer = 0xffffffff;
+constexpr uint16_t SftNextTableOffset = 0x0;
+constexpr uint16_t SftNumberOfFilesOffset = 0x04;
+
+// Fake SFT table for use by DOS_MultiplexFunctions() ax = 0x1216
+extern RealPt fake_sft_table;
+
 /* internal Dos Tables */
 
 extern DOS_File * Files[DOS_FILES];

--- a/src/dos/dos_classes.cpp
+++ b/src/dos/dos_classes.cpp
@@ -122,13 +122,13 @@ void DOS_InfoBlock::SetLocation(uint16_t segment)
 	const RealPt sft_addr = RealMake(segment, sft_offset);
 	SSET_DWORD(sDIB, firstFileTable, sft_addr);
 	// Next File Table
-	real_writed(segment, sft_offset + 0x00, RealMake(segment + 0x26, 0));
+	real_writed(segment, sft_offset + SftNextTableOffset, RealMake(segment + 0x26, 0));
 	// File Table supports 100 files
-	real_writew(segment, sft_offset + 0x04, 100);
+	real_writew(segment, sft_offset + SftNumberOfFilesOffset, 100);
 	// Last File Table
-	real_writed(segment + 0x26, 0x00, 0xffffffff);
+	real_writed(segment + 0x26, SftNextTableOffset, SftEndPointer);
 	// File Table supports 100 files
-	real_writew(segment + 0x26, 0x04, 100);
+	real_writew(segment + 0x26, SftNumberOfFilesOffset, 100);
 }
 
 void DOS_InfoBlock::SetBuffers(uint16_t x, uint16_t y)

--- a/src/dos/dos_classes.cpp
+++ b/src/dos/dos_classes.cpp
@@ -118,32 +118,17 @@ void DOS_InfoBlock::SetLocation(uint16_t segment)
 	SSET_BYTE(sDIB, nulString[7], uint8_t(0x20));
 
 	// Create a fake SFT, so programs think there are 100 file handles
-	constexpr int FakeHandles = 100;
-
-	constexpr uint32_t EndPointer = 0xffffffff;
-	constexpr uint16_t NextTableOffset = 0x0;
-	constexpr uint16_t NumberOfFilesOffset = 0x04;
-
-	// We only need to actually allocate enough space for 16 handles
-	// This is the maximum that will get written to by DOS_MultiplexFunctions() in dos_misc.cpp
-	constexpr int BytesPerPage = 16;
-	constexpr int TotalBytes = SftHeaderSize + (SftEntrySize * SftNumEntries);
-	constexpr int NumPages = (TotalBytes / BytesPerPage) + std::min(TotalBytes % BytesPerPage, 1);
-
-	const uint16_t first_sft_segment = DOS_GetMemory(NumPages);
-	const RealPt first_sft_addr = RealMake(first_sft_segment, 0);
-	SSET_DWORD(sDIB, firstFileTable, first_sft_addr);
-
-	// Windows for Workgroups requires a 2nd linked SFT table
-	// This one only needs to allocate the header
-	const uint16_t second_sft_segment = DOS_GetMemory(1);
-	const RealPt second_sft_addr = RealMake(second_sft_segment, 0);
-
-	real_writed(first_sft_segment, NextTableOffset, second_sft_addr);
-	real_writew(first_sft_segment, NumberOfFilesOffset, FakeHandles);
-
-	real_writed(second_sft_segment, NextTableOffset, EndPointer);
-	real_writew(second_sft_segment, NumberOfFilesOffset, FakeHandles);
+	const uint16_t sft_offset = offsetof(sDIB, firstFileTable) + 0xa2;
+	const RealPt sft_addr = RealMake(segment, sft_offset);
+	SSET_DWORD(sDIB, firstFileTable, sft_addr);
+	// Next File Table
+	real_writed(segment, sft_offset + 0x00, RealMake(segment + 0x26, 0));
+	// File Table supports 100 files
+	real_writew(segment, sft_offset + 0x04, 100);
+	// Last File Table
+	real_writed(segment + 0x26, 0x00, 0xffffffff);
+	// File Table supports 100 files
+	real_writew(segment + 0x26, 0x04, 100);
 }
 
 void DOS_InfoBlock::SetBuffers(uint16_t x, uint16_t y)

--- a/src/dos/dos_misc.cpp
+++ b/src/dos/dos_misc.cpp
@@ -75,7 +75,7 @@ static bool DOS_MultiplexFunctions(void) {
 		LOG(LOG_DOSMISC,LOG_ERROR)("Some BAD filetable call used bx=%X",reg_bx);
 		if(reg_bx <= DOS_FILES) CALLBACK_SCF(false);
 		else CALLBACK_SCF(true);
-		if (reg_bx < SftNumEntries) {
+		if (reg_bx < FakeSftEntries) {
 			// Initalized by DOS_SetupTables()
 			assert(fake_sft_table != 0);
 

--- a/src/dos/dos_misc.cpp
+++ b/src/dos/dos_misc.cpp
@@ -25,6 +25,8 @@
 #include "mem.h"
 #include "regs.h"
 
+RealPt fake_sft_table = 0;
+
 static callback_number_t call_int2f = 0;
 static callback_number_t call_int2a = 0;
 
@@ -74,9 +76,12 @@ static bool DOS_MultiplexFunctions(void) {
 		if(reg_bx <= DOS_FILES) CALLBACK_SCF(false);
 		else CALLBACK_SCF(true);
 		if (reg_bx < SftNumEntries) {
-			RealPt sftrealpt=mem_readd(RealToPhysical(dos_infoblock.GetPointer())+4);
-			PhysPt sftptr=RealToPhysical(sftrealpt);
-			Bitu sftofs= SftHeaderSize + reg_bx * SftEntrySize;
+			// Initalized by DOS_SetupTables()
+			assert(fake_sft_table != 0);
+
+			RealPt sftrealpt = fake_sft_table;
+			PhysPt sftptr = RealToPhysical(sftrealpt);
+			Bitu sftofs = SftHeaderSize + reg_bx * SftEntrySize;
 
 			if (Files[reg_bx]) mem_writeb(sftptr+sftofs,Files[reg_bx]->refCtr);
 			else mem_writeb(sftptr+sftofs,0);

--- a/src/dos/dos_tables.cpp
+++ b/src/dos/dos_tables.cpp
@@ -188,13 +188,13 @@ void DOS_SetupTables(void) {
 
 	// Allocate a fake SFT table for use by DOS_MultiplexFunctions() ax = 0x1216
 	constexpr int BytesPerPage = 16;
-	constexpr int TotalBytes = SftHeaderSize + (SftEntrySize * SftNumEntries);
+	constexpr int TotalBytes = SftHeaderSize + (SftEntrySize * FakeSftEntries);
 	constexpr int NumPages = (TotalBytes / BytesPerPage) + std::min(TotalBytes % BytesPerPage, 1);
 
 	const auto fake_sft_segment = DOS_GetMemory(NumPages);
 
 	real_writed(fake_sft_segment, SftNextTableOffset, SftEndPointer);
-	real_writeb(fake_sft_segment, SftNumberOfFilesOffset, SftNumEntries);
+	real_writeb(fake_sft_segment, SftNumberOfFilesOffset, FakeSftEntries);
 
 	fake_sft_table = RealMake(fake_sft_segment, 0);
 }

--- a/src/dos/dos_tables.cpp
+++ b/src/dos/dos_tables.cpp
@@ -185,4 +185,16 @@ void DOS_SetupTables(void) {
 	/* Add it to country structure */
 	host_writed(country_info + 0x12, CALLBACK_RealPointer(call_casemap));
 	dos.tables.country=country_info;
+
+	// Allocate a fake SFT table for use by DOS_MultiplexFunctions() ax = 0x1216
+	constexpr int BytesPerPage = 16;
+	constexpr int TotalBytes = SftHeaderSize + (SftEntrySize * SftNumEntries);
+	constexpr int NumPages = (TotalBytes / BytesPerPage) + std::min(TotalBytes % BytesPerPage, 1);
+
+	const auto fake_sft_segment = DOS_GetMemory(NumPages);
+
+	real_writed(fake_sft_segment, SftNextTableOffset, SftEndPointer);
+	real_writeb(fake_sft_segment, SftNumberOfFilesOffset, SftNumEntries);
+
+	fake_sft_table = RealMake(fake_sft_segment, 0);
 }


### PR DESCRIPTION
# Description

This includes a clean revert of my previous SFT change https://github.com/dosbox-staging/dosbox-staging/commit/201950e3111afcb7a3fda1e1e606e911de598798

I took a look at what DOSBox-X did but they're moving several other things around that I didn't feel confident in doing without extensive regression testing (they moved the location of an interrupt, the CON driver, and the "magic" CON strings needed for Windows 3.1).

The location of the first SFT table is hard-coded at a set location by MS-DOS but that was correct in DOSBox before my SFT change so a revert is all that was needed to match that.

To fix the Dunkle Schatten 2 issue, I am simply allocating a separate fake SFT table exclusively for use by the DOS multiplex interrupt that it needs.  This interrupt is kind of a hack that just writes into memory on-demand and then hands the game a pointer.  It doesn't really matter where this is located.  This lets Windows 3.1 continue to use the tried-and-true memory layout that DOSBox has been using for many years now.

## Related issues

Fixes #3694

# Manual testing

Windows 3.1 continues to work.  MS-DOS prompt no longer causes a crash.  Word for Windows continues to work.

Dunkle Schatten 2 continues to work.

Tested a few DOS games (although I don't expect regressions there):  Wolfenstein 3D, Doom, Space Quest 3


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

