### PR TITLE
Replace Ultima VIII keyboard hack with a proper solution

### DIFF
--- a/src/cpu/callback.cpp
+++ b/src/cpu/callback.cpp
@@ -288,7 +288,17 @@ static uint8_t callback_setup_extra(const callback_number_t callback_number,
 		break;
 	case CB_IRQ1: // keyboard INT9
 		add_instruction_1(0x50);                   // push ax
+		// Disable keyboard port
+		add_instruction_2(0xb0, 0xad);             // mov al, 0xad
+		add_instruction_2(0xe6, 0x64);             // out 0x64, al
+		// Read the keyboard input
 		add_instruction_2(0xe4, 0x60);             // in al, 0x60
+		// Re-enable keyboard port
+		add_instruction_1(0x50);                   // push ax
+		add_instruction_2(0xb0, 0xae);             // mov al, 0xae
+		add_instruction_2(0xe6, 0x64);             // out 0x64, al
+		add_instruction_1(0x58);                   // pop ax
+		// Handle keyboard interception via INT 15h
 		add_instruction_2(0xb4, 0x4f);             // mov ah, 0x4f
 		add_instruction_1(0xf9);                   // stc
 		add_instruction_2(0xcd, 0x15);             // int 0x15
@@ -297,6 +307,7 @@ static uint8_t callback_setup_extra(const callback_number_t callback_number,
 			add_native_call_4(callback_number);
 			// jump here to (skip):
 		}
+		// Process the key, handle PIC
 		add_instruction_1(0xfa);                   // cli
 		add_instruction_2(0xb0, 0x20);             // mov al, 0x20
 		add_instruction_2(0xe6, 0x20);             // out 0x20, al

--- a/src/hardware/input/intel8042.cpp
+++ b/src/hardware/input/intel8042.cpp
@@ -672,11 +672,6 @@ static bool is_cmd_vendor_lines(const Command command)
 	return (code >= 0xb0) && (code <= 0xbd);
 }
 
-static void request_system_reset()
-{
-	restart_dosbox();
-}
-
 static void execute_command(const Command command)
 {
 	// LOG_INFO("I8042: Command 0x%02x", static_cast<int>(command));
@@ -928,7 +923,7 @@ static void execute_command(const Command command, const uint8_t param)
 		MEM_A20_Enable(bit::is(param, b1));
 		if (!bit::is(param, b0)) {
 			LOG_WARNING("I8042: Clearing P2 bit 0 locks a real PC");
-			request_system_reset();
+			restart_dosbox();
 		}
 		break;
 	case Command::SimulateInputKbd: // 0xd2
@@ -963,7 +958,8 @@ static void execute_command(const Command command, const uint8_t param)
 				warn_line_pulse();
 			}
 			if (code == 0xf0 && !(lines & 0b0001)) {
-				request_system_reset();
+				// System reset via keyboard controller
+				restart_dosbox();
 			}
 		} else {
 			// If we are here, than either this function

--- a/src/ints/bios_keyboard.cpp
+++ b/src/ints/bios_keyboard.cpp
@@ -659,49 +659,11 @@ void BIOS_SetupKeyboard(void) {
 	call_irq1=CALLBACK_Allocate();	
 	CALLBACK_Setup(call_irq1,&IRQ1_Handler,CB_IRQ1,RealToPhysical(BIOS_DEFAULT_IRQ1_LOCATION),"IRQ 1 Keyboard");
 	RealSetVec(0x09,BIOS_DEFAULT_IRQ1_LOCATION);
-	// pseudocode for CB_IRQ1:
-	//	push ax
-	//	in al, 0x60
-	//	mov ah, 0x4f
-	//	stc
-	//	int 15
-	//	jc skip
-	//	callback IRQ1_Handler
-	//	label skip:
-	//	cli
-	//	mov al, 0x20
-	//	out 0x20, al
-	//	pop ax
-	//	iret
-	//	cli
-	//	mov al, 0x20
-	//	out 0x20, al
-	//	push bp
-	//	int 0x05
-	//	pop bp
-	//	pop ax
-	//	iret
 
 	if (machine==MCH_PCJR) {
 		call_irq6=CALLBACK_Allocate();
 		CALLBACK_Setup(call_irq6,nullptr,CB_IRQ6_PCJR,"PCJr kb irq");
 		RealSetVec(0x0e,CALLBACK_RealPointer(call_irq6));
-		// pseudocode for CB_IRQ6_PCJR:
-		//	push ax
-		//	in al, 0x60
-		//	cmp al, 0xe0
-		//	je skip
-		//	push ds
-		//	push 0x40
-		//	pop ds
-		//	int 0x09
-		//	pop ds
-		//	label skip:
-		//	cli
-		//	mov al, 0x20
-		//	out 0x20, al
-		//	pop ax
-		//	iret
 	}
 }
 


### PR DESCRIPTION
# Description

The previous Ultima VIII keyboard fix was a very hacky one - due to upcoming release, I have changed the keyboard disable command to timeout. This PR implements a better solution instead - it performs similar actions than real BIOS, it now disables the keyboard, reads a byte, and enables the keyboard again.

I have confirmed the behavior by running a real BIOS under _86Box 4.1.1_, I have added prints in the `kbc_at_process_cmd` function:

```C++
        /* Clear the keyboard controller queue. */
        kbc_at_queue_reset(dev);

        printf("XXX kbc_at_process_cmd 0x%02x\n", dev->ib);
        switch (dev->ib) {
            /* Read data from KBC memory. */
```

and in the `kbc_at_read` function:

```C++
    switch (port) {
        case 0x60:
            ret = dev->ob;
            printf("XXX kbc_at_read port 0x60, 0x%02x\n", ret);
            dev->status &= ~STAT_OFULL;
```

## Related issues

https://github.com/dosbox-staging/dosbox-staging/issues/3104


# Manual testing

- checked that Tyrian 2000 hardware setup tool has usable menu
- played Gods for a while, checked that pressed keys no longer appear to get stuck
- checked that it is still possible to type player name in Ultima VIII: Pagan
- tested Windows 3.11 for Workgroups with standard PS/2 mouse driver, VirtualBox mouse driver, A4tech 3DMouse driver - both mouse and keyboard should work
- played some games for a while - Wolfenstein 3D, DOOM, Duke Nukem 3D, Grand Theft Auto, Stunts


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

