### PR TITLE
Further mixer fixes and improvements mega PR #2

### DIFF
--- a/include/mixer.h
+++ b/include/mixer.h
@@ -41,8 +41,6 @@
 
 #include <Iir.h>
 
-typedef void (*MIXER_MixHandler)(uint8_t* sampdate, int len);
-
 // The mixer callback can accept a static function or a member function
 // using a std::bind. The callback typically requests enough frames to
 // fill one millisecond with of audio. For an audio channel running at
@@ -242,28 +240,28 @@ public:
 	float GetChorusLevel() const;
 
 	template <class Type, bool stereo, bool signeddata, bool nativeorder>
-	void AddSamples(const int len, const Type* data);
+	void AddSamples(const int num_frames, const Type* data);
 
-	void AddSamples_m8(const int len, const uint8_t* data);
-	void AddSamples_s8(const int len, const uint8_t* data);
-	void AddSamples_m8s(const int len, const int8_t* data);
-	void AddSamples_s8s(const int len, const int8_t* data);
-	void AddSamples_m16(const int len, const int16_t* data);
-	void AddSamples_s16(const int len, const int16_t* data);
-	void AddSamples_m16u(const int len, const uint16_t* data);
-	void AddSamples_s16u(const int len, const uint16_t* data);
-	void AddSamples_m32(const int len, const int32_t* data);
-	void AddSamples_s32(const int len, const int32_t* data);
-	void AddSamples_mfloat(const int len, const float* data);
-	void AddSamples_sfloat(const int len, const float* data);
-	void AddSamples_m16_nonnative(const int len, const int16_t* data);
-	void AddSamples_s16_nonnative(const int len, const int16_t* data);
-	void AddSamples_m16u_nonnative(const int len, const uint16_t* data);
-	void AddSamples_s16u_nonnative(const int len, const uint16_t* data);
-	void AddSamples_m32_nonnative(const int len, const int32_t* data);
-	void AddSamples_s32_nonnative(const int len, const int32_t* data);
+	void AddSamples_m8(const int num_frames, const uint8_t* data);
+	void AddSamples_s8(const int num_frames, const uint8_t* data);
+	void AddSamples_m8s(const int num_frames, const int8_t* data);
+	void AddSamples_s8s(const int num_frames, const int8_t* data);
+	void AddSamples_m16(const int num_frames, const int16_t* data);
+	void AddSamples_s16(const int num_frames, const int16_t* data);
+	void AddSamples_m16u(const int num_frames, const uint16_t* data);
+	void AddSamples_s16u(const int num_frames, const uint16_t* data);
+	void AddSamples_m32(const int num_frames, const int32_t* data);
+	void AddSamples_s32(const int num_frames, const int32_t* data);
+	void AddSamples_mfloat(const int num_frames, const float* data);
+	void AddSamples_sfloat(const int num_frames, const float* data);
+	void AddSamples_m16_nonnative(const int num_frames, const int16_t* data);
+	void AddSamples_s16_nonnative(const int num_frames, const int16_t* data);
+	void AddSamples_m16u_nonnative(const int num_frames, const uint16_t* data);
+	void AddSamples_s16u_nonnative(const int num_frames, const uint16_t* data);
+	void AddSamples_m32_nonnative(const int num_frames, const int32_t* data);
+	void AddSamples_s32_nonnative(const int num_frames, const int32_t* data);
 
-	void AddStretched(const int len, int16_t* data);
+	void AddStretched(const int num_frames, int16_t* data);
 
 	void FillUp();
 	void Enable(const bool should_enable);

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -359,7 +359,7 @@ private:
 	bool last_samples_were_stereo  = false;
 	bool last_samples_were_silence = true;
 
-	ResampleMethod resample_method = {};
+	ResampleMethod resample_method = ResampleMethod::Resample;
 	bool do_resample               = false;
 	bool do_zoh_upsample           = false;
 

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -250,16 +250,12 @@ public:
 	void AddSamples_s16(const int num_frames, const int16_t* data);
 	void AddSamples_m16u(const int num_frames, const uint16_t* data);
 	void AddSamples_s16u(const int num_frames, const uint16_t* data);
-	void AddSamples_m32(const int num_frames, const int32_t* data);
-	void AddSamples_s32(const int num_frames, const int32_t* data);
 	void AddSamples_mfloat(const int num_frames, const float* data);
 	void AddSamples_sfloat(const int num_frames, const float* data);
 	void AddSamples_m16_nonnative(const int num_frames, const int16_t* data);
 	void AddSamples_s16_nonnative(const int num_frames, const int16_t* data);
 	void AddSamples_m16u_nonnative(const int num_frames, const uint16_t* data);
 	void AddSamples_s16u_nonnative(const int num_frames, const uint16_t* data);
-	void AddSamples_m32_nonnative(const int num_frames, const int32_t* data);
-	void AddSamples_s32_nonnative(const int num_frames, const int32_t* data);
 
 	void AddStretched(const int num_frames, int16_t* data);
 

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -137,10 +137,11 @@ struct MixerChannelSettings {
 };
 
 enum class ResampleMethod {
-	// Use simple linear interpolation to resample from the channel sample
-	// rate to the mixer rate. This is the legacy behaviour, and it acts as a
-	// sort of a low-pass filter.
-	LinearInterpolation,
+	// If the channel sample rate is higher than the mixer sample rate,
+	// we'll do proper downsampling via Speex (e.g., when the mixer rate is
+	// 44,100 Hz but the Sound Blaster is running at its 45,454 Hz maximum
+	// rate, or the OPL channel at its native 49,716 Hz rate).
+	LerpUpsampleOrResample,
 
 	// Upsample from the channel sample rate to the zero-order-hold target
 	// frequency first (this is basically the "nearest-neighbour" equivalent
@@ -284,8 +285,8 @@ private:
 	AudioFrame ConvertNextFrame(const Type* data, const int pos);
 
 	template <class Type, bool stereo, bool signeddata, bool nativeorder>
-	void ConvertSamples(const Type* data, const int frames,
-	                    std::vector<float>& out);
+	void ConvertSamplesAndMaybeZohUpsample(const Type* data, const int frames,
+	                                       std::vector<float>& out);
 
 	void ConfigureResampler();
 	void ClearResampler();
@@ -360,8 +361,10 @@ private:
 	bool last_samples_were_silence = true;
 
 	ResampleMethod resample_method = ResampleMethod::Resample;
-	bool do_resample               = false;
-	bool do_zoh_upsample           = false;
+
+	bool do_lerp_upsample = false;
+	bool do_zoh_upsample  = false;
+	bool do_resample      = false;
 
 	struct {
 		float pos             = 0.0f;

--- a/include/ring_buffer.h
+++ b/include/ring_buffer.h
@@ -70,6 +70,7 @@ public:
 		return data_.size();
 	}
 
+	// TODO Add const_iterator support, then start using it in `mixer.cpp`
 	class RingBufferIterator {
 		RingBuffer* array;
 		size_t index;

--- a/src/hardware/covox.cpp
+++ b/src/hardware/covox.cpp
@@ -38,8 +38,9 @@ void Covox::ConfigureFilters(const FilterState state)
 {
 	assert(channel);
 	if (state == FilterState::On) {
-		constexpr uint8_t lp_order = 2;
-		const uint16_t lp_cutoff_freq_hz = 9000;
+		constexpr auto lp_order          = 2;
+		constexpr auto lp_cutoff_freq_hz = 9000;
+
 		channel->ConfigureLowPassFilter(lp_order, lp_cutoff_freq_hz);
 	}
 	channel->SetLowPassFilter(state);

--- a/src/hardware/disney.cpp
+++ b/src/hardware/disney.cpp
@@ -49,7 +49,7 @@ void Disney::ConfigureFilters(const FilterState state)
 	assert(channel);
 
 	// Run the ZoH up-sampler at the higher mixer rate
-	const auto mixer_rate_hz = check_cast<uint16_t>(channel->GetSampleRate());
+	const auto mixer_rate_hz = channel->GetSampleRate();
 	channel->SetZeroOrderHoldUpsamplerTargetRate(mixer_rate_hz);
 	channel->SetResampleMethod(ResampleMethod::ZeroOrderHoldAndResample);
 

--- a/src/hardware/disney.cpp
+++ b/src/hardware/disney.cpp
@@ -1,4 +1,6 @@
 /*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
  *  Copyright (C) 2021-2024  The DOSBox Staging Team
  *  Copyright (C) 2002-2021  The DOSBox Team
  *

--- a/src/hardware/disney.cpp
+++ b/src/hardware/disney.cpp
@@ -56,8 +56,8 @@ void Disney::ConfigureFilters(const FilterState state)
 	channel->SetResampleMethod(ResampleMethod::ZeroOrderHoldAndResample);
 
 	// Pull audio frames from the Disney DAC at 7 kHz
-	channel->SetSampleRate(dss_7khz_rate_hz);
-	ms_per_frame = MillisInSecond / dss_7khz_rate_hz;
+	channel->SetSampleRate(DisneySampleRateHz);
+	ms_per_frame = MillisInSecond / DisneySampleRateHz;
 
 	if (state == FilterState::On) {
 		// The filters are meant to emulate the Disney's bandwidth
@@ -90,7 +90,7 @@ AudioFrame Disney::Render()
 
 bool Disney::IsFifoFull() const
 {
-	return fifo.size() >= max_fifo_size;
+	return fifo.size() >= MaxFifoSize;
 }
 
 void Disney::WriteData(const io_port_t, const io_val_t data, const io_width_t)

--- a/src/hardware/disney.h
+++ b/src/hardware/disney.h
@@ -45,8 +45,8 @@ private:
 	void WriteControl(const io_port_t, const io_val_t value, const io_width_t);
 
 	// The DSS is an LPT DAC with a 16-level FIFO running at 7kHz
-	static constexpr auto dss_7khz_rate_hz = 7000;
-	static constexpr uint8_t max_fifo_size = 16;
+	static constexpr auto DisneySampleRateHz = 7000;
+	static constexpr auto MaxFifoSize        = 16;
 
 	// Managed objects
 	std::queue<uint8_t> fifo = {};

--- a/src/hardware/gameblaster.cpp
+++ b/src/hardware/gameblaster.cpp
@@ -22,8 +22,11 @@
 #include "gameblaster.h"
 
 #include "channel_names.h"
+#include "checks.h"
 #include "pic.h"
 #include "setup.h"
+
+CHECK_NARROWING();
 
 // The Game Blaster is nothing else than a rebranding of Creative's first PC
 // sound card, the Creative Music System (C/MS).

--- a/src/hardware/gameblaster.h
+++ b/src/hardware/gameblaster.h
@@ -40,32 +40,37 @@
 
 class GameBlaster {
 public:
-	void Open(const int port_choice, const std::string &card_choice,
-	          const std::string &filter_choice);
+	void Open(const int port_choice, const std::string& card_choice,
+	          const std::string& filter_choice);
 
 	void Close();
-	~GameBlaster() { Close(); }
+
+	~GameBlaster()
+	{
+		Close();
+	}
 
 private:
 	// Audio rendering
 	AudioFrame RenderFrame();
-	std::vector<int16_t> GetFrame();
-	void AudioCallback(const uint16_t requested_frames);
+	void AudioCallback(const int requested_frames);
 	void RenderUpToNow();
 
 	// IO callbacks to the left SAA1099 device
 	void WriteDataToLeftDevice(io_port_t port, io_val_t value, io_width_t width);
-	void WriteControlToLeftDevice(io_port_t port, io_val_t value, io_width_t width);
+	void WriteControlToLeftDevice(io_port_t port, io_val_t value,
+	                              io_width_t width);
 
 	// IO callbacks to the right SAA1099 device
 	void WriteDataToRightDevice(io_port_t port, io_val_t value, io_width_t width);
-	void WriteControlToRightDevice(io_port_t port, io_val_t value, io_width_t width);
+	void WriteControlToRightDevice(io_port_t port, io_val_t value,
+	                               io_width_t width);
 
 	// IO callbacks to the Game Blaster detection chip
 	void WriteToDetectionPort(io_port_t port, io_val_t value, io_width_t width);
 	uint8_t ReadFromDetectionPort(io_port_t port, io_width_t width) const;
 
-	const char *CardName() const;
+	const char* CardName() const;
 
 	// Managed objects
 	MixerChannelPtr channel = nullptr;
@@ -79,11 +84,10 @@ private:
 	std::queue<AudioFrame> fifo = {};
 
 	// Static rate-related configuration
-	static constexpr auto chip_clock     = 14318180 / 2;
-	static constexpr auto render_divisor = 32;
-	static constexpr auto render_rate_hz = ceil_sdivide(chip_clock,
-	                                                    render_divisor);
-	static constexpr auto ms_per_render  = MillisInSecond / render_rate_hz;
+	static constexpr auto ChipClockHz   = 14318180 / 2;
+	static constexpr auto RenderDivisor = 32;
+	static constexpr auto RenderRateHz = ceil_sdivide(ChipClockHz, RenderDivisor);
+	static constexpr auto MsPerRender = MillisInSecond / RenderRateHz;
 
 	// Runtime states
 	double last_rendered_ms        = 0;

--- a/src/hardware/gameblaster.h
+++ b/src/hardware/gameblaster.h
@@ -29,6 +29,7 @@
 #include <string>
 #include <vector>
 
+#include "audio_frame.h"
 #include "inout.h"
 #include "math_utils.h"
 #include "mixer.h"
@@ -36,8 +37,6 @@
 
 #include "mame/emu.h"
 #include "mame/saa1099.h"
-
-#include "residfp/resample/TwoPassSincResampler.h"
 
 class GameBlaster {
 public:
@@ -49,7 +48,7 @@ public:
 
 private:
 	// Audio rendering
-	bool MaybeRenderFrame(AudioFrame &frame);
+	AudioFrame RenderFrame();
 	std::vector<int16_t> GetFrame();
 	void AudioCallback(const uint16_t requested_frames);
 	void RenderUpToNow();
@@ -75,8 +74,7 @@ private:
 	IO_WriteHandleObject write_handler_for_detection = {};
 	IO_ReadHandleObject read_handler_for_detection   = {};
 
-	std::unique_ptr<saa1099_device> devices[2]                   = {};
-	std::unique_ptr<reSIDfp::TwoPassSincResampler> resamplers[2] = {};
+	std::unique_ptr<saa1099_device> devices[2] = {};
 
 	std::queue<AudioFrame> fifo = {};
 

--- a/src/hardware/lpt_dac.cpp
+++ b/src/hardware/lpt_dac.cpp
@@ -31,7 +31,7 @@
 #include "disney.h"
 #include "ston1_dac.h"
 
-LptDac::LptDac(const std::string_view name, const uint16_t channel_rate_hz,
+LptDac::LptDac(const std::string_view name, const int channel_rate_hz,
                std::set<ChannelFeature> extra_features)
         : dac_name(name)
 {
@@ -97,7 +97,7 @@ void LptDac::RenderUpToNow()
 	}
 }
 
-void LptDac::AudioCallback(const uint16_t requested_frames)
+void LptDac::AudioCallback(const int requested_frames)
 {
 	assert(channel);
 

--- a/src/hardware/lpt_dac.h
+++ b/src/hardware/lpt_dac.h
@@ -34,7 +34,7 @@
 // Provides mandatory scafolding for derived LPT DAC devices
 class LptDac {
 public:
-	LptDac(const std::string_view name, const uint16_t channel_rate_hz,
+	LptDac(const std::string_view name, const int channel_rate_hz,
 	       std::set<ChannelFeature> extra_features = {});
 
 	virtual ~LptDac();
@@ -57,7 +57,7 @@ protected:
 	// Base LPT DAC functionality
 	virtual AudioFrame Render() = 0;
 	void RenderUpToNow();
-	void AudioCallback(const uint16_t requested_frames);
+	void AudioCallback(const int requested_frames);
 	std::queue<AudioFrame> render_queue = {};
 
 	MixerChannelPtr channel = {};

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -647,8 +647,8 @@ void MIXER_DeregisterChannel(MixerChannelPtr& channel_to_remove)
 
 	MIXER_LockAudioDevice();
 
-	auto it = mixer.channels.begin();
-	while (it != mixer.channels.end()) {
+	auto it = mixer.channels.cbegin();
+	while (it != mixer.channels.cend()) {
 		const auto [name, channel] = *it;
 
 		if (channel.get() == channel_to_remove.get()) {
@@ -1998,11 +1998,11 @@ void MixerChannel::AddSamples(const int num_frames, const Type* data)
 	if (do_lerp_upsample) {
 		auto& s = lerp_upsampler;
 
-		auto in_pos = mixer.temp_buf.begin();
+		auto in_pos = mixer.temp_buf.cbegin();
 		auto& out   = mixer.out_buf;
 		out.resize(0);
 
-		while (in_pos != mixer.temp_buf.end()) {
+		while (in_pos != mixer.temp_buf.cend()) {
 			AudioFrame curr_frame = {*in_pos, *(in_pos + 1)};
 
 			assert(s.pos >= 0.0f && s.pos <= 1.0f);
@@ -2074,9 +2074,9 @@ void MixerChannel::AddSamples(const int num_frames, const Type* data)
 	auto aux_reverb_pos   = mixer.aux_reverb.begin() + pos_offset;
 	auto aux_chorus_pos   = mixer.aux_chorus.begin() + pos_offset;
 
-	auto out_buf_pos = mixer.out_buf.begin();
+	auto out_buf_pos = mixer.out_buf.cbegin();
 
-	while (out_buf_pos != mixer.out_buf.end()) {
+	while (out_buf_pos != mixer.out_buf.cend()) {
 		AudioFrame frame = {*out_buf_pos++, *out_buf_pos++};
 
 		if (filters.highpass.state == FilterState::On) {

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -2158,7 +2158,6 @@ void MixerChannel::AddStretched(const int len, int16_t* data)
 		switch (resample_method) {
 		case ResampleMethod::LerpUpsampleOrResample:
 		case ResampleMethod::Resample:
-			assert(pos >= 0.0f && pos <= 1.0f);
 			out_sample = lerp(prev_sample, curr_sample, pos);
 			break;
 

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -3009,11 +3009,10 @@ static void init_mixer_dosbox_settings(Section_prop& sec_prop)
 	constexpr bool DefaultAllowNegotiate = true;
 #endif
 
-	constexpr auto Always      = Property::Changeable::Always;
 	constexpr auto WhenIdle    = Property::Changeable::WhenIdle;
 	constexpr auto OnlyAtStart = Property::Changeable::OnlyAtStart;
 
-	auto bool_prop = sec_prop.Add_bool("nosound", Always, false);
+	auto bool_prop = sec_prop.Add_bool("nosound", OnlyAtStart, false);
 	assert(bool_prop);
 	bool_prop->Set_help(
 	        "Enable silent mode (disabled by default).\n"

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -2973,9 +2973,13 @@ static void init_mixer_dosbox_settings(Section_prop& sec_prop)
 
 	auto int_prop = sec_prop.Add_int("rate", OnlyAtStart, DefaultSampleRateHz);
 	assert(int_prop);
-	int_prop->Set_values(
-	        {"8000", "11025", "16000", "22050", "32000", "44100", "48000"});
-	int_prop->Set_help("Mixer sample rate in Hz (%s by default).");
+	int_prop->SetMinMax(8000, 96000);
+	int_prop->Set_help(
+	        "Sample rate of DOSBox's internal audio mixer in Hz (%s by default).\n"
+	        "Valid range is 8000 to 96000 Hz. The vast majority of consumer-grade audio\n"
+	        "hardware uses a native rate of 48000 Hz. Recommend leaving this as-is unless\n"
+	        "you have good reason to change it. The OS will most likely resample non-standard\n"
+	        "sample rates to 48000 Hz anyway.");
 
 	int_prop = sec_prop.Add_int("blocksize", OnlyAtStart, DefaultBlocksize);
 	int_prop->Set_values({"128", "256", "512", "1024", "2048", "4096", "8192"});

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -3064,10 +3064,12 @@ static void init_mixer_dosbox_settings(Section_prop& sec_prop)
 	        "sample rates to 48000 Hz anyway.");
 
 	int_prop = sec_prop.Add_int("blocksize", OnlyAtStart, DefaultBlocksize);
-	int_prop->Set_values({"128", "256", "512", "1024", "2048", "4096", "8192"});
+	int_prop->SetMinMax(64, 8192);
 	int_prop->Set_help(
-	        "Mixer block size in sample frames (%s by default). Larger values might help\n"
-	        "with sound stuttering but the sound will also be more lagged.");
+	        "Block size of the host audio device in sample frames (%s by default).\n"
+	        "Valid range is 64 to 8192. Should be set to power-of-two values (e.g., 256,\n"
+	        "512, 1024, etc.) Larger values might help with sound stuttering but will\n"
+	        "introduce more latency. Also see 'negotiate'.");
 
 	int_prop = sec_prop.Add_int("prebuffer", OnlyAtStart, DefaultPrebufferMs);
 	int_prop->SetMinMax(0, MaxPrebufferMs);
@@ -3079,8 +3081,8 @@ static void init_mixer_dosbox_settings(Section_prop& sec_prop)
 	bool_prop = sec_prop.Add_bool("negotiate", OnlyAtStart, DefaultAllowNegotiate);
 	bool_prop->Set_help(
 	        "Negotiate a possibly better 'blocksize' setting (%s by default).\n"
-	        "Enable it if you're not getting audio or the sound is stuttering with manually\n"
-	        "set 'blocksize' settings.");
+	        "Enable it if you're not getting audio or the sound is stuttering with your\n"
+	        "'blocksize' setting. Disable it to force the manually set 'blocksize' value.");
 
 	constexpr auto DefaultOn = true;
 	bool_prop = sec_prop.Add_bool("compressor", WhenIdle, DefaultOn);

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -1237,7 +1237,7 @@ static int clamp_filter_cutoff_freq([[maybe_unused]] const std::string& channel_
 		return cutoff_freq_hz;
 	} else {
 		LOG_DEBUG(
-		        "%s: Filter cutoff frequency %d Hz is not below half of the "
+		        "%s: Filter cutoff frequency %d Hz is above half the "
 		        "sample rate, clamping to %d Hz",
 		        channel_name.c_str(),
 		        cutoff_freq_hz,

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -1713,10 +1713,10 @@ AudioFrame MixerChannel::ConvertNextFrame(const Type* data, const int pos)
 // clicks, and optionally performs zero-order-hold-upsampling.
 template <class Type, bool stereo, bool signeddata, bool nativeorder>
 void MixerChannel::ConvertSamplesAndMaybeZohUpsample(const Type* data,
-                                                     const int frames,
+                                                     const int num_frames,
                                                      std::vector<float>& out)
 {
-	assert(frames >= 0);
+	assert(num_frames >= 0);
 
 	const auto mapped_output_left  = output_map.left;
 	const auto mapped_output_right = output_map.right;
@@ -1729,7 +1729,7 @@ void MixerChannel::ConvertSamplesAndMaybeZohUpsample(const Type* data,
 
 	out.resize(0);
 
-	while (pos < frames) {
+	while (pos < num_frames) {
 		prev_frame = next_frame;
 
 		if (std::is_same<Type, float>::value) {
@@ -1966,9 +1966,9 @@ bool MixerChannel::WakeUp()
 }
 
 template <class Type, bool stereo, bool signeddata, bool nativeorder>
-void MixerChannel::AddSamples(const int frames, const Type* data)
+void MixerChannel::AddSamples(const int num_frames, const Type* data)
 {
-	assert(frames > 0);
+	assert(num_frames > 0);
 
 	last_samples_were_stereo = stereo;
 
@@ -1989,7 +1989,7 @@ void MixerChannel::AddSamples(const int frames, const Type* data)
 	                               : mixer.out_buf;
 
 	ConvertSamplesAndMaybeZohUpsample<Type, stereo, signeddata, nativeorder>(
-	        data, frames, convert_dest_buf);
+	        data, num_frames, convert_dest_buf);
 
 	if (do_lerp_upsample) {
 		auto& s = lerp_upsampler;
@@ -2192,77 +2192,94 @@ void MixerChannel::AddStretched(const int len, int16_t* data)
 	MIXER_UnlockAudioDevice();
 }
 
-void MixerChannel::AddSamples_m8(const int len, const uint8_t* data)
+void MixerChannel::AddSamples_m8(const int num_frames, const uint8_t* data)
 {
-	AddSamples<uint8_t, false, false, true>(len, data);
+	AddSamples<uint8_t, false, false, true>(num_frames, data);
 }
-void MixerChannel::AddSamples_s8(const int len, const uint8_t* data)
+
+void MixerChannel::AddSamples_s8(const int num_frames, const uint8_t* data)
 {
-	AddSamples<uint8_t, true, false, true>(len, data);
+	AddSamples<uint8_t, true, false, true>(num_frames, data);
 }
-void MixerChannel::AddSamples_m8s(const int len, const int8_t* data)
+
+void MixerChannel::AddSamples_m8s(const int num_frames, const int8_t* data)
 {
-	AddSamples<int8_t, false, true, true>(len, data);
+	AddSamples<int8_t, false, true, true>(num_frames, data);
 }
-void MixerChannel::AddSamples_s8s(const int len, const int8_t* data)
+
+void MixerChannel::AddSamples_s8s(const int num_frames, const int8_t* data)
 {
-	AddSamples<int8_t, true, true, true>(len, data);
+	AddSamples<int8_t, true, true, true>(num_frames, data);
 }
-void MixerChannel::AddSamples_m16(const int len, const int16_t* data)
+
+void MixerChannel::AddSamples_m16(const int num_frames, const int16_t* data)
 {
-	AddSamples<int16_t, false, true, true>(len, data);
+	AddSamples<int16_t, false, true, true>(num_frames, data);
 }
-void MixerChannel::AddSamples_s16(const int len, const int16_t* data)
+
+void MixerChannel::AddSamples_s16(const int num_frames, const int16_t* data)
 {
-	AddSamples<int16_t, true, true, true>(len, data);
+	AddSamples<int16_t, true, true, true>(num_frames, data);
 }
-void MixerChannel::AddSamples_m16u(const int len, const uint16_t* data)
+
+void MixerChannel::AddSamples_m16u(const int num_frames, const uint16_t* data)
 {
-	AddSamples<uint16_t, false, false, true>(len, data);
+	AddSamples<uint16_t, false, false, true>(num_frames, data);
 }
-void MixerChannel::AddSamples_s16u(const int len, const uint16_t* data)
+
+void MixerChannel::AddSamples_s16u(const int num_frames, const uint16_t* data)
 {
-	AddSamples<uint16_t, true, false, true>(len, data);
+	AddSamples<uint16_t, true, false, true>(num_frames, data);
 }
-void MixerChannel::AddSamples_m32(const int len, const int32_t* data)
+
+void MixerChannel::AddSamples_m32(const int num_frames, const int32_t* data)
 {
-	AddSamples<int32_t, false, true, true>(len, data);
+	AddSamples<int32_t, false, true, true>(num_frames, data);
 }
-void MixerChannel::AddSamples_s32(const int len, const int32_t* data)
+
+void MixerChannel::AddSamples_s32(const int num_frames, const int32_t* data)
 {
-	AddSamples<int32_t, true, true, true>(len, data);
+	AddSamples<int32_t, true, true, true>(num_frames, data);
 }
-void MixerChannel::AddSamples_mfloat(const int len, const float* data)
+
+void MixerChannel::AddSamples_mfloat(const int num_frames, const float* data)
 {
-	AddSamples<float, false, true, true>(len, data);
+	AddSamples<float, false, true, true>(num_frames, data);
 }
-void MixerChannel::AddSamples_sfloat(const int len, const float* data)
+
+void MixerChannel::AddSamples_sfloat(const int num_frames, const float* data)
 {
-	AddSamples<float, true, true, true>(len, data);
+	AddSamples<float, true, true, true>(num_frames, data);
 }
-void MixerChannel::AddSamples_m16_nonnative(const int len, const int16_t* data)
+
+void MixerChannel::AddSamples_m16_nonnative(const int num_frames, const int16_t* data)
 {
-	AddSamples<int16_t, false, true, false>(len, data);
+	AddSamples<int16_t, false, true, false>(num_frames, data);
 }
-void MixerChannel::AddSamples_s16_nonnative(const int len, const int16_t* data)
+
+void MixerChannel::AddSamples_s16_nonnative(const int num_frames, const int16_t* data)
 {
-	AddSamples<int16_t, true, true, false>(len, data);
+	AddSamples<int16_t, true, true, false>(num_frames, data);
 }
-void MixerChannel::AddSamples_m16u_nonnative(const int len, const uint16_t* data)
+
+void MixerChannel::AddSamples_m16u_nonnative(const int num_frames, const uint16_t* data)
 {
-	AddSamples<uint16_t, false, false, false>(len, data);
+	AddSamples<uint16_t, false, false, false>(num_frames, data);
 }
-void MixerChannel::AddSamples_s16u_nonnative(const int len, const uint16_t* data)
+
+void MixerChannel::AddSamples_s16u_nonnative(const int num_frames, const uint16_t* data)
 {
-	AddSamples<uint16_t, true, false, false>(len, data);
+	AddSamples<uint16_t, true, false, false>(num_frames, data);
 }
-void MixerChannel::AddSamples_m32_nonnative(const int len, const int32_t* data)
+
+void MixerChannel::AddSamples_m32_nonnative(const int num_frames, const int32_t* data)
 {
-	AddSamples<int32_t, false, true, false>(len, data);
+	AddSamples<int32_t, false, true, false>(num_frames, data);
 }
-void MixerChannel::AddSamples_s32_nonnative(const int len, const int32_t* data)
+
+void MixerChannel::AddSamples_s32_nonnative(const int num_frames, const int32_t* data)
 {
-	AddSamples<int32_t, true, true, false>(len, data);
+	AddSamples<int32_t, true, true, false>(num_frames, data);
 }
 
 void MixerChannel::FillUp()
@@ -2616,17 +2633,17 @@ static void SDLCALL mixer_callback([[maybe_unused]] void* userdata,
 	auto output = reinterpret_cast<int16_t*>(stream);
 
 	if (frames_requested != reduce_frames) {
-		// We're doing a very crude sample-skipping style audio stretching
-		// here. However, it's worth keeping it as this path is almost
-		// exclusively used in the fast-forward mode to achieves that cool
-		// "tape speed-up" effect.
+		// We're doing a very crude sample-skipping style audio
+		// stretching here. However, it's worth keeping it as this path
+		// is almost exclusively used in the fast-forward mode to
+		// achieves that cool "tape speed-up" effect.
 		//
 		// Without this effect, the audio becomes a crackling mess when
 		// fast-forwarding.
-		auto frames   = std::min(reduce_frames, frames_requested);
-		auto work_pos = mixer.work.begin() + mixer.pos.load();
+		auto num_frames = std::min(reduce_frames, frames_requested);
+		auto work_pos   = mixer.work.begin() + mixer.pos.load();
 
-		while (frames--) {
+		while (num_frames--) {
 			index += index_add;
 
 			const auto frame = *(work_pos + static_cast<int>(index));
@@ -2635,10 +2652,10 @@ static void SDLCALL mixer_callback([[maybe_unused]] void* userdata,
 			*output++ = clamp_to_int16(frame.right);
 		}
 	} else {
-		auto frames   = reduce_frames;
-		auto work_pos = mixer.work.begin() + mixer.pos.load();
+		auto num_frames = reduce_frames;
+		auto work_pos   = mixer.work.begin() + mixer.pos.load();
 
-		while (frames--) {
+		while (num_frames--) {
 			const auto frame = *work_pos++;
 
 			*output++ = clamp_to_int16(frame.left);
@@ -2648,14 +2665,14 @@ static void SDLCALL mixer_callback([[maybe_unused]] void* userdata,
 
 	// Clear the used buffers
 	{
-		auto frames = reduce_frames;
+		auto num_frames = reduce_frames;
 
 		const auto pos_offset = mixer.pos.load();
 		auto work_pos         = mixer.work.begin() + pos_offset;
 		auto aux_reverb_pos   = mixer.aux_reverb.begin() + pos_offset;
 		auto aux_chorus_pos   = mixer.aux_chorus.begin() + pos_offset;
 
-		while (frames--) {
+		while (num_frames--) {
 			constexpr AudioFrame Silence = {0.0f};
 
 			*work_pos++       = Silence;

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -2232,16 +2232,6 @@ void MixerChannel::AddSamples_s16u(const int num_frames, const uint16_t* data)
 	AddSamples<uint16_t, true, false, true>(num_frames, data);
 }
 
-void MixerChannel::AddSamples_m32(const int num_frames, const int32_t* data)
-{
-	AddSamples<int32_t, false, true, true>(num_frames, data);
-}
-
-void MixerChannel::AddSamples_s32(const int num_frames, const int32_t* data)
-{
-	AddSamples<int32_t, true, true, true>(num_frames, data);
-}
-
 void MixerChannel::AddSamples_mfloat(const int num_frames, const float* data)
 {
 	AddSamples<float, false, true, true>(num_frames, data);
@@ -2270,16 +2260,6 @@ void MixerChannel::AddSamples_m16u_nonnative(const int num_frames, const uint16_
 void MixerChannel::AddSamples_s16u_nonnative(const int num_frames, const uint16_t* data)
 {
 	AddSamples<uint16_t, true, false, false>(num_frames, data);
-}
-
-void MixerChannel::AddSamples_m32_nonnative(const int num_frames, const int32_t* data)
-{
-	AddSamples<int32_t, false, true, false>(num_frames, data);
-}
-
-void MixerChannel::AddSamples_s32_nonnative(const int num_frames, const int32_t* data)
-{
-	AddSamples<int32_t, true, true, false>(num_frames, data);
 }
 
 void MixerChannel::FillUp()

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -1299,7 +1299,7 @@ bool MixerChannel::TryParseAndSetCustomFilter(const std::string& filter_prefs)
 	if (!(single_filter || dual_filter)) {
 		LOG_WARNING(
 		        "%s: Invalid custom filter definition: '%s'. Must be "
-		        "specified in \"lfp|hpf ORDER CUTOFF_FREQUENCY\" format",
+		        "specified in \"lpf|hpf ORDER CUTOFF_FREQUENCY\" format",
 		        name.c_str(),
 		        filter_prefs.c_str());
 		return false;

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -1048,12 +1048,13 @@ void MixerChannel::Mix(const int frames_requested)
 
 	frames_needed = frames_requested;
 
-	auto freq_add = static_cast<float>(sample_rate_hz) /
-	                static_cast<float>(mixer.sample_rate_hz);
+	auto stretch_factor = static_cast<float>(sample_rate_hz) /
+	                      static_cast<float>(mixer.sample_rate_hz);
 
 	while (frames_needed > frames_done) {
 		auto frames_remaining = iceil(
-		        static_cast<float>(frames_needed - frames_done) + freq_add);
+		        static_cast<float>(frames_needed - frames_done) *
+		        stretch_factor);
 
 		// Avoid underflow
 		if (frames_remaining <= 0) {

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -1731,6 +1731,9 @@ void MixerChannel::ConvertSamplesAndMaybeZohUpsample(const Type* data,
 	auto pos             = 0;
 	AudioFrame out_frame = {};
 
+	// We set size to zero which will not change the data in the container
+	// at all. Then we overwrite the data below with `emplace_back()` which
+	// will set the correct length.
 	out.resize(0);
 
 	while (pos < num_frames) {
@@ -2000,6 +2003,10 @@ void MixerChannel::AddSamples(const int num_frames, const Type* data)
 
 		auto in_pos = mixer.temp_buf.cbegin();
 		auto& out   = mixer.out_buf;
+
+		// We set size to zero which will not change the data in the
+		// container at all. Then we overwrite the data below with
+		// `emplace_back()` which will set the correct length.
 		out.resize(0);
 
 		while (in_pos != mixer.temp_buf.cend()) {

--- a/src/hardware/ps1audio.cpp
+++ b/src/hardware/ps1audio.cpp
@@ -175,7 +175,7 @@ Ps1Dac::Ps1Dac(const std::string& filter_choice)
 	                          io_width_t::byte);
 
 	// Operate at native sampling rates
-	sample_rate_hz = check_cast<uint32_t>(channel->GetSampleRate());
+	sample_rate_hz = channel->GetSampleRate();
 	last_write = 0;
 	Reset(true);
 }

--- a/src/hardware/ps1audio.cpp
+++ b/src/hardware/ps1audio.cpp
@@ -41,10 +41,17 @@
 #include "mame/sn76496.h"
 
 struct Ps1Registers {
-	uint8_t status = 0;     // Read via port 0x202 control status
-	uint8_t command = 0;    // Written via port 0x202 for control, read via 0x200 for DAC
-	uint8_t divisor = 0;    // Read via port 0x203 for FIFO timing
-	uint8_t fifo_level = 0; // Written via port 0x204 when FIFO is almost empty
+	// Read via port 0x202 control status
+	uint8_t status  = 0;
+
+	// Written via port 0x202 for control, read via 0x200 for DAC
+	uint8_t command = 0;
+
+	// Read via port 0x203 for FIFO timing
+	uint8_t divisor = 0;
+
+	// Written via port 0x204 when FIFO is almost empty
+	uint8_t fifo_level = 0;
 };
 
 class Ps1Dac {
@@ -437,9 +444,9 @@ public:
 
 private:
 	// Block alternate construction routes
-	Ps1Synth()                            = delete;
-	Ps1Synth(const Ps1Synth &)            = delete;
-	Ps1Synth &operator=(const Ps1Synth &) = delete;
+	Ps1Synth()                           = delete;
+	Ps1Synth(const Ps1Synth&)            = delete;
+	Ps1Synth& operator=(const Ps1Synth&) = delete;
 
 	void AudioCallback(uint16_t requested_frames);
 	float RenderSample();
@@ -454,15 +461,15 @@ private:
 	sn76496_device device;
 
 	// Static rate-related configuration
-	static constexpr auto ps1_psg_clock_hz = 4000000;
+	static constexpr auto ps1_psg_clock_hz = 4'000'000;
 	static constexpr auto render_divisor   = 16;
 	static constexpr auto render_rate_hz   = ceil_sdivide(ps1_psg_clock_hz,
                                                             render_divisor);
-	static constexpr auto ms_per_render    = MillisInSecond / render_rate_hz;
+	static constexpr auto ms_per_render = MillisInSecond / render_rate_hz;
 
 	// Runtime states
-	device_sound_interface *dsi = static_cast<sn76496_base_device *>(&device);
-	double last_rendered_ms     = 0.0;
+	device_sound_interface* dsi = static_cast<sn76496_base_device*>(&device);
+	double last_rendered_ms = 0.0;
 };
 
 Ps1Synth::Ps1Synth(const std::string& filter_choice)
@@ -503,7 +510,7 @@ Ps1Synth::Ps1Synth(const std::string& filter_choice)
 	        std::bind(&Ps1Synth::WriteSoundGeneratorPort205, this, _1, _2, _3);
 
 	write_handler.Install(0x205, generate_sound, io_width_t::byte);
-	static_cast<device_t &>(device).device_start();
+	static_cast<device_t&>(device).device_start();
 	device.convert_samplerate(render_rate_hz);
 }
 
@@ -515,7 +522,7 @@ float Ps1Synth::RenderSample()
 
 	// Request a mono sample from the audio device
 	int16_t sample;
-	int16_t *buf[] = {&sample, nullptr};
+	int16_t* buf[] = {&sample, nullptr};
 
 	dsi->sound_stream_update(ss, nullptr, buf, 1);
 
@@ -588,7 +595,7 @@ Ps1Synth::~Ps1Synth()
 static std::unique_ptr<Ps1Dac> ps1_dac     = {};
 static std::unique_ptr<Ps1Synth> ps1_synth = {};
 
-static void PS1AUDIO_ShutDown([[maybe_unused]] Section *sec)
+static void PS1AUDIO_ShutDown([[maybe_unused]] Section* sec)
 {
 	LOG_MSG("PS1: Shutting down IBM PS/1 Audio card");
 	ps1_dac.reset();
@@ -599,22 +606,22 @@ bool PS1AUDIO_IsEnabled()
 {
 	const auto section = control->GetSection("speaker");
 	assert(section);
-	const auto properties = static_cast<Section_prop *>(section);
+	const auto properties = static_cast<Section_prop*>(section);
 	return properties->Get_bool("ps1audio");
 }
 
-void PS1AUDIO_Init(Section *section)
+void PS1AUDIO_Init(Section* section)
 {
 	assert(section);
-	const auto prop = static_cast<Section_prop *>(section);
+	const auto prop = static_cast<Section_prop*>(section);
 
-	if (!PS1AUDIO_IsEnabled())
+	if (!PS1AUDIO_IsEnabled()) {
 		return;
+	}
 
 	ps1_dac = std::make_unique<Ps1Dac>(prop->Get_string("ps1audio_dac_filter"));
 
-	ps1_synth = std::make_unique<Ps1Synth>(
-	        prop->Get_string("ps1audio_filter"));
+	ps1_synth = std::make_unique<Ps1Synth>(prop->Get_string("ps1audio_filter"));
 
 	LOG_MSG("PS1: Initialised IBM PS/1 Audio card");
 

--- a/src/hardware/ps1audio.cpp
+++ b/src/hardware/ps1audio.cpp
@@ -28,6 +28,7 @@
 #include <queue>
 
 #include "channel_names.h"
+#include "checks.h"
 #include "control.h"
 #include "dma.h"
 #include "inout.h"
@@ -39,6 +40,8 @@
 
 #include "mame/emu.h"
 #include "mame/sn76496.h"
+
+CHECK_NARROWING();
 
 struct Ps1Registers {
 	// Read via port 0x202 control status

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -562,7 +562,7 @@ static void configure_sb_filter_for_model(MixerChannelPtr channel,
 
 	case FilterType::Modern:
 		// Linear interpolation upsampling is the legacy DOSBox behaviour
-		config.resample_method = ResampleMethod::LinearInterpolation;
+		config.resample_method = ResampleMethod::LerpUpsampleOrResample;
 		break;
 	}
 

--- a/src/hardware/ston1_dac.cpp
+++ b/src/hardware/ston1_dac.cpp
@@ -41,8 +41,8 @@ void StereoOn1::ConfigureFilters(const FilterState state)
 {
 	assert(channel);
 	if (state == FilterState::On) {
-		constexpr uint8_t lp_order       = 2;
-		const uint16_t lp_cutoff_freq_hz = 9000;
+		constexpr auto lp_order      = 2;
+		const auto lp_cutoff_freq_hz = 9000;
 		channel->ConfigureLowPassFilter(lp_order, lp_cutoff_freq_hz);
 	}
 	channel->SetLowPassFilter(state);

--- a/src/hardware/ston1_dac.h
+++ b/src/hardware/ston1_dac.h
@@ -1,5 +1,7 @@
 /*
- *  Copyright (C) 2022-2023  The DOSBox Staging Team
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2022-2024  The DOSBox Staging Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/hardware/ston1_dac.h
+++ b/src/hardware/ston1_dac.h
@@ -31,7 +31,7 @@
 class StereoOn1 final : public LptDac {
 public:
 	StereoOn1()
-	        : LptDac(ChannelName::StereoOn1Dac, ston1_max_30_khz,
+	        : LptDac(ChannelName::StereoOn1Dac, SampleRateHz,
 	                 {ChannelFeature::Stereo})
 	{}
 
@@ -45,7 +45,7 @@ protected:
 	void WriteControl(const io_port_t, const io_val_t value, const io_width_t);
 
 private:
-	static constexpr uint16_t ston1_max_30_khz = 30000u;
+	static constexpr auto SampleRateHz = 30000;
 
 	uint8_t stereo_data[2] = {data_reg, data_reg};
 };

--- a/src/hardware/tandy_sound.cpp
+++ b/src/hardware/tandy_sound.cpp
@@ -47,6 +47,7 @@
 #include <string_view>
 
 #include "bios.h"
+#include "checks.h"
 #include "channel_names.h"
 #include "dma.h"
 #include "hardware.h"
@@ -59,6 +60,8 @@
 
 #include "mame/emu.h"
 #include "mame/sn76496.h"
+
+CHECK_NARROWING();
 
 // Constants used by the DAC and PSG
 constexpr uint16_t CardBaseOffset = 288;
@@ -360,7 +363,9 @@ uint8_t TandyDAC::ReadFromPort(io_port_t port, io_width_t)
 #endif
 	switch (port) {
 	case 0xc4:
-		return (regs.mode & 0x77) | (regs.irq_activated ? 0x08 : 0x00);
+		return check_cast<uint8_t>((regs.mode & 0x77) |
+		                           (regs.irq_activated ? 0x08 : 0x00));
+
 	case 0xc6: return static_cast<uint8_t>(regs.clock_divider & 0xff);
 	case 0xc7:
 		return static_cast<uint8_t>(((regs.clock_divider >> 8) & 0xf) |
@@ -400,7 +405,9 @@ void TandyDAC::WriteToPort(io_port_t port, io_val_t value, io_width_t)
 		break;
 
 	case 0xc6:
-		regs.clock_divider = (regs.clock_divider & 0xf00) | data;
+		regs.clock_divider = check_cast<uint16_t>(
+		        (regs.clock_divider & 0xf00) | data);
+
 		switch (regs.mode & 3) {
 		case 0: // joystick mode
 			break;


### PR DESCRIPTION
# Description

- Fix mixer time stretching regression (see first commit for details). It's relatively hard to trigger, but a regression nonetheless.

- The LERP upsampler can now also downsample if required. This resampling mode was introduced specifically for the default `sb_filter = modern` mode, which emulates the old DOSBox linear interpolation "resampler."

- Previously, the upsampler did nothing if the channel rate exceeded the host rate. This resulted in lower-pitched audio, e.g., when a program uses the maximum native 45,454 Hz Sound Blaster rate and the host rate is 44,100 Hz. Or if you set a 22,050 Hz host rate and the SB rate is above that. Now that's fixed; in these scenarios, now we use the Speex resampler to do proper downsampling.

- Because of an oversight, all audio channels defaulted to the LERP upsampler. This generally worked out fine as long as your host rate was 44.1 kHz or 48 kHz. For example, the max GUS rate is 44.1 kHz, so if your host rate is 44.1 kHz, you could never hit the lower-pitched audio bug... unless you set a lower than 44.1k host rate, then you could 🥶 Anyway, the LERP upsampler is now fixed, but we also default to the Speex resampler on all channels as the default resampling method (the individual audio devices can override this, of course).

- Host sample rates can now be set continuously from 8,000 to 96,000 Hz. What's the bloody point of that, one might wonder? Well, many DOS devices have non-standard sample rates, e.g. the MT-32 is fixed 32,000 Hz, the OPL 49,716 Hz, the Sound Blaster up to 45,454 Hz, etc. By setting custom sample rates, you can render WAV files at an audio device's native rate without resampling. This might be useful for debugging (e.g., for _yours truly_). Sure, going up to 96 kHz is rather pointless, but FluidSynth supports it, so why not, plus we need an upper limit anyway. 96 kHz is as good as any.

- I've got rid of the `TwoPassSincResampler` in Game Blaster, PS/1 Audio, and Tandy 3-Voice, and I'm using our standard Speex resampler instead. This partially addresses https://github.com/dosbox-staging/dosbox-staging/issues/3595. See the commit messages for the details.

- The `nosound` option now works better because it renders the audio and progresses the "audio frames rendered" counters. Previously, programs that somehow timed themselves to these counters counters were completely stalled in "no sound" mode (e.g., FastTracker II). Additionally, now you can capture the audio to a WAV file even in "no sound" mode.

- `blocksize` can now be set to non-power-of-two values too. It seems SDL negotiates such buffer sizes on certain audio cards.

# Manual testing

Executed all the [audio emulation test cases](https://github.com/dosbox-staging/dosbox-staging/wiki/Audio-emulation-tests), and the following additional tests:

- Start DOSBox normally without specifying `rate` in the config and confirm in the logs that 48 kHz host sample rate is being used. Run `PT.BAT` and `CM.BAT` to play the same music in PT4DOS (SB Pro) and CapaMod (GUS), respectively, to familiarise yourself how the music should sound when played back at normal speed.

- Set `rate = 22050` and confirm the music plays at normal speed in both programs, not at half-speed, like `main`. 

- Set `nosound = on` in the config and confirm that:
  - Both programs show the playback animations, and are not stalled like `main`.
  - Capturing the audio records the music at the correct speed.

- Confirm arbitrary rates can be set both (e.g., `rate = 33333`) both with `negotiate` enabled or disabled. Confirm audio capturing works at these arbitraty rates (e.g., load the WAV into Audacity and check the sample rate).

- Confirm `stype = sb16` works with:
  - `sb_filter = auto` and 8000, 22050, 44100, 48000, and 96000 rates.
  - `sb_filter = modern` and the same rates.
  - `sb_filter = off` and the same rates.

- Repeat the tests with `sbtype = sbpro2`.

- Confirm 8000 Hz and 96000 Hz sample rates work, and that reverb and chorus work fine at these rates too (the audio will sound muffled on 8000 Hz; that's normal).

- Confirm the below audio devices work fine at 8 Khz and 96 Khz (these devices render directly at the mixer rate without resampling at the mixer level).
  - CD Audio, Covox, Disney, Game Blaster, GUS, Innovation, PC Speaker (both modes), PS1 Audio, ReelMagic, Tandy

- Confirm the mixer is not reinitialised when changing any of these settings at runtime:
  - `chorus`, `compressor`, `crossfeed`, `reverb`

- Change the above settings at runtime and confirm the sound output is as expected.


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

