### PR TITLE
Use linear 128 KB video memory pages for VESA modes

### DIFF
--- a/src/ints/int10_modes.cpp
+++ b/src/ints/int10_modes.cpp
@@ -1683,10 +1683,15 @@ bool INT10_SetVideoMode(uint16_t mode)
 	case M_LIN32:
 	case M_VGA:
 		// 256 color mode
-		gfx_data[0x5]|=0x40;
+		gfx_data[0x5] |= 0x40;
 
-		// graphics mode at 0xa000-affff
-		gfx_data[0x6]|=0x05;
+		if (VESA_IsVesaMode(mode)) {
+			// graphics mode at A0000-BFFFF (128 KB page)
+			gfx_data[0x6] |= 0x01;
+		} else {
+			// graphics mode at A0000-AFFFF (64 KB page)
+			gfx_data[0x6] |= 0x05;
+		}
 		break;
 
 	case M_LIN4:
@@ -1695,14 +1700,15 @@ bool INT10_SetVideoMode(uint16_t mode)
 			// only planes 0 and 2 are used
 			gfx_data[0x7] = 0x05;
 		}
-		// graphics mode at 0xa000-affff
+		// graphics mode at A0000-AFFFF
 		gfx_data[0x6] |= 0x05;
 		break;
 
 	case M_CGA4:
 		// CGA mode
 		gfx_data[0x5]|=0x20;
-		// graphics mode at at 0xb800=0xbfff
+
+		// graphics mode at B800-BFFF
 		gfx_data[0x6]|=0x0f;
 		if (machine == MCH_EGA) {
 			gfx_data[0x5] |= 0x10;
@@ -1711,10 +1717,10 @@ bool INT10_SetVideoMode(uint16_t mode)
 
 	case M_CGA2:
 		if (machine == MCH_EGA) {
-			// graphics mode at at 0xb800=0xbfff
+			// graphics mode at B800-BFFF
 			gfx_data[0x6] |= 0x0d;
 		} else {
-			// graphics mode at at 0xb800=0xbfff
+			// graphics mode at B800-BFFF
 			gfx_data[0x6] |= 0x0f;
 		}
 		break;


### PR DESCRIPTION
# Description

Fixes https://github.com/dosbox-staging/dosbox-staging/issues/3762

(The PVS-Studio warnings are fixed here https://github.com/dosbox-staging/dosbox-staging/pull/3758; I somehow introduced those to main today...)

This gets rid of the odd horizontal black line in the following Synthetic Dimensions games, and maybe other games and demos.

- Chronicles of the Sword
- Druid — Daemons of the Mind
- Perfect Assassin

This seems like a very safe change to me as most normal programs won't attempt to write past the 64K VESA page boundary. Then these outliers that do will simply just work without the black line glitch.

Where I could see regressions theoretically are some weird demos that intentionally exploit some wraparound behaviour of 64K VESA pages, if such a thing even exists... But frankly, I would not care about those; just go watch a hardware capture on [Demozoo](https://demozoo.org/) or YouTube 😆 

I also refuse to call this a "bug"... well, it's not really that. Let's call it a video-related enhancement that improves compatibility with shoddy coding practices 😄 

Thanks @interloper98 for pointing me into the right direction regarding the fix 🎉 

# Manual testing

Synthetic Dimensions games don't have the black line anymore:

- Chronicles of the Sword
- Druids — Daemons of the Mind
- Perfect Assassin

Games that use the 640x480 / 256-colour or higher VESA modes continue to work fine:

- Callahan's Crosstime Saloon
- Dungeon Keeper
- Eric the Unready
- Myst (Win 3.11)
- Tomb Raider Gold
- Under a Killing Moon

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

