### PR TITLE
Do not hard exit when running `SET /P`

### DIFF
--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -663,6 +663,8 @@ void SHELL_Init() {
 
 	MSG_Add("SHELL_CMD_SET_NOT_SET", "Environment variable '%s' not defined.\n");
 	MSG_Add("SHELL_CMD_SET_OUT_OF_SPACE", "Not enough environment space left.\n");
+	MSG_Add("SHELL_CMD_SET_OPTION_P_UNSUPPORTED",
+	        "Option /P is not supported; please use the CHOICE command.\n");
 
 	MSG_Add("SHELL_CMD_IF_EXIST_MISSING_FILENAME", "IF EXIST: Missing filename.\n");
 	MSG_Add("SHELL_CMD_IF_ERRORLEVEL_MISSING_NUMBER", "IF ERRORLEVEL: Missing number.\n");

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -1466,9 +1466,13 @@ void DOS_Shell::CMD_SET(char * args) {
 	}
 	//There are args:
 	char * pcheck = args;
-	while ( *pcheck && (*pcheck == ' ' || *pcheck == '\t')) pcheck++;
+
+	while (*pcheck && (*pcheck == ' ' || *pcheck == '\t')) {
+		pcheck++;
+	}
 	if (*pcheck && strlen(pcheck) > 3 && (strncasecmp(pcheck, "/p ", 3) == 0)) {
-		E_Exit("Set /P is not supported. Use Choice!");
+		WriteOut(MSG_Get("SHELL_CMD_SET_OPTION_P_UNSUPPORTED"));
+		return;
 	}
 
 	char* p = strpbrk(args, "=");


### PR DESCRIPTION
# Description

As per title.


## Related issues

Fixed https://github.com/dosbox-staging/dosbox-staging/discussions/3787

# Manual testing

1. `SET /P` doesn't hard exit anymore but prints a hint instead:

<img width="847" alt="image" src="https://github.com/dosbox-staging/dosbox-staging/assets/698770/58d080d7-f4e3-446b-b6ce-6aab8eb83d13">


2. Tried `INSTALL.BAT` from the [Star Control Collection ISO](https://archive.org/details/starcontroliandiicollectiondos1995) referenced in the linked ticket, and at least we don't get a hard exit, but you can't get past this screen 🤷🏻 

<img width="799" alt="image" src="https://github.com/dosbox-staging/dosbox-staging/assets/698770/00b40e38-d263-47ea-9d53-4bb46e654538">



# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

