### PR TITLE
Fix programmatic toggling of the Sound Blaster Pro 2 output filter

### DIFF
--- a/include/bitops.h
+++ b/include/bitops.h
@@ -255,7 +255,7 @@ constexpr bool any(const T reg, const unsigned int bits)
 	return reg & static_cast<T>(bits);
 }
 
-// Check if the indicated bits is cleisd (not set)
+// Check if the indicated bits is cleared (not set)
 template <typename T>
 constexpr bool cleared(const T reg, const unsigned int bits)
 {

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -2332,15 +2332,15 @@ static void ctmixer_write(const uint8_t val)
 		// Output/Stereo Select
 		sb.mixer.stereo_enabled = bit::is(val, b1);
 
-		const auto last_filter_enabled = sb.mixer.filter_enabled;
-
-		// This is not a mistake; clearing bit 5 enables the filter as per
-		// the official Creative documentation.
-		sb.mixer.filter_enabled = bit::cleared(val, b5);
-
 		if (sb.type == SbType::SBPro2) {
 			// Toggling the filter programmatically is only possible
 			// on the Sound Blaster Pro 2.
+
+			const auto last_filter_enabled = sb.mixer.filter_enabled;
+
+			// This is not a mistake; clearing bit 5 enables the
+			// filter as per the official Creative documentation.
+			sb.mixer.filter_enabled = bit::cleared(val, b5);
 
 			if (sb.mixer.filter_configured &&
 			    sb.mixer.filter_enabled != last_filter_enabled) {

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -211,7 +211,7 @@ struct SbInfo {
 
 		bool stereo_enabled = false;
 
-		bool filter_enabled    = false;
+		bool filter_enabled    = true;
 		bool filter_configured = false;
 		bool filter_always_on  = false;
 


### PR DESCRIPTION
# Description

Previously, toggling the analog output filter programmatically on the Sound Blaster Pro 2 (`sbtype = sbpro2`) was flipped due to a coding error.

From the official "Sound Blaster Series Hardware Programming Guide" by Creative Labs ([download link](https://pdos.csail.mit.edu/6.828/2018/readings/hardware/SoundBlaster.pdf)), page 67:

<img width="476" alt="image" src="https://github.com/dosbox-staging/dosbox-staging/assets/698770/dbcd2e3a-758f-4328-b3d0-c59e0106ef21">

So the stereo bit was handled correctly (1=stereo, 0=mono), but the filter bit handling was inverted (0 means **ON**, and 1 means **OFF**!).

Nobody noticed this because sound card output filtering wasn't implemented in any DOSBox fork for a long time. DOSBox-X implemented output filtering before I did my own implementation from scratch, but the X code handles the filter bit incorrectly, too (@joncampbell123, you too might wanna fix this).

For people who think PCem/86box are more accurate than Staging: PCem doesn't handle the filter bit at all, but the 86box folks [got it right](https://github.com/86Box/86Box/blob/master/src/sound/snd_sb.c#L876). So that's a +1 for 86box 😎 


## Related issues

Fixes https://github.com/dosbox-staging/dosbox-staging/issues/2869

# Manual testing

The analog output filter can only be programmatically toggled on the Sound Blaster Pro 2. It cannot be toggled on any other model, including the SB Pro 1.

So it's important to use the following config for testing:

```ini
[sblaster]
sbtype = sbpro2
sb_filter = auto
```

Use Creative's `SBP-SET.EXE` utility that came with the SB Pro 2 cards to toggle the filter:
[SBP-SET.zip](https://github.com/user-attachments/files/16173073/SBP-SET.zip)

## Test 1

1. Start Staging (use the above config).
2. Make sure the filter is enabled for startup (look for `SB: Low-pass filter enabled (12 dB/oct at 3200 Hz)` in the logs).
3. Disable the filter with `SBP-SET /dnfi:off`. You'll see the following log entry when using a debug build:

   
    <img width="523" alt="image" src="https://github.com/dosbox-staging/dosbox-staging/assets/698770/6575e155-2e0e-4c18-a35c-737f6b8279fd">

4. Enable the filter with `SBP-SET /dnfi:on`. This should be logged:

    <img width="670" alt="image" src="https://github.com/dosbox-staging/dosbox-staging/assets/698770/bbfa7010-e9f9-4463-abe3-2c644f82c27f">


## Test 2

1. Disable the filter as per above.
2. Start DOOM (eXoDOS version) and confirm the game enables the filter:

    <img width="1340" alt="image" src="https://github.com/dosbox-staging/dosbox-staging/assets/698770/e2c72627-8c39-46b6-afc5-532f61110b3a">

3. Exit DOOM and confirm the game disables the filter on exit:

    <img width="1319" alt="image" src="https://github.com/dosbox-staging/dosbox-staging/assets/698770/7dd4d2fc-a567-42bb-a021-88a80801620e">



# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

