### PR TITLE
`CONFIG -h` should only list visible setting values

### DIFF
--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -4334,12 +4334,15 @@ static void config_add_sdl()
 	pstring->SetDeprecatedWithAlternateValue("texturepp", "texture");
 	pstring->Set_values({
 #if C_OPENGL
-		"opengl_default",
+		        "opengl",
+#endif
+		        "texture", "texturenb",
+	});
+	pstring->SetEnabledOptions({
+#if C_OPENGL
+		"opengl_default", "opengl",
 #else
 		"texture_default",
-#endif
-#if C_OPENGL
-		        "opengl",
 #endif
 		        "texture", "texturenb",
 	});


### PR DESCRIPTION
# Description

All options valid for a certain configuration were visible. These should only be the available values.

Also ran a search for '_default"', which (luckily) came up empty, so I expect this to be the only instance where this went wrong.

# Manual testing

Ran setup -help output, which now shows the proper output without displaying "opengl_default".

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

