### PR TITLE
Add warning about CMake support being experimental

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -31,6 +31,13 @@ CCACHE_COMPRESSLEVEL=6
 CCACHE_SLOPPINESS="pch_defines,time_macros"
 ```
 
+> **Note**
+>
+> CMake support is currently an experimental internal-only, work-in-progress
+> feature; it's not ready for public consumption yet. Please ignore the
+> `CMakeLists.txt` files in the source tree.
+
+
 ## OS-specific instructions
 
 Instructions in this article assume you're using Linux or BSD but will work

--- a/README.md
+++ b/README.md
@@ -99,6 +99,13 @@ git clone https://github.com/dosbox-staging/dosbox-staging.git
 
 Read [BUILD.md] for the comprehensive compilation guide.
 
+> **Note**
+>
+> CMake support is currently an experimental internal-only, work-in-progress
+> feature; it's not ready for public consumption yet. Please ignore the
+> `CMakeLists.txt` files in the source tree.
+
+
 ### Linux, macOS
 
 Install build dependencies appropriate for your OS:

--- a/docs/build-freebsd.md
+++ b/docs/build-freebsd.md
@@ -6,6 +6,13 @@ Before getting started, you should know that FreeBSD isn't fully supported or
 used by the current maintainers. It's been lightly tested on a big-endian
 PowerPC system.
 
+> **Note**
+>
+> CMake support is currently an experimental internal-only, work-in-progress
+> feature; it's not ready for public consumption yet. Please ignore the
+> `CMakeLists.txt` files in the source tree.
+
+
 ## Pre-requisites
 
 ### Setup your `bin` path

--- a/docs/build-haiku.md
+++ b/docs/build-haiku.md
@@ -2,6 +2,13 @@
 
 Haiku builds can be created with Clang or GCC using the Meson buildsystem.
 
+> **Note**
+>
+> CMake support is currently an experimental internal-only, work-in-progress
+> feature; it's not ready for public consumption yet. Please ignore the
+> `CMakeLists.txt` files in the source tree.
+
+
 ## Build instructions
 
 Install dependencies:

--- a/docs/build-macos.md
+++ b/docs/build-macos.md
@@ -7,6 +7,12 @@ MacPorts package managers.
 We recommend using Homebrew and Clang because Apple's Core SDKs can be used
 only with Apple's fork of the Clang compiler.
 
+> **Note**
+>
+> CMake support is currently an experimental internal-only, work-in-progress
+> feature; it's not ready for public consumption yet. Please ignore the
+> `CMakeLists.txt` files in the source tree.
+
 
 ## Installing Xcode
 

--- a/docs/build-nix.md
+++ b/docs/build-nix.md
@@ -4,6 +4,13 @@ Compiling code on Nix requires slightly different inputs from other linux distro
 since the appropriate environment variables for pkg-config are only avaliable
 under the `nix-shell` command.
 
+> **Note**
+>
+> CMake support is currently an experimental internal-only, work-in-progress
+> feature; it's not ready for public consumption yet. Please ignore the
+> `CMakeLists.txt` files in the source tree.
+
+
 ## Installing the dependencies under Nix
 
 Nix has a unique toolset where you are not required to install the dependencies

--- a/docs/build-openbsd.md
+++ b/docs/build-openbsd.md
@@ -6,6 +6,13 @@ Before getting started, you should know that OpenBSD isn't fully supported or
 used by the current maintainers. It's been lightly tested on a big-endian
 PowerPC system.
 
+> **Note**
+>
+> CMake support is currently an experimental internal-only, work-in-progress
+> feature; it's not ready for public consumption yet. Please ignore the
+> `CMakeLists.txt` files in the source tree.
+
+
 ## Pre-requisites
 
 ### Expand the systems' memory limits

--- a/docs/build-windows.md
+++ b/docs/build-windows.md
@@ -8,6 +8,13 @@ Windows builds can be created using:
 - The Clang or GCC compilers using the Meson buildsystem running within the
   MSYS2 environment to provide dependencies.
 
+> **Note**
+>
+> CMake support is currently an experimental internal-only, work-in-progress
+> feature; it's not ready for public consumption yet. Please ignore the
+> `CMakeLists.txt` files in the source tree.
+
+
 ## Build using Visual Studio
 
 1. Install Visual Studio Community 2022: <https://visualstudio.microsoft.com/vs/community/>.


### PR DESCRIPTION
# Description

As per title.

## Related issues

- https://github.com/dosbox-staging/dosbox-staging/pull/3361

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [x] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

