### PR TITLE
Mirror the Adlib command port (388h) in the GUS

### DIFF
--- a/include/hardware.h
+++ b/include/hardware.h
@@ -28,6 +28,7 @@
 #include <string>
 
 #include "control.h"
+#include "inout.h"
 
 class Section;
 
@@ -51,10 +52,14 @@ void OPL_AddConfigSettings(const ConfigPtr &conf);
 
 bool TANDYSOUND_GetAddress(Bitu& tsaddr, Bitu& tsirq, Bitu& tsdma);
 
-extern uint8_t adlib_commandreg;
-
 // Gravis UltraSound configuration and initialisation
 void GUS_AddConfigSection(const ConfigPtr &conf);
+
+// The Gravis UltraSound mirrors the AdLib's command register (written to the
+// command port 388h) on its own port 20Ah. This function passes the command
+// onto the GUS (if available)
+void GUS_MirrorAdLibCommandPortWrite(const io_port_t port, const io_val_t reg_value,
+                                     const io_width_t = io_width_t::byte);
 
 // IBM Music Feature Card configuration and initialisation
 void IMFC_AddConfigSection(const ConfigPtr& conf);

--- a/include/inout.h
+++ b/include/inout.h
@@ -116,6 +116,15 @@ static inline uint8_t IO_Read(io_port_t port)
 
 // Hardware I/O port numbers
 
+namespace Port {
+
+namespace AdLib {
+
+constexpr io_port_t Command = 0x388u;
+
+}
+} // namespace Port
+
 // Intel 8042 keyboard/mouse port microcontroller
 constexpr io_port_t port_num_i8042_data    = 0x60u;
 constexpr io_port_t port_num_i8042_status  = 0x64u; // read-only

--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -1328,8 +1328,6 @@ void Gus::RegisterIoHandlers()
 
 void Gus::StopAndReset() noexcept
 {
-	assert(!reset_register.is_running);
-
 	// Halt playback before altering the DSP state
 	audio_channel->Enable(false);
 
@@ -1351,6 +1349,8 @@ void Gus::StopAndReset() noexcept
 	selected_register     = 0;
 	should_change_irq_dma = false;
 	PIC_RemoveEvents(GUS_TimerEvent);
+
+	reset_register.data = {};
 }
 
 static void GUS_TimerEvent(uint32_t t)

--- a/src/hardware/opl.cpp
+++ b/src/hardware/opl.cpp
@@ -824,9 +824,8 @@ Opl::Opl(Section* configuration, const OplMode _opl_mode)
 	const auto write_to  = std::bind(&Opl::PortWrite, this, _1, _2, _3);
 
 	// 0x388-0x38b ports (read/write)
-	constexpr io_port_t port_0x388 = 0x388;
-	WriteHandler[0].Install(port_0x388, write_to, io_width_t::byte, 4);
-	ReadHandler[0].Install(port_0x388, read_from, io_width_t::byte, 4);
+	WriteHandler[0].Install(Port::AdLib::Command, write_to, io_width_t::byte, 4);
+	ReadHandler[0].Install(Port::AdLib::Command, read_from, io_width_t::byte, 4);
 
 	// 0x220-0x223 ports (read/write)
 	if (dual_opl) {
@@ -845,7 +844,7 @@ Opl::Opl(Section* configuration, const OplMode _opl_mode)
 	        channel->GetName().c_str(),
 	        to_string(opl.mode),
 	        base,
-	        port_0x388);
+	        Port::AdLib::Command);
 }
 
 Opl::~Opl()

--- a/src/hardware/opl.cpp
+++ b/src/hardware/opl.cpp
@@ -657,6 +657,11 @@ void Opl::PortWrite(const io_port_t port, const io_val_t value, const io_width_t
 			        format_str("Invalid OPL mode: %s",
 			                   to_string(opl.mode)));
 		}
+
+		// Pass the command value onto the GUS (regardless of OPL card type)
+		if (port == Port::AdLib::Command) {
+			GUS_MirrorAdLibCommandPortWrite(port, val);
+		}
 	}
 }
 

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -2873,12 +2873,6 @@ static void write_sb(const io_port_t port, const io_val_t value, const io_width_
 	}
 }
 
-static void adlib_gus_forward(const io_port_t, const io_val_t value, const io_width_t)
-{
-	const auto val = check_cast<uint8_t>(value);
-	adlib_commandreg = (uint8_t)(val & 0xff);
-}
-
 bool SB_GetAddress(uint16_t &sbaddr, uint8_t &sbirq, uint8_t &sbdma)
 {
 	sbaddr = 0;
@@ -3173,7 +3167,7 @@ public:
 		switch (oplmode) {
 		case OplMode::None:
 			write_handlers[0].Install(Port::AdLib::Command,
-			                          adlib_gus_forward,
+			                          GUS_MirrorAdLibCommandPortWrite,
 			                          io_width_t::byte);
 			break;
 

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -3172,7 +3172,7 @@ public:
 		// Init OPL
 		switch (oplmode) {
 		case OplMode::None:
-			write_handlers[0].Install(0x388,
+			write_handlers[0].Install(Port::AdLib::Command,
 			                          adlib_gus_forward,
 			                          io_width_t::byte);
 			break;


### PR DESCRIPTION
# Description

This mirrors the Adlib command port (388h) in the GUS 20Ah as explained by @gmcn42. Turns out this was already in the code using a global variable in `hardware.h`, however it just wasn't fully connected on the OPL side (maybe it was at one point?).

I noticed this global variable didn't match with the existing design patterns, so I swapped it out with a new function instead, which looked like a better fit and more self-documenting.

(This PR also fixes an unintended assert that I accidentally introduced in the prior PR. Oops!)

## Related issues

Fixes https://github.com/dosbox-staging/dosbox-staging/issues/1446.

# Manual testing

`ULTRINIT` and `MIDIDEMO` work OK using @FeralChild64's conf (in #1446):

![sb-and-gus-ultrinit](https://github.com/dosbox-staging/dosbox-staging/assets/165201780/ff625802-e72b-49fc-a35d-d0fccd0abc25)

... and now for some inspiration 90s MIDI! :dark_sunglasses: 

https://github.com/dosbox-staging/dosbox-staging/assets/165201780/51d51595-0406-4098-9a51-ae9ae1642281

Also re-tested all the same GUS games and demos that I tested in the GUS reset PR.

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

