### PR TITLE
Add bisecting notes to build documentation

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -255,6 +255,24 @@ Concrete example:
 ./build/debug/tests/bitops --gtest_filter=bitops.nominal_byte
 ```
 
+### Bisecting and building old versions
+
+To automate and ensure successful builds when bisecting or building old
+versions, run `meson setup --wipe` on your build area before every build.
+
+This updates the build area with critical metadata to match that of the
+checked out sources, such as the C++ language standard.
+
+An alias like the following can be used on macOS, Linux, and Windows MSYS
+environments to build versions 0.77 and newer:
+
+`alias build_staging='meson setup --wipe build && ninja -C build'`
+
+Prior to version 0.77 the Autotools build system was used. A build script
+available in these old versions can be used (choose one for your compiler):
+
+`./scripts/build.sh -c clang -t release` or `./scripts/build.sh -c gcc -t release`
+
 ### Build test coverage report
 
 Prerequisite: Install Clang's `lcov` package and/or the GCC-equivalent `gcovr` package.


### PR DESCRIPTION
# Description

Add bisecting notes to build documentation

## Related issues

Fixes https://github.com/dosbox-staging/dosbox-staging/issues/3693


# Manual testing

Confirmed recommended commands work on old and new source versions.

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [ ] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [x] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [x] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

