### PR TITLE
Add DOS Files to shutdown step to avoid a crash when shutting down

### DIFF
--- a/include/dos_inc.h
+++ b/include/dos_inc.h
@@ -250,6 +250,7 @@ bool DOS_IOCTL(void);
 bool DOS_GetSTDINStatus();
 uint8_t DOS_FindDevice(const char* name);
 void DOS_SetupDevices();
+void DOS_ClearDrivesAndFiles();
 void DOS_ShutDownDevices();
 
 /* Execute and new process creation */

--- a/include/dos_inc.h
+++ b/include/dos_inc.h
@@ -118,7 +118,7 @@ constexpr int FakeSftEntries = 16;
 
 /* internal Dos Tables */
 
-extern std::unique_ptr<DOS_File> Files[DOS_FILES];
+extern std::array<std::unique_ptr<DOS_File>, DOS_FILES> Files;
 extern std::array<std::shared_ptr<DOS_Drive>, DOS_DRIVES> Drives;
 extern DOS_Device * Devices[DOS_DEVICES];
 

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -1534,10 +1534,17 @@ public:
 			dos.version.minor = new_version.minor;
 		}
 	}
-	~DOS(){
-		// Clear the driver pointers. The actual objects are managed by
-		// the drive manager class.
-		Drives.fill(nullptr);
+
+	// Shutdown the DOS OS constructs leaving only the BIOS and hardware
+	// layers.
+	~DOS()
+	{
+		// Clear the drive pointers and file objects. The actual drive
+		// objects are managed by the drive manager class. The 'Files'
+		// destructors depend on the DOS API (file flush, close, and
+		// date and time lookup), so it's import to shut these down when
+		// DOS is still available.
+		DOS_ClearDrivesAndFiles();
 
 		// de-init devices, this allows DOSBox to cleanly re-initialize
 		// without throwing an inevitable `DOS: Too many devices added`

--- a/src/dos/dos_files.cpp
+++ b/src/dos/dos_files.cpp
@@ -44,7 +44,7 @@
 #define FCB_ERR_EOF     3
 #define FCB_ERR_WRITE   1
 
-std::unique_ptr<DOS_File> Files[DOS_FILES] = {};
+std::array<std::unique_ptr<DOS_File>, DOS_FILES> Files = {};
 
 std::array<std::shared_ptr<DOS_Drive>, DOS_DRIVES> Drives = {};
 

--- a/src/dos/dos_files.cpp
+++ b/src/dos/dos_files.cpp
@@ -1800,12 +1800,7 @@ bool DOS_SetFileDate(uint16_t entry, uint16_t ntime, uint16_t ndate)
 
 void DOS_SetupFiles()
 {
-	/* Setup the File Handles */
-	for (uint8_t i = 0; i < DOS_FILES; ++i)
-		Files[i] = nullptr;
-	/* Setup the Virtual Disk System */
-	for (uint8_t i = 0; i < DOS_DRIVES; ++i)
-		Drives[i] = nullptr;
+	DOS_ClearDrivesAndFiles();
 
 	const auto z_drive_index = drive_index('Z');
 
@@ -1855,4 +1850,17 @@ bool DOS_UnlockFile(const uint16_t entry, const uint32_t pos, const uint32_t len
 	}
 	DOS_SetError(DOSERR_LOCK_VIOLATION);
 	return false;
+}
+
+void DOS_ClearDrivesAndFiles()
+{
+	// Clear all the DOS files. This calls the files' derived destructors,
+	// which might be LocalFiles, OverlayFile, etc.
+	for (auto& f : Files) {
+		f = nullptr;
+	}
+
+	// Clear the shared drive pointers. The actual objects are managed by
+	// the drive manager class.
+	Drives.fill(nullptr);
 }


### PR DESCRIPTION
# Description

When closing Windows 3.11 with Ctrl+F9, my debug build on RetroPie would crash with:

```
11      0x62fedb2b4753 std::unique_ptr<DOS_File, std::default_delete<DOS_File> >::~unique_ptr() + 67
10      0x62fedb2b613c std::default_delete<DOS_File>::operator()(DOS_File*) const + 44
9       0x62fedb3545c9 localFile::~localFile() + 25
8       0x62fedb354560 localFile::~localFile() + 64
7       0x62fedb354337 localFile::Close() + 295
6       0x62fedb35406b localFile::MaybeFlushTime() + 203
5       0x62fedb297a32 DOS_GetBiosTimePacked() + 18
4       0x62fedb55a383 unsigned int mem_readd<(MemOpMode)0>(unsigned int) + 19
```

What's happening is that there's a global array holding the open DOS file objects:

```
std::unique_ptr<DOS_File> Files[DOS_FILES] = {};
```

Adding some tracing, it looks like DOSBox shutdowns each of the 'Init'd subsystems in reverse order that they were setup. 
 - One of them is the the DOS subsystem (in dos.cpp), which clears the DOS drives, devices, and memory layout.
 - The overall DOSBox shutdown sequence keeps going and clears our the physical layers like the RAM.

However, that global array holding the DOS files is still active. Those DOS File objects are finally destructed just before the DOSBox Staging process ends -- but by then the DOS subystem is long gone so those DOS File destructors aren't able to access things like 'DOS_GetBiosTimePacked' (which require reading into DOS memory space). 

So this PR just adds the DOS files to that DOS shutdown phase, so they're not left orphaned.

## Related issues

None.

# Manual testing

Tested controlled and force shutdowns (Ctrl+F9) with Windows 3.11 and various games; and didn't hit any crashes.

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

