### PR TITLE
Use native file I/O in local and overlay drive

### DIFF
--- a/include/dos_system.h
+++ b/include/dos_system.h
@@ -27,6 +27,7 @@
 
 #include "bit_view.h"
 #include "cross.h"
+#include "fs_utils.h"
 #include "mem.h"
 #include "support.h"
 
@@ -189,7 +190,7 @@ private:
 
 class localFile : public DOS_File {
 public:
-	localFile(const char* name, const std_fs::path& path, FILE* handle,
+	localFile(const char* name, const std_fs::path& path, const NativeFileHandle handle,
 	          const char* basedir, bool _read_only_medium);
 	localFile(const localFile&)            = delete; // prevent copying
 	localFile& operator=(const localFile&) = delete; // prevent assignment
@@ -199,7 +200,6 @@ public:
 	bool Close() override;
 	uint16_t GetInformation() override;
 	bool UpdateDateTimeFromHost() override;
-	void Flush();
 	bool IsOnReadOnlyMedium() const override { return read_only_medium; }
 	const char* GetBaseDir() const
 	{
@@ -209,21 +209,13 @@ public:
 	{
 		return path;
 	}
-	FILE* fhandle = nullptr; // todo handle this properly
+	NativeFileHandle file_handle = InvalidNativeFileHandle;
 private:
 	const std_fs::path path = {};
 	const char* basedir     = nullptr;
-	long stream_pos         = 0;
-
-	bool ftell_and_check();
-	void fseek_and_check(int whence);
-	bool fseek_to_and_check(long pos, int whence);
 
 	const bool read_only_medium = false;
 	bool set_archive_on_close   = false;
-
-	enum class LastAction : uint8_t { None, Read, Write };
-	LastAction last_action = LastAction::None;
 };
 
 /* The following variable can be lowered to free up some memory.

--- a/include/dos_system.h
+++ b/include/dos_system.h
@@ -190,8 +190,9 @@ private:
 
 class localFile : public DOS_File {
 public:
-	localFile(const char* name, const std_fs::path& path, const NativeFileHandle handle,
-	          const char* basedir, bool _read_only_medium);
+	localFile(const char* name, const std_fs::path& path,
+	          const NativeFileHandle handle, const char* basedir,
+	          bool _read_only_medium);
 	localFile(const localFile&)            = delete; // prevent copying
 	localFile& operator=(const localFile&) = delete; // prevent assignment
 	bool Read(uint8_t* data, uint16_t* size) override;
@@ -210,6 +211,7 @@ public:
 		return path;
 	}
 	NativeFileHandle file_handle = InvalidNativeFileHandle;
+
 private:
 	const std_fs::path path = {};
 	const char* basedir     = nullptr;

--- a/include/drives.h
+++ b/include/drives.h
@@ -507,8 +507,8 @@ public:
 	bool Rename(const char* oldname, const char* newname) override;
 	void EmptyCache(void) override;
 
-	std::pair<FILE*, std_fs::path> create_file_in_overlay(const char* dos_filename,
-	                                                      const char* mode);
+	std::pair<NativeFileHandle, std_fs::path> create_file_in_overlay(const char* dos_filename,
+	                                                                 const FatAttributeFlags attributes);
 
 	Bits UnMount(void) override;
 	bool TestDir(const char* dir) override;

--- a/include/drives.h
+++ b/include/drives.h
@@ -507,8 +507,8 @@ public:
 	bool Rename(const char* oldname, const char* newname) override;
 	void EmptyCache(void) override;
 
-	std::pair<NativeFileHandle, std_fs::path> create_file_in_overlay(const char* dos_filename,
-	                                                                 const FatAttributeFlags attributes);
+	std::pair<NativeFileHandle, std_fs::path> create_file_in_overlay(
+	        const char* dos_filename, const FatAttributeFlags attributes);
 
 	Bits UnMount(void) override;
 	bool TestDir(const char* dir) override;

--- a/include/fs_utils.h
+++ b/include/fs_utils.h
@@ -46,21 +46,14 @@
 
 constexpr int64_t NativeSeekFailed = -1;
 
-struct NativeIoResult
-{
+struct NativeIoResult {
 	int64_t num_bytes = 0;
-	bool error = false;
+	bool error        = false;
 };
 
-enum class NativeSeek
-{
-	Set,
-	Current,
-	End
-};
+enum class NativeSeek { Set, Current, End };
 
-struct DosDateTime
-{
+struct DosDateTime {
 	uint16_t date = 0;
 	uint16_t time = 0;
 };
@@ -207,17 +200,20 @@ uint16_t local_drive_get_attributes(const std_fs::path& path,
 uint16_t local_drive_set_attributes(const std_fs::path& path,
                                     const FatAttributeFlags attributes);
 
-
 // Native file I/O wrappers.
-// Currently only used by local drive and overlay drive but suitable for use elsewhere.
+// Currently only used by local drive and overlay drive but suitable for use
+// elsewhere.
 NativeFileHandle open_native_file(const std_fs::path& path, const bool write_access);
 NativeFileHandle create_native_file(const std_fs::path& path,
                                     const std::optional<FatAttributeFlags> attributes);
 
-NativeIoResult read_native_file(const NativeFileHandle handle, uint8_t *buffer, const int64_t num_bytes_requested);
-NativeIoResult write_native_file(const NativeFileHandle handle, const uint8_t *buffer, const int64_t num_bytes_requested);
+NativeIoResult read_native_file(const NativeFileHandle handle, uint8_t* buffer,
+                                const int64_t num_bytes_requested);
+NativeIoResult write_native_file(const NativeFileHandle handle, const uint8_t* buffer,
+                                 const int64_t num_bytes_requested);
 
-int64_t seek_native_file(const NativeFileHandle handle, const int64_t offset, const NativeSeek type);
+int64_t seek_native_file(const NativeFileHandle handle, const int64_t offset,
+                         const NativeSeek type);
 
 // Returns offset from beginning of file
 int64_t get_native_file_position(const NativeFileHandle handle);

--- a/src/dos/dos_files.cpp
+++ b/src/dos/dos_files.cpp
@@ -702,6 +702,10 @@ bool DOS_WriteFile(uint16_t entry,uint8_t * data,uint16_t * amount,bool fcb) {
 }
 
 bool DOS_SeekFile(uint16_t entry,uint32_t * pos,uint32_t type,bool fcb) {
+	if (type > DOS_SEEK_END) {
+		DOS_SetError(DOSERR_FUNCTION_NUMBER_INVALID);
+		return false;
+	}
 	uint32_t handle = fcb?entry:RealHandle(entry);
 	if (handle>=DOS_FILES) {
 		DOS_SetError(DOSERR_INVALID_HANDLE);

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -186,11 +186,12 @@ bool localDrive::FileOpen(DOS_File **file, const char *name, uint8_t flags)
 	// If we couldn't open the file, then it's possible that
 	// the file is simply write-protected and the flags requested
 	// RW access.  So check if this is the case:
-	if (file_handle == InvalidNativeFileHandle && write_access && always_open_ro_files) {
+	if (file_handle == InvalidNativeFileHandle && write_access &&
+	    always_open_ro_files) {
 		// If yes, check if the file can be opened with Read-only access:
 		file_handle = open_native_file(host_filename, false);
 		if (file_handle != InvalidNativeFileHandle) {
-			flags = OPEN_READ;
+			flags                = OPEN_READ;
 			fallback_to_readonly = true;
 		}
 	}
@@ -581,7 +582,7 @@ bool localFile::Read(uint8_t *data, uint16_t *size)
 	}
 
 	const auto ret = read_native_file(file_handle, data, *size);
-	*size = check_cast<uint16_t>(ret.num_bytes);
+	*size          = check_cast<uint16_t>(ret.num_bytes);
 	if (ret.error) {
 		DOS_SetError(DOSERR_ACCESS_DENIED);
 		return false;
@@ -622,7 +623,7 @@ bool localFile::Write(uint8_t *data, uint16_t *size)
 
 	// Otherwise we have some data to write
 	const auto ret = write_native_file(file_handle, data, *size);
-	*size = check_cast<uint16_t>(ret.num_bytes);
+	*size          = check_cast<uint16_t>(ret.num_bytes);
 	if (ret.error) {
 		DOS_SetError(DOSERR_ACCESS_DENIED);
 		return false;
@@ -635,24 +636,16 @@ bool localFile::Seek(uint32_t *pos_addr, uint32_t type)
 {
 	NativeSeek seek_type;
 	switch (type) {
-		case DOS_SEEK_SET:
-			seek_type = NativeSeek::Set;
-			break;
-		case DOS_SEEK_CUR:
-			seek_type = NativeSeek::Current;
-			break;
-		case DOS_SEEK_END:
-			seek_type = NativeSeek::End;
-			break;
-		default:
-			assertm(false, "Invalid seek type");
-			return false;
+	case DOS_SEEK_SET: seek_type = NativeSeek::Set; break;
+	case DOS_SEEK_CUR: seek_type = NativeSeek::Current; break;
+	case DOS_SEEK_END: seek_type = NativeSeek::End; break;
+	default: assertm(false, "Invalid seek type"); return false;
 	}
 
 	// The inbound position is actually an int32_t being passed through a
 	// uint32_t* pointer (pos_addr), so reinterpret the underlying memory as
 	// such to prevent rollover into the unsigned range.
-	const auto requested_pos = *reinterpret_cast<int32_t *>(pos_addr);
+	const auto requested_pos = *reinterpret_cast<int32_t*>(pos_addr);
 
 	auto returned_pos = seek_native_file(file_handle, requested_pos, seek_type);
 
@@ -664,7 +657,8 @@ bool localFile::Seek(uint32_t *pos_addr, uint32_t type)
 		// the end of file, which satisfies Black Thorne.
 		returned_pos = seek_native_file(file_handle, 0, NativeSeek::End);
 		if (returned_pos == NativeSeekFailed) {
-			// Unlikely to fail but this matches behavior of the old code using fseek()
+			// Unlikely to fail but this matches behavior of the old
+			// code using fseek()
 			returned_pos = 0;
 		}
 	}
@@ -674,7 +668,7 @@ bool localFile::Seek(uint32_t *pos_addr, uint32_t type)
 	// back into it we first ensure the current long stream_pos (which is a
 	// signed 64-bit on some platforms + OSes) can fit within the int32_t
 	// range before assigning it.
-	*reinterpret_cast<int32_t *>(pos_addr) = check_cast<int32_t>(returned_pos);
+	*reinterpret_cast<int32_t*>(pos_addr) = check_cast<int32_t>(returned_pos);
 
 	return true;
 }
@@ -746,8 +740,9 @@ uint16_t localFile::GetInformation(void)
 	return read_only_medium ? 0x40 : 0;
 }
 
-localFile::localFile(const char* _name, const std_fs::path& path, const NativeFileHandle handle,
-                     const char* _basedir, const bool _read_only_medium)
+localFile::localFile(const char* _name, const std_fs::path& path,
+                     const NativeFileHandle handle, const char* _basedir,
+                     const bool _read_only_medium)
         : file_handle(handle),
           path(path),
           basedir(_basedir),

--- a/src/dos/drive_overlay.cpp
+++ b/src/dos/drive_overlay.cpp
@@ -206,8 +206,9 @@ bool Overlay_Drive::TestDir(const char * dir) {
 
 class OverlayFile final : public localFile {
 public:
-	OverlayFile(const char* name, const std_fs::path& path, NativeFileHandle handle,
-	            const char* basedir, const bool _read_only_medium)
+	OverlayFile(const char* name, const std_fs::path& path,
+	            NativeFileHandle handle, const char* basedir,
+	            const bool _read_only_medium)
 	        : localFile(name, path, handle, basedir, _read_only_medium),
 	          overlay_active(false)
 	{
@@ -245,7 +246,9 @@ public:
 std::pair<NativeFileHandle, std_fs::path> Overlay_Drive::create_file_in_overlay(
         const char* dos_filename, const FatAttributeFlags attributes)
 {
-	if (logoverlay) LOG_MSG("create_file_in_overlay called %s", dos_filename);
+	if (logoverlay) {
+		LOG_MSG("create_file_in_overlay called %s", dos_filename);
+	}
 	char newname[CROSS_LEN];
 	safe_strcpy(newname, overlaydir); // TODO GOG make part of class and
 	                                  // join in
@@ -285,7 +288,8 @@ static void copy_file_contents(const NativeFileHandle src, const NativeFileHandl
 	}
 }
 
-bool OverlayFile::create_copy() {
+bool OverlayFile::create_copy()
+{
 	//test if open/valid/etc
 	//ensure file position
 	if (logoverlay) LOG_MSG("create_copy called %s",GetName());
@@ -295,12 +299,14 @@ bool OverlayFile::create_copy() {
 	const auto location_in_old_file = get_native_file_position(file_handle);
 	if (location_in_old_file == NativeSeekFailed) {
 		LOG_ERR("OVERLAY: Failed getting current position in file '%s': %s",
-		        GetName(), strerror(errno));
+		        GetName(),
+		        strerror(errno));
 		return false;
 	}
 	if (seek_native_file(file_handle, 0, NativeSeek::Set) == NativeSeekFailed) {
 		LOG_ERR("OVERLAY: Failed seeking to the beginning of file '%s': %s",
-		        GetName(), strerror(errno));
+		        GetName(),
+		        strerror(errno));
 		return false;
 	}
 
@@ -312,7 +318,9 @@ bool OverlayFile::create_copy() {
 			FatAttributeFlags attributes = {};
 			local_drive_get_attributes(GetPath(), attributes);
 			std_fs::path newpath = {};
-			std::tie(newhandle, newpath) = od->create_file_in_overlay(GetName(), attributes);
+			std::tie(newhandle,
+			         newpath) = od->create_file_in_overlay(GetName(),
+			                                               attributes);
 		}
 	}
 
@@ -323,20 +331,21 @@ bool OverlayFile::create_copy() {
 	copy_file_contents(file_handle, newhandle);
 
 	//Set copied file handle to position of the old one
-	if (seek_native_file(newhandle, location_in_old_file, NativeSeek::Set) == NativeSeekFailed) {
+	if (seek_native_file(newhandle, location_in_old_file, NativeSeek::Set) ==
+	    NativeSeekFailed) {
 		LOG_ERR("OVERLAY: Failed seeking to position %lld in file '%s': %s",
-		        static_cast<long long>(location_in_old_file), GetName(), strerror(errno));
+		        static_cast<long long>(location_in_old_file),
+		        GetName(),
+		        strerror(errno));
 		close_native_file(newhandle);
 		return false;
 	}
 	close_native_file(file_handle);
 	file_handle = newhandle;
-	//Flags ?
+	// Flags ?
 	if (logoverlay) LOG_MSG("success");
 	return true;
 }
-
-
 
 static OverlayFile* ccc(DOS_File* file) {
 	localFile* l = dynamic_cast<localFile*>(file);
@@ -464,18 +473,12 @@ bool Overlay_Drive::FileOpen(DOS_File** file, const char* name, uint8_t flags)
 {
 	bool write_access = false;
 	switch (flags & 0xf) {
-		case OPEN_READ:
-		//No modification of dates. LORD4.07 uses this
-		case OPEN_READ_NO_MOD:
-			write_access = false;
-			break;
-		case OPEN_WRITE:
-		case OPEN_READWRITE:
-			write_access = true;
-			break;
-		default:
-			DOS_SetError(DOSERR_ACCESS_CODE_INVALID);
-			return false;
+	case OPEN_READ:
+	// No modification of dates. LORD4.07 uses this
+	case OPEN_READ_NO_MOD: write_access = false; break;
+	case OPEN_WRITE:
+	case OPEN_READWRITE: write_access = true; break;
+	default: DOS_SetError(DOSERR_ACCESS_CODE_INVALID); return false;
 	}
 
 	//Todo check name first against local tree
@@ -1278,7 +1281,9 @@ bool Overlay_Drive::Rename(const char * oldname, const char * newname) {
 		CROSS_FILENAME(newold);
 		dirCache.ExpandNameAndNormaliseCase(newold);
 		NativeFileHandle o = open_native_file(newold, false);
-		if (o == InvalidNativeFileHandle) return false;
+		if (o == InvalidNativeFileHandle) {
+			return false;
+		}
 		auto [n, path] = create_file_in_overlay(newname, attr);
 		if (n == InvalidNativeFileHandle) {
 			close_native_file(o);

--- a/src/misc/fs_utils.cpp
+++ b/src/misc/fs_utils.cpp
@@ -181,3 +181,8 @@ uint16_t local_drive_create_dir(const std_fs::path& path)
 
 	return (result == 0) ? DOSERR_NONE : DOSERR_ACCESS_DENIED;
 }
+
+int64_t get_native_file_position(const NativeFileHandle handle)
+{
+	return seek_native_file(handle, 0, NativeSeek::Current);
+}

--- a/src/misc/fs_utils_posix.cpp
+++ b/src/misc/fs_utils_posix.cpp
@@ -338,8 +338,7 @@ uint16_t local_drive_set_attributes(const std_fs::path& path,
 	return status ? DOSERR_NONE : DOSERR_ACCESS_DENIED;
 }
 
-NativeFileHandle open_native_file(const std_fs::path& path,
-                                  const bool write_access)
+NativeFileHandle open_native_file(const std_fs::path& path, const bool write_access)
 {
 	return open(path.c_str(), write_access ? O_RDWR : O_RDONLY);
 }
@@ -358,16 +357,20 @@ NativeFileHandle create_native_file(const std_fs::path& path,
 }
 
 // POSIX does not guarantee to read or write all bytes requested at once.
-// On Linux, it will read the entire chunk in one call (assuming it's a normal file).
-// On Windows, it does not always do so (although we're not using these functions on Windows).
-// On Mac and the various BSDs, who knows. So be safe and do a loop.
-NativeIoResult read_native_file(const NativeFileHandle handle, uint8_t *buffer, const int64_t num_bytes_requested)
+// On Linux, it will read the entire chunk in one call (assuming it's a normal
+// file). On Windows, it does not always do so (although we're not using these
+// functions on Windows). On Mac and the various BSDs, who knows. So be safe and
+// do a loop.
+NativeIoResult read_native_file(const NativeFileHandle handle, uint8_t* buffer,
+                                const int64_t num_bytes_requested)
 {
 	NativeIoResult ret = {};
-	ret.num_bytes = 0;
-	ret.error = false;
+	ret.num_bytes      = 0;
+	ret.error          = false;
 	while (ret.num_bytes < num_bytes_requested) {
-		const auto num_bytes_read = read(handle, buffer + ret.num_bytes, num_bytes_requested - ret.num_bytes);
+		const auto num_bytes_read = read(handle,
+		                                 buffer + ret.num_bytes,
+		                                 num_bytes_requested - ret.num_bytes);
 		if (num_bytes_read <= 0) {
 			ret.error = num_bytes_read < 0;
 			break;
@@ -377,13 +380,17 @@ NativeIoResult read_native_file(const NativeFileHandle handle, uint8_t *buffer, 
 	return ret;
 }
 
-NativeIoResult write_native_file(const NativeFileHandle handle, const uint8_t *buffer, const int64_t num_bytes_requested)
+NativeIoResult write_native_file(const NativeFileHandle handle, const uint8_t* buffer,
+                                 const int64_t num_bytes_requested)
 {
 	NativeIoResult ret = {};
-	ret.num_bytes = 0;
-	ret.error = false;
+	ret.num_bytes      = 0;
+	ret.error          = false;
 	while (ret.num_bytes < num_bytes_requested) {
-		const auto num_bytes_written = write(handle, buffer + ret.num_bytes, num_bytes_requested - ret.num_bytes);
+		const auto num_bytes_written = write(handle,
+		                                     buffer + ret.num_bytes,
+		                                     num_bytes_requested -
+		                                             ret.num_bytes);
 		if (num_bytes_written <= 0) {
 			ret.error = num_bytes_written < 0;
 			break;
@@ -393,22 +400,15 @@ NativeIoResult write_native_file(const NativeFileHandle handle, const uint8_t *b
 	return ret;
 }
 
-int64_t seek_native_file(const NativeFileHandle handle, const int64_t offset, const NativeSeek type)
+int64_t seek_native_file(const NativeFileHandle handle, const int64_t offset,
+                         const NativeSeek type)
 {
 	int posix_seek_type = SEEK_SET;
 	switch (type) {
-		case NativeSeek::Set:
-			posix_seek_type = SEEK_SET;
-			break;
-		case NativeSeek::Current:
-			posix_seek_type = SEEK_CUR;
-			break;
-		case NativeSeek::End:
-			posix_seek_type = SEEK_END;
-			break;
-		default:
-			assertm(false, "Invalid seek type");
-			return NativeSeekFailed;
+	case NativeSeek::Set: posix_seek_type = SEEK_SET; break;
+	case NativeSeek::Current: posix_seek_type = SEEK_CUR; break;
+	case NativeSeek::End: posix_seek_type = SEEK_END; break;
+	default: assertm(false, "Invalid seek type"); return NativeSeekFailed;
 	}
 
 	const auto position = lseek(handle, offset, posix_seek_type);
@@ -438,8 +438,8 @@ DosDateTime get_dos_file_time(const NativeFileHandle handle)
 {
 	// Legal defaults if we're unable to populate them
 	DosDateTime ret = {};
-	ret.time = 1;
-	ret.date = 1;
+	ret.time        = 1;
+	ret.date        = 1;
 
 	struct stat file_info = {};
 	if (fstat(handle, &file_info) == -1) {

--- a/src/misc/fs_utils_posix.cpp
+++ b/src/misc/fs_utils_posix.cpp
@@ -295,22 +295,6 @@ static bool set_xattr([[maybe_unused]] const int file_descriptor,
 	return (result == 0);
 }
 
-FILE* local_drive_create_file(const std_fs::path& path,
-                              const FatAttributeFlags attributes)
-{
-	FILE* file_pointer = nullptr;
-
-	const auto file_descriptor = open(path.c_str(),
-	                                  O_CREAT | O_RDWR | O_TRUNC,
-	                                  PermissionsRW);
-	if (file_descriptor != -1) {
-		set_xattr(file_descriptor, attributes);
-		file_pointer = fdopen(file_descriptor, "wb+");
-	}
-
-	return file_pointer;
-}
-
 uint16_t local_drive_get_attributes(const std_fs::path& path,
                                     FatAttributeFlags& attributes)
 {
@@ -352,6 +336,125 @@ uint16_t local_drive_set_attributes(const std_fs::path& path,
 	}
 
 	return status ? DOSERR_NONE : DOSERR_ACCESS_DENIED;
+}
+
+NativeFileHandle open_native_file(const std_fs::path& path,
+                                  const bool write_access)
+{
+	return open(path.c_str(), write_access ? O_RDWR : O_RDONLY);
+}
+
+NativeFileHandle create_native_file(const std_fs::path& path,
+                                    const std::optional<FatAttributeFlags> attributes)
+{
+	const auto file_descriptor = open(path.c_str(),
+	                                  O_CREAT | O_RDWR | O_TRUNC,
+	                                  PermissionsRW);
+	if (attributes && file_descriptor != InvalidNativeFileHandle) {
+		set_xattr(file_descriptor, *attributes);
+	}
+
+	return file_descriptor;
+}
+
+// POSIX does not guarantee to read or write all bytes requested at once.
+// On Linux, it will read the entire chunk in one call (assuming it's a normal file).
+// On Windows, it does not always do so (although we're not using these functions on Windows).
+// On Mac and the various BSDs, who knows. So be safe and do a loop.
+NativeIoResult read_native_file(const NativeFileHandle handle, uint8_t *buffer, const int64_t num_bytes_requested)
+{
+	NativeIoResult ret = {};
+	ret.num_bytes = 0;
+	ret.error = false;
+	while (ret.num_bytes < num_bytes_requested) {
+		const auto num_bytes_read = read(handle, buffer + ret.num_bytes, num_bytes_requested - ret.num_bytes);
+		if (num_bytes_read <= 0) {
+			ret.error = num_bytes_read < 0;
+			break;
+		}
+		ret.num_bytes += num_bytes_read;
+	}
+	return ret;
+}
+
+NativeIoResult write_native_file(const NativeFileHandle handle, const uint8_t *buffer, const int64_t num_bytes_requested)
+{
+	NativeIoResult ret = {};
+	ret.num_bytes = 0;
+	ret.error = false;
+	while (ret.num_bytes < num_bytes_requested) {
+		const auto num_bytes_written = write(handle, buffer + ret.num_bytes, num_bytes_requested - ret.num_bytes);
+		if (num_bytes_written <= 0) {
+			ret.error = num_bytes_written < 0;
+			break;
+		}
+		ret.num_bytes += num_bytes_written;
+	}
+	return ret;
+}
+
+int64_t seek_native_file(const NativeFileHandle handle, const int64_t offset, const NativeSeek type)
+{
+	int posix_seek_type = SEEK_SET;
+	switch (type) {
+		case NativeSeek::Set:
+			posix_seek_type = SEEK_SET;
+			break;
+		case NativeSeek::Current:
+			posix_seek_type = SEEK_CUR;
+			break;
+		case NativeSeek::End:
+			posix_seek_type = SEEK_END;
+			break;
+		default:
+			assertm(false, "Invalid seek type");
+			return NativeSeekFailed;
+	}
+
+	const auto position = lseek(handle, offset, posix_seek_type);
+	if (position < 0) {
+		return NativeSeekFailed;
+	}
+
+	return position;
+}
+
+void close_native_file(const NativeFileHandle handle)
+{
+	close(handle);
+}
+
+// Sets the file size to be equal to the current file position
+bool truncate_native_file(const NativeFileHandle handle)
+{
+	const auto current_position = lseek(handle, 0, SEEK_CUR);
+	if (current_position < 0) {
+		return false;
+	}
+	return ftruncate(handle, current_position) == 0;
+}
+
+DosDateTime get_dos_file_time(const NativeFileHandle handle)
+{
+	// Legal defaults if we're unable to populate them
+	DosDateTime ret = {};
+	ret.time = 1;
+	ret.date = 1;
+
+	struct stat file_info = {};
+	if (fstat(handle, &file_info) == -1) {
+		return ret;
+	}
+
+	struct tm datetime = {};
+	if (!cross::localtime_r(&file_info.st_mtime, &datetime)) {
+		return ret;
+	}
+
+	ret.time = DOS_PackTime(datetime);
+	ret.date = DOS_PackDate(datetime);
+
+	return ret;
 }
 
 #endif

--- a/src/misc/fs_utils_win32.cpp
+++ b/src/misc/fs_utils_win32.cpp
@@ -127,15 +127,19 @@ NativeIoResult read_native_file(const NativeFileHandle handle, uint8_t* buffer,
 	constexpr auto max_dword = std::numeric_limits<DWORD>::max();
 
 	NativeIoResult ret = {};
-	ret.num_bytes = 0;
-	ret.error = false;
+	ret.num_bytes      = 0;
+	ret.error          = false;
 	while (ret.num_bytes < num_bytes_requested) {
 		int64_t clamped_bytes_requested = num_bytes_requested - ret.num_bytes;
 		if (clamped_bytes_requested > max_dword) {
 			clamped_bytes_requested = max_dword;
 		}
 		DWORD num_bytes_read = 0;
-		const auto success = ReadFile(handle, buffer + ret.num_bytes, clamped_bytes_requested, &num_bytes_read, nullptr);
+		const auto success   = ReadFile(handle,
+                                              buffer + ret.num_bytes,
+                                              clamped_bytes_requested,
+                                              &num_bytes_read,
+                                              nullptr);
 		ret.num_bytes += num_bytes_read;
 		ret.error = !success;
 		if (ret.error || num_bytes_read == 0) {
@@ -145,22 +149,25 @@ NativeIoResult read_native_file(const NativeFileHandle handle, uint8_t* buffer,
 	return ret;
 }
 
-NativeIoResult write_native_file(const NativeFileHandle handle,
-                                 const uint8_t* buffer,
+NativeIoResult write_native_file(const NativeFileHandle handle, const uint8_t* buffer,
                                  const int64_t num_bytes_requested)
 {
 	constexpr auto max_dword = std::numeric_limits<DWORD>::max();
 
 	NativeIoResult ret = {};
-	ret.num_bytes = 0;
-	ret.error = false;
+	ret.num_bytes      = 0;
+	ret.error          = false;
 	while (ret.num_bytes < num_bytes_requested) {
 		int64_t clamped_bytes_requested = num_bytes_requested - ret.num_bytes;
 		if (clamped_bytes_requested > max_dword) {
 			clamped_bytes_requested = max_dword;
 		}
 		DWORD num_bytes_written = 0;
-		const auto success = WriteFile(handle, buffer + ret.num_bytes, clamped_bytes_requested, &num_bytes_written, nullptr);
+		const auto success      = WriteFile(handle,
+                                               buffer + ret.num_bytes,
+                                               clamped_bytes_requested,
+                                               &num_bytes_written,
+                                               nullptr);
 		ret.num_bytes += num_bytes_written;
 		ret.error = !success;
 		if (ret.error || num_bytes_written == 0) {
@@ -170,23 +177,15 @@ NativeIoResult write_native_file(const NativeFileHandle handle,
 	return ret;
 }
 
-int64_t seek_native_file(const NativeFileHandle handle,
-                         const int64_t offset, const NativeSeek type)
+int64_t seek_native_file(const NativeFileHandle handle, const int64_t offset,
+                         const NativeSeek type)
 {
 	DWORD win32_seek_type = FILE_BEGIN;
 	switch (type) {
-		case NativeSeek::Set:
-			win32_seek_type = FILE_BEGIN;
-			break;
-		case NativeSeek::Current:
-			win32_seek_type = FILE_CURRENT;
-			break;
-		case NativeSeek::End:
-			win32_seek_type = FILE_END;
-			break;
-		default:
-			assertm(false, "Invalid seek type");
-			return NativeSeekFailed;
+	case NativeSeek::Set: win32_seek_type = FILE_BEGIN; break;
+	case NativeSeek::Current: win32_seek_type = FILE_CURRENT; break;
+	case NativeSeek::End: win32_seek_type = FILE_END; break;
+	default: assertm(false, "Invalid seek type"); return NativeSeekFailed;
 	}
 
 	// Microsoft in their infinite knowledge decided to split the offset
@@ -200,8 +199,8 @@ int64_t seek_native_file(const NativeFileHandle handle,
 	// HighPart is both an input and output value
 	li.LowPart = SetFilePointer(handle, li.LowPart, &li.HighPart, win32_seek_type);
 
-	// If we have a large offset, INVALID_SET_FILE_POINTER is also valid as the low word
-	// So we must also check GetLastError() to know if we failed
+	// If we have a large offset, INVALID_SET_FILE_POINTER is also valid as
+	// the low word So we must also check GetLastError() to know if we failed
 	if (li.LowPart == INVALID_SET_FILE_POINTER && GetLastError() != NO_ERROR) {
 		return NativeSeekFailed;
 	}
@@ -244,7 +243,6 @@ DosDateTime get_dos_file_time(const NativeFileHandle handle)
 	ret.date = DOS_PackDate(system_time.wYear,
 	                        system_time.wMonth,
 	                        system_time.wDay);
-
 
 	return ret;
 }


### PR DESCRIPTION
# Description

This PR replaces the use of C library I/O (`fopen()` and friends) with native file I/O.  Windows uses Win32 API calls and everyone else uses POSIX.

I was also able to remove some hacky `ftell()` + `fseek()` nonsense that should not be needed since there's no library buffering.  The OS itself will still buffer but that should be fine.  All we care about is that a write followed by a read will return the new data.

I have some more work on the file I/O planned to better handle timestamps (which will depend on native file I/O) but I thought it would be best to put that in a separate PR and get this in first.

# Manual testing

Tested on Windows (both MSYS2/GCC and MSVC/Clang) and Linux.  Crystal Caves and Mortal Kombat saves work which had been problematic on Windows in the past.

Other games with save state tested:  Secret of Monkey Island 2, Quake, Doom, Space Quest 1

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

