### PR TITLE
Fix division regression by resetting flag type

### DIFF
--- a/src/cpu/flags.cpp
+++ b/src/cpu/flags.cpp
@@ -1066,8 +1066,8 @@ constexpr bool is_negative(const T value)
 template <typename T>
 void set_cpu_test_flags_for_division(const T quotient) noexcept
 {
-	// Set the instruction type to division
-	lflags.type = t_DIV;
+	// Reset the flag type being used
+	lflags.type = {};
 
 	// Create a new test flags object with the flags we'll be settings
 	CpuTestFlags div_test_flags(FLAG_CF | FLAG_OF | FLAG_PF | FLAG_SF | FLAG_ZF);


### PR DESCRIPTION
# Description

Fixes the regressions reported by @FeralChild64 (thanks for quickly testing and reporting these!)

## Related issues

- Fixes #3794: confirmed fixed by @FeralChild64 and myself
- Beefy Windows 3.11 for Workgroups [issue](https://github.com/dosbox-staging/dosbox-staging/issues/3794#issuecomment-2189368073): confirmed fixed by @FeralChild64
- Windows 95 with IntelliPoint 3.0 driver [issue](https://github.com/dosbox-staging/dosbox-staging/issues/3794#issuecomment-2189387232): confirmed fixed by @FeralChild64
- [PNG CRC error](https://github.com/dosbox-staging/dosbox-staging/issues/3793#issuecomment-2189474016) in moralhardcandy by Blasphemy: confirmed fixed by @FeralChild64

# Manual testing

- Silmarils games continue to have proper intro tone fade-down with all cores.
- Retested games from the prior PR and did not hit regressions.

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [ ] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

