### PR TITLE
Search for numbered clang-format binaries in format-commit.sh

### DIFF
--- a/scripts/format-commit.sh
+++ b/scripts/format-commit.sh
@@ -56,8 +56,9 @@ main () {
 
 handle_dependencies () {
 	assign_gnu_sed
+	assign_clang_format
 	assert_min_version git 1007010 "Use git version 1.7.10 or newer."
-	assert_min_version clang-format 15000000 "Use clang-format version 15.0.0 or newer."
+	assert_min_version "$CLANG_FORMAT" 15000000 "Use clang-format version 15.0.0 or newer."
 }
 
 SED=""
@@ -76,6 +77,30 @@ assign_gnu_sed () {
 		else
 			echo "Install GNU sed with your package manager."
 		fi
+		exit 1
+	fi
+}
+
+CLANG_FORMAT=""
+assign_clang_format() {
+	local -r binaries=(
+		"clang-format-18"
+		"clang-format-17"
+		"clang-format-16"
+		"clang-format-15"
+		"clang-format"
+	)
+
+	for binary in "${binaries[@]}"
+	do
+		if command -v "$binary" &> /dev/null; then
+			CLANG_FORMAT=$binary
+			break
+		fi
+	done
+
+	if [[ $CLANG_FORMAT == "" ]]; then
+		echo "Failed to find clang-format."
 		exit 1
 	fi
 }
@@ -164,8 +189,8 @@ run_clang_format () {
 		done < <(git_diff_to_clang_line_range "$src_file" "$since_ref")
 
 		if (( "${#ranges[@]}" )); then
-			echo "clang-format -i ${ranges[*]} \"$src_file\""
-			clang-format -i "${ranges[@]}" "$src_file"
+			echo "$CLANG_FORMAT -i ${ranges[*]} \"$src_file\""
+			$CLANG_FORMAT -i "${ranges[@]}" "$src_file"
 		fi
 	done
 }


### PR DESCRIPTION
# Description

Debian (and I believe Ubuntu as well) has multiple versions of Clang and associated tools in the repos.  `clang-format` itself points to version 14 which is too old for the script and I don't even have installed but `clang-format-16` is valid as a separate package in the repos.

This is just a quick fix to search for these numbered versions in the path.

# Manual testing

It works on my machine™


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

