### PR TITLE
Fix MMX crash on moralhardcandy

### DIFF
--- a/src/cpu/mmx.cpp
+++ b/src/cpu/mmx.cpp
@@ -107,9 +107,6 @@ MMX_reg* lookupRMregMM[256] = {
 
 void setFPUTagEmpty()
 {
-	FPU_SetCW(0x37F);
-	fpu.sw      = 0;
-	TOP         = FPU_GET_TOP();
 	fpu.tags[0] = TAG_Empty;
 	fpu.tags[1] = TAG_Empty;
 	fpu.tags[2] = TAG_Empty;


### PR DESCRIPTION
# Description

The MMX EMMS instruction should only set the FPU tags to empty, don't nuke any of the other FPU state. https://www.felixcloutier.com/x86/emms

## Related issues

#3793 

# Manual testing

Ran moralhardcandy, Heaven 7, Matrix, and Z.A.R. demo in MMX mode (zarmmx.exe).

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

