### PR TITLE
Simple documentation fixes

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -287,7 +287,7 @@ Build and generate report:
 
 ``` shell
 meson setup -Dbuildtype=debug build/debug
-meson compile -C build/debug scan-build
+ninja -C build/debug scan-build
 ```
 
 ### Make a sanitizer build

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Install build dependencies appropriate for your OS:
 sudo dnf install ccache gcc-c++ meson alsa-lib-devel libatomic libpng-devel \
                  SDL2-devel SDL2_net-devel opusfile-devel \
                  fluidsynth-devel iir1-devel mt32emu-devel libslirp-devel \
-                 speexdsp-devel libXi-devel
+                 speexdsp-devel libXi-devel zlib-ng-devel
 ```
 
 ``` shell


### PR DESCRIPTION
# Description

- Fix instructions for running static analyzer (CI had correct command since forever, should stay as it is)
- Add `zlib-ng`  to Fedora development dependencies. Same should probably be done for all other distros, but I need to spin Docker to test first.

# Manual testing

I ran static analysis manually by copy/pasting instructions.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [x] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [x] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

