### PR TITLE
Replace botched Tyrian 2000 setup fix with a (hopefully) proper one

### DIFF
--- a/src/hardware/input/intel8042.cpp
+++ b/src/hardware/input/intel8042.cpp
@@ -915,10 +915,6 @@ static void execute_command(const Command command, const uint8_t param)
 		// firmware allow everything? writing bits 4,5 and 6
 		// should be safe in real implementation, how about here?
 		sanitize_config_byte();
-		// Make sure only the needed IRQs are activated
-		PIC_DeActivateIRQ(get_irq_mouse());
-		PIC_DeActivateIRQ(get_irq_keyboard());
-		activate_irqs_if_needed();
 		break;
 	case Command::WriteControllerMode: // 0xcb
 		// Changes controller mode to PS/2 or AT
@@ -1001,7 +997,6 @@ static uint8_t read_data_port(io_port_t, io_width_t) // port 0x60
 	}
 
 	if (is_data_from_aux) {
-		PIC_DeActivateIRQ(get_irq_mouse());
 		assert(waiting_bytes_from_aux);
 		--waiting_bytes_from_aux;
 		if (I8042_IsReadyForAuxFrame()) {
@@ -1010,7 +1005,6 @@ static uint8_t read_data_port(io_port_t, io_width_t) // port 0x60
 	}
 
 	if (is_data_from_kbd) {
-		PIC_DeActivateIRQ(get_irq_keyboard());
 		assert(waiting_bytes_from_kbd);
 		--waiting_bytes_from_kbd;
 		if (I8042_IsReadyForKbdFrame()) {

--- a/src/hardware/input/intel8042.cpp
+++ b/src/hardware/input/intel8042.cpp
@@ -1018,7 +1018,10 @@ static uint8_t read_data_port(io_port_t, io_width_t) // port 0x60
 	is_data_from_aux = false;
 	is_data_from_kbd = false;
 
-	maybe_transfer_buffer();
+	// Enforce the simulated data transfer delay, as some software
+	// (Tyrian 2000 setup) reads the port without waiting for the
+	// interrupt.
+	restart_delay_timer(PortDelayMs);
 
 	return ret_val;
 }

--- a/src/hardware/input/intel8042.cpp
+++ b/src/hardware/input/intel8042.cpp
@@ -740,7 +740,7 @@ static void execute_command(const Command command)
 		buffer_add(0);
 		break;
 	case Command::ReadFwRevision: // 0xa1
-		// Reads the keybaord copntroller firmware
+		// Reads the keyboard controller firmware
 		// revision, always one byte
 		flush_buffer();
 		buffer_add(FirmwareRevision);
@@ -835,7 +835,7 @@ static void execute_command(const Command command)
 		buffer_add(get_input_port());
 		break;
 	case Command::ReadControllerMode: // 0xca
-		// Reads keybaord controller mode
+		// Reads keyboard controller mode
 		// 0x00: ISA (AT)
 		// 0x01: PS/2 (MCA)
 		flush_buffer();


### PR DESCRIPTION
# Description

This replaces the old (improper) fix for the _Tyrian 2000_ hardware setup tool with a port 0x60 timing fix.


## Related issues

Fixes https://github.com/dosbox-staging/dosbox-staging/issues/3691
https://github.com/dosbox-staging/dosbox-staging/issues/3632


# Manual testing

- checked that _Tyrian 2000_ hardware setup tool has usable menu
- played _Gods_ for a while, checked that pressed keys no longer appear to get stuck
- checked that it is still possible to type player name in _Ultima VIII: Pagan_
- tested _Windows 3.11 for Workgroups_ with standard PS/2 mouse driver, VirtualBox mouse driver, A4tech 3DMouse driver
- played some games for a while - Wolfenstein 3D, DOOM, Duke Nukem 3D, Grand Theft Auto


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

