### PR TITLE
Fix the GUS reset register's startup behavior

### DIFF
--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -273,7 +273,6 @@ private:
 	uint16_t ReadFromPort(io_port_t port, io_width_t width);
 
 	void RegisterIoHandlers();
-	void Reset(uint8_t state);
 
 	const std::vector<AudioFrame>& RenderFrames(const int num_requested_frames);
 


### PR DESCRIPTION
# Description

Fixes a regression in Soltys (1995) where the GUS was not starting up after the game auto-detects the GUS.

The fix involves always processing the three reset register bits (instead of using if/else logic), and starting the GUS running once the run bit is positive.

**_Edit:_** The change also goes a bit further and uses a `bit_view` to define the GUS Reset Register and uses it directly on read and write (which turns out to simplify the code quite a bit). Thanks for this tip, @johnnovak.

## Related issues

Caught by the  eXoDOS team @parricc, @SmilingSpectre, and @Python-Exoproject reported in https://github.com/exoscoriae/eXoDOS/issues/5213

# Manual testing

When [soltys.zip](https://github.com/user-attachments/files/15757169/soltys.zip) starts, you can test GUS:
- full auto-detect with 'Automatic'
- partial auto-detect (select 'GUS', then click all 'Auto' settings) 
- full manual (select 'GUS' followed by 240h base, IRQ 5, and DMA 3)

You can also select GUS + MIDI provided you select '330h' for the MIDI port.

Here are those results:

GUS full auto-detect:

https://github.com/dosbox-staging/dosbox-staging/assets/165201780/dfd1d4dc-44c0-4149-b42f-0f75ed895d99

GUS + MIDI (manual settings):


https://github.com/dosbox-staging/dosbox-staging/assets/165201780/26bfe388-3c74-4170-8eb9-d27f9be0faf7

Also tested GUS games like One Must Fall, Star Control 2, Blood, Descent, Duke 3D, Hocus Pocus, Rise of the Triad, lots of Pinball games, and Jazz Jackrabbit. Tested some well known GUS  demos like 1st Infection, Second Reality, and Unreal by Future Crew.

If there are other tests, let me know!

## Related documentation

![gus-reset-register](https://github.com/dosbox-staging/dosbox-staging/assets/165201780/7b73b54a-8518-400d-aecc-8c5690c2f60a)

https://www.infania.net/misc1/GUS/SOURCE%20CODE/UltraSound%20Lowlevel%20ToolKit%20v2.22%20(21%20December%201994).pdf

Attached incase source goes defunct:

[UltraSound Lowlevel ToolKit v2.22 (21 December 1994).pdf](https://github.com/user-attachments/files/15777966/UltraSound.Lowlevel.ToolKit.v2.22.21.December.1994.pdf)


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [ ] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

