### PR TITLE
Add carry, sign, zero, and parity flags to integer division instructions

### DIFF
--- a/include/regs.h
+++ b/include/regs.h
@@ -23,26 +23,67 @@
 #include "mem.h"
 #endif
 
-#define FLAG_CF		0x00000001
-#define FLAG_PF		0x00000004
-#define FLAG_AF		0x00000010
-#define FLAG_ZF		0x00000040
-#define FLAG_SF		0x00000080
-#define FLAG_OF		0x00000800
+// x86 CPU FLAGS register bit positions
+// - Intel iAXP 286 Programmer's Reference Manual
+// - Intel 64 and IA-32 Architectures Software Developer's Manual. Vol.1
 
-#define FLAG_TF		0x00000100
-#define FLAG_IF		0x00000200
-#define FLAG_DF		0x00000400
+// Carry Flag (bit 0), 1 indicates an arithmetic carry or borrow has been
+// generated out of the most significant arithmetic logic unit (ALU) bit
+// position.
+constexpr uint32_t FLAG_CF = 1 << 0;
 
-#define FLAG_IOPL	0x00003000
-#define FLAG_NT		0x00004000
-#define FLAG_VM		0x00020000
-#define FLAG_AC		0x00040000
-#define FLAG_ID		0x00200000
+// Parity Flag (bit 2) indicates whether the modulo 2 sum of the low-order eight
+// bits of the result is even (PF=O) or odd (PF=1).
+constexpr uint32_t FLAG_PF = 1 << 2;
 
-#define FMASK_TEST		(FLAG_CF | FLAG_PF | FLAG_AF | FLAG_ZF | FLAG_SF | FLAG_OF)
-#define FMASK_NORMAL	(FMASK_TEST | FLAG_DF | FLAG_TF | FLAG_IF )	
-#define FMASK_ALL		(FMASK_NORMAL | FLAG_IOPL | FLAG_NT)
+// Auxiliary Carry Flag (bit 4), 1 indicates a carry from the lower nibble or a
+// for the lower nibble in BCD (Binary-coded Decimal) operations.
+constexpr uint32_t FLAG_AF = 1 << 4;
+
+// Zero Flag (bit 6), 1 indicates the result is zero.
+constexpr uint32_t FLAG_ZF = 1 << 6;
+
+// Sign Flag (bit 7), 1 indicates the result is negative.
+constexpr uint32_t FLAG_SF = 1 << 7;
+
+// Overflow Flag (bit 11), 1 indicates that the operation has overflowed; the
+// complete result was too large to be stored in the resulting register.
+constexpr uint32_t FLAG_OF = 1 << 11;
+
+// Trap flag (bit 8) 1 indicates that the processor is in single-step mode
+// (debugging).
+constexpr uint32_t FLAG_TF = 1 << 8;
+
+// I/O level flag (bit 9), 1 indicates that interrupts are enabled.
+constexpr uint32_t FLAG_IF = 1 << 9;
+
+// direction flag (bit 10), 1 indicates the direction is down. The meaning of
+// 'down' is in context to the instruction.
+constexpr uint32_t FLAG_DF = 1 << 10;
+
+// I/O privilege level flags (bits 12 and 13). 286+ only. This is all ones on
+// 8086 and 186.
+constexpr uint32_t FLAG_IOPL = (1 << 12) | (1 << 13);
+
+// Nested task flag (bit 14), 286+ only. This is always 1 on 8086 and 186.
+constexpr uint32_t FLAG_NT = 1 << 14;
+
+// Virtual 8086 mode flag (bit 17), 386+ only.
+constexpr uint32_t FLAG_VM = 1 << 17;
+
+// Alignment Check (bit 18), 486+-only.
+constexpr uint32_t FLAG_AC = 1 << 18;
+
+// CPUID instruction availability (bit 21), Pentium+-only.
+constexpr uint32_t FLAG_ID = 1 << 21;
+
+// Flag groups:
+constexpr uint32_t FMASK_TEST = FLAG_CF | FLAG_PF | FLAG_AF | FLAG_ZF |
+                                FLAG_SF | FLAG_OF;
+
+constexpr uint32_t FMASK_NORMAL = FMASK_TEST | FLAG_DF | FLAG_TF | FLAG_IF;
+
+constexpr uint32_t FMASK_ALL = FMASK_NORMAL | FLAG_IOPL | FLAG_NT;
 
 #define SETFLAGBIT(TYPE,TEST) if (TEST) reg_flags|=FLAG_ ## TYPE; else reg_flags&=~FLAG_ ## TYPE
 

--- a/src/cpu/core_dyn_x86/decoder.h
+++ b/src/cpu/core_dyn_x86/decoder.h
@@ -1741,6 +1741,10 @@ static void dyn_grp3_eb(void) {
 		if (decode.modrm.mod==3)
 			gen_dop_byte(DOP_MOV,DREG(TMPB),0,&DynRegs[decode.modrm.rm&3],decode.modrm.rm&4);
 		gen_releasereg(DREG(EAX));
+
+		// The division helpers update the CPU test flags
+		set_skipflags(false);
+
 		gen_call_function((decode.modrm.reg==6) ? (void *)&dyn_helper_divb : (void *)&dyn_helper_idivb,
 			"%Rd%Drd",DREG(TMPB),DREG(TMPB));
 		dyn_check_bool_exception(DREG(TMPB));
@@ -1781,6 +1785,10 @@ static void dyn_grp3_ev(void) {
 		if (decode.modrm.mod==3)
 			gen_dop_word(DOP_MOV,decode.big_op,DREG(TMPW),&DynRegs[decode.modrm.rm]);
 		gen_releasereg(DREG(EAX));gen_releasereg(DREG(EDX));
+
+		// The division helpers update the CPU test flags
+		set_skipflags(false);
+
 		void * func=(decode.modrm.reg==6) ?
 			(decode.big_op ? (void *)&dyn_helper_divd : (void *)&dyn_helper_divw) :
 			(decode.big_op ? (void *)&dyn_helper_idivd : (void *)&dyn_helper_idivw);

--- a/src/cpu/core_dyn_x86/helpers.h
+++ b/src/cpu/core_dyn_x86/helpers.h
@@ -16,6 +16,8 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
+#include "../flags.h"
+
 static bool dyn_helper_divb(uint8_t val) {
 	if (!val) return CPU_PrepareException(0,0);
 	Bitu quo=reg_ax / val;
@@ -24,6 +26,7 @@ static bool dyn_helper_divb(uint8_t val) {
 	if (quo>0xff) return CPU_PrepareException(0,0);
 	reg_ah=rem;
 	reg_al=quo8;
+	set_cpu_test_flags_for_division(quo8);
 	return false;
 }
 
@@ -35,6 +38,7 @@ static bool dyn_helper_idivb(int8_t val) {
 	if (quo!=(int16_t)quo8s) return CPU_PrepareException(0,0);
 	reg_ah=rem;
 	reg_al=quo8s;
+	set_cpu_test_flags_for_division(quo8s);
 	return false;
 }
 
@@ -47,6 +51,7 @@ static bool dyn_helper_divw(uint16_t val) {
 	if (quo!=(uint32_t)quo16) return CPU_PrepareException(0,0);
 	reg_dx=rem;
 	reg_ax=quo16;
+	set_cpu_test_flags_for_division(quo16);
 	return false;
 }
 
@@ -59,6 +64,7 @@ static bool dyn_helper_idivw(int16_t val) {
 	if (quo!=(int32_t)quo16s) return CPU_PrepareException(0,0);
 	reg_dx=rem;
 	reg_ax=quo16s;
+	set_cpu_test_flags_for_division(quo16s);
 	return false;
 }
 
@@ -71,6 +77,7 @@ static bool dyn_helper_divd(uint32_t val) {
 	if (quo!=(uint64_t)quo32) return CPU_PrepareException(0,0);
 	reg_edx=rem;
 	reg_eax=quo32;
+	set_cpu_test_flags_for_division(quo32);
 	return false;
 }
 
@@ -83,5 +90,6 @@ static bool dyn_helper_idivd(int32_t val) {
 	if (quo!=(int64_t)quo32s) return CPU_PrepareException(0,0);
 	reg_edx=rem;
 	reg_eax=quo32s;
+	set_cpu_test_flags_for_division(quo32s);
 	return false;
 }

--- a/src/cpu/core_dynrec/operators.h
+++ b/src/cpu/core_dynrec/operators.h
@@ -16,6 +16,7 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
+#include "../flags.h"
 #include "include/math_utils.h"
 
 static uint8_t DRC_CALL_CONV dynrec_add_byte(uint8_t op1,uint8_t op2) DRC_FC;
@@ -1480,6 +1481,7 @@ static bool DRC_CALL_CONV dynrec_div_byte(uint8_t op) {
 	if (quo>0xff) return CPU_PrepareException(0,0);
 	reg_ah=rem;
 	reg_al=quo8;
+	set_cpu_test_flags_for_division(quo8);
 	return false;
 }
 
@@ -1493,6 +1495,7 @@ static bool DRC_CALL_CONV dynrec_idiv_byte(uint8_t op) {
 	if (quo!=(int16_t)quo8s) return CPU_PrepareException(0,0);
 	reg_ah=rem;
 	reg_al=quo8s;
+	set_cpu_test_flags_for_division(quo8s);
 	return false;
 }
 
@@ -1507,6 +1510,7 @@ static bool DRC_CALL_CONV dynrec_div_word(uint16_t op) {
 	if (quo!=(uint32_t)quo16) return CPU_PrepareException(0,0);
 	reg_dx=rem;
 	reg_ax=quo16;
+	set_cpu_test_flags_for_division(quo16);
 	return false;
 }
 
@@ -1521,6 +1525,7 @@ static bool DRC_CALL_CONV dynrec_idiv_word(uint16_t op) {
 	if (quo!=(int32_t)quo16s) return CPU_PrepareException(0,0);
 	reg_dx=rem;
 	reg_ax=quo16s;
+	set_cpu_test_flags_for_division(quo16s);
 	return false;
 }
 
@@ -1535,6 +1540,7 @@ static bool DRC_CALL_CONV dynrec_div_dword(uint32_t op) {
 	if (quo!=(uint64_t)quo32) return CPU_PrepareException(0,0);
 	reg_edx=rem;
 	reg_eax=quo32;
+	set_cpu_test_flags_for_division(quo32);
 	return false;
 }
 
@@ -1549,6 +1555,7 @@ static bool DRC_CALL_CONV dynrec_idiv_dword(uint32_t op) {
 	if (quo!=(int64_t)quo32s) return CPU_PrepareException(0,0);
 	reg_edx=rem;
 	reg_eax=quo32s;
+	set_cpu_test_flags_for_division(quo32s);
 	return false;
 }
 

--- a/src/cpu/flags.cpp
+++ b/src/cpu/flags.cpp
@@ -1054,7 +1054,7 @@ void set_cpu_test_flags_for_division(const T quotient) noexcept
 	SETFLAGBIT(OF, false);
 }
 
-// Explicit instantiations (replaces 12 instances)
+// Explicit instantiations (replaces 18 instances)
 template void set_cpu_test_flags_for_division<uint8_t>(const uint8_t) noexcept;
 template void set_cpu_test_flags_for_division<uint16_t>(const uint16_t) noexcept;
 template void set_cpu_test_flags_for_division<uint32_t>(const uint32_t) noexcept;

--- a/src/cpu/flags.cpp
+++ b/src/cpu/flags.cpp
@@ -1051,6 +1051,8 @@ void FillFlagsNoCFOF(void) {
 template <typename T>
 void set_cpu_test_flags_for_division(const T quotient) noexcept
 {
+	// Set the instruction type to division
+	lflags.type = t_DIV;
 
 	// Create a new test flags object with the flags we'll be settings
 	CpuTestFlags div_test_flags(FLAG_OF);

--- a/src/cpu/flags.cpp
+++ b/src/cpu/flags.cpp
@@ -1051,7 +1051,13 @@ void FillFlagsNoCFOF(void) {
 template <typename T>
 void set_cpu_test_flags_for_division(const T quotient) noexcept
 {
-	SETFLAGBIT(OF, false);
+
+	// Create a new test flags object with the flags we'll be settings
+	CpuTestFlags div_test_flags(FLAG_OF);
+
+	div_test_flags.has_overflow = false;
+
+	cpu_regs.ApplyTestFlags(div_test_flags);
 }
 
 // Explicit instantiations (replaces 18 instances)

--- a/src/cpu/flags.cpp
+++ b/src/cpu/flags.cpp
@@ -1046,7 +1046,13 @@ void FillFlagsNoCFOF(void) {
 	}
 	lflags.type=t_UNKNOWN;
 }
-   
+
+template <typename T>
+constexpr bool is_negative(const T value)
+{
+	return std::is_signed_v<T> && value < 0;
+}
+
 // Set CPU test flags for all IDIV and DIV quotients
 template <typename T>
 void set_cpu_test_flags_for_division(const T quotient) noexcept
@@ -1055,7 +1061,7 @@ void set_cpu_test_flags_for_division(const T quotient) noexcept
 	lflags.type = t_DIV;
 
 	// Create a new test flags object with the flags we'll be settings
-	CpuTestFlags div_test_flags(FLAG_CF | FLAG_OF);
+	CpuTestFlags div_test_flags(FLAG_CF | FLAG_OF | FLAG_SF);
 
 	// After performing IDIV, Intel's micro-operation clears the carry and
 	// overflow flags. Curiously, the 8086 documentation declares that the
@@ -1066,8 +1072,9 @@ void set_cpu_test_flags_for_division(const T quotient) noexcept
 	//
 	//_https://www.righto.com/2023/04/reverse-engineering-8086-divide-microcode.html
 	//
-	div_test_flags.has_carry    = false;
-	div_test_flags.has_overflow = false;
+	div_test_flags.has_carry        = false;
+	div_test_flags.has_overflow     = false;
+	div_test_flags.is_sign_negative = is_negative(quotient);
 
 	cpu_regs.ApplyTestFlags(div_test_flags);
 }

--- a/src/cpu/flags.cpp
+++ b/src/cpu/flags.cpp
@@ -1046,6 +1046,22 @@ void FillFlagsNoCFOF(void) {
 	}
 	lflags.type=t_UNKNOWN;
 }
+   
+// Set CPU test flags for all IDIV and DIV quotients
+template <typename T>
+void set_cpu_test_flags_for_division(const T quotient) noexcept
+{
+	SETFLAGBIT(OF, false);
+}
+
+// Explicit instantiations
+template void set_cpu_test_flags_for_division<uint8_t>(const uint8_t) noexcept;
+template void set_cpu_test_flags_for_division<uint16_t>(const uint16_t) noexcept;
+template void set_cpu_test_flags_for_division<uint32_t>(const uint32_t) noexcept;
+
+template void set_cpu_test_flags_for_division<int8_t>(const int8_t) noexcept;
+template void set_cpu_test_flags_for_division<int16_t>(const int16_t) noexcept;
+template void set_cpu_test_flags_for_division<int32_t>(const int32_t) noexcept;
 
 void DestroyConditionFlags(void) {
 	lflags.type=t_UNKNOWN;

--- a/src/cpu/flags.cpp
+++ b/src/cpu/flags.cpp
@@ -1047,6 +1047,15 @@ void FillFlagsNoCFOF(void) {
 	lflags.type=t_UNKNOWN;
 }
 
+// Helper function to assess a value for the parity flag, which indicates
+// whether the modulo 2 sum of the low-order eight bits of the result is even
+// (PF=O) or odd (PF=1).
+template <typename T>
+constexpr bool lower_8_has_odd_parity(const T value)
+{
+	return parity_lookup[value & 0xff] != 0;
+}
+
 template <typename T>
 constexpr bool is_negative(const T value)
 {
@@ -1061,7 +1070,7 @@ void set_cpu_test_flags_for_division(const T quotient) noexcept
 	lflags.type = t_DIV;
 
 	// Create a new test flags object with the flags we'll be settings
-	CpuTestFlags div_test_flags(FLAG_CF | FLAG_OF | FLAG_SF | FLAG_ZF);
+	CpuTestFlags div_test_flags(FLAG_CF | FLAG_OF | FLAG_PF | FLAG_SF | FLAG_ZF);
 
 	// After performing IDIV, Intel's micro-operation clears the carry and
 	// overflow flags. Curiously, the 8086 documentation declares that the
@@ -1074,6 +1083,7 @@ void set_cpu_test_flags_for_division(const T quotient) noexcept
 	//
 	div_test_flags.has_carry        = false;
 	div_test_flags.has_overflow     = false;
+	div_test_flags.has_odd_parity   = lower_8_has_odd_parity(quotient);
 	div_test_flags.is_sign_negative = is_negative(quotient);
 	div_test_flags.is_zero          = (quotient == 0);
 

--- a/src/cpu/flags.cpp
+++ b/src/cpu/flags.cpp
@@ -1055,8 +1055,18 @@ void set_cpu_test_flags_for_division(const T quotient) noexcept
 	lflags.type = t_DIV;
 
 	// Create a new test flags object with the flags we'll be settings
-	CpuTestFlags div_test_flags(FLAG_OF);
+	CpuTestFlags div_test_flags(FLAG_CF | FLAG_OF);
 
+	// After performing IDIV, Intel's micro-operation clears the carry and
+	// overflow flags. Curiously, the 8086 documentation declares that the
+	// status flags are undefined following IDIV, but the microcode
+	// explicitly clears the carry and overflow flags. Signed DIV re-uses
+	// the above IDIV routine, so this is true for both signed and unsigned
+	// division.
+	//
+	//_https://www.righto.com/2023/04/reverse-engineering-8086-divide-microcode.html
+	//
+	div_test_flags.has_carry    = false;
 	div_test_flags.has_overflow = false;
 
 	cpu_regs.ApplyTestFlags(div_test_flags);

--- a/src/cpu/flags.cpp
+++ b/src/cpu/flags.cpp
@@ -1054,7 +1054,7 @@ void set_cpu_test_flags_for_division(const T quotient) noexcept
 	SETFLAGBIT(OF, false);
 }
 
-// Explicit instantiations
+// Explicit instantiations (replaces 12 instances)
 template void set_cpu_test_flags_for_division<uint8_t>(const uint8_t) noexcept;
 template void set_cpu_test_flags_for_division<uint16_t>(const uint16_t) noexcept;
 template void set_cpu_test_flags_for_division<uint32_t>(const uint32_t) noexcept;

--- a/src/cpu/flags.cpp
+++ b/src/cpu/flags.cpp
@@ -1061,7 +1061,7 @@ void set_cpu_test_flags_for_division(const T quotient) noexcept
 	lflags.type = t_DIV;
 
 	// Create a new test flags object with the flags we'll be settings
-	CpuTestFlags div_test_flags(FLAG_CF | FLAG_OF | FLAG_SF);
+	CpuTestFlags div_test_flags(FLAG_CF | FLAG_OF | FLAG_SF | FLAG_ZF);
 
 	// After performing IDIV, Intel's micro-operation clears the carry and
 	// overflow flags. Curiously, the 8086 documentation declares that the
@@ -1075,6 +1075,7 @@ void set_cpu_test_flags_for_division(const T quotient) noexcept
 	div_test_flags.has_carry        = false;
 	div_test_flags.has_overflow     = false;
 	div_test_flags.is_sign_negative = is_negative(quotient);
+	div_test_flags.is_zero          = (quotient == 0);
 
 	cpu_regs.ApplyTestFlags(div_test_flags);
 }

--- a/src/cpu/flags.h
+++ b/src/cpu/flags.h
@@ -1,0 +1,37 @@
+/*
+ *  Copyright (C) 2024-2024  The DOSBox Staging Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#ifndef DOSBOX_CPU_FLAGS_H
+#define DOSBOX_CPU_FLAGS_H
+
+// This header holds flag-related functions available to all the cores (normal,
+// dynrec, and dynamic).
+//
+// Note that within the dynamic core, be sure to add a call to
+// 'set_skipflags(false)' before calling these functions to ensure the CPU's
+// flags are handled. For an example of this pattern, see the division helper
+// functions in core_dyn_x86/helpers.h and the use of set_skipflags in
+// core_dyn_x86/decoder.h.
+
+
+// Set CPU test flags for all IDIV and DIV quotients
+template <typename T>
+void set_cpu_test_flags_for_division(const T quotient) noexcept;
+
+#endif
+

--- a/src/cpu/instructions.h
+++ b/src/cpu/instructions.h
@@ -16,6 +16,7 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
+#include "flags.h"
 #include "lazyflags.h"
 
 /* Jumps */
@@ -641,9 +642,8 @@
 	if (quo>0xff) EXCEPTION(0);								\
 	reg_ah=rem;												\
 	reg_al=quo8;											\
-	SETFLAGBIT(OF,false);									\
+	set_cpu_test_flags_for_division(quo8); \
 }
-
 
 #define DIVW(op1,load,save)									\
 {															\
@@ -656,7 +656,7 @@
 	if (quo!=(uint32_t)quo16) EXCEPTION(0);					\
 	reg_dx=rem;												\
 	reg_ax=quo16;											\
-	SETFLAGBIT(OF,false);									\
+	set_cpu_test_flags_for_division(quo16); \
 }
 
 #define DIVD(op1,load,save)									\
@@ -670,7 +670,7 @@
 	if (quo!=(uint64_t)quo32) EXCEPTION(0);					\
 	reg_edx=rem;											\
 	reg_eax=quo32;											\
-	SETFLAGBIT(OF,false);									\
+	set_cpu_test_flags_for_division(quo32); \
 }
 
 
@@ -684,7 +684,7 @@
 	if (quo!=(int16_t)quo8s) EXCEPTION(0);					\
 	reg_ah=rem;												\
 	reg_al=quo8s;											\
-	SETFLAGBIT(OF,false);									\
+	set_cpu_test_flags_for_division(quo8s); \
 }
 
 #define IDIVW(op1, load, save) \
@@ -700,7 +700,7 @@
 			EXCEPTION(0); \
 		reg_ax = quo16s; \
 		reg_dx = static_cast<int16_t>(rem); \
-		SETFLAGBIT(OF, false); \
+		set_cpu_test_flags_for_division(quo16s); \
 	}
 
 #define IDIVD(op1,load,save)								\
@@ -714,9 +714,8 @@
 	if (quo!=(int64_t)quo32s) EXCEPTION(0);					\
 	reg_edx=rem;											\
 	reg_eax=quo32s;											\
-	SETFLAGBIT(OF,false);									\
+	set_cpu_test_flags_for_division(quo32s); \
 }
-
 #define IMULB(op1,load,save)								\
 {															\
 	reg_ax=((int8_t)reg_al) * ((int8_t)(load(op1)));			\


### PR DESCRIPTION
# Description

The existing integer division instructions (unsigned `IDIV*()` and signed `DIV*()`)  already set the overflow flag, however they weren't setting the other relevant flags (carry, sign, zero, and parity) or resetting the other flags back to their undefined state.

Presumably the majority of DOS applications and games out there just grab the resulting quotient and don't care about the flag bits.

Silmarils games use an unsigned 16-bit division and its resulting flags to calculate an attenuation value passed to OPL channel 1 across roughly 100 video frames. Every frame, the calculation (typically) produces a larger attenuation value until it reaches `0x3f`, which is the OPL chip's max channel attenuation (or silence).

**Without the division flags**

The game only sets the initial attenuation (0% or max volume) and final attenuation value (100% or silent) leaving the 100-frame loop ineffective - so the tone blasts at max volume for the roughly 1.5 seconds.

```
7.211 | OPL: Attenuating volume of channel 1 by 0.00%

1.5 seconds elapse with channel 1 at full volume without the attenuation loop

8.623 | OPL: Attenuating volume of channel 1 by 100.00%
```

https://github.com/dosbox-staging/dosbox-staging/assets/165201780/ac758a6d-ec7d-4207-8552-cf7ca5c89ff6


---

**With the division flags**

The game calculates and applies increasing attenuation:

```
6.167 | OPL: Attenuating volume of channel 1 by 1.59%
6.181 | OPL: Attenuating volume of channel 1 by 1.59%
6.196 | OPL: Attenuating volume of channel 1 by 3.17%
6.209 | OPL: Attenuating volume of channel 1 by 4.76%
6.223 | OPL: Attenuating volume of channel 1 by 4.76%
6.238 | OPL: Attenuating volume of channel 1 by 6.35%
6.252 | OPL: Attenuating volume of channel 1 by 6.35%
6.267 | OPL: Attenuating volume of channel 1 by 7.94%
6.281 | OPL: Attenuating volume of channel 1 by 9.52%
6.295 | OPL: Attenuating volume of channel 1 by 9.52%
6.310 | OPL: Attenuating volume of channel 1 by 11.11%
6.323 | OPL: Attenuating volume of channel 1 by 12.70%
6.338 | OPL: Attenuating volume of channel 1 by 12.70%
6.352 | OPL: Attenuating volume of channel 1 by 14.29%
6.366 | OPL: Attenuating volume of channel 1 by 15.87%
6.380 | OPL: Attenuating volume of channel 1 by 15.87%
6.394 | OPL: Attenuating volume of channel 1 by 17.46%
6.409 | OPL: Attenuating volume of channel 1 by 17.46%
6.423 | OPL: Attenuating volume of channel 1 by 19.05%
6.437 | OPL: Attenuating volume of channel 1 by 20.63%
6.453 | OPL: Attenuating volume of channel 1 by 20.63%
6.466 | OPL: Attenuating volume of channel 1 by 22.22%
6.480 | OPL: Attenuating volume of channel 1 by 23.81%
6.495 | OPL: Attenuating volume of channel 1 by 23.81%
6.510 | OPL: Attenuating volume of channel 1 by 25.40%
6.523 | OPL: Attenuating volume of channel 1 by 26.98%
6.538 | OPL: Attenuating volume of channel 1 by 26.98%
6.551 | OPL: Attenuating volume of channel 1 by 28.57%
6.567 | OPL: Attenuating volume of channel 1 by 28.57%
6.580 | OPL: Attenuating volume of channel 1 by 30.16%
6.595 | OPL: Attenuating volume of channel 1 by 31.75%
6.608 | OPL: Attenuating volume of channel 1 by 31.75%
6.623 | OPL: Attenuating volume of channel 1 by 33.33%
6.638 | OPL: Attenuating volume of channel 1 by 34.92%
6.651 | OPL: Attenuating volume of channel 1 by 34.92%
6.666 | OPL: Attenuating volume of channel 1 by 36.51%
6.681 | OPL: Attenuating volume of channel 1 by 36.51%
6.694 | OPL: Attenuating volume of channel 1 by 38.10%
6.708 | OPL: Attenuating volume of channel 1 by 39.68%
6.724 | OPL: Attenuating volume of channel 1 by 39.68%
6.737 | OPL: Attenuating volume of channel 1 by 41.27%
6.752 | OPL: Attenuating volume of channel 1 by 42.86%
6.765 | OPL: Attenuating volume of channel 1 by 42.86%
6.780 | OPL: Attenuating volume of channel 1 by 44.44%
6.794 | OPL: Attenuating volume of channel 1 by 46.03%
6.808 | OPL: Attenuating volume of channel 1 by 46.03%
6.822 | OPL: Attenuating volume of channel 1 by 47.62%
6.837 | OPL: Attenuating volume of channel 1 by 47.62%
6.851 | OPL: Attenuating volume of channel 1 by 49.21%
6.866 | OPL: Attenuating volume of channel 1 by 50.79%
6.880 | OPL: Attenuating volume of channel 1 by 50.79%
6.895 | OPL: Attenuating volume of channel 1 by 52.38%
6.909 | OPL: Attenuating volume of channel 1 by 53.97%
6.922 | OPL: Attenuating volume of channel 1 by 53.97%
6.937 | OPL: Attenuating volume of channel 1 by 55.56%
6.951 | OPL: Attenuating volume of channel 1 by 57.14%
6.965 | OPL: Attenuating volume of channel 1 by 57.14%
6.980 | OPL: Attenuating volume of channel 1 by 58.73%
6.995 | OPL: Attenuating volume of channel 1 by 58.73%
7.009 | OPL: Attenuating volume of channel 1 by 60.32%
7.022 | OPL: Attenuating volume of channel 1 by 61.90%
7.037 | OPL: Attenuating volume of channel 1 by 61.90%
7.052 | OPL: Attenuating volume of channel 1 by 63.49%
7.065 | OPL: Attenuating volume of channel 1 by 65.08%
7.079 | OPL: Attenuating volume of channel 1 by 65.08%
7.094 | OPL: Attenuating volume of channel 1 by 66.67%
7.108 | OPL: Attenuating volume of channel 1 by 68.25%
7.122 | OPL: Attenuating volume of channel 1 by 68.25%
7.137 | OPL: Attenuating volume of channel 1 by 69.84%
7.151 | OPL: Attenuating volume of channel 1 by 69.84%
7.165 | OPL: Attenuating volume of channel 1 by 71.43%
7.179 | OPL: Attenuating volume of channel 1 by 73.02%
7.194 | OPL: Attenuating volume of channel 1 by 73.02%
7.208 | OPL: Attenuating volume of channel 1 by 74.60%
7.222 | OPL: Attenuating volume of channel 1 by 76.19%
7.236 | OPL: Attenuating volume of channel 1 by 76.19%
7.251 | OPL: Attenuating volume of channel 1 by 77.78%
7.265 | OPL: Attenuating volume of channel 1 by 79.37%
7.279 | OPL: Attenuating volume of channel 1 by 79.37%
7.293 | OPL: Attenuating volume of channel 1 by 80.95%
7.308 | OPL: Attenuating volume of channel 1 by 80.95%
7.322 | OPL: Attenuating volume of channel 1 by 82.54%
7.337 | OPL: Attenuating volume of channel 1 by 84.13%
7.350 | OPL: Attenuating volume of channel 1 by 84.13%
7.366 | OPL: Attenuating volume of channel 1 by 85.71%
7.379 | OPL: Attenuating volume of channel 1 by 87.30%
7.394 | OPL: Attenuating volume of channel 1 by 87.30%
7.407 | OPL: Attenuating volume of channel 1 by 88.89%
7.423 | OPL: Attenuating volume of channel 1 by 88.89%
7.437 | OPL: Attenuating volume of channel 1 by 90.48%
7.455 | OPL: Attenuating volume of channel 1 by 92.06%
7.465 | OPL: Attenuating volume of channel 1 by 92.06%
7.479 | OPL: Attenuating volume of channel 1 by 93.65%
7.493 | OPL: Attenuating volume of channel 1 by 95.24%
7.508 | OPL: Attenuating volume of channel 1 by 95.24%
7.522 | OPL: Attenuating volume of channel 1 by 96.83%
7.536 | OPL: Attenuating volume of channel 1 by 98.41%
7.551 | OPL: Attenuating volume of channel 1 by 98.41%
7.564 | OPL: Attenuating volume of channel 1 by 100.00%
7.579 | OPL: Attenuating volume of channel 1 by 100.00%
7.579 | OPL: Attenuating volume of channel 1 by 100.00%
```

https://github.com/dosbox-staging/dosbox-staging/assets/165201780/01d58c44-20b8-460e-9236-4bad029adbfb

To inspect the OPL channel attenuation, save this to `log_opl_channel_attenuation.patch` then `git apply log_opl_channel_attenuation.patch` in the root of DOSBox Staging source tree:

```diff
diff --git a/src/hardware/opl.cpp b/src/hardware/opl.cpp
index b640ff79b..328a96dea 100644
--- a/src/hardware/opl.cpp
+++ b/src/hardware/opl.cpp
@@ -315,6 +315,13 @@ void Opl::WriteReg(const io_port_t selected_reg, const uint8_t val)
 
 
        } else { // OPL
+               if (selected_reg >= 0x40 && selected_reg <= (0x40 + 18)) {
+                       const auto opl_channel = 1 + selected_reg - 0x40;
+                       const auto attenuation_percent = (val * 100.0) / 0x3f;
+                       LOG_MSG("OPL: Attenuating volume of channel %d by %.2f%%",
+                               opl_channel,
+                               attenuation_percent);
+               }
                OPL3_WriteRegBuffered(&opl.chip, selected_reg, val);
                if (selected_reg == 0x105) {
                        opl.newm = selected_reg & 0x01;
```

## Related issues

Finishing touches on https://github.com/dosbox-staging/dosbox-staging/issues/3504

# Manual testing

Tested plenty of real mode, protected mode, and various Windows 3.1 programs and did not notice any problems or differences.

I suppose this could impact performance a bit, but I didn't see any (despite doing more work on the host). 


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [ ] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

