### PR TITLE
The great DOS_File/DOS_Drive Refactor (plus some timestamp improvements)

### DIFF
--- a/include/bios_disk.h
+++ b/include/bios_disk.h
@@ -84,10 +84,8 @@ void incrementFDD(void);
 
 #define MAX_DISK_IMAGES (2 + MAX_HDD_IMAGES)
 
-// Merely pointers. The actual raw image objects are managed by the drive
-// manager class.
-extern std::array<imageDisk*, MAX_DISK_IMAGES> imageDiskList;
-extern std::array<imageDisk*, MAX_SWAPPABLE_DISKS> diskSwap;
+extern std::array<std::shared_ptr<imageDisk>, MAX_DISK_IMAGES> imageDiskList;
+extern std::array<std::shared_ptr<imageDisk>, MAX_SWAPPABLE_DISKS> diskSwap;
 
 extern uint16_t imgDTASeg; /* Real memory location of temporary DTA pointer for fat image disk access */
 extern RealPt imgDTAPtr; /* Real memory location of temporary DTA pointer for fat image disk access */

--- a/include/bios_disk.h
+++ b/include/bios_disk.h
@@ -58,7 +58,7 @@ public:
 	imageDisk(const imageDisk&) = delete; // prevent copy
 	imageDisk& operator=(const imageDisk&) = delete; // prevent assignment
 
-	virtual ~imageDisk()
+	~imageDisk()
 	{
 		if (diskimg != nullptr)
 			fclose(diskimg);

--- a/include/dos_inc.h
+++ b/include/dos_inc.h
@@ -196,6 +196,21 @@ constexpr uint16_t DOS_PackDate(const struct tm &datetime) noexcept
 	                    static_cast<uint16_t>(datetime.tm_mday));
 }
 
+constexpr struct tm DOS_UnpackDateTime(const uint16_t date, const uint16_t time)
+{
+	struct tm ret = {};
+	ret.tm_sec = (time & 0x1f) * 2;
+	ret.tm_min = (time >> 5) & 0x3f;
+	ret.tm_hour = (time >> 11) & 0x1f;
+	ret.tm_mday = date & 0x1f;
+	ret.tm_mon = ((date >> 5) & 0x0f) - 1;
+	ret.tm_year = (date >> 9) + 1980 - 1900;
+	// have the C run-time library code compute whether standard
+	// time or daylight saving time is in effect.
+	ret.tm_isdst = -1;
+	return ret;
+}
+
 /* Routines for Drive Class */
 bool DOS_OpenFile(const char* name, uint8_t flags, uint16_t* entry, bool fcb = false);
 bool DOS_OpenFileExtended(const char* name, uint16_t flags,

--- a/include/dos_inc.h
+++ b/include/dos_inc.h
@@ -119,7 +119,7 @@ constexpr int FakeSftEntries = 16;
 /* internal Dos Tables */
 
 extern std::unique_ptr<DOS_File> Files[DOS_FILES];
-extern std::array<DOS_Drive*, DOS_DRIVES> Drives;
+extern std::array<std::shared_ptr<DOS_Drive>, DOS_DRIVES> Drives;
 extern DOS_Device * Devices[DOS_DEVICES];
 
 extern uint8_t dos_copybuf[0x10000];

--- a/include/dos_inc.h
+++ b/include/dos_inc.h
@@ -118,7 +118,7 @@ constexpr int FakeSftEntries = 16;
 
 /* internal Dos Tables */
 
-extern DOS_File * Files[DOS_FILES];
+extern std::unique_ptr<DOS_File> Files[DOS_FILES];
 extern std::array<DOS_Drive*, DOS_DRIVES> Drives;
 extern DOS_Device * Devices[DOS_DEVICES];
 

--- a/include/dos_system.h
+++ b/include/dos_system.h
@@ -124,7 +124,7 @@ public:
 	virtual bool	Read(uint8_t * data,uint16_t * size)=0;
 	virtual bool	Write(uint8_t * data,uint16_t * size)=0;
 	virtual bool	Seek(uint32_t * pos,uint32_t type)=0;
-	virtual bool	Close()=0;
+	virtual void	Close()=0;
 	virtual uint16_t	GetInformation(void)=0;
 	virtual bool IsOnReadOnlyMedium() const = 0;
 
@@ -168,7 +168,7 @@ public:
 	bool Read(uint8_t* data, uint16_t* size) override;
 	bool Write(uint8_t* data, uint16_t* size) override;
 	bool Seek(uint32_t* pos, uint32_t type) override;
-	bool Close() override;
+	void Close() override;
 	uint16_t GetInformation(void) override;
 	bool IsOnReadOnlyMedium() const override { return false; }
 	virtual bool ReadFromControlChannel(PhysPt bufptr, uint16_t size,
@@ -195,7 +195,7 @@ public:
 	bool Read(uint8_t* data, uint16_t* size) override;
 	bool Write(uint8_t* data, uint16_t* size) override;
 	bool Seek(uint32_t* pos, uint32_t type) override;
-	bool Close() override;
+	void Close() override;
 	uint16_t GetInformation() override;
 	bool UpdateDateTimeFromHost() override;
 	bool IsOnReadOnlyMedium() const override { return read_only_medium; }

--- a/include/dos_system.h
+++ b/include/dos_system.h
@@ -190,38 +190,6 @@ private:
 	Bitu devnum;
 };
 
-class localFile : public DOS_File {
-public:
-	localFile(const char* name, const std_fs::path& path,
-	          const NativeFileHandle handle, const char* basedir,
-	          bool _read_only_medium);
-	localFile(const localFile&)            = delete; // prevent copying
-	localFile& operator=(const localFile&) = delete; // prevent assignment
-	bool Read(uint8_t* data, uint16_t* size) override;
-	bool Write(uint8_t* data, uint16_t* size) override;
-	bool Seek(uint32_t* pos, uint32_t type) override;
-	void Close() override;
-	uint16_t GetInformation() override;
-	bool IsOnReadOnlyMedium() const override { return read_only_medium; }
-	const char* GetBaseDir() const
-	{
-		return basedir;
-	}
-	std_fs::path GetPath() const
-	{
-		return path;
-	}
-	NativeFileHandle file_handle = InvalidNativeFileHandle;
-
-private:
-	void MaybeFlushTime();
-	const std_fs::path path = {};
-	const char* basedir     = nullptr;
-
-	const bool read_only_medium = false;
-	bool set_archive_on_close   = false;
-};
-
 /* The following variable can be lowered to free up some memory.
  * The negative side effect: The stored searches will be turned over faster.
  * Should not have impact on systems with few directory entries. */

--- a/include/dos_system.h
+++ b/include/dos_system.h
@@ -317,26 +317,27 @@ public:
 	                                           uint8_t flags) = 0;
 	virtual std::unique_ptr<DOS_File> FileCreate(const char* name,
 	                                             FatAttributeFlags attributes) = 0;
-	virtual bool FileUnlink(const char* _name) = 0;
-	virtual bool RemoveDir(const char * _dir)=0;
-	virtual bool MakeDir(const char * _dir)=0;
-	virtual bool TestDir(const char * _dir)=0;
-	virtual bool FindFirst(const char * _dir,DOS_DTA & dta,bool fcb_findfirst=false)=0;
-	virtual bool FindNext(DOS_DTA & dta)=0;
+	virtual bool FileUnlink(const char* name)                           = 0;
+	virtual bool RemoveDir(const char* dir)                             = 0;
+	virtual bool MakeDir(const char* dir)                               = 0;
+	virtual bool TestDir(const char* dir)                               = 0;
+	virtual bool FindFirst(const char* dir, DOS_DTA& dta,
+	                       bool fcb_findfirst = false)                  = 0;
+	virtual bool FindNext(DOS_DTA& dta)                                 = 0;
 	virtual bool GetFileAttr(const char* name, FatAttributeFlags* attr) = 0;
 	virtual bool SetFileAttr(const char* name, const FatAttributeFlags attr) = 0;
 	virtual bool Rename(const char* oldname, const char* newname) = 0;
 	virtual bool AllocationInfo(uint16_t* _bytes_sector, uint8_t* _sectors_cluster,
 	                            uint16_t* _total_clusters,
 	                            uint16_t* _free_clusters) = 0;
-	virtual bool FileExists(const char* name)=0;
-	virtual uint8_t GetMediaByte(void)=0;
-	virtual void SetDir(const char *path);
+	virtual bool FileExists(const char* name)                     = 0;
+	virtual uint8_t GetMediaByte(void)                            = 0;
+	virtual void SetDir(const char* path);
 	virtual void EmptyCache() { dirCache.EmptyCache(); }
 	virtual bool IsReadOnly() const = 0;
-	virtual bool IsRemote(void)=0;
-	virtual bool IsRemovable(void)=0;
-	virtual Bits UnMount(void)=0;
+	virtual bool IsRemote(void)     = 0;
+	virtual bool IsRemovable(void)  = 0;
+	virtual Bits UnMount(void)      = 0;
 
 	DosDriveType GetType() const
 	{

--- a/include/dos_system.h
+++ b/include/dos_system.h
@@ -130,7 +130,6 @@ public:
 
 	virtual void AddRef() { refCtr++; }
 	virtual Bits RemoveRef() { return --refCtr; }
-	virtual bool UpdateDateTimeFromHost() { return true; }
 
 	void SetDrive(uint8_t drv) { hdrive=drv;}
 	uint8_t GetDrive(void) { return hdrive;}
@@ -197,7 +196,6 @@ public:
 	bool Seek(uint32_t* pos, uint32_t type) override;
 	void Close() override;
 	uint16_t GetInformation() override;
-	bool UpdateDateTimeFromHost() override;
 	bool IsOnReadOnlyMedium() const override { return read_only_medium; }
 	const char* GetBaseDir() const
 	{

--- a/include/dos_system.h
+++ b/include/dos_system.h
@@ -128,7 +128,6 @@ public:
 	virtual uint16_t	GetInformation(void)=0;
 	virtual bool IsOnReadOnlyMedium() const = 0;
 
-	virtual bool IsOpen() { return open; }
 	virtual void AddRef() { refCtr++; }
 	virtual Bits RemoveRef() { return --refCtr; }
 	virtual bool UpdateDateTimeFromHost() { return true; }
@@ -140,7 +139,6 @@ public:
 	uint16_t date    = 0;
 	FatAttributeFlags attr = {};
 	Bits refCtr      = 0;
-	bool open        = false;
 	std::string name = {};
 	bool newtime     = false;
 	std::vector<FileRegionLock> region_locks = {};
@@ -157,14 +155,13 @@ public:
 		: DOS_File(orig),
 		  devnum(orig.devnum)
 	{
-		open = true;
+
 	}
 
 	DOS_Device &operator=(const DOS_Device &orig)
 	{
 		DOS_File::operator=(orig);
 		devnum = orig.devnum;
-		open = true;
 		return *this;
 	}
 

--- a/include/dos_system.h
+++ b/include/dos_system.h
@@ -343,10 +343,11 @@ public:
 	DOS_Drive();
 	virtual ~DOS_Drive() = default;
 
-	virtual bool FileOpen(DOS_File** file, const char* name, uint8_t flags) = 0;
-	virtual bool FileCreate(DOS_File** file, const char* name,
-	                        FatAttributeFlags attributes) = 0;
-	virtual bool FileUnlink(const char* _name)=0;
+	virtual std::unique_ptr<DOS_File> FileOpen(const char* name,
+	                                           uint8_t flags) = 0;
+	virtual std::unique_ptr<DOS_File> FileCreate(const char* name,
+	                                             FatAttributeFlags attributes) = 0;
+	virtual bool FileUnlink(const char* _name) = 0;
 	virtual bool RemoveDir(const char * _dir)=0;
 	virtual bool MakeDir(const char * _dir)=0;
 	virtual bool TestDir(const char * _dir)=0;

--- a/include/dos_system.h
+++ b/include/dos_system.h
@@ -104,6 +104,12 @@ struct FileRegionLock {
 	uint32_t len = 0;
 };
 
+enum class FlushTimeOnClose {
+	NoUpdate,
+	ManuallySet,
+	CurrentTime,
+};
+
 class DOS_File {
 public:
 	DOS_File() = default;
@@ -139,7 +145,7 @@ public:
 	FatAttributeFlags attr = {};
 	Bits refCtr      = 0;
 	std::string name = {};
-	bool newtime     = false;
+	FlushTimeOnClose flush_time_on_close = FlushTimeOnClose::NoUpdate;
 	std::vector<FileRegionLock> region_locks = {};
 	/* Some Device Specific Stuff */
 private:
@@ -208,6 +214,7 @@ public:
 	NativeFileHandle file_handle = InvalidNativeFileHandle;
 
 private:
+	void MaybeFlushTime();
 	const std_fs::path path = {};
 	const char* basedir     = nullptr;
 

--- a/include/drives.h
+++ b/include/drives.h
@@ -40,18 +40,18 @@ class imageDisk; // forward declare
 
 class DriveManager {
 public:
-	using filesystem_images_t = std::vector<std::unique_ptr<DOS_Drive>>;
+	using filesystem_images_t = std::vector<std::shared_ptr<DOS_Drive>>;
 	struct DriveInfo {
 		filesystem_images_t disks = {};
 		uint16_t current_disk     = 0;
 	};
 	using drive_infos_t = std::array<DriveInfo, DOS_DRIVES>;
 
-	static std::vector<DOS_Drive*> AppendFilesystemImages(
-	        const int drive, filesystem_images_t& filesystem_images);
+	static void AppendFilesystemImages(const int drive,
+	                                   const filesystem_images_t& filesystem_images);
 
-	static DOS_Drive* RegisterFilesystemImage(
-	        const int drive, std::unique_ptr<DOS_Drive>&& filesystem_image);
+	static void RegisterFilesystemImage(const int drive,
+	                                    std::shared_ptr<DOS_Drive> filesystem_image);
 
 	static void InitializeDrive(int drive);
 	static int UnmountDrive(int drive);

--- a/include/drives.h
+++ b/include/drives.h
@@ -88,11 +88,11 @@ public:
 	           uint8_t _sectors_cluster, uint16_t _total_clusters,
 	           uint16_t _free_clusters, uint8_t _mediaid,
 	           bool _readonly, bool _always_open_ro_files = false);
-	bool FileOpen(DOS_File** file, const char* name, uint8_t flags) override;
+	std::unique_ptr<DOS_File> FileOpen(const char* name, uint8_t flags) override;
+	std::unique_ptr<DOS_File> FileCreate(const char* name,
+	                                     FatAttributeFlags attributes) override;
 	FILE* GetHostFilePtr(const char* const name, const char* const type);
 	std::string MapDosToHostFilename(const char* const dos_name);
-	bool FileCreate(DOS_File** file, const char* name,
-	                FatAttributeFlags attributes) override;
 	bool FileUnlink(const char* name) override;
 	bool RemoveDir(const char* dir) override;
 	bool MakeDir(const char* dir) override;
@@ -202,9 +202,9 @@ public:
 	         bool roflag);
 	fatDrive(const fatDrive&)            = delete; // prevent copying
 	fatDrive& operator=(const fatDrive&) = delete; // prevent assignment
-	bool FileOpen(DOS_File** file, const char* name, uint8_t flags) override;
-	bool FileCreate(DOS_File** file, const char* name,
-	                FatAttributeFlags attributes) override;
+	std::unique_ptr<DOS_File> FileOpen(const char* name, uint8_t flags) override;
+	std::unique_ptr<DOS_File> FileCreate(const char* name,
+	                                     FatAttributeFlags attributes) override;
 	bool FileUnlink(const char* name) override;
 	bool RemoveDir(const char* dir) override;
 	bool MakeDir(const char* dir) override;
@@ -277,9 +277,9 @@ public:
 	           uint16_t _bytes_sector, uint8_t _sectors_cluster,
 	           uint16_t _total_clusters, uint16_t _free_clusters,
 	           uint8_t _mediaid, int& error);
-	bool FileOpen(DOS_File** file, const char* name, uint8_t flags) override;
-	bool FileCreate(DOS_File** file, const char* name,
-	                FatAttributeFlags attributes) override;
+	std::unique_ptr<DOS_File> FileOpen(const char* name, uint8_t flags) override;
+	std::unique_ptr<DOS_File> FileCreate(const char* name,
+	                                     FatAttributeFlags attributes) override;
 	bool FileUnlink(const char* name) override;
 	bool RemoveDir(const char* dir) override;
 	bool MakeDir(const char* dir) override;
@@ -378,9 +378,9 @@ public:
 	isoDrive(char driveLetter, const char* device_name, uint8_t mediaid,
 	         int& error);
 	~isoDrive() override;
-	bool FileOpen(DOS_File** file, const char* name, uint8_t flags) override;
-	bool FileCreate(DOS_File** file, const char* name,
-	                FatAttributeFlags attributes) override;
+	std::unique_ptr<DOS_File> FileOpen(const char* name, uint8_t flags) override;
+	std::unique_ptr<DOS_File> FileCreate(const char* name,
+	                                     FatAttributeFlags attributes) override;
 	bool FileUnlink(const char* name) override;
 	bool RemoveDir(const char* dir) override;
 	bool MakeDir(const char* dir) override;
@@ -450,9 +450,9 @@ using vfile_block_t = std::shared_ptr<VFILE_Block>;
 class Virtual_Drive final : public DOS_Drive {
 public:
 	Virtual_Drive();
-	bool FileOpen(DOS_File** file, const char* name, uint8_t flags) override;
-	bool FileCreate(DOS_File** file, const char* name,
-	                FatAttributeFlags attributes) override;
+	std::unique_ptr<DOS_File> FileOpen(const char* name, uint8_t flags) override;
+	std::unique_ptr<DOS_File> FileCreate(const char* name,
+	                                     FatAttributeFlags attributes) override;
 	bool FileUnlink(const char* name) override;
 	bool RemoveDir(const char* dir) override;
 	bool MakeDir(const char* dir) override;
@@ -495,9 +495,9 @@ public:
 	              uint8_t _mediaid,
 	              uint8_t &error);
 
-	bool FileOpen(DOS_File** file, const char* name, uint8_t flags) override;
-	bool FileCreate(DOS_File** file, const char* name,
-	                FatAttributeFlags attributes) override;
+	std::unique_ptr<DOS_File> FileOpen(const char* name, uint8_t flags) override;
+	std::unique_ptr<DOS_File> FileCreate(const char* name,
+	                                     FatAttributeFlags attributes) override;
 	bool FindFirst(const char* _dir, DOS_DTA& dta, bool fcb_findfirst) override;
 	bool FindNext(DOS_DTA& dta) override;
 	bool FileUnlink(const char* name) override;

--- a/include/drives.h
+++ b/include/drives.h
@@ -366,7 +366,8 @@ struct isoDirEntry {
 #define IS_HIDDEN(fileFlags)	(!!(fileFlags & ISO_HIDDEN))
 #define ISO_MAX_HASH_TABLE_SIZE 	100
 
-class isoDrive final : public DOS_Drive {
+// Must be constructed with a shared_ptr or it will throw an exception on internal call to shared_from_this()
+class isoDrive final : public DOS_Drive, public std::enable_shared_from_this<isoDrive> {
 public:
 	isoDrive(char driveLetter, const char* device_name, uint8_t mediaid,
 	         int& error);

--- a/include/drives.h
+++ b/include/drives.h
@@ -64,7 +64,6 @@ public:
 
 private:
 	static drive_infos_t drive_infos;
-	static uint8_t currentDrive;
 };
 
 class localDrive : public DOS_Drive {

--- a/include/drives.h
+++ b/include/drives.h
@@ -29,6 +29,13 @@
 #include "dos_inc.h"
 #include "dos_system.h"
 
+// GCC throws a warning about non-virtual destructor for std::enable_shared_from_this
+// This is normally a helpful warning. Ex: If DOS_Drive had a non-virtual destructor, it would be a problem.
+// In this case, it is safe so hide the warning for this file.
+// It gets restored at the end.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wnon-virtual-dtor"
+
 void Set_Label(const char* const input, char* const output, bool cdrom);
 std::string To_Label(const char* name);
 std::string generate_8x3(const char *lfn, const unsigned int num, const bool start = false);
@@ -179,7 +186,9 @@ struct partTable {
 #endif
 //Forward
 class imageDisk;
-class fatDrive final : public DOS_Drive {
+
+// Must be constructed with a shared_ptr or it will throw an exception on internal call to shared_from_this()
+class fatDrive final : public DOS_Drive, public std::enable_shared_from_this<fatDrive> {
 public:
 	fatDrive(const char* sysFilename, uint32_t bytesector,
 	         uint32_t cylsector, uint32_t headscyl, uint32_t cylinders,
@@ -531,5 +540,7 @@ private:
 	std::vector<std::string> DOSdirs_cache; //Can not blindly change its type. it is important that subdirs come after the parent directory.
 	const std::string special_prefix;
 };
+
+#pragma GCC diagnostic pop
 
 #endif

--- a/include/drives.h
+++ b/include/drives.h
@@ -41,7 +41,6 @@ class imageDisk; // forward declare
 class DriveManager {
 public:
 	using filesystem_images_t = std::vector<std::unique_ptr<DOS_Drive>>;
-	using raw_images_t        = std::vector<std::unique_ptr<imageDisk>>;
 	struct DriveInfo {
 		filesystem_images_t disks = {};
 		uint16_t current_disk     = 0;
@@ -54,18 +53,6 @@ public:
 	static DOS_Drive* RegisterFilesystemImage(
 	        const int drive, std::unique_ptr<DOS_Drive>&& filesystem_image);
 
-	static imageDisk* RegisterNumberedImage(FILE* img_file,
-	                                        const std::string& img_name,
-	                                        const uint32_t img_size_kb,
-	                                        const bool is_hdd);
-
-	static void CloseNumberedImage(const imageDisk* image_ptr);
-
-	static imageDisk* RegisterRawFloppyImage(FILE* img_file,
-	                                         const std::string& img_name,
-	                                         const uint32_t img_size_kb);
-	static void CloseRawFddImages();
-
 	static void InitializeDrive(int drive);
 	static int UnmountDrive(int drive);
 //	static void CycleDrive(bool pressed);
@@ -74,11 +61,9 @@ public:
 	static void CycleAllDisks(void);
 	static char *GetDrivePosition(int drive);
 	static void Init(Section* sec);
-	
+
 private:
 	static drive_infos_t drive_infos;
-	static raw_images_t indexed_images;
-	static raw_images_t raw_floppy_images;
 	static uint8_t currentDrive;
 };
 

--- a/include/drives.h
+++ b/include/drives.h
@@ -22,8 +22,9 @@
 #include "dosbox.h"
 
 #include <memory>
-#include <unordered_set>
 #include <string>
+#include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "dos_inc.h"
@@ -73,7 +74,9 @@ private:
 	static drive_infos_t drive_infos;
 };
 
-class localDrive : public DOS_Drive {
+// Must be constructed with a shared_ptr as it uses weak_from_this()
+class localDrive : public DOS_Drive,
+                   public std::enable_shared_from_this<localDrive> {
 public:
 	localDrive(const char* startdir, uint16_t _bytes_sector,
 	           uint8_t _sectors_cluster, uint16_t _total_clusters,
@@ -106,6 +109,8 @@ public:
 	{
 		return basedir;
 	}
+
+	std::unordered_map<std::string, DosDateTime> timestamp_cache = {};
 
 protected:
 	char basedir[CROSS_LEN] = "";
@@ -478,6 +483,8 @@ private:
 	bool vfile_name_exists(const std::string& name) const;
 };
 
+// Must be constructed with a shared_ptr as it uses weak_from_this()
+// std::enable_shared_from_this inherited from localDrive
 class Overlay_Drive final : public localDrive {
 public:
 	Overlay_Drive(const char *startdir,

--- a/include/fs_utils.h
+++ b/include/fs_utils.h
@@ -224,5 +224,6 @@ void close_native_file(const NativeFileHandle handle);
 bool truncate_native_file(const NativeFileHandle handle);
 
 DosDateTime get_dos_file_time(const NativeFileHandle handle);
+void set_dos_file_time(const NativeFileHandle handle, const uint16_t date, const uint16_t time);
 
 #endif

--- a/include/serialport.h
+++ b/include/serialport.h
@@ -496,7 +496,7 @@ public:
 	bool Read(uint8_t* data, uint16_t* size) override;
 	bool Write(uint8_t* data, uint16_t* size) override;
 	bool Seek(uint32_t* pos, uint32_t type) override;
-	bool Close() override;
+	void Close() override;
 	uint16_t GetInformation() override;
 
 private:

--- a/include/serialport.h
+++ b/include/serialport.h
@@ -493,7 +493,6 @@ public:
 	// Creates a COM device that communicates with the num-th parallel port,
 	// i.e. is LPTnum
 	device_COM(class CSerial* sc);
-	~device_COM() override;
 	bool Read(uint8_t* data, uint16_t* size) override;
 	bool Write(uint8_t* data, uint16_t* size) override;
 	bool Seek(uint32_t* pos, uint32_t type) override;

--- a/src/dos/cdrom_image.cpp
+++ b/src/dos/cdrom_image.cpp
@@ -1408,7 +1408,7 @@ bool CDROM_Interface_Image::GetRealFileName(std::string &filename, std::string &
 		return false;
 	}
 
-	const auto ldp = dynamic_cast<localDrive*>(Drives.at(drive));
+	const auto ldp = std::dynamic_pointer_cast<localDrive>(Drives.at(drive));
 	if (ldp) {
 		const std::string host_filename = ldp->MapDosToHostFilename(fullname);
 		if (path_exists(host_filename)) {

--- a/src/dos/dev_con.h
+++ b/src/dos/dev_con.h
@@ -34,7 +34,7 @@ public:
 	bool Read(uint8_t* data, uint16_t* size) override;
 	bool Write(uint8_t* data, uint16_t* size) override;
 	bool Seek(uint32_t* pos, uint32_t type) override;
-	bool Close() override;
+	void Close() override;
 	uint16_t GetInformation(void) override;
 	bool ReadFromControlChannel(PhysPt /*bufptr*/, uint16_t /*size*/,
 	                            uint16_t* /*retcode*/) override
@@ -416,8 +416,7 @@ bool device_CON::Seek(uint32_t * pos,uint32_t /*type*/) {
 	return true;
 }
 
-bool device_CON::Close() {
-	return true;
+void device_CON::Close() {
 }
 
 uint16_t device_CON::GetInformation(void) {

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -1331,7 +1331,7 @@ static Bitu DOS_27Handler(void) {
 
 static uint16_t DOS_SectorAccess(const bool read)
 {
-	const auto drive = dynamic_cast<fatDrive*>(Drives.at(reg_al));
+	const auto drive = std::dynamic_pointer_cast<fatDrive>(Drives.at(reg_al));
 	assert(drive);
 
 	auto bufferSeg = SegValue(ds);

--- a/src/dos/dos_devices.cpp
+++ b/src/dos/dos_devices.cpp
@@ -369,7 +369,7 @@ DOS_File &DOS_File::operator=(const DOS_File &orig)
 	date=orig.date;
 	attr=orig.attr;
 	refCtr=orig.refCtr;
-	newtime = orig.newtime;
+	flush_time_on_close = orig.flush_time_on_close;
 	hdrive=orig.hdrive;
 	name = orig.name;
 	return *this;

--- a/src/dos/dos_devices.cpp
+++ b/src/dos/dos_devices.cpp
@@ -371,7 +371,6 @@ DOS_File &DOS_File::operator=(const DOS_File &orig)
 	date=orig.date;
 	attr=orig.attr;
 	refCtr=orig.refCtr;
-	open=orig.open;
 	newtime = orig.newtime;
 	hdrive=orig.hdrive;
 	name = orig.name;

--- a/src/dos/dos_devices.cpp
+++ b/src/dos/dos_devices.cpp
@@ -53,7 +53,7 @@ public:
 	bool Read(uint8_t* data, uint16_t* size) override;
 	bool Write(uint8_t* data, uint16_t* size) override;
 	bool Seek(uint32_t* pos, uint32_t type) override;
-	bool Close() override;
+	void Close() override;
 	uint16_t GetInformation() override;
 	bool ReadFromControlChannel(PhysPt bufptr, uint16_t size,
 	                            uint16_t* retcode) override;
@@ -161,9 +161,8 @@ bool DOS_ExtDevice::Write(uint8_t *data, uint16_t *size)
 	return true;
 }
 
-bool DOS_ExtDevice::Close()
+void DOS_ExtDevice::Close()
 {
-	return true;
 }
 
 bool DOS_ExtDevice::Seek([[maybe_unused]] uint32_t *pos, [[maybe_unused]] uint32_t type)
@@ -290,9 +289,8 @@ public:
 		LOG(LOG_IOCTL, LOG_NORMAL)("%s:SEEK", GetName());
 		return true;
 	}
-	bool Close() override
+	void Close() override
 	{
-		return true;
 	}
 	uint16_t GetInformation() override
 	{
@@ -339,8 +337,8 @@ bool DOS_Device::Seek(uint32_t * pos,uint32_t type) {
 	return Devices[devnum]->Seek(pos,type);
 }
 
-bool DOS_Device::Close() {
-	return Devices[devnum]->Close();
+void DOS_Device::Close() {
+	Devices[devnum]->Close();
 }
 
 uint16_t DOS_Device::GetInformation() { 

--- a/src/dos/dos_files.cpp
+++ b/src/dos/dos_files.cpp
@@ -1757,10 +1757,6 @@ bool DOS_GetFileDate(uint16_t entry, uint16_t* otime, uint16_t* odate)
 		DOS_SetError(DOSERR_INVALID_HANDLE);
 		return false;
 	};
-	if (!Files[handle]->UpdateDateTimeFromHost()) {
-		DOS_SetError(DOSERR_INVALID_HANDLE);
-		return false; 
-	}
 	*otime = Files[handle]->time;
 	*odate = Files[handle]->date;
 	return true;

--- a/src/dos/dos_files.cpp
+++ b/src/dos/dos_files.cpp
@@ -643,7 +643,7 @@ bool DOS_ReadFile(uint16_t entry,uint8_t * data,uint16_t * amount,bool fcb) {
 		DOS_SetError(DOSERR_INVALID_HANDLE);
 		return false;
 	};
-	if (!Files[handle] || !Files[handle]->IsOpen()) {
+	if (!Files[handle]) {
 		DOS_SetError(DOSERR_INVALID_HANDLE);
 		return false;
 	};
@@ -675,7 +675,7 @@ bool DOS_WriteFile(uint16_t entry,uint8_t * data,uint16_t * amount,bool fcb) {
 		DOS_SetError(DOSERR_INVALID_HANDLE);
 		return false;
 	};
-	if (!Files[handle] || !Files[handle]->IsOpen()) {
+	if (!Files[handle]) {
 		DOS_SetError(DOSERR_INVALID_HANDLE);
 		return false;
 	};
@@ -711,7 +711,7 @@ bool DOS_SeekFile(uint16_t entry,uint32_t * pos,uint32_t type,bool fcb) {
 		DOS_SetError(DOSERR_INVALID_HANDLE);
 		return false;
 	};
-	if (!Files[handle] || !Files[handle]->IsOpen()) {
+	if (!Files[handle]) {
 		DOS_SetError(DOSERR_INVALID_HANDLE);
 		return false;
 	};
@@ -728,9 +728,7 @@ bool DOS_CloseFile(uint16_t entry, bool fcb, uint8_t * refcnt) {
 		DOS_SetError(DOSERR_INVALID_HANDLE);
 		return false;
 	};
-	if (Files[handle]->IsOpen()) {
-		Files[handle]->Close();
-	}
+	Files[handle]->Close();
 
 	DOS_PSP psp(dos.psp());
 	if (!fcb) psp.SetFileHandle(entry,0xff);
@@ -750,7 +748,7 @@ bool DOS_FlushFile(uint16_t entry) {
 		DOS_SetError(DOSERR_INVALID_HANDLE);
 		return false;
 	};
-	if (!Files[handle] || !Files[handle]->IsOpen()) {
+	if (!Files[handle]) {
 		DOS_SetError(DOSERR_INVALID_HANDLE);
 		return false;
 	};
@@ -1084,7 +1082,7 @@ bool DOS_DuplicateEntry(uint16_t entry,uint16_t * newentry) {
 		DOS_SetError(DOSERR_INVALID_HANDLE);
 		return false;
 	};
-	if (!Files[handle] || !Files[handle]->IsOpen()) {
+	if (!Files[handle]) {
 		DOS_SetError(DOSERR_INVALID_HANDLE);
 		return false;
 	};
@@ -1109,7 +1107,7 @@ bool DOS_ForceDuplicateEntry(uint16_t entry,uint16_t newentry) {
 		DOS_SetError(DOSERR_INVALID_HANDLE);
 		return false;
 	};
-	if (!Files[orig] || !Files[orig]->IsOpen()) {
+	if (!Files[orig]) {
 		DOS_SetError(DOSERR_INVALID_HANDLE);
 		return false;
 	};
@@ -1690,7 +1688,7 @@ bool DOS_FCBRenameFile(uint16_t seg, uint16_t offset)
 
 	DOS_PSP psp(dos.psp());
 	for (uint8_t i = 0; i < DOS_FILES; ++i) {
-		if (Files[i] && Files[i]->IsOpen() && Files[i]->IsName(fullname)) {
+		if (Files[i] && Files[i]->IsName(fullname)) {
 			uint16_t handle = psp.FindEntryByHandle(i);
 			//(more than once maybe)
 			if (handle == 0xFF) {
@@ -1757,7 +1755,7 @@ bool DOS_GetFileDate(uint16_t entry, uint16_t* otime, uint16_t* odate)
 		DOS_SetError(DOSERR_INVALID_HANDLE);
 		return false;
 	};
-	if (!Files[handle] || !Files[handle]->IsOpen()) {
+	if (!Files[handle]) {
 		DOS_SetError(DOSERR_INVALID_HANDLE);
 		return false;
 	};

--- a/src/dos/dos_files.cpp
+++ b/src/dos/dos_files.cpp
@@ -1422,15 +1422,6 @@ bool DOS_FCBOpen(uint16_t seg, uint16_t offset)
 	if (!DOS_MakeName(shortname, fullname, &drive))
 		return false;
 
-	/* Check, if file is already opened */
-	for (uint8_t i = 0; i < DOS_FILES; ++i) {
-		if (Files[i] && Files[i]->IsOpen() && Files[i]->IsName(fullname)) {
-			Files[i]->AddRef();
-			fcb.FileOpen(i);
-			return true;
-		}
-	}
-
 	if (!DOS_OpenFile(shortname,OPEN_READWRITE,&handle,true)) return false;
 	fcb.FileOpen((uint8_t)handle);
 	return true;

--- a/src/dos/dos_ioctl.cpp
+++ b/src/dos/dos_ioctl.cpp
@@ -73,7 +73,10 @@ bool DOS_IOCTL(void) {
 			return false;
 		} else {
 			if (Files[handle]->GetInformation() & 0x8000) {	//Check for device
-				reg_al = reinterpret_cast<DOS_Device *>(Files[handle])->GetStatus(true);
+				const auto device_ptr = dynamic_cast<DOS_Device*>(
+				        Files[handle].get());
+				assert(device_ptr);
+				reg_al = device_ptr->GetStatus(true);
 			} else {
 				DOS_SetError(DOSERR_FUNCTION_NUMBER_INVALID);
 				return false;
@@ -85,8 +88,11 @@ bool DOS_IOCTL(void) {
 			/* is character device with IOCTL support */
 			PhysPt bufptr=PhysicalMake(SegValue(ds),reg_dx);
 			uint16_t retcode=0;
-			if (((DOS_Device*)(Files[handle]))->ReadFromControlChannel(bufptr,reg_cx,&retcode)) {
-				reg_ax=retcode;
+			const auto device_ptr = dynamic_cast<DOS_Device*>(
+			        Files[handle].get());
+			assert(device_ptr);
+			if (device_ptr->ReadFromControlChannel(bufptr, reg_cx, &retcode)) {
+				reg_ax = retcode;
 				return true;
 			}
 		}
@@ -97,8 +103,11 @@ bool DOS_IOCTL(void) {
 			/* is character device with IOCTL support */
 			PhysPt bufptr=PhysicalMake(SegValue(ds),reg_dx);
 			uint16_t retcode=0;
-			if (((DOS_Device*)(Files[handle]))->WriteToControlChannel(bufptr,reg_cx,&retcode)) {
-				reg_ax=retcode;
+			const auto device_ptr = dynamic_cast<DOS_Device*>(
+			        Files[handle].get());
+			assert(device_ptr);
+			if (device_ptr->WriteToControlChannel(bufptr, reg_cx, &retcode)) {
+				reg_ax = retcode;
 				return true;
 			}
 		}
@@ -123,7 +132,10 @@ bool DOS_IOCTL(void) {
 		return true;
 	case 0x07:		/* Get Output Status */
 		if (Files[handle]->GetInformation() & EXT_DEVICE_BIT) {
-			reg_al = reinterpret_cast<DOS_Device *>(Files[handle])->GetStatus(false);
+			const auto device_ptr = dynamic_cast<DOS_Device*>(
+			        Files[handle].get());
+			assert(device_ptr);
+			reg_al = device_ptr->GetStatus(false);
 			return true;
 		}
 		LOG(LOG_IOCTL, LOG_NORMAL)("07:Fakes output status is ready for handle %u", handle);

--- a/src/dos/dos_keyboard_layout.cpp
+++ b/src/dos/dos_keyboard_layout.cpp
@@ -59,7 +59,7 @@ static FILE_unique_ptr open_layout_file(const char *name, const char *resource_d
 	char fullname[DOS_PATHLENGTH] = {};
 	if (DOS_MakeName(name, fullname, &drive)) try {
 		// try to open file on mounted drive first
-		const auto ldp = dynamic_cast<localDrive*>(Drives[drive]);
+		const auto ldp = std::dynamic_pointer_cast<localDrive>(Drives[drive]);
 		if (ldp) {
 			if (const auto fp = ldp->GetHostFilePtr(fullname, file_perms); fp) {
 				return FILE_unique_ptr(fp);

--- a/src/dos/dos_mscdex.cpp
+++ b/src/dos/dos_mscdex.cpp
@@ -1361,9 +1361,8 @@ public:
 	{
 		return false;
 	}
-	bool Close() override
+	void Close() override
 	{
-		return false;
 	}
 	uint16_t GetInformation(void) override
 	{

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -49,7 +49,6 @@ public:
 	bool Seek(uint32_t * pos,uint32_t type) override;
 	void Close() override;
 	uint16_t GetInformation(void) override;
-	bool UpdateDateTimeFromHost(void) override;
 	bool IsOnReadOnlyMedium() const override;
 public:
 	std::shared_ptr<fatDrive> myDrive   = nullptr;
@@ -319,10 +318,6 @@ bool fatFile::IsOnReadOnlyMedium() const
 
 uint16_t fatFile::GetInformation(void) {
 	return 0;
-}
-
-bool fatFile::UpdateDateTimeFromHost(void) {
-	return true;
 }
 
 uint32_t fatDrive::getClustFirstSect(uint32_t clustNum) {

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -94,7 +94,6 @@ fatFile::fatFile(const char* /*name*/, uint32_t startCluster, uint32_t fileLen,
           read_only_medium(_read_only_medium)
 {
 	uint32_t seekto = 0;
-	open = true;
 	if(filelength > 0) {
 		Seek(&seekto, DOS_SEEK_SET);
 	}

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -821,7 +821,7 @@ fatDrive::fatDrive(const char *sysFilename,
 	is_hdd   = (filesize > 2880);
 
 	/* Load disk image */
-	loadedDisk.reset(new imageDisk(diskfile, sysFilename, filesize, is_hdd));
+	loadedDisk = std::make_shared<imageDisk>(diskfile, sysFilename, filesize, is_hdd);
 
 	if(is_hdd) {
 		/* Set user specified harddrive parameters */

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -47,7 +47,7 @@ public:
 	bool Read(uint8_t * data,uint16_t * size) override;
 	bool Write(uint8_t * data,uint16_t * size) override;
 	bool Seek(uint32_t * pos,uint32_t type) override;
-	bool Close() override;
+	void Close() override;
 	uint16_t GetInformation(void) override;
 	bool UpdateDateTimeFromHost(void) override;
 	bool IsOnReadOnlyMedium() const override;
@@ -285,7 +285,7 @@ bool fatFile::Seek(uint32_t *pos, uint32_t type) {
 	return true;
 }
 
-bool fatFile::Close()
+void fatFile::Close()
 {
 	if ((flags & 0xf) != OPEN_READ && !myDrive->IsReadOnly()) {
 		if (newtime || set_archive_on_close) {
@@ -310,8 +310,6 @@ bool fatFile::Close()
 	}
 
 	set_archive_on_close = false;
-
-	return true;
 }
 
 bool fatFile::IsOnReadOnlyMedium() const

--- a/src/dos/drive_iso.cpp
+++ b/src/dos/drive_iso.cpp
@@ -65,7 +65,6 @@ isoFile::isoFile(isoDrive *iso_drive, const char *name, FileStat_Block *stat, ui
 	time = stat->time;
 	date = stat->date;
 	attr = static_cast<uint8_t>(stat->attr);
-	open = true;
 }
 
 bool isoFile::Read(uint8_t *data, uint16_t *size) {
@@ -136,7 +135,6 @@ bool isoFile::Seek(uint32_t *pos, uint32_t type) {
 }
 
 bool isoFile::Close() {
-	if (refCtr == 1) open = false;
 	return true;
 }
 

--- a/src/dos/drive_iso.cpp
+++ b/src/dos/drive_iso.cpp
@@ -32,7 +32,7 @@
 
 class isoFile final : public DOS_File {
 public:
-	isoFile(isoDrive *drive, const char *name, FileStat_Block *stat, uint32_t offset);
+	isoFile(std::shared_ptr<isoDrive> drive, const char *name, FileStat_Block *stat, uint32_t offset);
 	isoFile(const isoFile &) = delete;            // prevent copying
 	isoFile &operator=(const isoFile &) = delete; // prevent assignment
 
@@ -44,7 +44,7 @@ public:
 	bool IsOnReadOnlyMedium() const override;
 
 private:
-	isoDrive *drive = nullptr;
+	std::shared_ptr<isoDrive> drive = nullptr;
 	int cachedSector = -1;
 	uint32_t fileBegin = 0;
 	uint32_t filePos = 0;
@@ -52,7 +52,7 @@ private:
 	uint8_t buffer[ISO_FRAMESIZE] = {{}};
 };
 
-isoFile::isoFile(isoDrive *iso_drive, const char *name, FileStat_Block *stat, uint32_t offset)
+isoFile::isoFile(std::shared_ptr<isoDrive> iso_drive, const char *name, FileStat_Block *stat, uint32_t offset)
         : drive(iso_drive),
           fileBegin(offset),
           filePos(offset),
@@ -226,7 +226,7 @@ std::unique_ptr<DOS_File> isoDrive::FileOpen(const char* name, uint8_t flags)
 	file_stat.date = DOS_PackDate(1900 + de.dateYear, de.dateMonth, de.dateDay);
 	file_stat.time = DOS_PackTime(de.timeHour, de.timeMin, de.timeSec);
 	auto file      = std::make_unique<isoFile>(
-                this, name, &file_stat, EXTENT_LOCATION(de) * ISO_FRAMESIZE);
+                shared_from_this(), name, &file_stat, EXTENT_LOCATION(de) * ISO_FRAMESIZE);
 	file->flags = flags;
 
 	return file;

--- a/src/dos/drive_iso.cpp
+++ b/src/dos/drive_iso.cpp
@@ -39,7 +39,7 @@ public:
 	bool Read(uint8_t *data, uint16_t *size) override;
 	bool Write(uint8_t *data, uint16_t *size) override;
 	bool Seek(uint32_t *pos, uint32_t type) override;
-	bool Close() override;
+	void Close() override;
 	uint16_t GetInformation(void) override;
 	bool IsOnReadOnlyMedium() const override;
 
@@ -134,8 +134,7 @@ bool isoFile::Seek(uint32_t *pos, uint32_t type) {
 	return true;
 }
 
-bool isoFile::Close() {
-	return true;
+void isoFile::Close() {
 }
 
 uint16_t isoFile::GetInformation(void) {

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -777,6 +777,20 @@ localFile::localFile(const char* _name, const std_fs::path& path,
 	SetName(_name);
 }
 
+localFile::~localFile()
+{
+	// Make sure we close the host file handle and flush the timestamps.
+	// This can happen if the user closes Dosbox while a game is running.
+	// It can also happen if a game leaks file handles. Ex: Crystal Caves
+	if (file_handle != InvalidNativeFileHandle) {
+		// Release all references so the close function will close the host file
+		refCtr = 1;
+
+		// Make sure to avoid virtual dispatch inside a destructor
+		localFile::Close();
+	}
+}
+
 // ********************************************
 // CDROM DRIVE
 // ********************************************

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -23,6 +23,7 @@
 // #define DEBUG 1
 
 #include "drives.h"
+#include "drive_local.h"
 
 #include <cerrno>
 #include <climits>

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -90,9 +90,10 @@ std::unique_ptr<DOS_File> localDrive::FileCreate(const char* name,
 		dirCache.AddEntry(newname, true);
 	}
 
-	DosDateTime dos_time = {};
-	dos_time.date        = DOS_GetBiosDatePacked();
-	dos_time.time        = DOS_GetBiosTimePacked();
+	const DosDateTime dos_time = {
+		.date = DOS_GetBiosDatePacked(),
+		.time = DOS_GetBiosTimePacked()
+	};
 
 	// The timestamp cache is for emulating DOS behavior, not performance.
 	// On some hosts, the timestamp will be updated with current host time

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -834,32 +834,32 @@ std::unique_ptr<DOS_File> cdromDrive::FileOpen(const char* name, uint8_t flags)
 	return localDrive::FileOpen(name, flags);
 }
 
-std::unique_ptr<DOS_File> cdromDrive::FileCreate(const char* /*name*/,
-                                                 FatAttributeFlags /*attributes*/)
+std::unique_ptr<DOS_File> cdromDrive::FileCreate([[maybe_unused]]const char* name,
+                                                 [[maybe_unused]]FatAttributeFlags attributes)
 {
 	DOS_SetError(DOSERR_ACCESS_DENIED);
 	return nullptr;
 }
 
-bool cdromDrive::FileUnlink(const char* /*name*/)
+bool cdromDrive::FileUnlink([[maybe_unused]]const char* name)
 {
 	DOS_SetError(DOSERR_ACCESS_DENIED);
 	return false;
 }
 
-bool cdromDrive::RemoveDir(const char* /*dir*/)
+bool cdromDrive::RemoveDir([[maybe_unused]]const char* dir)
 {
 	DOS_SetError(DOSERR_ACCESS_DENIED);
 	return false;
 }
 
-bool cdromDrive::MakeDir(const char* /*dir*/)
+bool cdromDrive::MakeDir([[maybe_unused]]const char* dir)
 {
 	DOS_SetError(DOSERR_ACCESS_DENIED);
 	return false;
 }
 
-bool cdromDrive::Rename(const char* /*oldname*/, const char* /*newname*/)
+bool cdromDrive::Rename([[maybe_unused]]const char* oldname, [[maybe_unused]]const char* newname)
 {
 	DOS_SetError(DOSERR_ACCESS_DENIED);
 	return false;
@@ -876,7 +876,7 @@ bool cdromDrive::GetFileAttr(const char* name, FatAttributeFlags* attr)
 	return result;
 }
 
-bool cdromDrive::FindFirst(const char* _dir, DOS_DTA& dta, bool /*fcb_findfirst*/)
+bool cdromDrive::FindFirst(const char* _dir, DOS_DTA& dta, [[maybe_unused]]bool fcb_findfirst)
 {
 	// If media has changed, reInit drivecache.
 	if (MSCDEX_HasMediaChanged(subUnit)) {

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -781,7 +781,7 @@ localFile::localFile(const char* _name, const std_fs::path& path,
 localFile::~localFile()
 {
 	// Make sure we close the host file handle and flush the timestamps.
-	// This can happen if the user closes Dosbox while a game is running.
+	// This can happen if the user closes DOSBox while a game is running.
 	// It can also happen if a game leaks file handles. Ex: Crystal Caves
 	if (file_handle != InvalidNativeFileHandle) {
 		// Release all references so the close function will close the host file

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -719,21 +719,15 @@ localFile::localFile(const char* _name, const std_fs::path& path,
           basedir(_basedir),
           read_only_medium(_read_only_medium)
 {
-	localFile::UpdateDateTimeFromHost();
-	attr = FatAttributeFlags::Archive;
-
-	SetName(_name);
-}
-
-bool localFile::UpdateDateTimeFromHost()
-{
 	assert(file_handle != InvalidNativeFileHandle);
-	const auto dos_time = get_dos_file_time(file_handle);
 
+	const auto dos_time = get_dos_file_time(file_handle);
 	time = dos_time.time;
 	date = dos_time.date;
 
-	return true;
+	attr = FatAttributeFlags::Archive;
+
+	SetName(_name);
 }
 
 // ********************************************

--- a/src/dos/drive_local.h
+++ b/src/dos/drive_local.h
@@ -21,12 +21,14 @@
 #define DOSBOX_DRIVE_LOCAL_H
 
 #include "dos_system.h"
+#include "drives.h"
 
 class localFile : public DOS_File {
 public:
 	localFile(const char* name, const std_fs::path& path,
 	          const NativeFileHandle handle, const char* basedir,
-	          bool _read_only_medium);
+	          const bool _read_only_medium, const std::weak_ptr<localDrive> drive,
+	          const DosDateTime dos_time, const uint8_t _flags);
 	localFile(const localFile&)            = delete; // prevent copying
 	localFile& operator=(const localFile&) = delete; // prevent assignment
 	bool Read(uint8_t* data, uint16_t* size) override;
@@ -43,6 +45,7 @@ public:
 	{
 		return path;
 	}
+	const std::weak_ptr<localDrive> local_drive = {};
 	NativeFileHandle file_handle = InvalidNativeFileHandle;
 
 private:

--- a/src/dos/drive_local.h
+++ b/src/dos/drive_local.h
@@ -1,0 +1,57 @@
+/*
+ *  Copyright (C) 2020-2024  The DOSBox Staging Team
+ *  Copyright (C) 2002-2021  The DOSBox Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#ifndef DOSBOX_DRIVE_LOCAL_H
+#define DOSBOX_DRIVE_LOCAL_H
+
+#include "dos_system.h"
+
+class localFile : public DOS_File {
+public:
+	localFile(const char* name, const std_fs::path& path,
+	          const NativeFileHandle handle, const char* basedir,
+	          bool _read_only_medium);
+	localFile(const localFile&)            = delete; // prevent copying
+	localFile& operator=(const localFile&) = delete; // prevent assignment
+	bool Read(uint8_t* data, uint16_t* size) override;
+	bool Write(uint8_t* data, uint16_t* size) override;
+	bool Seek(uint32_t* pos, uint32_t type) override;
+	void Close() override;
+	uint16_t GetInformation() override;
+	bool IsOnReadOnlyMedium() const override { return read_only_medium; }
+	const char* GetBaseDir() const
+	{
+		return basedir;
+	}
+	std_fs::path GetPath() const
+	{
+		return path;
+	}
+	NativeFileHandle file_handle = InvalidNativeFileHandle;
+
+private:
+	void MaybeFlushTime();
+	const std_fs::path path = {};
+	const char* basedir     = nullptr;
+
+	const bool read_only_medium = false;
+	bool set_archive_on_close   = false;
+};
+
+#endif

--- a/src/dos/drive_local.h
+++ b/src/dos/drive_local.h
@@ -31,6 +31,7 @@ public:
 	          const DosDateTime dos_time, const uint8_t _flags);
 	localFile(const localFile&)            = delete; // prevent copying
 	localFile& operator=(const localFile&) = delete; // prevent assignment
+	~localFile() override;
 	bool Read(uint8_t* data, uint16_t* size) override;
 	bool Write(uint8_t* data, uint16_t* size) override;
 	bool Seek(uint32_t* pos, uint32_t type) override;

--- a/src/dos/drive_overlay.cpp
+++ b/src/dos/drive_overlay.cpp
@@ -505,14 +505,15 @@ std::unique_ptr<DOS_File> Overlay_Drive::FileOpen(const char* name, uint8_t flag
 			dos_time = cache_entry->second;
 		}
 
-		auto file            = std::make_unique<OverlayFile>(name,
-                                                          newname,
-                                                          file_handle,
-                                                          overlaydir,
-                                                          IsReadOnly(),
-                                                          weak_from_this(),
-                                                          dos_time,
-                                                          flags);
+		auto file = std::make_unique<OverlayFile>(name,
+		                                          newname,
+		                                          file_handle,
+		                                          overlaydir,
+		                                          IsReadOnly(),
+		                                          weak_from_this(),
+		                                          dos_time,
+		                                          flags);
+
 		file->overlay_active = true;
 
 		return file;
@@ -568,14 +569,15 @@ std::unique_ptr<DOS_File> Overlay_Drive::FileCreate(const char* name,
 	dos_time.time                  = DOS_GetBiosTimePacked();
 	timestamp_cache[path.string()] = dos_time;
 
-	auto file            = std::make_unique<OverlayFile>(name,
-                                                  path,
-                                                  file_handle,
-                                                  overlaydir,
-                                                  IsReadOnly(),
-                                                  weak_from_this(),
-                                                  dos_time,
-                                                  OPEN_READWRITE);
+	auto file = std::make_unique<OverlayFile>(name,
+	                                          path,
+	                                          file_handle,
+	                                          overlaydir,
+	                                          IsReadOnly(),
+	                                          weak_from_this(),
+	                                          dos_time,
+	                                          OPEN_READWRITE);
+
 	file->overlay_active = true;
 
 	// create fake name for the drive cache

--- a/src/dos/drive_overlay.cpp
+++ b/src/dos/drive_overlay.cpp
@@ -564,9 +564,11 @@ std::unique_ptr<DOS_File> Overlay_Drive::FileCreate(const char* name,
 		return nullptr;
 	}
 
-	DosDateTime dos_time           = {};
-	dos_time.date                  = DOS_GetBiosDatePacked();
-	dos_time.time                  = DOS_GetBiosTimePacked();
+	const DosDateTime dos_time = {
+		.date = DOS_GetBiosDatePacked(),
+		.time = DOS_GetBiosTimePacked()
+	};
+
 	timestamp_cache[path.string()] = dos_time;
 
 	auto file = std::make_unique<OverlayFile>(name,

--- a/src/dos/drive_overlay.cpp
+++ b/src/dos/drive_overlay.cpp
@@ -1260,21 +1260,21 @@ bool Overlay_Drive::Rename(const char * oldname, const char * newname) {
 
 	//No need to check if the original is marked as deleted, as GetFileAttr would fail if it did.
 
-	bool result = false;
+	bool success = false;
 
 	// check if overlaynameold exists and if so rename it to overlaynamenew
 	std::error_code ec = {};
 	if (std_fs::exists(overlaynameold, ec)) {
 		std_fs::rename(overlaynameold, overlaynamenew, ec);
 
-		result = !ec; // success if no error-code
+		success = !ec; // success if no error-code
 
-		if (result == true) {
+		if (success) {
 			timestamp_cache.erase(overlaynameold);
 		}
 
 		// Overlay file renamed: mark the old base file as deleted.
-		if (result == true && localDrive::FileExists(oldname)) {
+		if (success && localDrive::FileExists(oldname)) {
 			add_deleted_file(oldname, true);
 		}
 	} else {
@@ -1302,13 +1302,13 @@ bool Overlay_Drive::Rename(const char * oldname, const char * newname) {
 		//Mark old file as deleted
 		add_deleted_file(oldname,true);
 		timestamp_cache.erase(newold);
-		result = true; //success
+		success = true;
 		if (logoverlay) {
 			LOG_MSG("OPTIMISE: update rename with copy took %" PRId64,
 			        GetTicksSince(aa));
 		}
 	}
-	if (result) {
+	if (success) {
 		//handle the drive_cache (a bit better)
 		//Ensure that the file is not marked as deleted anymore.
 		if (is_deleted_file(newname)) remove_deleted_file(newname,true);
@@ -1318,7 +1318,7 @@ bool Overlay_Drive::Rename(const char * oldname, const char * newname) {
 			LOG_MSG("OPTIMISE: rename took %" PRId64, GetTicksSince(a));
 		}
 	}
-	return result;
+	return success;
 
 }
 #endif

--- a/src/dos/drive_overlay.cpp
+++ b/src/dos/drive_overlay.cpp
@@ -961,49 +961,6 @@ bool Overlay_Drive::FileUnlink(const char * name) {
 			return true;
 //			E_Exit("trying to remove existing non-overlay file %s",name);
 		}
-
-		//Do we have access?
-		FILE* file_writable = fopen(overlayname,"rb+");
-		if(!file_writable) {
-			DOS_SetError(DOSERR_ACCESS_DENIED);
-			return false;
-		}
-		fclose(file_writable);
-
-		//File exists and can technically be deleted, nevertheless it failed.
-		//This means that the file is probably open by some process.
-		//See if We have it open.
-		bool found_file = false;
-		for (uint8_t i = 0; i < DOS_FILES; ++i) {
-			if(Files[i] && Files[i]->IsName(name)) {
-				uint8_t max = DOS_FILES;
-				while(Files[i]->IsOpen() && max--) {
-					Files[i]->Close();
-					if (Files[i]->RemoveRef()<=0) break;
-				}
-				found_file=true;
-			}
-		}
-		if(!found_file) {
-			DOS_SetError(DOSERR_ACCESS_DENIED);
-			return false;
-		}
-		std::error_code ec = {};
-		if (std_fs::remove(overlayname, ec)) {
-			// Overlay file removed, mark basefile as deleted if it
-			// exists:
-			if (localDrive::FileExists(name))
-				add_deleted_file(name, true);
-			remove_DOSname_from_cache(name); // Should be an else ?
-			                                 // although better safe
-			                                 // than sorry.
-			// Handle this better
-			dirCache.DeleteEntry(basename);
-			update_cache(false);
-			//Check if it exists in the base dir as well
-			
-			return true;
-		}
 		DOS_SetError(DOSERR_ACCESS_DENIED);
 		return false;
 	} else { //Removed from overlay.

--- a/src/dos/drive_overlay.cpp
+++ b/src/dos/drive_overlay.cpp
@@ -493,7 +493,7 @@ std::unique_ptr<DOS_File> Overlay_Drive::FileOpen(const char* name, uint8_t flag
 	NativeFileHandle file_handle = open_native_file(newname, write_access);
 	if (file_handle != InvalidNativeFileHandle) {
 		if (logoverlay) {
-			LOG_MSG("overlay file opened %s", newname);
+			LOG_MSG("FS: Overlay file '%s' opened.", newname);
 		}
 
 		DosDateTime dos_time   = {};
@@ -534,7 +534,7 @@ std::unique_ptr<DOS_File> Overlay_Drive::FileOpen(const char* name, uint8_t flag
 	}
 
 	if (logoverlay) {
-		LOG_MSG("file opened %s", name);
+		LOG_MSG("FS: File '%s' opened.", name);
 	}
 	// Convert file to OverlayFile
 	auto overlay_file   = std::make_unique<OverlayFile>(local_file);

--- a/src/dos/drive_overlay.cpp
+++ b/src/dos/drive_overlay.cpp
@@ -224,6 +224,10 @@ public:
 	          overlay_active(false)
 	{
 		refCtr = file->refCtr;
+
+		// We are taking ownership of the file handle.
+		// Set this to invalid so localFile's destructor won't close it.
+		file->file_handle = InvalidNativeFileHandle;
 	}
 
 	bool Write(uint8_t* data, uint16_t* size) override

--- a/src/dos/drive_overlay.cpp
+++ b/src/dos/drive_overlay.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "drives.h"
+#include "drive_local.h"
 
 #include <algorithm>
 #include <cerrno>

--- a/src/dos/drive_overlay.cpp
+++ b/src/dos/drive_overlay.cpp
@@ -319,7 +319,8 @@ bool OverlayFile::create_copy()
 	NativeFileHandle newhandle = InvalidNativeFileHandle;
 	uint8_t drive_set = GetDrive();
 	if (drive_set != 0xff && drive_set < DOS_DRIVES && Drives[drive_set]){
-		const auto od = dynamic_cast<Overlay_Drive*>(Drives[drive_set]);
+		const auto od = std::dynamic_pointer_cast<Overlay_Drive>(
+		        Drives[drive_set]);
 		if (od) {
 			FatAttributeFlags attributes = {};
 			local_drive_get_attributes(GetPath(), attributes);

--- a/src/dos/drive_virtual.cpp
+++ b/src/dos/drive_virtual.cpp
@@ -343,7 +343,6 @@ Virtual_File::Virtual_File(const vfile_data_t& in_data)
 {
 	date = default_date;
 	time = default_time;
-	open = true;
 }
 
 bool Virtual_File::Read(uint8_t* data, uint16_t* bytes_requested)

--- a/src/dos/drive_virtual.cpp
+++ b/src/dos/drive_virtual.cpp
@@ -424,28 +424,29 @@ Virtual_Drive::Virtual_Drive() : search_file()
 		parent_dir = std::make_shared<VFILE_Block>();
 }
 
-bool Virtual_Drive::FileOpen(DOS_File** file, const char* name, uint8_t flags) {
+std::unique_ptr<DOS_File> Virtual_Drive::FileOpen(const char* name, uint8_t flags)
+{
 	assert(name);
 	if (*name == 0) {
 		DOS_SetError(DOSERR_ACCESS_DENIED);
-		return false;
+		return nullptr;
 	}
 	/* Scan through the internal list of files */
 	auto vfile = find_vfile_by_name(name);
 	if (vfile) {
 		/* We have a match */
-		*file          = new Virtual_File(vfile->data);
-		(*file)->flags = flags;
-		return true;
+		auto file   = std::make_unique<Virtual_File>(vfile->data);
+		file->flags = flags;
+		return file;
 	}
-	return false;
+	return nullptr;
 }
 
-bool Virtual_Drive::FileCreate(DOS_File** /*file*/, const char* /*name*/,
-                               FatAttributeFlags /*attributes*/)
+std::unique_ptr<DOS_File> Virtual_Drive::FileCreate(const char* /*name*/,
+                                                    FatAttributeFlags /*attributes*/)
 {
 	DOS_SetError(DOSERR_ACCESS_DENIED);
-	return false;
+	return nullptr;
 }
 
 bool Virtual_Drive::FileUnlink(const char * /*name*/) {

--- a/src/dos/drive_virtual.cpp
+++ b/src/dos/drive_virtual.cpp
@@ -328,7 +328,7 @@ public:
 	bool Read(uint8_t* data, uint16_t* size) override;
 	bool Write(uint8_t* data, uint16_t* size) override;
 	bool Seek(uint32_t* pos, uint32_t type) override;
-	bool Close() override;
+	void Close() override;
 	uint16_t GetInformation() override;
 	bool IsOnReadOnlyMedium() const override;
 
@@ -401,9 +401,8 @@ bool Virtual_File::Seek(uint32_t* new_pos, uint32_t type)
 	return true;
 }
 
-bool Virtual_File::Close()
+void Virtual_File::Close()
 {
-	return true;
 }
 
 uint16_t Virtual_File::GetInformation() {

--- a/src/dos/drives.cpp
+++ b/src/dos/drives.cpp
@@ -195,8 +195,7 @@ void DOS_Drive::SetDir(const char *path)
 }
 
 // static members variables
-uint8_t DriveManager::currentDrive                       = 0;
-DriveManager::drive_infos_t DriveManager::drive_infos    = {};
+DriveManager::drive_infos_t DriveManager::drive_infos = {};
 
 DOS_Drive* DriveManager::RegisterFilesystemImage(const int drive,
                                                  std::unique_ptr<DOS_Drive>&& image)
@@ -224,13 +223,12 @@ std::vector<DOS_Drive*> DriveManager::AppendFilesystemImages(const int drive,
 }
 
 void DriveManager::InitializeDrive(int drive) {
-	currentDrive    = check_cast<uint8_t>(drive);
-	auto& drive_info = drive_infos.at(currentDrive);
+	auto& drive_info = drive_infos.at(drive);
 	if (!drive_info.disks.empty()) {
 		drive_info.current_disk = 0;
 		const auto disk_pointer =
 		        drive_info.disks[drive_info.current_disk].get();
-		Drives.at(currentDrive) = disk_pointer;
+		Drives.at(drive) = disk_pointer;
 		if (disk_pointer && drive_info.disks.size() > 1) {
 			disk_pointer->Activate();
 		}
@@ -339,7 +337,6 @@ char *DriveManager::GetDrivePosition(int drive)
 
 void DriveManager::Init(Section* /* sec */) {
 	// setup drive_infos structure
-	currentDrive = 0;
 	for(int i = 0; i < DOS_DRIVES; i++) {
 		drive_infos.at(i).current_disk = 0;
 	}

--- a/src/dos/drives.cpp
+++ b/src/dos/drives.cpp
@@ -197,37 +197,26 @@ void DOS_Drive::SetDir(const char *path)
 // static members variables
 DriveManager::drive_infos_t DriveManager::drive_infos = {};
 
-DOS_Drive* DriveManager::RegisterFilesystemImage(const int drive,
-                                                 std::unique_ptr<DOS_Drive>&& image)
+void DriveManager::RegisterFilesystemImage(const int drive,
+                                           std::shared_ptr<DOS_Drive> image)
 {
 	auto& disks = drive_infos.at(drive).disks;
 	disks.clear();
-	return disks.emplace_back(std::move(image)).get();
+	disks.push_back(image);
 }
 
-std::vector<DOS_Drive*> DriveManager::AppendFilesystemImages(const int drive,
-                                                             filesystem_images_t& images)
+void DriveManager::AppendFilesystemImages(const int drive,
+                                          const filesystem_images_t& images)
 {
-	std::vector<DOS_Drive*> pointers = {};
-
 	auto& disks = drive_infos.at(drive).disks;
-
-	// Move all the source images into the drive's disk vector, and add the
-	// resulting pointers back to our return vector.
-	for (auto& image : images) {
-		pointers.emplace_back(disks.emplace_back(std::move(image)).get());
-	}
-
-	images.clear();
-	return pointers;
+	disks.insert(std::end(disks), std::begin(images), std::end(images));
 }
 
 void DriveManager::InitializeDrive(int drive) {
 	auto& drive_info = drive_infos.at(drive);
 	if (!drive_info.disks.empty()) {
 		drive_info.current_disk = 0;
-		const auto disk_pointer =
-		        drive_info.disks[drive_info.current_disk].get();
+		const auto disk_pointer = drive_info.disks[drive_info.current_disk];
 		Drives.at(drive) = disk_pointer;
 		if (disk_pointer && drive_info.disks.size() > 1) {
 			disk_pointer->Activate();
@@ -257,13 +246,14 @@ void DriveManager::CycleDisks(int requested_drive, bool notify)
 			IDE_CDROM_Detach_Ret(index, slave, drive);
 		}
 
-		const auto old_disk     = drive_info.disks[current_disk].get();
+		const auto old_disk     = drive_info.disks[current_disk];
 		current_disk            = (current_disk + 1) % num_disks;
-		const auto new_disk     = drive_info.disks[current_disk].get();
+		const auto new_disk     = drive_info.disks[current_disk];
 		drive_info.current_disk = current_disk;
 		if (drive < MAX_DISK_IMAGES && imageDiskList.at(drive)) {
 			if (new_disk && new_disk->GetType() == DosDriveType::Fat) {
-				const auto fat_drive = dynamic_cast<fatDrive*>(new_disk);
+				const auto fat_drive = std::dynamic_pointer_cast<fatDrive>(
+				        new_disk);
 				imageDiskList[drive] = fat_drive->loadedDisk;
 			}
 			if ((drive == 2 || drive == 3) && imageDiskList[drive] && imageDiskList[drive]->hardDrive) {

--- a/src/dos/drives.cpp
+++ b/src/dos/drives.cpp
@@ -314,9 +314,6 @@ void DriveManager::CycleDisks(int requested_drive, bool notify)
 			if (new_disk && new_disk->GetType() == DosDriveType::Fat) {
 				const auto fat_drive = dynamic_cast<fatDrive*>(new_disk);
 				imageDiskList[drive] = fat_drive->loadedDisk.get();
-			} else {
-				imageDiskList[drive] = dynamic_cast<imageDisk*>(
-				        new_disk);
 			}
 			if ((drive == 2 || drive == 3) && imageDiskList[drive] && imageDiskList[drive]->hardDrive) {
 				updateDPT();

--- a/src/dos/program_biostest.cpp
+++ b/src/dos/program_biostest.cpp
@@ -39,13 +39,12 @@ void BIOSTEST::Run(void) {
 
 	uint8_t drive;
 	char fullname[DOS_PATHLENGTH];
-	localDrive *ldp = nullptr;
 	if (!DOS_MakeName((char *)temp_line.c_str(), fullname, &drive))
 		return;
 
 	try {
 		// try to read ROM file into buffer
-		ldp = dynamic_cast<localDrive*>(Drives.at(drive));
+		const auto ldp = std::dynamic_pointer_cast<localDrive>(Drives.at(drive));
 		if (!ldp)
 			return;
 

--- a/src/dos/program_boot.cpp
+++ b/src/dos/program_boot.cpp
@@ -51,9 +51,11 @@ FILE* BOOT::getFSFile_mounted(const char* filename, uint32_t* ksize,
 		return nullptr;
 
 	try {
-		const auto ldp = dynamic_cast<localDrive*>(Drives.at(drive));
-		if (!ldp)
+		const auto ldp = std::dynamic_pointer_cast<localDrive>(
+		        Drives.at(drive));
+		if (!ldp) {
 			return nullptr;
+		}
 
 		tmpfile = ldp->GetHostFilePtr(fullname, "rb");
 		if (tmpfile == nullptr) {

--- a/src/dos/program_boot.cpp
+++ b/src/dos/program_boot.cpp
@@ -250,8 +250,8 @@ void BOOT::Run(void)
 			FILE *usefile = getFSFile(temp_line.c_str(),
 			                          &floppysize, &rombytesize);
 			if (usefile != nullptr) {
-				diskSwap[i] = DriveManager::RegisterRawFloppyImage(
-				        usefile, temp_line, floppysize);
+				diskSwap[i] = std::make_shared<imageDisk>(
+				        usefile, temp_line.c_str(), floppysize, false);
 				if (usefile_1 == nullptr) {
 					usefile_1 = usefile;
 					rombytesize_1 = rombytesize;
@@ -341,7 +341,6 @@ void BOOT::Run(void)
 						        "PROGRAM_BOOT_CART_NO_CMDS"));
 					}
 					diskSwap.fill(nullptr);
-					DriveManager::CloseRawFddImages();
 
 					return;
 				} else {
@@ -374,7 +373,6 @@ void BOOT::Run(void)
 							        "PROGRAM_BOOT_CART_NO_CMDS"));
 						}
 						diskSwap.fill(nullptr);
-						DriveManager::CloseRawFddImages();
 						return;
 					}
 				}
@@ -465,7 +463,6 @@ void BOOT::Run(void)
 
 			// Close cardridges
 			diskSwap.fill(nullptr);
-			DriveManager::CloseRawFddImages();
 
 			NotifyBooting();
 

--- a/src/dos/program_imgmount.cpp
+++ b/src/dos/program_imgmount.cpp
@@ -489,8 +489,7 @@ void IMGMOUNT::Run(void)
 		const auto is_floppy = (drive == 'A' || drive == 'B') && !has_hdd;
 		const auto is_hdd = (drive == 'C' || drive == 'D') && has_hdd;
 		if (is_floppy || is_hdd) {
-			imageDiskList.at(
-			        drive_index(drive)) = fat_image->loadedDisk.get();
+			imageDiskList.at(drive_index(drive)) = fat_image->loadedDisk;
 			updateDPT();
 		}
 	} else if (fstype == "iso") {
@@ -586,8 +585,8 @@ void IMGMOUNT::Run(void)
 
 		const auto drive_index = drive - '0';
 
-		imageDiskList.at(drive_index) = DriveManager::RegisterNumberedImage(
-		        new_disk, temp_line, imagesize, is_hdd);
+		imageDiskList.at(drive_index) = std::make_shared<imageDisk>(
+		        new_disk, temp_line.c_str(), imagesize, is_hdd);
 
 		if (is_hdd) {
 			imageDiskList.at(drive_index)

--- a/src/dos/program_loadrom.cpp
+++ b/src/dos/program_loadrom.cpp
@@ -50,7 +50,8 @@ void LOADROM::Run(void)
 
 	try {
 		/* try to read ROM file into buffer */
-		const auto ldp = dynamic_cast<localDrive*>(Drives.at(drive));
+		const auto ldp = std::dynamic_pointer_cast<localDrive>(
+		        Drives.at(drive));
 		if (!ldp) {
 			return;
 		}

--- a/src/dos/program_mount_common.cpp
+++ b/src/dos/program_mount_common.cpp
@@ -63,7 +63,6 @@ const char *UnmountHelper(char umount)
 
 	if (i_drive < MAX_DISK_IMAGES && imageDiskList[i_drive]) {
 		imageDiskList[i_drive] = nullptr;
-		DriveManager::CloseNumberedImage(imageDiskList[i_drive]);
 	}
 
 	return MSG_Get("PROGRAM_MOUNT_UMOUNT_SUCCESS");

--- a/src/hardware/ide.cpp
+++ b/src/hardware/ide.cpp
@@ -169,7 +169,7 @@ public:
 	std::string id_model = "DOSBox IDE disk";
 	uint8_t bios_disk_index;
 
-	imageDisk* getBIOSdisk();
+	std::shared_ptr<imageDisk> getBIOSdisk();
 
 	void update_from_biosdisk();
 	/* read from 1F0h data port from IDE device */
@@ -2134,7 +2134,7 @@ IDEATADevice::IDEATADevice(IDEController *c, uint8_t disk_index)
 IDEATADevice::~IDEATADevice()
 {}
 
-imageDisk* IDEATADevice::getBIOSdisk()
+std::shared_ptr<imageDisk> IDEATADevice::getBIOSdisk()
 {
 	if (bios_disk_index >= (2 + MAX_HDD_IMAGES))
 		return nullptr;
@@ -2945,7 +2945,7 @@ static void IDE_DelayedCommand(uint32_t idx /*which IDE controller*/)
 		IDEATADevice *ata = (IDEATADevice *)dev;
 		uint32_t sectorn = 0; /* TBD: expand to uint64_t when adding LBA48 emulation */
 		uint32_t sectcount;
-		imageDisk* disk = nullptr;
+		std::shared_ptr<imageDisk> disk = nullptr;
 		//      int i;
 
 		switch (dev->command) {

--- a/src/hardware/serialport/serialport.cpp
+++ b/src/hardware/serialport/serialport.cpp
@@ -81,8 +81,7 @@ bool device_COM::Seek(uint32_t *pos, uint32_t type)
 	return true;
 }
 
-bool device_COM::Close() {
-	return false;
+void device_COM::Close() {
 }
 
 uint16_t device_COM::GetInformation()

--- a/src/hardware/serialport/serialport.cpp
+++ b/src/hardware/serialport/serialport.cpp
@@ -95,11 +95,6 @@ device_COM::device_COM(class CSerial* sc) {
 	SetName(serial_comname[sclass->port_index]);
 }
 
-device_COM::~device_COM() {
-}
-
-
-
 // COM1 - COM4 objects
 CSerial *serialports[SERIAL_MAX_PORTS] = {nullptr};
 

--- a/src/ints/bios_disk.cpp
+++ b/src/ints/bios_disk.cpp
@@ -60,8 +60,8 @@ static bool swapping_requested;
 void BIOS_SetEquipment(uint16_t equipment);
 
 /* 2 floppys and 2 harddrives, max */
-std::array<imageDisk*, MAX_DISK_IMAGES> imageDiskList = {};
-std::array<imageDisk*, MAX_SWAPPABLE_DISKS> diskSwap  = {};
+std::array<std::shared_ptr<imageDisk>, MAX_DISK_IMAGES> imageDiskList = {};
+std::array<std::shared_ptr<imageDisk>, MAX_SWAPPABLE_DISKS> diskSwap  = {};
 
 unsigned int swapPosition;
 
@@ -598,14 +598,10 @@ void BIOS_SetupDisks(void) {
 	RealSetVec(0x13,CALLBACK_RealPointer(call_int13));
 
 	// Clean any the numbered images
-	for (auto &image_ptr : imageDiskList) {
-		DriveManager::CloseNumberedImage(image_ptr);
-		image_ptr = nullptr;
-	}
+	imageDiskList.fill(nullptr);
 
 	// Clear any raw disk images
 	diskSwap.fill(nullptr);
-	DriveManager::CloseRawFddImages();
 
 	diskparm0 = CALLBACK_Allocate();
 	diskparm1 = CALLBACK_Allocate();

--- a/src/ints/ems.cpp
+++ b/src/ints/ems.cpp
@@ -124,9 +124,8 @@ public:
 	{
 		return false;
 	}
-	bool Close() override
+	void Close() override
 	{
-		return false;
 	}
 	uint16_t GetInformation(void) override
 	{

--- a/src/misc/fs_utils_posix.cpp
+++ b/src/misc/fs_utils_posix.cpp
@@ -457,4 +457,29 @@ DosDateTime get_dos_file_time(const NativeFileHandle handle)
 	return ret;
 }
 
+void set_dos_file_time(const NativeFileHandle handle, const uint16_t date, const uint16_t time)
+{
+	auto datetime = DOS_UnpackDateTime(date, time);
+
+	const auto unix_seconds = mktime(&datetime);
+	if (unix_seconds == -1) {
+		return;
+	}
+
+	struct timespec unix_times[2] = {};
+
+	// Last access time
+	// We don't really care about this but apparently it must be updated as well
+	unix_times[0].tv_sec = unix_seconds;
+	unix_times[0].tv_nsec = 0;
+
+	// Last modification time
+	unix_times[1].tv_sec = unix_seconds;
+	unix_times[1].tv_nsec = 0;
+
+	// I like hating on Win32 API but at least they have better function names...
+	// F U too Mr. Timens
+	futimens(handle, unix_times);
+}
+
 #endif

--- a/src/misc/fs_utils_win32.cpp
+++ b/src/misc/fs_utils_win32.cpp
@@ -231,19 +231,7 @@ DosDateTime get_dos_file_time(const NativeFileHandle handle)
 		return ret;
 	}
 
-	SYSTEMTIME system_time = {};
-	if (!FileTimeToSystemTime(&last_write_time, &system_time)) {
-		return ret;
-	}
-
-	ret.time = DOS_PackTime(system_time.wHour,
-	                        system_time.wMinute,
-	                        system_time.wSecond);
-
-	ret.date = DOS_PackDate(system_time.wYear,
-	                        system_time.wMonth,
-	                        system_time.wDay);
-
+	FileTimeToDosDateTime(&last_write_time, &ret.date, &ret.time);
 	return ret;
 }
 

--- a/src/misc/fs_utils_win32.cpp
+++ b/src/misc/fs_utils_win32.cpp
@@ -235,4 +235,12 @@ DosDateTime get_dos_file_time(const NativeFileHandle handle)
 	return ret;
 }
 
+void set_dos_file_time(const NativeFileHandle handle, const uint16_t date, const uint16_t time)
+{
+	FILETIME last_write_time = {};
+	if (DosDateTimeToFileTime(date, time, &last_write_time)) {
+		SetFileTime(handle, nullptr, nullptr, &last_write_time);
+	}
+}
+
 #endif

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -1860,7 +1860,6 @@ void DOS_Shell::CMD_SUBST (char * args) {
  * E.g. make basedir member dos_drive instead of localdrive
  */
 	HELP("SUBST");
-	localDrive* ldp=nullptr;
 	char mountstring[DOS_PATHLENGTH+CROSS_LEN+20];
 	char temp_str[2] = { 0,0 };
 	try {
@@ -1906,7 +1905,8 @@ void DOS_Shell::CMD_SUBST (char * args) {
 			throw 0;
 		}
 
-		ldp = dynamic_cast<localDrive*>(Drives.at(drive));
+		const auto ldp = std::dynamic_pointer_cast<localDrive>(
+		        Drives.at(drive));
 		if (!ldp) {
 			throw 0;
 		}


### PR DESCRIPTION
# Description

Several changes here.  Probably recommend reviewing by commit because I've got broken down decently well.

General overview:

- DOS_Files array moved from raw pointer to `unique_ptr`
- DOS_Drive moved from "owning" vectors of `unique_ptr` with lots of raw pointers everywhere to `shared_ptr`.
- Improvements to timestamp handling to better match MS-DOS behavior


## Related issues

Fixes #620


# Manual testing

Wrote test programs in x86 assembly and ran on MS-DOS 6.22 to confirm behavior of various combinations of DOS interrupts to see when timestamps get updated.  Opened multiple handles to the same file. Used the get date interrupt to verify when the timestamp gets updated after write, truncate, create, set date interrupt, etc.

Tested a few games with save files to verify they still work:  Crystal Caves, Doom, Secret of Monkey Island 2

Tested the case on #620 to verify that we now set the timestamp equal to Dosbox's BIOS rather than host time.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

