### PR TITLE
Fix Ring Buffer PrevIndex() wrapping behavior for non power of 2 size

### DIFF
--- a/include/ring_buffer.h
+++ b/include/ring_buffer.h
@@ -167,9 +167,10 @@ public:
 			--index;
 			index &= IndexMask;
 #else
-			--index;
-			if (index == array->size()) {
-				index = 0;
+			if (index == 0) {
+				index = array->size() - 1;
+			} else {
+				--index;
 			}
 #endif
 		}


### PR DESCRIPTION
# Description
This is currently a compile time constant that is hard-coded to off so there is no visible bug but might as well make this correct.

Wrapping behavior was wrong.  This would result in a crash the next time index would be used as it would wrap to the max value of `size_t`.

# Manual testing
Compiled and tested by setting `#define POWER_OF_TWO_ARRAY_SIZE 0`.  The only place I found that the decrement operator is called is in the ring buffer unit test.  On `main` with power of 2 turned off, the unit test fails with the following:

```
[ RUN      ] RingBuffer.iterator_sub_wraparound
/usr/bin/../lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/array:208: reference std::array<int, 16>::operator[](size_type) [_Tp = int, _Nm = 16]: Assertion '__n < this->size()' failed.
Aborted (core dumped)
```

With this PR, all tests pass.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

