### PR TITLE
Fix compilation warnings reported by g++ 14.1

### DIFF
--- a/src/hardware/imfc.cpp
+++ b/src/hardware/imfc.cpp
@@ -1762,7 +1762,7 @@ public:
 	InputOutputPin(const InputOutputPin& other)            = delete;
 	InputOutputPin& operator=(const InputOutputPin& other) = delete;
 
-	explicit InputOutputPin<DataType>(const std::string& name)
+	explicit InputOutputPin(const std::string& name)
 	        : InputPin<DataType>(name),
 	          m_dataContainer(nullptr)
 	{}

--- a/src/hardware/reelmagic/driver.cpp
+++ b/src/hardware/reelmagic/driver.cpp
@@ -664,8 +664,8 @@ static void CleanupFromUserCallback(void)
 static uint32_t FMPDRV_driver_call(const uint8_t command, const uint8_t media_handle,
                                    const uint16_t subfunc, const uint16_t param1, const uint16_t param2)
 {
-	ReelMagic_MediaPlayer* player;
-	ReelMagic_PlayerConfiguration* cfg;
+	ReelMagic_MediaPlayer* player = nullptr;
+	ReelMagic_PlayerConfiguration* cfg = nullptr;
 	uint32_t rv;
 	switch (command) {
 	//
@@ -882,7 +882,7 @@ static uint32_t FMPDRV_driver_call(const uint8_t command, const uint8_t media_ha
 			 (unsigned short)param1);
 			return 0;
 		}
-		if (media_handle != 0)
+		if (player != nullptr)
 			player->NotifyConfigChange();
 
 		return rv;


### PR DESCRIPTION
# Description

Quoting commit messages should be enough:

```
Fix maybe-uninitialized warning in ReelMagic

In context of this code, (media_handle != 0) implies that
(player != nullptr), so it's only us being super pedantic.

Reported as warning by g++ 14.1.1 release build:

    warning: ‘player’ may be used uninitialized [-Wmaybe-uninitialized]
      886 |                         player->NotifyConfigChange();
          |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~^~
```
```
Fix template-id-cdtor warning in ctor

C++20 made this construction invalid: https://cplusplus.github.io/CWG/issues/2237.html

Reported as warning by g++ 14.1.1:

    warning: template-id not allowed for constructor in C++20 [-Wtemplate-id-cdtor]
     1765 |         explicit InputOutputPin<DataType>(const std::string& name)
          |                                          ^
    ../src/hardware/imfc.cpp:1765:42: note: remove the ‘< >’
```

# Manual testing

Build with gcc 14.1+ (default on Fedora 40).

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

