### PR TITLE
Paginate the CONFIG command's output

### DIFF
--- a/contrib/resources/translations/README.md
+++ b/contrib/resources/translations/README.md
@@ -65,10 +65,9 @@ to learn more about it, here are a few links:
 
 For example `CONFIG_FULLSCREEN`.
 
-Do not exceed 79 characters on a line, or commands such as `config -h fullscreen`
+Do not exceed 80 characters on a line, or commands such as `config -h fullscreen`
 won't be able to display the help properly, and might wrap the text or display blank
-lines. The limit might be increased to 80 characters in the future, but
-the implementation is not there yet.
+lines.
 
 ### Command or program help
 

--- a/include/programs.h
+++ b/include/programs.h
@@ -28,6 +28,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <vector>
 
 #include "dos_inc.h"
 #include "help_util.h"

--- a/src/dos/program_mode.cpp
+++ b/src/dos/program_mode.cpp
@@ -100,70 +100,71 @@ static void set_8x8_font()
 	CALLBACK_RunRealInt(0x10);
 }
 
-void MODE::HandleSetDisplayMode(const std::string& _mode)
+void MODE::HandleSetDisplayMode(const std::string& _mode_str)
 {
-	auto mode = _mode;
+	auto mode_str = _mode_str;
 
 	// These formats are all valid:
 	//   80X25
 	//   80x25
 	//   80,25
-	lowcase(mode);
-	mode = replace(mode, ',', 'x');
+	lowcase(mode_str);
+	mode_str = replace(mode_str, ',', 'x');
 
-	if (!is_valid_video_mode(mode)) {
-		WriteOut(MSG_Get("PROGRAM_MODE_INVALID_DISPLAY_MODE"), mode.c_str());
+	if (!is_valid_video_mode(mode_str)) {
+		WriteOut(MSG_Get("PROGRAM_MODE_INVALID_DISPLAY_MODE"),
+		         mode_str.c_str());
 		return;
 	}
 
 	switch (machine) {
 	case MCH_HERC:
-		if (mode == "80x25") {
+		if (mode_str == "80x25") {
 			INT10_SetVideoMode(0x07);
 		} else {
 			WriteOut(MSG_Get("PROGRAM_MODE_UNSUPPORTED_DISPLAY_MODE"),
-					 mode.c_str());
+			         mode_str.c_str());
 		}
 		break;
 
 	case MCH_CGA:
 	case MCH_TANDY:
 	case MCH_PCJR:
-		if (mode == "40x25") {
+		if (mode_str == "40x25") {
 			INT10_SetVideoMode(0x01);
 
-		} else if (mode == "80x25") {
+		} else if (mode_str == "80x25") {
 			INT10_SetVideoMode(0x03);
 
 		} else {
 			WriteOut(MSG_Get("PROGRAM_MODE_UNSUPPORTED_DISPLAY_MODE"),
-			         mode.c_str());
+			         mode_str.c_str());
 		}
 		break;
 
 	case MCH_EGA:
-		if (mode == "40x25") {
+		if (mode_str == "40x25") {
 			INT10_SetVideoMode(0x01);
 
-		} else if (mode == "80x25") {
+		} else if (mode_str == "80x25") {
 			INT10_SetVideoMode(0x03);
 
-		} else if (mode == "80x43") {
+		} else if (mode_str == "80x43") {
 			INT10_SetVideoMode(0x03);
 			set_8x8_font();
 
 		} else {
 			WriteOut(MSG_Get("PROGRAM_MODE_UNSUPPORTED_DISPLAY_MODE"),
-			         mode.c_str());
+			         mode_str.c_str());
 		}
 		break;
 
 	case MCH_VGA:
 		if (svgaCard == SVGA_S3Trio) {
-			if (const auto it = video_mode_map_svga_s3.find(mode);
+			if (const auto it = video_mode_map_svga_s3.find(mode_str);
 			    it != video_mode_map_svga_s3.end()) {
 
-				const auto mode = it->second;
+				const auto& mode = it->second;
 
 				if (mode < MinVesaBiosModeNumber) {
 					INT10_SetVideoMode(mode);
@@ -172,17 +173,19 @@ void MODE::HandleSetDisplayMode(const std::string& _mode)
 				}
 			} else {
 				WriteOut(MSG_Get("PROGRAM_MODE_UNSUPPORTED_DISPLAY_MODE"),
-				         mode.c_str());
+				         mode_str.c_str());
 			}
 
 		} else {
 			// SVGA non-S3
-			if (const auto it = video_mode_map_svga_other.find(mode);
+			if (const auto it = video_mode_map_svga_other.find(mode_str);
 			    it != video_mode_map_svga_other.end()) {
-				INT10_SetVideoMode(it->second);
+
+				const auto& mode = it->second;
+				INT10_SetVideoMode(mode);
 			} else {
 				WriteOut(MSG_Get("PROGRAM_MODE_UNSUPPORTED_DISPLAY_MODE"),
-				         mode.c_str());
+				         mode_str.c_str());
 			}
 		}
 		break;
@@ -244,7 +247,7 @@ void MODE::Run()
 		const auto command = args[0];
 
 		if (is_set_display_mode_command(command)) {
-			const auto mode = command;
+			const auto& mode = command;
 			HandleSetDisplayMode(mode);
 		} else {
 			WriteOut(MSG_Get("PROGRAM_MODE_INVALID_COMMAND"));

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -317,7 +317,7 @@ private:
 		return;
 	}
 
-	bool securemode_check()
+	bool CheckSecureMode()
 	{
 		if (control->SecureMode()) {
 			WriteOut(MSG_Get("PROGRAM_CONFIG_SECURE_DISALLOW"));
@@ -372,7 +372,7 @@ void CONFIG::Run(void)
 		presult = (enum prs)cmd->GetParameterFromList(params, pvars);
 		switch (presult) {
 		case P_RESTART:
-			if (securemode_check()) {
+			if (CheckSecureMode()) {
 				return;
 			}
 			if (pvars.size() == 0) {
@@ -426,7 +426,7 @@ void CONFIG::Run(void)
 			break;
 		}
 		case P_WRITECONF_DEFAULT: {
-			if (securemode_check()) {
+			if (CheckSecureMode()) {
 				return;
 			}
 			if (pvars.size() > 0) {
@@ -438,7 +438,7 @@ void CONFIG::Run(void)
 		}
 		case P_WRITECONF:
 		case P_WRITECONF2:
-			if (securemode_check()) {
+			if (CheckSecureMode()) {
 				return;
 			}
 			if (pvars.size() > 1) {
@@ -714,7 +714,7 @@ void CONFIG::Run(void)
 		case P_REC_AVI_START: CAPTURE_StartVideoCapture(); break;
 		case P_REC_AVI_STOP: CAPTURE_StopVideoCapture(); break;
 		case P_START_MAPPER:
-			if (securemode_check()) {
+			if (CheckSecureMode()) {
 				return;
 			}
 			MAPPER_Run(false);
@@ -888,7 +888,7 @@ void CONFIG::Run(void)
 		case P_WRITELANG2:
 			// In secure mode don't allow a new languagefile to be
 			// created Who knows which kind of file we would overwrite.
-			if (securemode_check()) {
+			if (CheckSecureMode()) {
 				return;
 			}
 			if (pvars.size() < 1) {

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -465,9 +465,7 @@ void CONFIG::HandleHelpCommand(const std::vector<std::string>& pvars_in)
 					// Print min & max for integer values if
 					// used
 					Prop_int* pint = dynamic_cast<Prop_int*>(p);
-					if (pint == nullptr) {
-						E_Exit("Int property dynamic cast failed.");
-					}
+					assert(pint);
 
 					if (pint->GetMin() != pint->GetMax()) {
 						std::ostringstream oss;
@@ -490,7 +488,6 @@ void CONFIG::HandleHelpCommand(const std::vector<std::string>& pvars_in)
 					}
 				}
 
-				output.AddString("\n");
 				output.AddString(MSG_Get("PROGRAM_CONFIG_HLP_PROPHLP"),
 				                 p->propname.c_str(),
 				                 sec->GetName());
@@ -764,9 +761,7 @@ void CONFIG::Run(void)
 						// autoexec section
 						Section_line* pline =
 						        dynamic_cast<Section_line*>(sec);
-						if (pline == nullptr) {
-							E_Exit("Section dynamic cast failed.");
-						}
+						assert(pline);
 
 						WriteOut("%s", pline->data.c_str());
 						break;
@@ -923,8 +918,9 @@ void CONFIG::Run(void)
 			WriteOut(MSG_Get("PROGRAM_CONFIG_SECURE_ON"));
 			return;
 
-		default: E_Exit("bug"); break;
+		default: assert(false); break;
 		}
+
 		first = false;
 	}
 }

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -548,6 +548,7 @@ void CONFIG::HandleHelpCommand(const std::vector<std::string>& pvars_in)
 				// Print 'changability'
 				if (p->GetChange() ==
 				    Property::Changeable::OnlyAtStart) {
+					output.AddString("\n");
 					output.AddString(MSG_Get(
 					        "PROGRAM_CONFIG_HLP_NOCHANGE"));
 

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -400,19 +400,14 @@ void CONFIG::HandleHelpCommand(const std::vector<std::string>& pvars_in)
 	}
 
 	Section_prop* psec = dynamic_cast<Section_prop*>(sec);
-	if (psec == nullptr) {
-		// Failed; maybe it's the autoexec section?
-		Section_line* pline = dynamic_cast<Section_line*>(sec);
-		if (pline == nullptr) {
-			E_Exit("Section dynamic cast failed.");
-		}
 
-		WriteOut(MSG_Get("PROGRAM_CONFIG_HLP_LINEHLP"),
-		         pline->GetName(),
-		         // This is 'unclean' but the autoexec section has no
-		         // help description.
-		         MSG_Get("AUTOEXEC_CONFIGFILE_HELP"),
-		         pline->data.c_str());
+	// Special [autoexec] section handling (if has no properties like all
+	// the other sections).
+	if (psec == nullptr) {
+		WriteOut("\n");
+		WriteOut(MSG_Get("PROGRAM_CONFIG_HLP_AUTOEXEC"),
+		         MSG_Get("AUTOEXEC_CONFIGFILE_HELP"));
+		WriteOut("\n");
 		return;
 	}
 
@@ -1024,10 +1019,10 @@ void PROGRAMS_Init(Section* sec)
 	MSG_Add("PROGRAM_CONFIG_HLP_PROPHLP_CURRENT_VALUE",
 	        "[color=white]Current value:[reset]    %s\n");
 
-	MSG_Add("PROGRAM_CONFIG_HLP_LINEHLP",
+	MSG_Add("PROGRAM_CONFIG_HLP_AUTOEXEC",
 	        "[color=white]Description of the "
-	        "[color=light-cyan][%s][color=white] section:[reset]\n"
-	        "%s\n[color=white]Current value:[reset]\n%s\n");
+	        "[color=light-cyan][autoexec][color=white] section:[reset]\n\n"
+	        "%s\n");
 
 	MSG_Add("PROGRAM_CONFIG_HLP_NOCHANGE",
 	        "[color=brown]This property cannot be changed at runtime.[reset]\n");

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -745,13 +745,18 @@ void CONFIG::Run(void)
 		case P_AUTOEXEC_TYPE: {
 			Section_line* sec = dynamic_cast<Section_line*>(
 			        control->GetSection(std::string("autoexec")));
+
 			if (!sec) {
 				WriteOut(MSG_Get("PROGRAM_CONFIG_SECTION_ERROR"));
 				return;
 			}
+
 			std::string line_dos = {};
 			utf8_to_dos(sec->data, line_dos, UnicodeFallback::Box);
-			WriteOut("\n%s", line_dos.c_str());
+
+			MoreOutputStrings output(*this);
+			output.AddString("\n%s\n\n", line_dos.c_str());
+			output.Display();
 			break;
 		}
 

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -344,12 +344,16 @@ void CONFIG::HandleHelpCommand(const std::vector<std::string>& pvars_in)
 	case 1: {
 		if (!strcasecmp("sections", pvars[0].c_str())) {
 			// List the sections
-			WriteOut(MSG_Get("PROGRAM_CONFIG_HLP_SECTLIST"));
+			MoreOutputStrings output(*this);
+			output.AddString(MSG_Get("PROGRAM_CONFIG_HLP_SECTLIST"));
+
 			for (const Section* sec : *control) {
 				if (sec->IsActive()) {
-					WriteOut("  - %s\n", sec->GetName());
+					output.AddString("  - %s\n", sec->GetName());
 				}
 			}
+			output.AddString("\n");
+			output.Display();
 			return;
 		}
 
@@ -367,6 +371,7 @@ void CONFIG::HandleHelpCommand(const std::vector<std::string>& pvars_in)
 		}
 		break;
 	}
+
 	case 2: {
 		Section* sec = control->GetSection(pvars[0]);
 		if (sec && !sec->IsActive()) {
@@ -387,6 +392,7 @@ void CONFIG::HandleHelpCommand(const std::vector<std::string>& pvars_in)
 		}
 		break;
 	}
+
 	default: DisplayHelp(); return;
 	}
 
@@ -404,15 +410,18 @@ void CONFIG::HandleHelpCommand(const std::vector<std::string>& pvars_in)
 	// Special [autoexec] section handling (if has no properties like all
 	// the other sections).
 	if (psec == nullptr) {
-		WriteOut("\n");
-		WriteOut(MSG_Get("PROGRAM_CONFIG_HLP_AUTOEXEC"),
-		         MSG_Get("AUTOEXEC_CONFIGFILE_HELP"));
-		WriteOut("\n");
+		MoreOutputStrings output(*this);
+		output.AddString(MSG_Get("PROGRAM_CONFIG_HLP_AUTOEXEC"),
+		                 MSG_Get("AUTOEXEC_CONFIGFILE_HELP"));
+		output.AddString("\n");
+		output.Display();
 		return;
 	}
 
 	if (pvars.size() == 1) {
-		WriteOut(MSG_Get("PROGRAM_CONFIG_HLP_SECTHLP"), pvars[0].c_str());
+		MoreOutputStrings output(*this);
+		output.AddString(MSG_Get("PROGRAM_CONFIG_HLP_SECTHLP"),
+		                 pvars[0].c_str());
 
 		size_t i = 0;
 		while (true) {
@@ -424,14 +433,17 @@ void CONFIG::HandleHelpCommand(const std::vector<std::string>& pvars_in)
 			if (p->IsDeprecated()) {
 				continue;
 			}
-			WriteOut("  - %s\n", p->propname.c_str());
+			output.AddString("  - %s\n", p->propname.c_str());
 		}
+		output.AddString("\n");
+		output.Display();
 
 	} else {
 		// pvars has more than 1 element
+		MoreOutputStrings output(*this);
 
-		// Find the property by it's name
-		size_t i = 0;
+		// Find the property by its name
+		auto i = 0;
 
 		while (true) {
 			Property* p = psec->Get_prop(i++);
@@ -478,32 +490,36 @@ void CONFIG::HandleHelpCommand(const std::vector<std::string>& pvars_in)
 					}
 				}
 
-				WriteOut("\n");
-				WriteOut(MSG_Get("PROGRAM_CONFIG_HLP_PROPHLP"),
-				         p->propname.c_str(),
-				         sec->GetName());
+				output.AddString("\n");
+				output.AddString(MSG_Get("PROGRAM_CONFIG_HLP_PROPHLP"),
+				                 p->propname.c_str(),
+				                 sec->GetName());
 
 				if (p->IsDeprecated()) {
-					WriteOut(MSG_Get("PROGRAM_CONFIG_DEPRECATED"));
-					WriteOut("\n");
+					output.AddString(MSG_Get(
+					        "PROGRAM_CONFIG_DEPRECATED"));
+					output.AddString("\n");
 				}
 
-				WriteOut(p->GetHelp().c_str());
-				WriteOut("\n\n");
+				output.AddString(p->GetHelp().c_str());
+				output.AddString("\n\n");
 
 				auto write_last_newline = false;
 
 				if (!p->IsDeprecated()) {
 					if (!possible_values.empty()) {
-						WriteOut(MSG_Get("PROGRAM_CONFIG_HLP_PROPHLP_POSSIBLE_VALUES"),
-						         possible_values.c_str());
+						output.AddString(
+						        MSG_Get("PROGRAM_CONFIG_HLP_PROPHLP_POSSIBLE_VALUES"),
+						        possible_values.c_str());
 					}
 
-					WriteOut(MSG_Get("PROGRAM_CONFIG_HLP_PROPHLP_DEFAULT_VALUE"),
-					         p->GetDefaultValue().ToString().c_str());
+					output.AddString(
+					        MSG_Get("PROGRAM_CONFIG_HLP_PROPHLP_DEFAULT_VALUE"),
+					        p->GetDefaultValue().ToString().c_str());
 
-					WriteOut(MSG_Get("PROGRAM_CONFIG_HLP_PROPHLP_CURRENT_VALUE"),
-					         p->GetValue().ToString().c_str());
+					output.AddString(
+					        MSG_Get("PROGRAM_CONFIG_HLP_PROPHLP_CURRENT_VALUE"),
+					        p->GetValue().ToString().c_str());
 
 					write_last_newline = true;
 				}
@@ -511,17 +527,19 @@ void CONFIG::HandleHelpCommand(const std::vector<std::string>& pvars_in)
 				// Print 'changability'
 				if (p->GetChange() ==
 				    Property::Changeable::OnlyAtStart) {
-					WriteOut(MSG_Get("PROGRAM_CONFIG_HLP_NOCHANGE"));
+					output.AddString(MSG_Get(
+					        "PROGRAM_CONFIG_HLP_NOCHANGE"));
 
 					write_last_newline = true;
 				}
 
 				if (write_last_newline) {
-					WriteOut("\n");
+					output.AddString("\n");
 				}
-				return;
 			}
 		}
+
+		output.Display();
 	}
 }
 

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -305,7 +305,8 @@ public:
 	void Run(void) override;
 
 private:
-	void restart(const char* useconfig);
+	void DisplayHelp();
+	void HandleHelpCommand(std::vector<std::string> pvars);
 
 	void WriteConfig(const std::string& name)
 	{

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -637,6 +637,7 @@ void CONFIG::Run(void)
 
 			if (size == 0) {
 				WriteOut(MSG_Get("PROGRAM_CONFIG_NOCONFIGFILE"));
+
 			} else {
 				WriteOut(MSG_Get("PROGRAM_CONFIG_PRIMARY_CONF"),
 				         control->configfiles.front().c_str());
@@ -651,15 +652,19 @@ void CONFIG::Run(void)
 					}
 				}
 			}
+
 			if (control->startup_params.size() > 0) {
 				std::string test;
 				for (size_t k = 0; k < control->startup_params.size();
 				     ++k) {
 					test += control->startup_params[k] + " ";
 				}
+
 				WriteOut(MSG_Get("PROGRAM_CONFIG_PRINT_STARTUP"),
 				         test.c_str());
 			}
+
+			WriteOut("\n");
 			break;
 		}
 

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -1108,7 +1108,7 @@ void PROGRAMS_Init(Section* sec)
 	        "%s\n");
 
 	MSG_Add("PROGRAM_CONFIG_HLP_NOCHANGE",
-	        "[color=brown]This property cannot be changed at runtime.[reset]\n");
+	        "[color=yellow]This setting cannot be changed at runtime.[reset]\n");
 
 	MSG_Add("PROGRAM_CONFIG_HLP_POSINT", "positive integer");
 
@@ -1127,7 +1127,7 @@ void PROGRAMS_Init(Section* sec)
 	MSG_Add("PROGRAM_CONFIG_SECTION_ERROR", "Section [%s] doesn't exist.\n");
 
 	MSG_Add("PROGRAM_CONFIG_VALUE_ERROR",
-	        "'%s' is not a valid value for property '%s'.\n");
+	        "'%s' is not a valid value for setting '%s'.\n");
 
 	MSG_Add("PROGRAM_CONFIG_GET_SYNTAX",
 	        "Usage: [color=light-green]config[reset] -get "
@@ -1146,7 +1146,7 @@ void PROGRAMS_Init(Section* sec)
 	MSG_Add("CONJUNCTION_AND", "and");
 
 	MSG_Add("PROGRAM_CONFIG_NOT_CHANGEABLE",
-	        "Property '%s' is not changeable at runtime.\n");
+	        "Setting '%s' is not changeable at runtime.\n");
 
 	MSG_Add("PROGRAM_CONFIG_DEPRECATED",
 	        "[color=light-red]This is a deprecated setting only kept for compatibility with old configs.\n"

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -725,7 +725,7 @@ bool PropMultiVal::SetValue(const std::string& input)
 		}
 
 		prevtype     = p->Get_type();
-		prevargument = in;
+		prevargument = std::move(in);
 	}
 
 	return is_valid;
@@ -1159,7 +1159,7 @@ bool Config::WriteConfig(const std_fs::path& path) const
 				// through printf-like functions (e.g.,
 				// WriteOut()). So we need to de-escape them before
 				// writing them into the config.
-				auto s = format_str(help.c_str());
+				auto s = format_str(help);
 
 				fprintf(outfile,
 				        "# %*s: %s",


### PR DESCRIPTION
# Description

As the title says. Displaying our built-in command's help with the `/?` or `-h` options does that already, so I've taught `CONFIG` the same trick.

It really bothered me that I had to make people type in things like `CONFIG -h glshader | MORE` in the getting started guide. Plus having to pipe things through `MORE` manually is just an annoyance for everybody.

I've also some made some further enhancements to the output (inserting some new lines here and there).

This fixes the PVS-Studio warnings too that I somehow introduced to `main`...

# Manual testing

Played around with the relevant `CONFIG` commands, and confirmed the output is now paginated.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

