### PR TITLE
Add comment about PPC64 big-endian and running 32-bit BE code

### DIFF
--- a/src/cpu/meson.build
+++ b/src/cpu/meson.build
@@ -23,7 +23,7 @@ core_selection = [
     [ ['aarch64'],                ['auto', 'dynrec'],  'C_DYNREC',      'ARMV8LE', 1,         1 ], # ARMv8+ (64-bit)
     [ ['arm'],                    ['auto', 'dynrec'],  'C_DYNREC',      'ARMV7LE', 1,         1 ], # ARMv7+
     [ ['armv6'],                  ['auto', 'dynrec'],  'C_DYNREC',      'ARMV4LE', 0,         0 ], # ARMv6 or older
-    [ ['ppc64',   'powerpc64'],   ['auto', 'dynrec'],  'C_DYNREC',      'POWERPC', 1,         1 ], # 64 bit PPC processors
+    [ ['ppc64',   'powerpc64'],   ['auto', 'dynrec'],  'C_DYNREC',      'POWERPC', 1,         1 ], # 64 bit PPC processors (big-endian), running 32-bit big-endian code
     [ ['ppc64le', 'powerpc64le'], ['auto', 'dynrec'],  'C_DYNREC',      'PPC64LE', 1,         1 ], # 64 bit PPC processors (little-endian)
     [ ['ppc',     'powerpc'],     ['auto', 'dynrec'],  'C_DYNREC',      'POWERPC', 1,         0 ], # 32 bit PPC processors (big-endian)
     [ ['mips'],                   ['auto', 'dynrec'],  'C_DYNREC',      'MIPSEL',  0,         0 ], # 32 bit MIPS processor


### PR DESCRIPTION
# Description

Capturing the outcome of [this discussion](https://github.com/dosbox-staging/dosbox-staging/pull/3826#discussion_r1683648975) into a comment.

# Manual testing

None, just adding to a comment

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [ ] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

I don't know how to add labels (maybe I don't have rights for that).

