### PR TITLE
Fix file open error in ISO Drive

### DIFF
--- a/src/dos/drive_iso.cpp
+++ b/src/dos/drive_iso.cpp
@@ -216,7 +216,7 @@ std::unique_ptr<DOS_File> isoDrive::FileOpen(const char* name, uint8_t flags)
 	}
 
 	isoDirEntry de;
-	if (!lookup(&de, name) && !IS_DIR(FLAGS1)) {
+	if (!(lookup(&de, name) && !IS_DIR(FLAGS1))) {
 		return nullptr;
 	}
 


### PR DESCRIPTION
# Description

Fixes regression from 92627ffddd6cfcc3815869fe5892be6d0a38c876

I had messed up a conditional for error checking while refactoring. This restores original behavior.


## Related issues

Fixes #3802


# Manual testing

Red Alert runs fine.  The installer still hangs after completion on a black screen saying "Please stand by".  I closed DOSBox when this happened and there's no more hangs playing the actual game afterwards.  Testing now to see if this is another regression or not.

EDIT:  Installer hang is not a recent regression.  Same behavior observed in v0.81.1.


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

