### PR TITLE
Fix improper handling of some characters in shell history

### DIFF
--- a/contrib/resources/mapping/ASCII.TXT
+++ b/contrib/resources/mapping/ASCII.TXT
@@ -1704,6 +1704,7 @@
 0x2033 "   #DOUBLE PRIME
 0x2039 <   #SINGLE LEFT-POINTING ANGLE QUOTATION MARK
 0x203a >   #SINGLE RIGHT-POINTING ANGLE QUOTATION MARK
+0x203c !   #DOUBLE EXCLAMATION MARK
 
 # ****************************************************************************
 # 0x2070 - 0x209f     Superscripts and Subscripts
@@ -1749,7 +1750,6 @@
 0x20bf B   #BITCOIN SIGN
 0x20c0 c   #SOM SIGN
 
-
 # ****************************************************************************
 # 0x2100 - 0x214f     Letterlike Symbols
 # ****************************************************************************
@@ -1765,6 +1765,18 @@
 0x2139 i   #INFORMATION SOURCE
 
 # ****************************************************************************
+# 0x2190 - 0x21ff     Arrows
+# ****************************************************************************
+
+0x2190 NNN #LEFTWARDS ARROW
+0x2191 NNN #UPWARDS ARROW
+0x2192 NNN #RIGHTWARDS ARROW
+0x2193 NNN #DOWNWARDS ARROW
+0x2194 NNN #LEFT RIGHT ARROW
+0x2195 NNN #UP DOWN ARROW
+0x21a8 NNN #UP DOWN ARROW WITH BASE
+
+# ****************************************************************************
 # 0x2200 - 0x22ff     Mathematical Operators
 # ****************************************************************************
 
@@ -1775,6 +1787,7 @@
 0x021d y   #LATIN SMALL LETTER YOGH
 0x221a NNN #SQUARE ROOT
 0x221e NNN #INFINITY
+0x221f NNN #RIGHT ANGLE
 0x2229 NNN #INTERSECTION
 0x2248 NNN #ALMOST EQUAL TO
 0x2261 =   #IDENTICAL TO
@@ -1856,6 +1869,30 @@
 # ****************************************************************************
 
 0x25a0 NNN #BLACK SQUARE
+0x25ac NNN #BLACK RECTANGLE
+0x25b2 NNN #BLACK UP-POINTING TRIANGLE
+0x25ba NNN #BLACK RIGHT-POINTING POINTER
+0x25bc NNN #BLACK DOWN-POINTING TRIANGLE
+0x25c4 NNN #BLACK LEFT-POINTING POINTER
+0x25cb NNN #WHITE CIRCLE
+0x25d8 NNN #INVERSE BULLET
+0x25d9 NNN #INVERSE WHITE CIRCLE
+
+# ****************************************************************************
+# 0x2600 - 0x26ff     Miscellaneous Symbols
+# ****************************************************************************
+
+0x263a NNN #WHITE SMILING FACE
+0x263b NNN #BLACK SMILING FACE
+0x263c NNN #WHITE SUN WITH RAYS
+0x2640 NNN #FEMALE SIGN
+0x2642 NNN #MALE SIGN
+0x2660 NNN #BLACK SPADE SUIT
+0x2663 NNN #BLACK CLUB SUIT
+0x2665 NNN #BLACK HEART SUIT
+0x2666 NNN #BLACK DIAMOND SUIT
+0x266a NNN #EIGHTH NOTE
+0x266b NNN #BEAMED EIGHTH NOTES
 
 # ****************************************************************************
 # 0x2c60 - 0x2c7f     Latin Extended-C (full coverage)

--- a/include/string_utils.h
+++ b/include/string_utils.h
@@ -296,19 +296,36 @@ uint16_t get_utf8_code_page();
 // Specifies what to do if the DOS code page does not contain character
 // representing given Unicode grapheme
 enum class UnicodeFallback {
+
 	// Convert all unknown graphemes to 0 - to be used in code like TREE
 	// command implementation, which has it's own specialized ASCII fallback
 	// drawing code
 	Null,
+
 	// Try to provide reasonable fallback using all the characters available
 	// in target DOS code page; use for features like clipboard content
 	// exchange with host system
 	Simple,
+
 	// Do not use certain DOS code page characters in order to draw boxes
 	// (tables) which are consistent; for example, if code page contains
 	// character '╠', but not '╣', both will be replaced with a fallback
 	// character ('║' for example)
 	Box
+};
+
+// Specifies how to interpret characters 0x00-0x1f and 0x7f in DOS strings
+enum class DosStringConvertMode {
+
+	// String contains control codes (new line, tabulation, delete, etc.)
+	WithControlCodes,
+
+	// String does not have any codes characters, consider all characters
+	// as screen codes
+	ScreenCodesOnly,
+
+	// String should not contain characters mentioned above
+	NoSpecialCharacters
 };
 
 // Convert the UTF-8 string to the format intended for display inside emulated
@@ -317,12 +334,15 @@ enum class UnicodeFallback {
 // Return value 'false' means there were problems with string decoding or
 // rendering, but the overall output should still be sane.
 bool utf8_to_dos(const std::string& in_str, std::string& out_str,
+                 const DosStringConvertMode convert_mode,
                  const UnicodeFallback fallback);
 bool utf8_to_dos(const std::string& in_str, std::string& out_str,
+                 const DosStringConvertMode convert_mode,
                  const UnicodeFallback fallback, const uint16_t code_page);
-void dos_to_utf8(const std::string& in_str, std::string& out_str);
 void dos_to_utf8(const std::string& in_str, std::string& out_str,
-                 const uint16_t code_page);
+                 const DosStringConvertMode convert_mode);
+void dos_to_utf8(const std::string& in_str, std::string& out_str,
+                 const DosStringConvertMode convert_mode, const uint16_t code_page);
 
 // Convert DOS code page string to lower/upper case; converters are aware of all
 // the national characters. Functions without 'code_page' parameter use current

--- a/src/dos/dos_locale.cpp
+++ b/src/dos/dos_locale.cpp
@@ -2620,7 +2620,10 @@ static void refresh_currency_format(const LocaleInfoEntry &source)
 
 		// Check if the currency can be converted to current code page
 
-		if (!utf8_to_dos(candidate_utf8, candidate, UnicodeFallback::Null)) {
+		if (!utf8_to_dos(candidate_utf8,
+		                 candidate,
+		                 DosStringConvertMode::NoSpecialCharacters,
+		                 UnicodeFallback::Null)) {
 			continue;
 		}
 		if (candidate.length() > MaxCurrencySymbolLength) {

--- a/src/dos/program_tree.cpp
+++ b/src/dos/program_tree.cpp
@@ -180,12 +180,19 @@ void TREE::PreRender()
 {
 	bool use_ascii_fallback = false;
 
+	auto to_dos = [](const std::string& in_str, std::string& out_str) {
+		return utf8_to_dos(in_str,
+		                   out_str,
+		                   DosStringConvertMode::NoSpecialCharacters,
+		                   UnicodeFallback::Null);
+	};
+
 	if (!has_option_ascii) {
 		// If current code page misses one or more characters used to
 		// draw the tree, use standard 7-bit ASCII characters
 
 		std::string tmp_str;
-		utf8_to_dos("─├│└", tmp_str, UnicodeFallback::Null);
+		to_dos("─├│└", tmp_str);
 		if (tmp_str.find('\0') != std::string::npos) {
 			use_ascii_fallback = true;
 		}
@@ -196,9 +203,9 @@ void TREE::PreRender()
 		str_last   = "\\---";
 		str_indent = "|   ";
 	} else {
-		utf8_to_dos("├───", str_child, UnicodeFallback::Null);
-		utf8_to_dos("└───", str_last, UnicodeFallback::Null);
-		utf8_to_dos("│   ", str_indent, UnicodeFallback::Null);
+		to_dos("├───", str_child);
+		to_dos("└───", str_last);
+		to_dos("│   ", str_indent);
 	}
 }
 

--- a/src/gui/titlebar.cpp
+++ b/src/gui/titlebar.cpp
@@ -441,8 +441,12 @@ void GFX_NotifyProgramName(const std::string& segment_name,
 	trim(segment_name_dos);
 
 	// Store new names as UTF-8, refresh titlebar
-	dos_to_utf8(segment_name_dos, state.segment_name);
-	dos_to_utf8(canonical_name, state.canonical_name);
+	dos_to_utf8(segment_name_dos,
+	            state.segment_name,
+	            DosStringConvertMode::ScreenCodesOnly);
+	dos_to_utf8(canonical_name,
+	            state.canonical_name,
+	            DosStringConvertMode::ScreenCodesOnly);
 	GFX_RefreshTitle();
 }
 

--- a/src/hardware/input/mouse_manymouse.cpp
+++ b/src/hardware/input/mouse_manymouse.cpp
@@ -178,7 +178,11 @@ void ManyMouseGlue::Rescan()
 		std::string name;
 		// We want the mouse name to be the same regardless of the code
 		// page set - so use 7-bit ASCII characters only
-		utf8_to_dos(name_utf8, name, UnicodeFallback::Simple, 0);
+		utf8_to_dos(name_utf8,
+		            name,
+		            DosStringConvertMode::NoSpecialCharacters,
+		            UnicodeFallback::Simple,
+		            0);
 
 		// Replace non-breaking space with a regular space
 		const char character_nbsp  = 0x7f;

--- a/src/misc/messages.cpp
+++ b/src/misc/messages.cpp
@@ -62,6 +62,7 @@ private:
 		if (output_msg_by_codepage[cp].empty()) {
 			if (!utf8_to_dos(msg,
 			                 output_msg_by_codepage[cp],
+			                 DosStringConvertMode::WithControlCodes,
 			                 UnicodeFallback::Box,
 			                 cp)) {
 				LOG_WARNING("LANG: Problem converting UTF8 string '%s' to DOS code page",
@@ -97,6 +98,7 @@ public:
 		if (rendered_msg_by_codepage[cp].empty()) {
 			if (!utf8_to_dos(rendered_msg,
 			                 rendered_msg_by_codepage[cp],
+			                 DosStringConvertMode::WithControlCodes,
 			                 UnicodeFallback::Box,
 			                 cp)) {
 				LOG_WARNING("LANG: Problem converting UTF8 string '%s' to DOS code page",

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -742,7 +742,9 @@ void CONFIG::Run(void)
 			}
 			for (const auto& pvar : pvars) {
 				std::string line_utf8 = {};
-				dos_to_utf8(pvar, line_utf8);
+				dos_to_utf8(pvar,
+				            line_utf8,
+				            DosStringConvertMode::WithControlCodes);
 				sec->HandleInputline(line_utf8);
 			}
 			break;
@@ -758,7 +760,10 @@ void CONFIG::Run(void)
 			}
 
 			std::string line_dos = {};
-			utf8_to_dos(sec->data, line_dos, UnicodeFallback::Box);
+			utf8_to_dos(sec->data,
+			            line_dos,
+			            DosStringConvertMode::WithControlCodes,
+			            UnicodeFallback::Box);
 
 			MoreOutputStrings output(*this);
 			output.AddString("\n%s\n\n", line_dos.c_str());
@@ -822,7 +827,9 @@ void CONFIG::Run(void)
 						}
 						std::string val_utf8 = p->GetValue().ToString();
 						std::string val_dos = {};
-						utf8_to_dos(val_utf8, val_dos,
+						utf8_to_dos(val_utf8,
+						            val_dos,
+						            DosStringConvertMode::NoSpecialCharacters,
 						            UnicodeFallback::Simple);
 						WriteOut("%s=%s\n",
 						         p->propname.c_str(),
@@ -841,7 +848,9 @@ void CONFIG::Run(void)
 					// it's a property name
 					std::string val_utf8 = sec->GetPropValue(pvars[0].c_str());
 					std::string val_dos = {};
-					utf8_to_dos(val_utf8, val_dos,
+					utf8_to_dos(val_utf8,
+					            val_dos,
+					            DosStringConvertMode::NoSpecialCharacters,
 					            UnicodeFallback::Simple);
 					WriteOut("%s", val_dos.c_str());
 					DOS_PSP(psp->GetParent())
@@ -869,7 +878,9 @@ void CONFIG::Run(void)
 					return;
 				}
 				std::string val_dos = {};
-				utf8_to_dos(val_utf8, val_dos,
+				utf8_to_dos(val_utf8,
+				            val_dos,
+				            DosStringConvertMode::NoSpecialCharacters,
 				            UnicodeFallback::Simple);
 				WriteOut("%s\n", val_dos.c_str());
 				DOS_PSP(psp->GetParent())
@@ -944,7 +955,9 @@ void CONFIG::Run(void)
 				tsec->ExecuteDestroy(false);
 
 				std::string line_utf8 = {};
-				dos_to_utf8(inputline, line_utf8);
+				dos_to_utf8(inputline,
+				            line_utf8,
+				            DosStringConvertMode::NoSpecialCharacters);
 
 				bool change_success = tsec->HandleInputline(
 				        line_utf8.c_str());

--- a/src/misc/unicode.cpp
+++ b/src/misc/unicode.cpp
@@ -43,7 +43,7 @@ CHECK_NARROWING();
 using box_drawing_set_t = std::array<uint16_t, 40>;
 
 // List of box drawing characters, ordered as in code page 437
-static constexpr box_drawing_set_t box_drawing_set_regular = {
+static constexpr box_drawing_set_t BoxDrawingSetRegular = {
         0x2502, // 0xb3 - '│', BOX DRAWINGS LIGHT VERTICAL
         0x2524, // 0xb4 - '┤', BOX DRAWINGS LIGHT VERTICAL AND LEFT
         0x2561, // 0xb5 - '╡', BOX DRAWINGS VERTICAL SINGLE AND LEFT DOUBLE
@@ -88,7 +88,7 @@ static constexpr box_drawing_set_t box_drawing_set_regular = {
 
 // Fallback list of box drawing characters, ordered as above;
 // effectively turns all double lines into light lines
-static constexpr box_drawing_set_t box_drawing_set_light = {
+static constexpr box_drawing_set_t BoxDrawingSetLight = {
         0x2502, // 0xb3 - '│'
         0x2524, // 0xb4 - '┤'
         0x2524, // 0xb5 - '┤' (instead of '╡')
@@ -265,20 +265,20 @@ static const std::string file_name_decomposition = "DECOMPOSITION.TXT";
 static const std::string dir_name_mapping        = "mapping";
 
 // Thresholds for UTF-8 decoding/encoding
-constexpr uint8_t decode_threshold_non_ascii = 0b1'000'0000;
-constexpr uint8_t decode_threshold_2_bytes   = 0b1'100'0000;
-constexpr uint8_t decode_threshold_3_bytes   = 0b1'110'0000;
-constexpr uint8_t decode_threshold_4_bytes   = 0b1'111'0000;
-constexpr uint8_t decode_threshold_5_bytes   = 0b1'111'1000;
-constexpr uint8_t decode_threshold_6_bytes   = 0b1'111'1100;
-constexpr uint16_t encode_threshold_2_bytes  = 0x0080;
-constexpr uint16_t encode_threshold_3_bytes  = 0x0800;
+constexpr uint8_t DecodeThresholdNonAscii = 0b1'000'0000;
+constexpr uint8_t DecodeThreshold2Bytes   = 0b1'100'0000;
+constexpr uint8_t DecodeThreshold3Bytes   = 0b1'110'0000;
+constexpr uint8_t DecodeThreshold4Bytes   = 0b1'111'0000;
+constexpr uint8_t DecodeThreshold5Bytes   = 0b1'111'1000;
+constexpr uint8_t DecodeThreshold6Bytes   = 0b1'111'1100;
+constexpr uint16_t EncodeThreshold2Bytes  = 0x0080;
+constexpr uint16_t EncodeThreshold3Bytes  = 0x0800;
 
 // Use the character below if there is no sane way to handle the Unicode glyph
-constexpr uint8_t unknown_character = 0x3f; // '?'
+constexpr uint8_t UnknownCharacter = 0x3f; // '?'
 
 // End of file marking, use in some files from unicode.org
-constexpr uint8_t end_of_file_marking = 0x1a;
+constexpr uint8_t EndOfFileMarking = 0x1a;
 
 // Main information about how to create Unicode mappings for given DOS code page
 static config_mappings_t config_mappings = {};
@@ -326,7 +326,8 @@ static std::map<uint16_t, code_page_maps_t> per_code_page_mappings = {};
 
 static bool is_combining_mark(const uint32_t code_point)
 {
-	static constexpr std::pair<uint16_t, uint16_t> ranges[] = {
+	static constexpr std::pair<uint16_t, uint16_t> Ranges[] = {
+		// clang-format off
 		{0x0300, 0x036f}, // Combining Diacritical Marks
 		{0x0653, 0x065f}, // Arabic Combining Marks
 		// Note: Arabic Combining Marks start from 0x064b, but some are
@@ -338,12 +339,13 @@ static bool is_combining_mark(const uint32_t code_point)
 		{0x1dc0, 0x1dff}, // Combining Diacritical Marks Supplement
 		{0x20d0, 0x20ff}, // Combining Diacritical Marks for Symbols
 		{0xfe20, 0xfe2f}, // Combining Half Marks
+		// clang-format on
 	};
 
 	auto in_range = [code_point](const auto& range) {
 		return code_point >= range.first && code_point <= range.second;
 	};
-	return std::any_of(std::begin(ranges), std::end(ranges), in_range);
+	return std::any_of(std::begin(Ranges), std::end(Ranges), in_range);
 }
 
 Grapheme::Grapheme(const uint16_t code_point)
@@ -395,7 +397,7 @@ void Grapheme::Invalidate()
 	is_empty = false;
 	is_valid = false;
 
-	code_point = unknown_character;
+	code_point = UnknownCharacter;
 	marks.clear();
 	marks_sorted.clear();
 }
@@ -501,25 +503,25 @@ bool Grapheme::operator<(const Grapheme& other) const
 // ***************************************************************************
 
 // Constants to detect whether DOS character is a control code
-constexpr uint8_t control_code_delete    = 0x7f;
-constexpr uint8_t control_code_threshold = 0x20;
+constexpr uint8_t ControlCodeDelete    = 0x7f;
+constexpr uint8_t ControlCodeThreshold = 0x20;
 
 // Unicode code points for screen codes from 0x00 to 0x1f
 // see: https://en.wikipedia.org/wiki/Code_page_437
-constexpr std::array<uint16_t, 0x20> screen_codes_wide = {
-        // clang-format off
-        0x0020, 0x263a, 0x263b, 0x2665, 0x2666, 0x2663, 0x2660, 0x2022, // 00-07
-        0x25d8, 0x25cb, 0x25d9, 0x2642, 0x2640, 0x266a, 0x266b, 0x263c, // 08-13
-        0x25ba, 0x25c4, 0x2195, 0x203c, 0x00b6, 0x00a7, 0x25ac, 0x21a8, // 10-17
-        0x2191, 0x2193, 0x2192, 0x2190, 0x221f, 0x2194, 0x25b2, 0x25bc  // 18-1f
-        // clang-format on
+constexpr std::array<uint16_t, 0x20> ScreenCodesWide = {
+	// clang-format off
+	0x0020, 0x263a, 0x263b, 0x2665, 0x2666, 0x2663, 0x2660, 0x2022, // 00-07
+	0x25d8, 0x25cb, 0x25d9, 0x2642, 0x2640, 0x266a, 0x266b, 0x263c, // 08-13
+	0x25ba, 0x25c4, 0x2195, 0x203c, 0x00b6, 0x00a7, 0x25ac, 0x21a8, // 10-17
+	0x2191, 0x2193, 0x2192, 0x2190, 0x221f, 0x2194, 0x25b2, 0x25bc  // 18-1f
+	// clang-format on
 };
 
-constexpr uint16_t screen_code_7f_wide = 0x2302; // 'del' character
+constexpr uint16_t ScreenCodeWide7f = 0x2302; // 'del' character
 
 static bool is_control_code(const uint16_t value)
 {
-	return (value < control_code_threshold) || (value == control_code_delete);
+	return (value < ControlCodeThreshold) || (value == ControlCodeDelete);
 }
 
 static std::optional<uint16_t> screen_code_to_wide(const uint8_t byte,
@@ -532,10 +534,10 @@ static std::optional<uint16_t> screen_code_to_wide(const uint8_t byte,
 
 	assert(convert_mode == DosStringConvertMode::ScreenCodesOnly);
 
-	if (byte == control_code_delete) {
-		return screen_code_7f_wide;
-	} else if (byte < control_code_threshold) {
-		return screen_codes_wide[byte];
+	if (byte == ControlCodeDelete) {
+		return ScreenCodeWide7f;
+	} else if (byte < ControlCodeThreshold) {
+		return ScreenCodesWide[byte];
 	}
 
 	return {};
@@ -577,15 +579,15 @@ static std::optional<uint8_t> grapheme_to_screen_code(const Grapheme& grapheme,
 		return {};
 	}
 
-	constexpr auto begin = screen_codes_wide.begin();
-	constexpr auto end   = screen_codes_wide.end();
+	constexpr auto Begin = ScreenCodesWide.begin();
+	constexpr auto End   = ScreenCodesWide.end();
 
-	const auto iter = std::find(begin, end, grapheme.GetCodePoint());
-	if (iter == end) {
+	const auto iter = std::find(Begin, End, grapheme.GetCodePoint());
+	if (iter == End) {
 		return {};
 	}
 
-	return check_cast<uint8_t>(std::distance(begin, iter));
+	return check_cast<uint8_t>(std::distance(Begin, iter));
 }
 
 // ***************************************************************************
@@ -618,8 +620,8 @@ static bool utf8_to_wide(const std::string& str_in, std::vector<uint16_t>& str_o
 			auto counter = std::min(remaining, bytes);
 			while (counter--) {
 				const auto byte_next = static_cast<uint8_t>(str_in[i + 1]);
-				if (byte_next < decode_threshold_non_ascii ||
-				    byte_next >= decode_threshold_2_bytes) {
+				if (byte_next < DecodeThresholdNonAscii ||
+				    byte_next >= DecodeThreshold2Bytes) {
 					break;
 				}
 				++i;
@@ -629,63 +631,63 @@ static bool utf8_to_wide(const std::string& str_in, std::vector<uint16_t>& str_o
 		};
 
 		// Retrieve code point
-		uint32_t code_point = unknown_character;
+		uint32_t code_point = UnknownCharacter;
 
 		// Support code point needing up to 3 bytes to encode; this
 		// includes Latin, Greek, Cyrillic, Hebrew, Arabic, VGA charset
 		// symbols, etc. More bytes are needed mainly for historic
 		// scripts, emoji, etc.
 
-		if (byte_1 >= decode_threshold_6_bytes) {
+		if (byte_1 >= DecodeThreshold6Bytes) {
 			// 6-byte code point (>= 31 bits), no support
 			advance(5);
-		} else if (byte_1 >= decode_threshold_5_bytes) {
+		} else if (byte_1 >= DecodeThreshold5Bytes) {
 			// 5-byte code point (>= 26 bits), no support
 			advance(4);
-		} else if (byte_1 >= decode_threshold_4_bytes) {
+		} else if (byte_1 >= DecodeThreshold4Bytes) {
 			// 4-byte code point (>= 21 bits), no support
 			advance(3);
-		} else if (byte_1 >= decode_threshold_3_bytes) {
+		} else if (byte_1 >= DecodeThreshold3Bytes) {
 			// 3-byte code point - decode 1st byte
-			code_point = static_cast<uint8_t>(
-			        byte_1 - decode_threshold_3_bytes);
+			code_point = static_cast<uint8_t>(byte_1 -
+			                                  DecodeThreshold3Bytes);
 			// Decode 2nd byte
 			code_point = code_point << 6;
-			if (byte_2 >= decode_threshold_non_ascii &&
-			    byte_2 < decode_threshold_2_bytes) {
+			if (byte_2 >= DecodeThresholdNonAscii &&
+			    byte_2 < DecodeThreshold2Bytes) {
 				++i;
 				code_point = code_point + byte_2 -
-				             decode_threshold_non_ascii;
+				             DecodeThresholdNonAscii;
 			} else {
 				status = false; // code point encoding too short
 			}
 			// Decode 3rd byte
 			code_point = code_point << 6;
-			if (byte_2 >= decode_threshold_non_ascii &&
-			    byte_2 < decode_threshold_2_bytes &&
-			    byte_3 >= decode_threshold_non_ascii &&
-			    byte_3 < decode_threshold_2_bytes) {
+			if (byte_2 >= DecodeThresholdNonAscii &&
+			    byte_2 < DecodeThreshold2Bytes &&
+			    byte_3 >= DecodeThresholdNonAscii &&
+			    byte_3 < DecodeThreshold2Bytes) {
 				++i;
 				code_point = code_point + byte_3 -
-				             decode_threshold_non_ascii;
+				             DecodeThresholdNonAscii;
 			} else {
 				status = false; // code point encoding too short
 			}
-		} else if (byte_1 >= decode_threshold_2_bytes) {
+		} else if (byte_1 >= DecodeThreshold2Bytes) {
 			// 2-byte code point - decode 1st byte
-			code_point = static_cast<uint8_t>(
-			        byte_1 - decode_threshold_2_bytes);
+			code_point = static_cast<uint8_t>(byte_1 -
+			                                  DecodeThreshold2Bytes);
 			// Decode 2nd byte
 			code_point = code_point << 6;
-			if (byte_2 >= decode_threshold_non_ascii &&
-			    byte_2 < decode_threshold_2_bytes) {
+			if (byte_2 >= DecodeThresholdNonAscii &&
+			    byte_2 < DecodeThreshold2Bytes) {
 				++i;
 				code_point = code_point + byte_2 -
-				             decode_threshold_non_ascii;
+				             DecodeThresholdNonAscii;
 			} else {
 				status = false; // code point encoding too short
 			}
-		} else if (byte_1 < decode_threshold_non_ascii) {
+		} else if (byte_1 < DecodeThresholdNonAscii) {
 			// 1-byte code point, ASCII compatible
 			code_point = byte_1;
 		} else {
@@ -709,10 +711,10 @@ static void wide_to_utf8(const std::vector<uint16_t>& str_in, std::string& str_o
 	};
 
 	for (const auto code_point : str_in) {
-		if (code_point < encode_threshold_2_bytes) {
+		if (code_point < EncodeThreshold2Bytes) {
 			// Encode using 1 byte
 			push(code_point);
-		} else if (code_point < encode_threshold_3_bytes) {
+		} else if (code_point < EncodeThreshold3Bytes) {
 			// Encode using 2 bytes
 			const auto to_byte_1 = code_point >> 6;
 			const auto to_byte_2 = 0b0'011'1111 & code_point;
@@ -790,7 +792,7 @@ static bool wide_to_dos(const std::vector<uint16_t>& str_in, std::string& str_ou
 		}
 
 		const auto code_point = grapheme.GetCodePoint();
-		if (code_point >= decode_threshold_non_ascii) {
+		if (code_point >= DecodeThresholdNonAscii) {
 			return false; // not a 7-bit ASCII character
 		}
 
@@ -828,7 +830,7 @@ static bool wide_to_dos(const std::vector<uint16_t>& str_in, std::string& str_ou
 		}
 
 		const auto alias_code_point = mapping_box->at(code_point);
-		if (alias_code_point >= decode_threshold_non_ascii) {
+		if (alias_code_point >= DecodeThresholdNonAscii) {
 			str_out.push_back(static_cast<char>(mapping->at(alias_code_point)));
 		} else {
 			str_out.push_back(static_cast<char>(alias_code_point));
@@ -883,7 +885,7 @@ static bool wide_to_dos(const std::vector<uint16_t>& str_in, std::string& str_ou
 		if (fallback == UnicodeFallback::Null) {
 			str_out.push_back(0);
 		} else {
-			str_out.push_back(static_cast<char>(unknown_character));
+			str_out.push_back(static_cast<char>(UnknownCharacter));
 			warn_code_point(code_point);
 		}
 		status = false;
@@ -967,13 +969,13 @@ static void dos_to_wide(const std::string& str_in, std::vector<uint16_t>& str_ou
 
 	for (const auto character : str_in) {
 		const auto byte = static_cast<uint8_t>(character);
-		if (byte >= decode_threshold_non_ascii) {
+		if (byte >= DecodeThresholdNonAscii) {
 			// Take from code page mapping
 			auto& mappings = per_code_page_mappings[code_page];
 
 			if ((per_code_page_mappings.count(code_page) == 0) ||
 			    (mappings.grapheme_to_dos.count(byte) == 0)) {
-				str_out.push_back(unknown_character);
+				str_out.push_back(UnknownCharacter);
 			} else {
 				mappings.grapheme_to_dos[byte].PushInto(str_out);
 			}
@@ -982,7 +984,7 @@ static void dos_to_wide(const std::string& str_in, std::vector<uint16_t>& str_ou
 			if (wide) {
 				str_out.push_back(*wide);
 			} else {
-				str_out.push_back(unknown_character);
+				str_out.push_back(UnknownCharacter);
 			}
 		} else {
 			str_out.push_back(byte);
@@ -1026,7 +1028,7 @@ static bool get_line(std::ifstream& in_file, std::string& line_str, size_t& line
 		if (!std::getline(in_file, line_str)) {
 			return false;
 		}
-		if (line_str.length() >= 1 && line_str[0] == end_of_file_marking) {
+		if (line_str.length() >= 1 && line_str[0] == EndOfFileMarking) {
 			return false; // end of definitions
 		}
 		++line_num;
@@ -1106,7 +1108,7 @@ static bool get_ascii(const std::string& token, uint8_t& out)
 	} else if (token == "HSH") {
 		out = '#';
 	} else if (token == "NNN") {
-		out = unknown_character;
+		out = UnknownCharacter;
 	} else {
 		return false;
 	}
@@ -1278,14 +1280,14 @@ static bool import_mapping_code_page(const std_fs::path& path_root,
 		if (tokens.size() == 1) {
 			// Handle undefined character entry, ignore 7-bit ASCII
 			// codes
-			if (character_code >= decode_threshold_non_ascii) {
+			if (character_code >= DecodeThresholdNonAscii) {
 				Grapheme grapheme;
 				add_if_not_mapped(new_mapping, character_code, grapheme);
 			}
 
 		} else if (tokens.size() <= 4) {
 			// Handle mapping entry, ignore 7-bit ASCII codes
-			if (character_code >= decode_threshold_non_ascii) {
+			if (character_code >= DecodeThresholdNonAscii) {
 				Grapheme grapheme;
 				if (!get_grapheme(tokens, grapheme)) {
 					error_parsing(file_name, line_num);
@@ -1463,7 +1465,7 @@ static void import_config_main(const std_fs::path& path_root)
 
 			if (tokens.size() == 1) {
 				// Handle undefined character entry
-				if (character_code >= decode_threshold_non_ascii) {
+				if (character_code >= DecodeThresholdNonAscii) {
 					// ignore 7-bit ASCII codes
 					Grapheme grapheme; // placeholder
 					add_if_not_mapped(new_mapping,
@@ -1475,7 +1477,7 @@ static void import_config_main(const std_fs::path& path_root)
 
 			} else if (tokens.size() <= 4) {
 				// Handle mapping entry
-				if (character_code >= decode_threshold_non_ascii) {
+				if (character_code >= DecodeThresholdNonAscii) {
 					// ignore 7-bit ASCII codes
 					Grapheme grapheme; // placeholder
 					if (!get_grapheme(tokens, grapheme)) {
@@ -1818,12 +1820,12 @@ static void construct_box_fallback(const map_grapheme_to_dos_t& code_page_mappin
 	};
 
 	auto try_set = [&](const box_drawing_set_t& drawing_set) {
-		assert(box_drawing_set_regular.size() == drawing_set.size());
+		assert(BoxDrawingSetRegular.size() == drawing_set.size());
 
 		// Create initial mapping
 		out_box_code_points.clear();
 		for (size_t idx = 0; idx < drawing_set.size(); ++idx) {
-			const auto code_point_1 = box_drawing_set_regular[idx];
+			const auto code_point_1 = BoxDrawingSetRegular[idx];
 			const auto code_point_2 = drawing_set[idx];
 			out_box_code_points[code_point_1] = code_point_2;
 		}
@@ -1856,17 +1858,17 @@ static void construct_box_fallback(const map_grapheme_to_dos_t& code_page_mappin
 
 	// Try to adjust regular (full) drawing character set for the code page,
 	// if failed try the reduced set without double lines
-	if (try_set(box_drawing_set_regular) || try_set(box_drawing_set_light)) {
+	if (try_set(BoxDrawingSetRegular) || try_set(BoxDrawingSetLight)) {
 		return;
 	}
 
 	// Last resort fallback - use 7-bit ASCII fallback for everything
 	out_box_code_points.clear();
-	for (const auto& code_point : box_drawing_set_regular) {
+	for (const auto& code_point : BoxDrawingSetRegular) {
 		if (mapping_ascii.count(code_point) > 0) {
 			out_box_code_points[code_point] = mapping_ascii.at(code_point);
 		} else {
-			out_box_code_points[code_point] = unknown_character;
+			out_box_code_points[code_point] = UnknownCharacter;
 		}
 	}
 }
@@ -1877,7 +1879,7 @@ static void construct_case_mapping(const map_code_point_case_t& map_case_global,
 {
 	out_map_case.resize(UINT8_MAX + 1);
 	for (uint16_t idx = 0; idx < UINT8_MAX + 1; ++idx) {
-		if (idx < decode_threshold_non_ascii &&
+		if (idx < DecodeThresholdNonAscii &&
 		    (map_case_global.count(idx) > 0)) {
 			out_map_case[idx] = static_cast<uint8_t>(
 			        map_case_global.at(idx));
@@ -1925,7 +1927,7 @@ static bool construct_mapping(const uint16_t code_page)
 	map_dos_to_grapheme_t new_mapping_reverse = {};
 
 	auto add_to_mappings = [&](const uint8_t first, const Grapheme& second) {
-		if (first < decode_threshold_non_ascii) {
+		if (first < DecodeThresholdNonAscii) {
 			return;
 		}
 		if (!add_if_not_mapped(new_mapping_reverse, first, second)) {
@@ -2090,12 +2092,12 @@ uint16_t get_utf8_code_page()
 {
 	load_config_if_needed();
 
-	constexpr uint16_t rom_code_page = 437; // United States
+	constexpr uint16_t RomCodePage = 437; // United States
 
 	// Below EGA it wasn't possible to change the character set
 	const uint16_t code_page = IS_EGAVGA_ARCH
 	                                 ? deduplicate_code_page(dos.loaded_codepage)
-	                                 : rom_code_page;
+	                                 : RomCodePage;
 
 	// For unsupported code pages revert to default one
 	if (prepare_code_page(code_page)) {

--- a/src/shell/autoexec.cpp
+++ b/src/shell/autoexec.cpp
@@ -215,7 +215,11 @@ static void create_autoexec_bat_dos(const std::string& input_utf8,
 {
 	// Convert UTF-8 AUTOEXEC.BAT to DOS code page
 	std::string autoexec_bat_dos = {};
-	utf8_to_dos(input_utf8, autoexec_bat_dos, UnicodeFallback::Box, code_page);
+	utf8_to_dos(input_utf8,
+	            autoexec_bat_dos,
+	            DosStringConvertMode::WithControlCodes,
+	            UnicodeFallback::Box,
+	            code_page);
 
 	// Convert the result to a binary format
 	auto autoexec_bat_bin = std::vector<uint8_t>(autoexec_bat_dos.begin(),

--- a/src/shell/shell_history.cpp
+++ b/src/shell/shell_history.cpp
@@ -38,7 +38,10 @@ void ShellHistory::Append(std::string command, uint16_t code_page)
 {
 	auto to_utf8_str = [code_page](const std::string& dos_str) {
 		std::string utf8_str = {};
-		dos_to_utf8(dos_str, utf8_str, code_page);
+		dos_to_utf8(dos_str,
+		            utf8_str,
+		            DosStringConvertMode::ScreenCodesOnly,
+		            code_page);
 		return utf8_str;
 	};
 
@@ -56,7 +59,11 @@ std::vector<std::string> ShellHistory::GetCommands(uint16_t code_page) const
 {
 	auto to_dos_str = [code_page](const std::string& utf8_str) {
 		std::string dos_str = {};
-		utf8_to_dos(utf8_str, dos_str, UnicodeFallback::Simple, code_page);
+		utf8_to_dos(utf8_str,
+		            dos_str,
+		            DosStringConvertMode::ScreenCodesOnly,
+		            UnicodeFallback::Simple,
+		            code_page);
 		return dos_str;
 	};
 


### PR DESCRIPTION
# Description

DRAFT for now, because I'm still testing this code.

I have discovered a small shell history related bug:
- STEP: Press <LEFT CONTROL>+a, <ENTER>
- RESULT: A smiley face is printed and illegal command error (OK)
- RESULT: A log is printed, _UNICODE: No fallback mapping for code point 0x263a_ (NOT OK)
- STEP: Press <CURSOR UP> to bring back the last command
- RESULT: A question mark is brought back instead of the smiley face (not OK)

![Screenshot](https://github.com/dosbox-staging/dosbox-staging/assets/48332137/25d99c4e-fc00-40ff-b581-4fcb0c849553)

Solution: the Unicode engine needs to be precisely told what kind of DOS string do we have - with control codes, with screen codes, or with no special characters like that at all.
The Unicode extension implemented here might be helpful for the future use cases too - for UTF8 host file names, or for the upcoming (hopefully someday) EDIT.COM replacement.


# Manual testing

- try to reproduce the problem according to steps within the PR description; make sure that `shell_history_file` config option is not empty check that after restarting DOSBox the shell history is preserved, including the smiley
- check that `tree` command works without graphic glitches
- execute `keyb br 3848` command and check that the `tree` command still works, this time with fallback artwork
- check that `intro` command still works and does not produce graphical glitches
- press `CTRL+F6`, pay attention to the animated recording mark on the title bar and task bar (if your OS has one...) - there should be no regression here
- set `language = pl` config option, there should be no graphical glitches in the default tittle bar (but a couple of Polish national characters)
- set `language = pl` config option, type execute `more z:\autoexec.bat` - there should be no graphical glitches
- with language set to Polish (as above), execute `keyb pl` and `more z:\autoexec.bat` - there should be no graphical glitches, the first line of the file shall end with _ń_ letter (accented n)
- execute 'config -wcd' command with non-empty `[autoexec]` section; config file should be written correctly, including the `[autoexec]` section
- execute `config -axadd FOO`, and `config -axtype` afterwards - content of the updated `[autoexec]` section should be correctly printed out
- display help of any command, for example execute `dir /?`


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

