### PR TITLE
Callback code generation rework

### DIFF
--- a/include/math_utils.h
+++ b/include/math_utils.h
@@ -262,6 +262,16 @@ constexpr uint8_t high_nibble(const uint8_t byte)
 	return (byte & 0xf0) >> 4;
 }
 
+constexpr uint8_t low_byte(const uint16_t word)
+{
+	return static_cast<uint8_t>(word & 0xff);
+}
+
+constexpr uint8_t high_byte(const uint16_t word)
+{
+	return static_cast<uint8_t>((word & 0xff00) >> 8);
+}
+
 inline float decibel_to_gain(const float decibel)
 {
 	return powf(10.0f, decibel / 20.0f);


### PR DESCRIPTION
# Description

I intend to change the code of one callback, so that it behaves more like the real BIOS. Unfortunately, the current code generator is rather hard to tamper with, one needs to constantly watch the offset from the start of the code and adapt it accordingly for every instruction after the inserted/deleted code.

This rework is intended to make the generator code a little bit easier to maintain. There is a potential for regressions (despite I have self-reviewed the code twice) - but it should be easy to withdraw specific parts of the rework to find out the root cause.


## Related issues

https://github.com/dosbox-staging/dosbox-staging/issues/3691 (rework related to the issue; PR does not fix the issue)


# Manual testing

Tried to run CtMouse 2.0, CtMouse 2.1, DOS Navigator, several games (Warcraft II, Settlers II, Colonization, etc.) - no problems found.


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

