### PR TITLE
Fix decrementing of MPU-401 track and conductor counters

### DIFF
--- a/src/hardware/mpu401.cpp
+++ b/src/hardware/mpu401.cpp
@@ -669,19 +669,21 @@ static void MPU401_Event(io_val_t)
 		for (uint8_t i = 0; i < 8; ++i) {
 			if (mpu.state.amask & (1 << i)) {
 				auto &counter = mpu.playbuf[i].counter;
-				switch (counter) {
-				case 0: counter = 0xff; break;
-				case 1: UpdateTrack(i); break;
-				default: --counter; break;
+				if (counter) {
+					--counter;
+				}
+				if (!counter) {
+					UpdateTrack(i);
 				}
 			}
 		}
 		if (mpu.state.conductor) {
 			auto &counter = mpu.condbuf.counter;
-			switch (counter) {
-			case 0: counter = 0xff; break;
-			case 1: UpdateConductor(); break;
-			default: --counter; break;
+			if (counter) {
+				--counter;
+			}
+			if (!counter) {
+				UpdateConductor();
 			}
 		}
 	}


### PR DESCRIPTION
# Description

Fixes a regression in Magic Candle 2, The - The Four and Forty (1991) where the second MIDI sequence doesn't playback.

The issue was bisected to commit 7546ef4, which appears to be a transition from prior DOSBox MPU code that used large signed counters to 8-bit unsigned registers.

This uses the original decrementing logic but modified to handle the unsigned counter registers.

https://github.com/dosbox-staging/dosbox-staging/assets/165201780/5b349e89-59c0-496e-98b1-f473a3da3a88

## Related issues

Fixes #3760

# Manual testing

Tested a handful of other MT-32 and MIDI games (Sierra, Ultimas, X-Wing, Heretic, Tyrian). Noticed an prior ticket involving MPU timing stuff and Eric the Unready, so grabbed a recording of that (if you can check it @johnnovak):

https://github.com/dosbox-staging/dosbox-staging/assets/165201780/6f741cef-f364-4da3-ab15-ecf3570410cf

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [ ] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

