### PR TITLE
Import missing S3 Trio64 XGA compare and fill routines from DOSBox-X

### DIFF
--- a/include/vga.h
+++ b/include/vga.h
@@ -382,6 +382,7 @@ struct VgaS3 {
 	uint8_t reg_52 = 0;
 	uint8_t reg_55 = 0;
 	uint8_t reg_58 = 0;
+	uint8_t reg_63 = 0;
 	uint8_t reg_6b = 0; // LFB BIOS scratchpad
 
 	uint8_t ex_hor_overflow = 0;

--- a/src/hardware/vga_s3.cpp
+++ b/src/hardware/vga_s3.cpp
@@ -386,8 +386,12 @@ uint8_t SVGA_S3_ReadCRTC(io_port_t reg, io_width_t)
 	case 0x2e:	/* New Chip ID  (low byte of PCI device ID) */
 		return 0x11;	// Trio64
 	case 0x2f:	/* Revision */
-		return 0x00;	// Trio64 (exact value?)
-//		return 0x44;	// Trio64 V+
+		// The documention leaves this unspecified and says "This will
+		// change with each stepping". Therefore we max this out under
+		// the assumption that newer steppings fix(ed) issues in prior
+		// steppings, and we want to avoid drivers witholding features
+		// based on stepping bugs.
+		return 0xff;
 	case 0x30:	/* CR30 Chip ID/REV register */
 		return 0xe1;	// Trio+ dual byte
 	case 0x31:	/* CR31 Memory Configuration */

--- a/src/hardware/vga_s3.cpp
+++ b/src/hardware/vga_s3.cpp
@@ -335,6 +335,9 @@ void SVGA_S3_WriteCRTC(io_port_t reg, io_val_t value, io_width_t)
 				(3d4h index 18h). Bit 8 is in 3d4h index 7 bit 4 and bit 9 in 3d4h
 				index 9 bit 6.
 		*/
+	case 0x63: // Extended Control Register CR63
+		vga.s3.reg_63 = val;
+		break;
 	case 0x67:	/* Extended Miscellaneous Control 2 */
 		/*
 			0	VCLK PHS. VCLK Phase With Respect to DCLK. If clear VLKC is inverted
@@ -452,6 +455,8 @@ uint8_t SVGA_S3_ReadCRTC(io_port_t reg, io_width_t)
 		return (vga.s3.la_window >> 8);
 	case 0x5a:	/* Linear Address Window Position Low */
 		return (vga.s3.la_window & 0xff);
+	case 0x63: // Extended Control Register CR63
+		return vga.s3.reg_63;
 	case 0x5D:	/* Extended Horizontal Overflow */
 		return vga.s3.ex_hor_overflow;
 	case 0x5e:	/* Extended Vertical Overflow */

--- a/src/hardware/vga_xga.cpp
+++ b/src/hardware/vga_xga.cpp
@@ -62,7 +62,9 @@ struct XGAStatus {
 	uint16_t backmix;
 
 	uint16_t curx, cury;
+	uint16_t curx2, cury2;
 	uint16_t destx, desty;
+	uint16_t destx2, desty2;
 
 	uint16_t ErrTerm;
 	uint16_t MIPcount;
@@ -1088,6 +1090,111 @@ static void XGA_DrawCmd(const uint32_t val)
 			
 			}
 			break;
+		case 3: /* Polygon fill (Trio64) */
+//			if (s3Card == S3_Trio64) {
+#if XGA_SHOW_COMMAND_TRACE == 1
+				LOG_MSG("XGA: Polygon fill (Trio64)");
+#endif
+				/* From the datasheet [http://hackipedia.org/browse.cgi/Computer/Platform/PC%2c%20IBM%20compatible/Video/VGA/SVGA/S3%20Graphics%2c%20Ltd/S3%20Trio32%e2%88%95Trio64%20Integrated%20Graphics%20Accelerators%20%281995%2d03%29%2epdf]
+				 * Section 13.3.3.12 Polygon Fill Solid (Trio64 only)
+				 *
+				 * The idea is that there are two current/dest X/Y pairs and this command
+				 * is used to draw the polygon top to bottom as a series of trapezoids,
+				 * sending new x/y coordinates for each left or right edge as the polygon
+				 * continues. The acceleration function is described as rendering to the
+				 * minimum of the two Y coordinates, and stopping. One side or the other
+				 * is updated, and the command starts the new edge and continues the other
+				 * edge.
+				 *
+				 * The card requires that the first and last segments have equal Y values,
+				 * though not X values in order to allow polygons with flat top and/or
+				 * bottom.
+				 *
+				 * That would imply that there's some persistent error term here, and it
+				 * would also imply that the card updates current Y position to the minimum
+				 * of either side so the new coordinates continue properly.
+				 *
+				 * NTS: The Windows 3.1 Trio64 driver likes to send this command every single
+				 *      time it updates any coordinate, contrary to the Trio64 datasheet that
+				 *      suggests setting cur/dest X/Y and cur2/dest2 X/Y THEN sending this
+				 *      command, then setting either dest X/Y and sending the command until
+				 *      the polygon has been rasterized. We can weed those out here by ignoring
+				 *      any command where the cur/dest Y coordinates would result in no movement.
+				 *
+				 *      The Windows 3.1 driver also seems to use cur/dest X/Y for the RIGHT side,
+				 *      and cur2/dest2 X/Y for the LEFT side, which is completely opposite from
+				 *      the example given in the datasheet. This also implies that whatever order
+				 *      the vertices end up, they draw a span when rasterizing, and the sides can
+				 *      cross one another if necessary.
+				 *
+				 * NTS: You can test this code by bringing up Paintbrush, and drawing with the
+				 *      brush tool. Despite drawing a rectangle, the S3 Trio64 driver uses the
+				 *      Polygon fill command to draw it.
+				 *
+				 *      More testing is possible in Microsoft Word 2.0 using the shapes/graphics
+				 *      editor, adding solid rectangles or rounded rectangles (but not circles).
+				 *
+				 * Vertex at (*)
+				 *
+				 *                       *             *     *
+				 *                       +             +-----+
+				 *                      / \           /       \
+				 *                     /   \         /         \
+				 *                    /_____\ *     /___________\ *
+				 *                   /      /      /            |
+				 *                * /______/    * /_____________|
+				 *                  \     /       \             |
+				 *                   \   /         \            |
+				 *                    \ /           \           |
+				 *                     +             \__________|
+				 *                     *             *          *
+				 *
+				 * Windows 3.1 driver behavior suggests this is also possible?
+				 *
+				 *                   *
+				 *                  / \
+				 *                 /   \
+				 *                /     \
+				 *             * /_______\
+				 *               \________\ *
+				 *                \       /
+				 *                 \     /
+				 *                  \   /
+				 *                   \ /
+				 *                    X      <- crossover point
+				 *                   / \
+				 *                  /   \
+				 *               * /_____\
+				 *                 \      \
+				 *                  \______\
+				 *                  *       *
+				 */
+
+				if (xga.cury < xga.desty && xga.cury2 < xga.desty2) {
+#if XGA_SHOW_COMMAND_TRACE == 1
+						LOG_MSG("XGA: Polygon fill: leftside=(%d,%d)-(%d,%d) rightside=(%d,%d)-(%d,%d)",
+						xga.curx, xga.cury, xga.destx, xga.desty,
+						xga.curx2,xga.cury2,xga.destx2,xga.desty2);
+#endif
+
+					// Not quite accurate, good enough for now.
+					xga.curx = xga.destx;
+					xga.cury = xga.desty;
+					xga.curx2 = xga.destx2;
+					xga.cury2 = xga.desty2;
+				}
+				else {
+#if XGA_SHOW_COMMAND_TRACE == 1
+					LOG_MSG("XGA: Polygon fill (nothing done)");
+#endif
+					// Windows 3.1 Trio64 driver behavior suggests that if Y doesn't move,
+					// the X coordinate may change if cur Y == dest Y, else the result
+					// when actual rendering doesn't make sense.
+					if (xga.cury == xga.desty) xga.curx = xga.destx;
+					if (xga.cury2 == xga.desty2) xga.curx2 = xga.destx2;
+				}
+//			}
+			break;
 		case 6: /* BitBLT */
 #if XGA_SHOW_COMMAND_TRACE == 1
 			LOG_MSG("XGA: Blit Rect");
@@ -1166,7 +1273,18 @@ void XGA_Write(io_port_t port, io_val_t val, io_width_t width)
 			xga.curx = (val >> 16) & 0x0fff;
 		break;
 	case 0x8102: xga.curx = val & 0x0fff; break;
-
+	case 0x8104:// drawing control: row (low word), column (high word)
+				// "CUR_X2" and "CUR_Y2" (see PORT 82EAh,PORT 86EAh)
+//		if (s3Card == S3_Trio64) { // Only on Trio64, not Trio64V+, not ViRGE
+			xga.cury2 = (uint16_t)(val & 0x0fff);
+			if(width == io_width_t::dword) xga.curx2 = (uint16_t)((val>>16)&0x0fff);
+//		}
+		break;
+	case 0x8106:
+//		if (s3Card == S3_Trio64) { // Only on Trio64, not Trio64V+, not ViRGE
+			xga.curx2 = (uint16_t)(val& 0x0fff);
+//		}
+		break;
 	case 0x8108: // DWORD drawing control: destination Y and axial step
 		// constant (low word), destination X and axial step
 		// constant (high word) (see PORT 8AE8h,PORT 8EE8h)
@@ -1175,6 +1293,19 @@ void XGA_Write(io_port_t port, io_val_t val, io_width_t width)
 			xga.destx = (val >> 16) & 0x3fff;
 		break;
 	case 0x810a: xga.destx = val & 0x3fff; break;
+	case 0x810c:// DWORD drawing control: destination Y and axial step
+				// constant (low word), destination X and axial step
+				// constant (high word) (see PORT 8AEAh,PORT 8EEAh)
+//		if (s3Card == S3_Trio64) { // Only on Trio64, not Trio64V+, not ViRGE
+			xga.desty2 = (uint16_t)(val&0x3FFF);
+			if(width == io_width_t::dword) xga.destx2 = (uint16_t)((val>>16)&0x3fff);
+//		}
+		break;
+	case 0x810e:
+//		if (s3Card == S3_Trio64) { // Only on Trio64, not Trio64V+, not ViRGE
+			xga.destx2 = (uint16_t)(val&0x3fff);
+//		}
+		break;
 	case 0x8110: // WORD error term (see PORT 92E8h)
 		xga.ErrTerm = val & 0x3FFF;
 		break;

--- a/src/hardware/vga_xga.cpp
+++ b/src/hardware/vga_xga.cpp
@@ -355,15 +355,16 @@ static void XGA_DrawLineVector(const uint32_t val, const bool skip_last_pixel)
 						srcval = xga.forecolor;
 						break;
 					case 0x02: /* Src is pixel data from PIX_TRANS register */
-						//srcval = tmpval;
 						//LOG_MSG("XGA: DrawRect: Wants data from PIX_TRANS register");
+						srcval = 0;
 						break;
 					case 0x03: /* Src is bitmap data */
 						LOG_MSG("XGA: DrawRect: Wants data from srcdata");
-						//srcval = srcdata;
+						srcval = 0;
 						break;
 					default:
 						LOG_MSG("XGA: DrawRect: Shouldn't be able to get here!");
+						srcval = 0;
 						break;
 				}
 				dstdata = XGA_GetPoint(xat, yat);

--- a/src/hardware/vga_xga.cpp
+++ b/src/hardware/vga_xga.cpp
@@ -892,12 +892,14 @@ void XGA_BlitRect(Bitu val) {
 					break;
 				case 0x02: /* Src is pixel data from PIX_TRANS register */
 					LOG_MSG("XGA: DrawPattern: Wants data from PIX_TRANS register");
+					srcval = 0;
 					break;
 				case 0x03: /* Src is bitmap data */
 					srcval = srcdata;
 					break;
 				default:
 					LOG_MSG("XGA: DrawPattern: Shouldn't be able to get here!");
+					srcval = 0;
 					break;
 			}
 			// For more information, see the "S3 Vision864 Graphics

--- a/src/hardware/vga_xga.cpp
+++ b/src/hardware/vga_xga.cpp
@@ -1035,12 +1035,14 @@ void XGA_DrawPattern(Bitu val) {
 					break;
 				case 0x02: /* Src is pixel data from PIX_TRANS register */
 					LOG_MSG("XGA: DrawPattern: Wants data from PIX_TRANS register");
+					srcval = 0;
 					break;
 				case 0x03: /* Src is bitmap data */
 					srcval = srcdata;
 					break;
 				default:
 					LOG_MSG("XGA: DrawPattern: Shouldn't be able to get here!");
+					srcval = 0;
 					break;
 			}
 

--- a/src/hardware/vga_xga.cpp
+++ b/src/hardware/vga_xga.cpp
@@ -979,10 +979,31 @@ void XGA_DrawPattern(Bitu val) {
 			dstdata = XGA_GetPoint(tarx, tary);
 			
 
-			if(mixselect == 0x3) {
-				// TODO lots of guessing here but best results this way
-				if(srcdata) mixmode = xga.foremix;
-				else mixmode = xga.backmix;
+			if (mixselect == 0x3) {
+				/* S3 Trio32/Trio64 Integrated Graphics Accelerators, section 13.2 Bitmap Access Through The Graphics Engine.
+				 *
+				 * [https://jon.nerdgrounds.com/jmcs/docs/browse/Computer/Platform/PC%2c%20IBM%20compatible/Video/VGA/SVGA/S3%20Graphics%2c%20Ltd/S3%20Trio32%e2%88%95Trio64%20Integrated%20Graphics%20Accelerators%20%281995%2d03%29%2epdf]
+				 *
+				 * "If bits 7-6 are set to 11b, the current display bit map is selected as the mask bit source. The Read Mask"
+				 * "register (AAE8H) is set up to indicate the active planes. When all bits of the read-enabled planes for a"
+				 * "pixel are a 1, the mask bit 'ONE' is generated. If anyone of the read-enabled planes is a 0, then a mask"
+				 * "bit 'ZERO' is generated. If the mask bit is 'ONE', the Foreground Mix register is used. If the mask bit is"
+				 * "'ZERO', the Background Mix register is used."
+				 *
+				 * Notice that when an application in Windows 3.1 draws a black rectangle, I see foreground=0 background=ff
+				 * and in this loop, srcdata=ff and readmask=ff. While the original DOSBox SVN "guess" code here would
+				 * misattribute that to the background color (and erroneously draw a white rectangle), what should actually
+				 * happen is that we use the foreground color because (srcdata&readmask)==readmask (all bits 1).
+				 *
+				 * This fixes visual bugs when running Windows 3.1 and Microsoft Creative Writer, and navigating to the
+				 * basement and clicking around in the dark to reveal funny random things, leaves white rectangles on the
+				 * screen where the image was when you released the mouse. Creative Writer clears the image by drawing a
+				 * BLACK rectangle, while the DOSBox SVN "guess" mistakenly chose the background color and therefore a
+				 * WHITE rectangle. */
+				if ((srcdata&xga.readmask) == xga.readmask)
+					mixmode = xga.foremix;
+				else
+					mixmode = xga.backmix;
 			}
 
 			Bitu srcval = 0;

--- a/src/hardware/vga_xga.cpp
+++ b/src/hardware/vga_xga.cpp
@@ -564,15 +564,16 @@ static void XGA_DrawRectangle(const uint32_t val, const bool skip_last_pixel)
 							srcval = xga.forecolor;
 							break;
 						case 0x02: /* Src is pixel data from PIX_TRANS register */
-							//srcval = tmpval;
 							LOG_MSG("XGA: DrawRect: Wants data from PIX_TRANS register");
+							srcval = 0;
 							break;
 						case 0x03: /* Src is bitmap data */
 							LOG_MSG("XGA: DrawRect: Wants data from srcdata");
-							//srcval = srcdata;
+							srcval = 0;
 							break;
 						default:
 							LOG_MSG("XGA: DrawRect: Shouldn't be able to get here!");
+							srcval = 0;
 							break;
 					}
 					dstdata = XGA_GetPoint(srcx, srcy);

--- a/src/hardware/vga_xga.cpp
+++ b/src/hardware/vga_xga.cpp
@@ -1355,7 +1355,7 @@ void XGA_Write(io_port_t port, io_val_t val, io_width_t width)
 	case 0x8108: // DWORD drawing control: destination Y and axial step
 		// constant (low word), destination X and axial step
 		// constant (high word) (see PORT 8AE8h,PORT 8EE8h)
-		xga.desty = val & 0x3FFF;
+		xga.desty = val & 0x3fff;
 		if (width == io_width_t::dword)
 			xga.destx = (val >> 16) & 0x3fff;
 		break;
@@ -1364,7 +1364,7 @@ void XGA_Write(io_port_t port, io_val_t val, io_width_t width)
 		// DWORD drawing control: destination Y and axial step
 		// constant (low word), destination X and axial step
 		// constant (high word) (see PORT 8AEAh,PORT 8EEAh)
-		xga.desty2 = static_cast<uint16_t>(val & 0x3FFF);
+		xga.desty2 = static_cast<uint16_t>(val & 0x3fff);
 		if (width == io_width_t::dword) {
 			xga.destx2 = static_cast<uint16_t>((val >> 16) & 0x3fff);
 		}
@@ -1373,7 +1373,7 @@ void XGA_Write(io_port_t port, io_val_t val, io_width_t width)
 		xga.destx2 = static_cast<uint16_t>(val & 0x3fff);
 		break;
 	case 0x8110: // WORD error term (see PORT 92E8h)
-		xga.ErrTerm = val & 0x3FFF;
+		xga.ErrTerm = val & 0x3fff;
 		break;
 
 	case 0x8120: // packed MMIO: DWORD background color (see PORT A2E8h)
@@ -1390,7 +1390,7 @@ void XGA_Write(io_port_t port, io_val_t val, io_width_t width)
 		break;
 	case 0x8134: // packed MMIO: DWORD	background mix (low word) and
 		// foreground mix (high word)	(see PORT B6E8h,PORT BAE8h)
-		xga.backmix = val & 0xFFFF;
+		xga.backmix = val & 0xffff;
 		if (width == io_width_t::dword)
 			xga.foremix = (val >> 16);
 		break;
@@ -1412,7 +1412,7 @@ void XGA_Write(io_port_t port, io_val_t val, io_width_t width)
 
 	case 0x8140: // DWORD data manipulation control (low word) and
 		// miscellaneous 2 (high word) (see PORT BEE8h,#P1047)
-		xga.pix_cntl = val & 0xFFFF;
+		xga.pix_cntl = val & 0xffff;
 		if (width == io_width_t::dword)
 			xga.control2 = (val >> 16) & 0x0fff;
 		break;
@@ -1429,7 +1429,7 @@ void XGA_Write(io_port_t port, io_val_t val, io_width_t width)
 			xga.MAPcount = (val >> 16) & 0x0fff;
 		break;
 	case 0x814a: xga.MAPcount = val & 0x0fff; break;
-	case 0x92e8: xga.ErrTerm = val & 0x3FFF; break;
+	case 0x92e8: xga.ErrTerm = val & 0x3fff; break;
 	case 0x96e8: xga.MAPcount = val & 0x0fff; break;
 	case 0x9ae8:
 	case 0x8118: // Trio64V+ packed MMIO
@@ -1536,8 +1536,8 @@ void VGA_SetupXGA(void) {
 
 	xga.scissors.y1 = 0;
 	xga.scissors.x1 = 0;
-	xga.scissors.y2 = 0xFFF;
-	xga.scissors.x2 = 0xFFF;
+	xga.scissors.y2 = 0xfff;
+	xga.scissors.x2 = 0xfff;
 
 	IO_RegisterWriteHandler(0x42e8, &XGA_Write, io_width_t::dword);
 	IO_RegisterReadHandler(0x42e8, &XGA_Read, io_width_t::dword);

--- a/src/hardware/vga_xga.cpp
+++ b/src/hardware/vga_xga.cpp
@@ -1298,13 +1298,13 @@ void XGA_Write(io_port_t port, io_val_t val, io_width_t width)
 	case 0x8104:
 		// Drawing control: row (low word), column (high word)
 		// "CUR_X2" and "CUR_Y2" (see PORT 82EAh,PORT 86EAh)
-		xga.cury2 = (uint16_t)(val & 0x0fff);
+		xga.cury2 = static_cast<uint16_t>(val & 0x0fff);
 		if (width == io_width_t::dword) {
-			xga.curx2 = (uint16_t)((val >> 16) & 0x0fff);
+			xga.curx2 = static_cast<uint16_t>((val >> 16) & 0x0fff);
 		}
 		break;
 	case 0x8106:
-		xga.curx2 = (uint16_t)(val & 0x0fff);
+		xga.curx2 = static_cast<uint16_t>(val & 0x0fff);
 		break;
 	case 0x8108: // DWORD drawing control: destination Y and axial step
 		// constant (low word), destination X and axial step
@@ -1318,13 +1318,13 @@ void XGA_Write(io_port_t port, io_val_t val, io_width_t width)
 		// DWORD drawing control: destination Y and axial step
 		// constant (low word), destination X and axial step
 		// constant (high word) (see PORT 8AEAh,PORT 8EEAh)
-		xga.desty2 = (uint16_t)(val & 0x3FFF);
+		xga.desty2 = static_cast<uint16_t>(val & 0x3FFF);
 		if (width == io_width_t::dword) {
-			xga.destx2 = (uint16_t)((val >> 16) & 0x3fff);
+			xga.destx2 = static_cast<uint16_t>((val >> 16) & 0x3fff);
 		}
 		break;
 	case 0x810e:
-		xga.destx2 = (uint16_t)(val & 0x3fff);
+		xga.destx2 = static_cast<uint16_t>(val & 0x3fff);
 		break;
 	case 0x8110: // WORD error term (see PORT 92E8h)
 		xga.ErrTerm = val & 0x3FFF;

--- a/src/hardware/vga_xga.cpp
+++ b/src/hardware/vga_xga.cpp
@@ -977,33 +977,52 @@ void XGA_DrawPattern(Bitu val) {
 			srcdata = XGA_GetPoint(srcx + (tarx & 0x7), srcy + (tary & 0x7));
 			//LOG_MSG("patternpoint (%3d/%3d)v%x",srcx + (tarx & 0x7), srcy + (tary & 0x7),srcdata);
 			dstdata = XGA_GetPoint(tarx, tary);
-			
 
 			if (mixselect == 0x3) {
-				/* S3 Trio32/Trio64 Integrated Graphics Accelerators, section 13.2 Bitmap Access Through The Graphics Engine.
-				 *
-				 * [https://jon.nerdgrounds.com/jmcs/docs/browse/Computer/Platform/PC%2c%20IBM%20compatible/Video/VGA/SVGA/S3%20Graphics%2c%20Ltd/S3%20Trio32%e2%88%95Trio64%20Integrated%20Graphics%20Accelerators%20%281995%2d03%29%2epdf]
-				 *
-				 * "If bits 7-6 are set to 11b, the current display bit map is selected as the mask bit source. The Read Mask"
-				 * "register (AAE8H) is set up to indicate the active planes. When all bits of the read-enabled planes for a"
-				 * "pixel are a 1, the mask bit 'ONE' is generated. If anyone of the read-enabled planes is a 0, then a mask"
-				 * "bit 'ZERO' is generated. If the mask bit is 'ONE', the Foreground Mix register is used. If the mask bit is"
-				 * "'ZERO', the Background Mix register is used."
-				 *
-				 * Notice that when an application in Windows 3.1 draws a black rectangle, I see foreground=0 background=ff
-				 * and in this loop, srcdata=ff and readmask=ff. While the original DOSBox SVN "guess" code here would
-				 * misattribute that to the background color (and erroneously draw a white rectangle), what should actually
-				 * happen is that we use the foreground color because (srcdata&readmask)==readmask (all bits 1).
-				 *
-				 * This fixes visual bugs when running Windows 3.1 and Microsoft Creative Writer, and navigating to the
-				 * basement and clicking around in the dark to reveal funny random things, leaves white rectangles on the
-				 * screen where the image was when you released the mouse. Creative Writer clears the image by drawing a
-				 * BLACK rectangle, while the DOSBox SVN "guess" mistakenly chose the background color and therefore a
-				 * WHITE rectangle. */
-				if ((srcdata&xga.readmask) == xga.readmask)
+
+				// S3 Trio32/Trio64 Integrated Graphics
+				// Accelerators, section 13.2 Bitmap Access
+				// Through The Graphics Engine.
+				// [https://jon.nerdgrounds.com/jmcs/docs/browse/Computer/Platform/PC%2c%20IBM%20compatible/Video/VGA/SVGA/S3%20Graphics%2c%20Ltd/S3%20Trio32%e2%88%95Trio64%20Integrated%20Graphics%20Accelerators%20%281995%2d03%29%2epdf]
+
+				// "If bits 7-6 are set to 11b, the current
+				// display bit map is selected as the mask bit
+				// source. The Read Mask" "register (AAE8H) is
+				// set up to indicate the active planes. When
+				// all bits of the read-enabled planes for a"
+				// "pixel are a 1, the mask bit 'ONE' is
+				// generated. If anyone of the read-enabled
+				// planes is a 0, then a mask" "bit 'ZERO' is
+				// generated. If the mask bit is 'ONE', the
+				// Foreground Mix register is used. If the mask
+				// bit is" "'ZERO', the Background Mix register
+				// is used." Notice that when an application in
+				// Windows 3.1 draws a black rectangle, I see
+				// foreground=0 background=ff and in this loop,
+				// srcdata=ff and readmask=ff. While the
+				// original DOSBox SVN "guess" code here would
+				// misattribute that to the background color
+				// (and erroneously draw a white rectangle),
+				// what should actually happen is that we use
+				// the foreground color because
+				// (srcdata&readmask)==readmask (all bits 1).
+
+				// This fixes visual bugs when running
+				// Windows 3.1 and Microsoft Creative Writer,
+				// and navigating to the basement and clicking
+				// around in the dark to reveal funny random
+				// things, leaves white rectangles on the screen
+				// where the image was when you released the
+				// mouse. Creative Writer clears the image by
+				// drawing a BLACK rectangle, while the DOSBox
+				// SVN "guess" mistakenly chose the background
+				// color and therefore a WHITE rectangle.
+
+				if ((srcdata & xga.readmask) == xga.readmask) {
 					mixmode = xga.foremix;
-				else
+				} else {
 					mixmode = xga.backmix;
+				}
 			}
 
 			Bitu srcval = 0;

--- a/src/hardware/vga_xga.cpp
+++ b/src/hardware/vga_xga.cpp
@@ -1090,121 +1090,143 @@ static void XGA_DrawCmd(const uint32_t val)
 			
 			}
 			break;
-		case 3: /* Polygon fill (Trio64) */
-//			if (s3Card == S3_Trio64) {
+	        case 3: // Polygon fill
 #if XGA_SHOW_COMMAND_TRACE == 1
-				LOG_MSG("XGA: Polygon fill (Trio64)");
+		        LOG_MSG("XGA: Polygon fill (Trio64)");
 #endif
-				/* From the datasheet [http://hackipedia.org/browse.cgi/Computer/Platform/PC%2c%20IBM%20compatible/Video/VGA/SVGA/S3%20Graphics%2c%20Ltd/S3%20Trio32%e2%88%95Trio64%20Integrated%20Graphics%20Accelerators%20%281995%2d03%29%2epdf]
-				 * Section 13.3.3.12 Polygon Fill Solid (Trio64 only)
-				 *
-				 * The idea is that there are two current/dest X/Y pairs and this command
-				 * is used to draw the polygon top to bottom as a series of trapezoids,
-				 * sending new x/y coordinates for each left or right edge as the polygon
-				 * continues. The acceleration function is described as rendering to the
-				 * minimum of the two Y coordinates, and stopping. One side or the other
-				 * is updated, and the command starts the new edge and continues the other
-				 * edge.
-				 *
-				 * The card requires that the first and last segments have equal Y values,
-				 * though not X values in order to allow polygons with flat top and/or
-				 * bottom.
-				 *
-				 * That would imply that there's some persistent error term here, and it
-				 * would also imply that the card updates current Y position to the minimum
-				 * of either side so the new coordinates continue properly.
-				 *
-				 * NTS: The Windows 3.1 Trio64 driver likes to send this command every single
-				 *      time it updates any coordinate, contrary to the Trio64 datasheet that
-				 *      suggests setting cur/dest X/Y and cur2/dest2 X/Y THEN sending this
-				 *      command, then setting either dest X/Y and sending the command until
-				 *      the polygon has been rasterized. We can weed those out here by ignoring
-				 *      any command where the cur/dest Y coordinates would result in no movement.
-				 *
-				 *      The Windows 3.1 driver also seems to use cur/dest X/Y for the RIGHT side,
-				 *      and cur2/dest2 X/Y for the LEFT side, which is completely opposite from
-				 *      the example given in the datasheet. This also implies that whatever order
-				 *      the vertices end up, they draw a span when rasterizing, and the sides can
-				 *      cross one another if necessary.
-				 *
-				 * NTS: You can test this code by bringing up Paintbrush, and drawing with the
-				 *      brush tool. Despite drawing a rectangle, the S3 Trio64 driver uses the
-				 *      Polygon fill command to draw it.
-				 *
-				 *      More testing is possible in Microsoft Word 2.0 using the shapes/graphics
-				 *      editor, adding solid rectangles or rounded rectangles (but not circles).
-				 *
-				 * Vertex at (*)
-				 *
-				 *                       *             *     *
-				 *                       +             +-----+
-				 *                      / \           /       \
-				 *                     /   \         /         \
-				 *                    /_____\ *     /___________\ *
-				 *                   /      /      /            |
-				 *                * /______/    * /_____________|
-				 *                  \     /       \             |
-				 *                   \   /         \            |
-				 *                    \ /           \           |
-				 *                     +             \__________|
-				 *                     *             *          *
-				 *
-				 * Windows 3.1 driver behavior suggests this is also possible?
-				 *
-				 *                   *
-				 *                  / \
-				 *                 /   \
-				 *                /     \
-				 *             * /_______\
-				 *               \________\ *
-				 *                \       /
-				 *                 \     /
-				 *                  \   /
-				 *                   \ /
-				 *                    X      <- crossover point
-				 *                   / \
-				 *                  /   \
-				 *               * /_____\
-				 *                 \      \
-				 *                  \______\
-				 *                  *       *
-				 */
+				// From the datasheet
+				// [http://hackipedia.org/browse.cgi/Computer/Platform/PC%2c%20IBM%20compatible/Video/VGA/SVGA/S3%20Graphics%2c%20Ltd/S3%20Trio32%e2%88%95Trio64%20Integrated%20Graphics%20Accelerators%20%281995%2d03%29%2epdf]
+				// Section 13.3.3.12 Polygon Fill Solid (Trio64 only)
+				// The idea is that there are two current/dest X/Y pairs
+				// and this command is used to draw the polygon top to
+				// bottom as a series of trapezoids, sending new x/y
+				// coordinates for each left or right edge as the
+				// polygon continues. The acceleration function is
+				// described as rendering to the minimum of the two Y
+				// coordinates, and stopping. One side or the other is
+				// updated, and the command starts the new edge and
+				// continues the other edge.
 
-				if (xga.cury < xga.desty && xga.cury2 < xga.desty2) {
+				// The card requires that the first and last segments
+				// have equal Y values, though not X values in order to
+				// allow polygons with flat top and/or bottom.
+
+				// That would imply that there's some persistent error
+				// term here, and it would also imply that the card
+				// updates current Y position to the minimum of either
+				// side so the new coordinates continue properly.
+
+				// NTS: The Windows 3.1 Trio64 driver likes to send this
+				// command every single time it updates any coordinate,
+				// contrary to the Trio64 datasheet that suggests setting
+				// cur/dest X/Y and cur2/dest2 X/Y THEN sending this
+				// command, then setting either dest X/Y and sending the
+				// command until the polygon has been rasterized. We can
+				// weed those out here by ignoring any command where the
+				// cur/dest Y coordinates would result in no movement.
+
+				// The Windows 3.1 driver also seems to use cur/dest X/Y
+				// for the RIGHT side, and cur2/dest2 X/Y for the LEFT
+				// side, which is completely opposite from the example
+				// given in the datasheet. This also implies that
+				// whatever order the vertices end up, they draw a span
+				// when rasterizing, and the sides can cross one another
+				// if necessary.
+
+				// NTS: You can test this code by bringing up
+				// Paintbrush, and drawing with the brush tool. Despite
+				// drawing a rectangle, the S3 Trio64 driver uses the
+				// Polygon fill command to draw it. More testing is
+				// possible in Microsoft Word 2.0 using the
+				// shapes/graphics editor, adding solid rectangles or
+				// rounded rectangles (but not circles).
+				/*
+				//  Vertex at (*)
+				//
+				//                        *             *     *
+				//                        +             +-----+
+				//                       / \           /       \
+				//                      /   \         /         \
+				//                     /_____\ *     /___________\ *
+				//                    /      /      /            |
+				//                 * /______/    * /_____________|
+				//                   \     /       \             |
+				//                    \   /         \            |
+				//                     \ /           \           |
+				//                      +             \__________|
+				//                      *             *          *
+				//
+				//  Windows 3.1 driver behavior suggests this is also
+				//  possible?
+				//
+				//                    *
+				//                   / \
+				//                  /   \
+				//                 /     \
+				//              * /_______\
+				//                \________\ *
+				//                 \       /
+				//                  \     /
+				//                   \   /
+				//                    \ /
+				//                     X      <- crossover point
+				//                    / \
+				//                   /   \
+				//                * /_____\
+				//                  \      \
+				//                   \______\
+				//                   *       *
+				*/
+
+		        if (xga.cury < xga.desty && xga.cury2 < xga.desty2) {
 #if XGA_SHOW_COMMAND_TRACE == 1
-						LOG_MSG("XGA: Polygon fill: leftside=(%d,%d)-(%d,%d) rightside=(%d,%d)-(%d,%d)",
-						xga.curx, xga.cury, xga.destx, xga.desty,
-						xga.curx2,xga.cury2,xga.destx2,xga.desty2);
+			        LOG_MSG("XGA: Polygon fill: leftside=(%d,%d)-(%d,%d) rightside=(%d,%d)-(%d,%d)",
+			                xga.curx,
+			                xga.cury,
+			                xga.destx,
+			                xga.desty,
+			                xga.curx2,
+			                xga.cury2,
+			                xga.destx2,
+			                xga.desty2);
 #endif
 
-					// Not quite accurate, good enough for now.
-					xga.curx = xga.destx;
-					xga.cury = xga.desty;
-					xga.curx2 = xga.destx2;
-					xga.cury2 = xga.desty2;
-				}
-				else {
+			        // Not quite accurate, good enough for now.
+			        xga.curx  = xga.destx;
+			        xga.cury  = xga.desty;
+			        xga.curx2 = xga.destx2;
+			        xga.cury2 = xga.desty2;
+		        } else {
 #if XGA_SHOW_COMMAND_TRACE == 1
-					LOG_MSG("XGA: Polygon fill (nothing done)");
+			        LOG_MSG("XGA: Polygon fill (nothing done)");
 #endif
-					// Windows 3.1 Trio64 driver behavior suggests that if Y doesn't move,
-					// the X coordinate may change if cur Y == dest Y, else the result
-					// when actual rendering doesn't make sense.
-					if (xga.cury == xga.desty) xga.curx = xga.destx;
-					if (xga.cury2 == xga.desty2) xga.curx2 = xga.destx2;
-				}
-//			}
-			break;
-		case 6: /* BitBLT */
+			        // Windows 3.1 Trio64 driver behavior suggests
+			        // that if Y doesn't move, the X coordinate may
+			        // change if cur Y == dest Y, else the result
+			        // when actual rendering doesn't make sense.
+			        if (xga.cury == xga.desty) {
+				        xga.curx = xga.destx;
+			        }
+			        if (xga.cury2 == xga.desty2) {
+				        xga.curx2 = xga.destx2;
+			        }
+		        }
+		        break;
+	        case 6: // BitBLT
 #if XGA_SHOW_COMMAND_TRACE == 1
-			LOG_MSG("XGA: Blit Rect");
+		        LOG_MSG("XGA: Blit Rect");
 #endif
-			XGA_BlitRect(val);
-			break;
-		case 7: /* Pattern fill */
+		        XGA_BlitRect(val);
+		        break;
+	        case 7: // Pattern fill
 #if XGA_SHOW_COMMAND_TRACE == 1
-			LOG_MSG("XGA: Pattern fill: src(%3d/%3d), dest(%3d/%3d), fill(%3d/%3d)",
-				xga.curx,xga.cury,xga.destx,xga.desty,xga.MAPcount,xga.MIPcount);
+		        LOG_MSG("XGA: Pattern fill: src(%3d/%3d), dest(%3d/%3d), fill(%3d/%3d)",
+		                xga.curx,
+		                xga.cury,
+		                xga.destx,
+		                xga.desty,
+		                xga.MAPcount,
+		                xga.MIPcount);
 #endif
 			XGA_DrawPattern(val);
 			break;
@@ -1273,17 +1295,16 @@ void XGA_Write(io_port_t port, io_val_t val, io_width_t width)
 			xga.curx = (val >> 16) & 0x0fff;
 		break;
 	case 0x8102: xga.curx = val & 0x0fff; break;
-	case 0x8104:// drawing control: row (low word), column (high word)
-				// "CUR_X2" and "CUR_Y2" (see PORT 82EAh,PORT 86EAh)
-//		if (s3Card == S3_Trio64) { // Only on Trio64, not Trio64V+, not ViRGE
-			xga.cury2 = (uint16_t)(val & 0x0fff);
-			if(width == io_width_t::dword) xga.curx2 = (uint16_t)((val>>16)&0x0fff);
-//		}
+	case 0x8104:
+		// Drawing control: row (low word), column (high word)
+		// "CUR_X2" and "CUR_Y2" (see PORT 82EAh,PORT 86EAh)
+		xga.cury2 = (uint16_t)(val & 0x0fff);
+		if (width == io_width_t::dword) {
+			xga.curx2 = (uint16_t)((val >> 16) & 0x0fff);
+		}
 		break;
 	case 0x8106:
-//		if (s3Card == S3_Trio64) { // Only on Trio64, not Trio64V+, not ViRGE
-			xga.curx2 = (uint16_t)(val& 0x0fff);
-//		}
+		xga.curx2 = (uint16_t)(val & 0x0fff);
 		break;
 	case 0x8108: // DWORD drawing control: destination Y and axial step
 		// constant (low word), destination X and axial step
@@ -1293,18 +1314,17 @@ void XGA_Write(io_port_t port, io_val_t val, io_width_t width)
 			xga.destx = (val >> 16) & 0x3fff;
 		break;
 	case 0x810a: xga.destx = val & 0x3fff; break;
-	case 0x810c:// DWORD drawing control: destination Y and axial step
-				// constant (low word), destination X and axial step
-				// constant (high word) (see PORT 8AEAh,PORT 8EEAh)
-//		if (s3Card == S3_Trio64) { // Only on Trio64, not Trio64V+, not ViRGE
-			xga.desty2 = (uint16_t)(val&0x3FFF);
-			if(width == io_width_t::dword) xga.destx2 = (uint16_t)((val>>16)&0x3fff);
-//		}
+	case 0x810c:
+		// DWORD drawing control: destination Y and axial step
+		// constant (low word), destination X and axial step
+		// constant (high word) (see PORT 8AEAh,PORT 8EEAh)
+		xga.desty2 = (uint16_t)(val & 0x3FFF);
+		if (width == io_width_t::dword) {
+			xga.destx2 = (uint16_t)((val >> 16) & 0x3fff);
+		}
 		break;
 	case 0x810e:
-//		if (s3Card == S3_Trio64) { // Only on Trio64, not Trio64V+, not ViRGE
-			xga.destx2 = (uint16_t)(val&0x3fff);
-//		}
+		xga.destx2 = (uint16_t)(val & 0x3fff);
 		break;
 	case 0x8110: // WORD error term (see PORT 92E8h)
 		xga.ErrTerm = val & 0x3FFF;

--- a/src/hardware/vga_xga.cpp
+++ b/src/hardware/vga_xga.cpp
@@ -54,6 +54,8 @@ struct XGAStatus {
 	uint32_t forecolor;
 	uint32_t backcolor;
 
+	uint32_t color_compare;
+
 	Bitu curcommand;
 
 	uint16_t foremix;
@@ -183,6 +185,21 @@ void XGA_DrawPoint(Bitu x, Bitu y, Bitu c) {
 	        default: break;
 	}
 
+}
+
+Bitu XGA_PointMask() {
+	switch(XGA_COLOR_MODE) {
+		case M_LIN8:
+			return 0xFFul;
+		case M_LIN15:
+		case M_LIN16:
+			return 0xFFFFul;
+		case M_LIN32:
+			return 0xFFFFFFFFul;
+		default:
+			break;
+	}
+	return 0;
 }
 
 Bitu XGA_GetPoint(Bitu x, Bitu y) {
@@ -814,6 +831,7 @@ void XGA_BlitRect(Bitu val) {
 	uint32_t xat, yat;
 	Bitu srcdata;
 	Bitu dstdata;
+	Bitu colorcmpdata;
 	Bits srcx, srcy, tarx, tary, dx, dy;
 
 	dx = -1;
@@ -821,6 +839,8 @@ void XGA_BlitRect(Bitu val) {
 
 	if(((val >> 5) & 0x01) != 0) dx = 1;
 	if(((val >> 7) & 0x01) != 0) dy = 1;
+
+	colorcmpdata = xga.color_compare & XGA_PointMask();
 
 	Bitu mixselect = (xga.pix_cntl >> 6) & 0x3;
 	uint32_t mixmode = 0x67; /* Source is bitmap data, mix mode is src */
@@ -882,10 +902,25 @@ void XGA_BlitRect(Bitu val) {
 					break;
 			}
 
-			const Bitu destval = GetMixResult(mixmode, srcval, dstdata);
-			//LOG_MSG("XGA: DrawPattern: Mixmode: %x Mixselect: %x", mixmode, mixselect);
+			bool doit = true;
 
-			XGA_DrawPoint(tarx, tary, destval);
+			/* For more information, see the "S3 Vision864 Graphics Accelerator" datasheet
+			 * [http://hackipedia.org/browse.cgi/Computer/Platform/PC%2c%20IBM%20compatible/Video/VGA/SVGA/S3%20Graphics%2c%20Ltd/S3%20Vision864%20Graphics%20Accelerator%20(1994-10).pdf]
+			 * Page 203 for "Multifunction Control Miscellaneous Register (MULT_MISC)" which this code holds as xga.control1, and
+			 * Page 198 for "Color Compare Register (COLOR_CMP)" which this code holds as xga.color_compare. */
+			if (xga.control1 & 0x100) { /* COLOR_CMP enabled. control1 corresponds to XGA register BEE8h */
+				/* control1 bit 7 is SRC_NE.
+				 * If clear, don't update if source value == COLOR_CMP.
+				 * If set, don't update if source value != COLOR_CMP */
+				doit = !!(((srcval == colorcmpdata)?0:1)^((xga.control1>>7u)&1u));
+			}
+
+			if (doit) {
+				Bitu destval = GetMixResult(mixmode, srcval, dstdata);
+				//LOG_MSG("XGA: DrawPattern: Mixmode: %x Mixselect: %x", mixmode, mixselect);
+
+				XGA_DrawPoint((Bitu)tarx, (Bitu)tary, destval);
+			}
 
 			srcx += dx;
 			tarx += dx;
@@ -1208,7 +1243,7 @@ void XGA_Write(io_port_t port, io_val_t val, io_width_t width)
 	case 0x86e8: xga.curx = val & 0x0fff; break;
 	case 0x8ae8: xga.desty = val & 0x3fff; break;
 	case 0x8ee8: xga.destx = val & 0x3fff; break;
-	case 0xb2e8: LOG_MSG("COLOR_CMP not implemented"); break;
+	case 0xb2e8: XGA_SetDualReg(xga.color_compare, val); break;
 	case 0xb6e8: xga.backmix = val; break;
 	case 0xbae8: xga.foremix = val; break;
 	case 0xbee8: XGA_Write_Multifunc(val); break;
@@ -1282,6 +1317,7 @@ uint32_t XGA_Read(io_port_t port, io_width_t width)
 		else
 			return 0x0;
 	case 0xbee8: return XGA_Read_Multifunc();
+	case 0xb2e8: return XGA_GetDualReg(xga.color_compare); break;
 	case 0xa2e8: return XGA_GetDualReg(xga.backcolor); break;
 	case 0xa6e8: return XGA_GetDualReg(xga.forecolor); break;
 	case 0xaae8: return XGA_GetDualReg(xga.writemask); break;


### PR DESCRIPTION
# Description

Imports the missing S3 Trio64 XGA compare and fill routines from DOSBox-X. 

Thanks for the through implementations, @joncampbell123, as well as the detailed comments in the code :+1: 

Followed the wiki on how to import changes:

https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages-for-patches-authored-by-someone-else

## Related issues

Fixes #2767

# Manual testing

Tested the Trio64 v1.42B22 and [v1.70.04](https://github.com/user-attachments/files/15878266/w3117004.zip) drivers with Microsoft Office, Critical Mass, and Wheel of Fortune.

Tested the 'S3ID' tool:

![s3id-trio64](https://github.com/dosbox-staging/dosbox-staging/assets/165201780/97b53f53-c3c5-4a2a-954b-d9b253a48e6a)

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

