### PR TITLE
Eliminate excessive repeat heap calls during normal runtime

### DIFF
--- a/include/object_pool.h
+++ b/include/object_pool.h
@@ -1,0 +1,109 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2024-2024  The DOSBox Staging Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#ifndef DOSBOX_OBJECT_POOL_H
+#define DOSBOX_OBJECT_POOL_H
+
+#include "dosbox.h"
+
+// This class is a generic object re-use pool. Consider using it if your program
+// performs tens of thousands (or more) large object heap allocations as part of
+// its normal and ongoing runtime loop. Avoiding excessive heap allocations can
+// save CPU time and reduce memory fragmentation.
+//
+// Ongoing runtime loop:
+//     auto my_obj_ptr = new HugeType(arg1, arg2);
+//     .. do a bit of work ..
+//     delete my_obj_ptr;
+//
+// If you have this pattern, then the ObjectPool is a good candidate:
+//
+//  Instantiate a long-lived pool for your HugeType:
+//     ObjectPool<HugeType> pool = {};
+//
+//  Ongoing runtime loop:
+//     auto my_obj_ptr = pool.Acquire(arg1, arg2);
+//     .. do a bit of work ..
+//     pool.Release(my_obj_ptr);
+
+#include <cassert>
+#include <memory>
+
+// Clang 15 for macOS 12 and 13 is missing C++17's <memory_resource>, however
+// Clang 15 for macOS 14 has it. When the build system eventually uses macOS 14
+// for all Apple builds then the '#else' portions can be removed. In the
+// meantime we simply fallback to 'new' and 'delete' for this deficient compiler.
+#ifdef HAVE_MEMORY_RESOURCE
+	#include <memory_resource>
+#endif
+
+template <typename T>
+class ObjectPool {
+public:
+	ObjectPool() = default;
+	~ObjectPool() = default;
+
+	// Acquire an object: allocate and construct it with the given arguments.
+	template <typename... Args>
+	constexpr T* Acquire(Args&&... args)
+	{
+#ifdef HAVE_MEMORY_RESOURCE
+		auto ptr = ObjectTraits::allocate(allocator, OneItem);
+		ObjectTraits::construct(allocator, ptr, std::forward<Args>(args)...);
+#else
+		auto ptr = new (std::nothrow) T(std::forward<Args>(args)...);
+#endif
+		assert(ptr);
+		return ptr;
+	}
+
+	// Release the object: destruct it and deallocate its memory.
+	constexpr void Release(T* ptr)
+	{
+#ifdef HAVE_MEMORY_RESOURCE
+		assert(ptr);
+		ObjectTraits::destroy(allocator, ptr);
+		ObjectTraits::deallocate(allocator, ptr, OneItem);
+#else
+        delete ptr;
+#endif
+	}
+
+#ifdef HAVE_MEMORY_RESOURCE
+private:
+	using ObjectAllocator = std::pmr::polymorphic_allocator<T>;
+	using ObjectTraits = std::allocator_traits<ObjectAllocator>;
+
+	constexpr static auto OneItem = 1;
+
+	// We use C++'s off-the-shelf pool resource as the backing memory for the
+	// object's allocator. The allocator is used in the above ObjectTraits::
+	// calls, so when we allocate() and deallocate() an object the memory comes
+	// from the pool (and not the heap).  More details:
+	// - https://en.cppreference.com/w/cpp/memory/allocator_traits
+	// - https://en.cppreference.com/w/cpp/memory/polymorphic_allocator
+	//
+	std::pmr::unsynchronized_pool_resource pool = {};
+	ObjectAllocator allocator{&pool};
+
+#endif
+};
+
+#endif

--- a/meson.build
+++ b/meson.build
@@ -461,6 +461,13 @@ if cc.has_function('__builtin___clear_cache')
     conf_data.set10('HAVE_BUILTIN_CLEAR_CACHE', true)
 endif
 
+if cxx.has_type(
+    'std::pmr::unsynchronized_pool_resource',
+    prefix: '#include <memory_resource>',
+)
+    conf_data.set10('HAVE_MEMORY_RESOURCE', true)
+endif
+
 if cc.has_function('mprotect', prefix: '#include <sys/mman.h>')
     conf_data.set10('HAVE_MPROTECT', true)
 endif

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -212,6 +212,9 @@
 #define HAVE_SYS_TYPES_H 1
 #mesondefine HAVE_SYS_XATTR_H
 
+// Check for C++ headers
+#mesondefine HAVE_MEMORY_RESOURCE
+
 /* Hardware-related defines
  */
 

--- a/src/cpu/dyn_cache.h
+++ b/src/cpu/dyn_cache.h
@@ -19,12 +19,14 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
+#include <array>
 #include <cassert>
 #include <cerrno>
 #include <new>
 #include <type_traits>
 
 #include "mem_unaligned.h"
+#include "object_pool.h"
 #include "paging.h"
 #include "types.h"
 
@@ -154,6 +156,32 @@ static uint8_t* cache_code_link_blocks = {};
 static std::vector<CacheBlock> cache_blocks(CACHE_BLOCKS);
 static CacheBlock link_blocks[2] = {}; // default linking (specially marked)
 
+// Use an object pool to manage the invalidation maps
+class InvalidationMapPool {
+private:
+	static constexpr size_t NumMapBytes = 4096;
+
+	using InvalidationMap = std::array<uint8_t, NumMapBytes>;
+
+	ObjectPool<InvalidationMap> pool = {};
+
+public:
+	constexpr uint8_t* Acquire()
+	{
+		auto invalidation_map = pool.Acquire();
+		invalidation_map->fill(0);
+		return invalidation_map->data();
+	}
+
+	void Release(uint8_t* ptr)
+	{
+		pool.Release(reinterpret_cast<InvalidationMap*>(ptr));
+	}
+};
+
+// Single object pool for all the invalidation maps
+InvalidationMapPool invalidation_map_pool = {};
+
 // the CodePageHandler class provides access to the contained
 // cache blocks and intercepts writes to the code for special treatment
 class CodePageHandler final : public PageHandler {
@@ -182,7 +210,7 @@ public:
 		memset(&hash_map,0,sizeof(hash_map));
 		memset(&write_map,0,sizeof(write_map));
 		if (invalidation_map) {
-			delete [] invalidation_map;
+			invalidation_map_pool.Release(invalidation_map);
 			invalidation_map = nullptr;
 		}
 	}
@@ -223,17 +251,6 @@ public:
 		return is_current_block;
 	}
 
-	uint8_t *alloc_invalidation_map() const
-	{
-		constexpr size_t map_size = 4096;
-		uint8_t *map = new (std::nothrow) uint8_t[map_size];
-		if (!map) {
-			E_Exit("failed to allocate invalidation_map");
-		}
-		memset(map, 0, map_size);
-		return map;
-	}
-
 	// the following functions will clean all cache blocks that are invalid
 	// now due to the write
 
@@ -259,7 +276,7 @@ public:
 				           // active_count is zero
 			return;
 		} else if (!invalidation_map) {
-			invalidation_map = alloc_invalidation_map();
+			invalidation_map = invalidation_map_pool.Acquire();
 		}
 		invalidation_map[addr]++;
 		InvalidateRange(addr,addr);
@@ -287,7 +304,7 @@ public:
 				           // active_count is zero
 			return;
 		} else if (!invalidation_map) {
-			invalidation_map = alloc_invalidation_map();
+			invalidation_map = invalidation_map_pool.Acquire();
 		}
 		host_addw(&invalidation_map[addr], 0x0101);
 		InvalidateRange(addr,addr+1);
@@ -315,7 +332,7 @@ public:
 				           // active_count is zero
 			return;
 		} else if (!invalidation_map) {
-			invalidation_map = alloc_invalidation_map();
+			invalidation_map = invalidation_map_pool.Acquire();
 		}
 		host_addd(&invalidation_map[addr], 0x01010101);
 		InvalidateRange(addr,addr+3);
@@ -342,7 +359,7 @@ public:
 			}
 		} else {
 			if (!invalidation_map)
-				invalidation_map = alloc_invalidation_map();
+				invalidation_map = invalidation_map_pool.Acquire();
 
 			invalidation_map[addr]++;
 			if (InvalidateRange(addr,addr)) {
@@ -375,7 +392,7 @@ public:
 			}
 		} else {
 			if (!invalidation_map)
-				invalidation_map = alloc_invalidation_map();
+				invalidation_map = invalidation_map_pool.Acquire();
 
 			host_addw(&invalidation_map[addr], 0x0101);
 			if (InvalidateRange(addr,addr+1)) {
@@ -408,7 +425,7 @@ public:
 			}
 		} else {
 			if (!invalidation_map)
-				invalidation_map = alloc_invalidation_map();
+				invalidation_map = invalidation_map_pool.Acquire();
 
 			host_addd(&invalidation_map[addr], 0x01010101);
 			if (InvalidateRange(addr,addr+3)) {

--- a/src/hardware/iohandler_containers.cpp
+++ b/src/hardware/iohandler_containers.cpp
@@ -73,7 +73,7 @@ constexpr io_val_t blocked_read(const io_port_t, const io_width_t)
 // type-sized IO handler API
 uint8_t read_byte_from_port(const io_port_t port)
 {
-	const auto [it, was_blocked] = io_read_byte_handler.emplace(port, blocked_read);
+	const auto [it, was_blocked] = io_read_byte_handler.try_emplace(port, blocked_read);
 	if (was_blocked)
 		LOG(LOG_IO, LOG_WARN)("Unhandled read from port %04Xh; blocking", port);
 	return it->second(port, io_width_t::byte) & 0xff;
@@ -109,7 +109,7 @@ constexpr void blocked_write(const io_port_t, const io_val_t, const io_width_t)
 
 void write_byte_to_port(const io_port_t port, const uint8_t val)
 {
-	const auto [it, was_blocked] = io_write_byte_handler.emplace(port, blocked_write);
+	const auto [it, was_blocked] = io_write_byte_handler.try_emplace(port, blocked_write);
 	if (was_blocked)
 		LOG(LOG_IO, LOG_WARN)("Unhandled write of value 0x%02x"
 		                      " (%u) to port %04Xh; blocking",

--- a/src/platform/visualc/config.h
+++ b/src/platform/visualc/config.h
@@ -77,6 +77,9 @@
 // Modern MSVC provides POSIX-like routines, so prefer that over built-in
 #define HAVE_STRNLEN
 
+// Modern MSVC provides the C++17 <memory_resource> header
+#define HAVE_MEMORY_RESOURCE
+
 // MSVC issues pedantic warnings on POSIX functions; for portability we don't
 // want to deal with these warnings, as the only way to avoid them is using
 // Microsoft-specific names and functions instead of POSIX conformant ones.


### PR DESCRIPTION
# Description

This PR uses an object pool to manage the invalidation maps used in the dynamic core's cache blocks. There can be thousands of cache blocks in flight, and their invalidation maps can come and go in rapid succession.

This PR switches to using `try_emplace` in the IO port byte handlers. The 'try_emplace' versus 'emplace' avoids creating a temporary object on the heap before emplacing.  `try_emplace` was added in C++17 is usually an improvement -- https://stackoverflow.com/a/46047547  (in this case, I'm suggesting we use it here because the IO ports can be hit tens of thousands of times a second).

I tested with optimised release builds to be sure the compiler has done all of its smart temporary value elimination and code elision.

On the raspberry pi, I used 'heaptrack /path/to/dosbox' to monitor heap allocations.

Before the PR, 60 second run of Quake timedemo 320x200:
 - Heap allocations: 700,000
 - Temporary heap allocation: 550,000

After the PR, 60 second run of Quake timedemo 320x200:
 - Heap allocations: 180,000
 - Temporary heap allocation: 14,000

I looked into the remainder, and most of these happen at startup and shutdown - which is fine, however there's still some burned at runtime and those are caused by the raspberry pi's video driver.  As for SDL and OpenGL -> these libraries aren't making any heap call during the runtime phase, which is great news. 

## Related issues

None.

# Manual testing

Tested various games, applications, and Windows 3.11 for workgroups.

For those on Linux, you can check on your system by installing 'heaptrack' and 'heaptrack-gui'.  I used optimized builds for comparisons.

Then launch with: `heaptrack /path/to/dosbox`

When DOSBox Staging quits, heaptrack will automatically open the results in its GUI.

Performance might have ticked up by a frame or two on the Pi. I was getting max results slightly better than I've been getting before with `main`.

Comparison of allocations (top=before, bottom=after):

![allocations](https://github.com/dosbox-staging/dosbox-staging/assets/165201780/201569aa-a267-4aea-9dfe-c2ba7500e1fe)

Comparison of temporary allocations (top=before, bottom=after):

![temporary_allocations](https://github.com/dosbox-staging/dosbox-staging/assets/165201780/5efd33bd-5df4-4cd3-8ad3-eb7a97bd966c)


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

