### PR TITLE
Minor FPU cleanup

### DIFF
--- a/include/fpu.h
+++ b/include/fpu.h
@@ -20,9 +20,11 @@
 #ifndef DOSBOX_FPU_H
 #define DOSBOX_FPU_H
 
+#include <optional>
+
 #ifndef DOSBOX_DOSBOX_H
-//So the right config.h gets included for C_DEBUG
-#include "dosbox.h"
+	// So the right config.h gets included for C_DEBUG
+	#include "dosbox.h"
 #endif
 
 #ifndef DOSBOX_MEM_H
@@ -89,8 +91,8 @@ enum FPU_Round : uint8_t {
 struct FPU_rec {
 	FPU_Reg regs[9]         = {};
 #if !C_FPU_X86
-	int64_t regs_memcpy[9]  = {}; // for FILD/FIST 64-bit memcpy fix
-	bool use_regs_memcpy[9] = {};
+    // for FILD/FIST 64-bit memcpy fix
+	std::optional<int64_t> regs_memcpy[9] = {};
 #endif
 	FPU_P_Reg p_regs[9]     = {};
 	MMX_reg mmx_regs[8]     = {};

--- a/src/cpu/core_dynrec/dyn_fpu.h
+++ b/src/cpu/core_dynrec/dyn_fpu.h
@@ -41,16 +41,15 @@ static void FPU_FNSTCW(PhysPt addr){
 static void FPU_FFREE(Bitu st) {
 	fpu.tags[st] = TAG_Empty;
 #if !C_FPU_X86
-	fpu.use_regs_memcpy[st] = false;
-#endif
+	fpu.regs_memcpy[st].reset();
+	#endif
 }
 
-#if C_FPU_X86
-#include "../../fpu/fpu_instructions_x86.h"
-#else
-#include "../../fpu/fpu_instructions.h"
-#endif
-
+	#if C_FPU_X86
+		#include "../../fpu/fpu_instructions_x86.h"
+	#else
+		#include "../../fpu/fpu_instructions.h"
+	#endif
 
 static inline void dyn_fpu_top() {
 	gen_mov_word_to_reg(FC_OP2,(void*)(&TOP),true);

--- a/src/cpu/mmx.cpp
+++ b/src/cpu/mmx.cpp
@@ -116,4 +116,10 @@ void setFPUTagEmpty()
 	fpu.tags[6] = TAG_Empty;
 	fpu.tags[7] = TAG_Empty;
 	fpu.tags[8] = TAG_Valid; // is only used by us
+
+#if !C_FPU_X86
+	for (auto& reg_memcpy : fpu.regs_memcpy) {
+		reg_memcpy.reset();
+	}
+#endif
 }

--- a/src/fpu/fpu.cpp
+++ b/src/fpu/fpu.cpp
@@ -78,7 +78,7 @@ void FPU_GetPRegsTo(uint8_t dyn_regs[8][10])
 			*/
 
 static void EATREE(Bitu _rm){
-	const uint8_t group=(_rm >> 3) & 7;
+	const uint8_t group = (_rm >> 3) & 7;
 	switch(group){
 		case 0x00:	/* FADD */
 			FPU_FADD_EA(TOP);
@@ -117,15 +117,11 @@ void FPU_ESC0_EA(Bitu rm,PhysPt addr) {
 }
 
 void FPU_ESC0_Normal(Bitu rm) {
-	const uint8_t group=(rm >> 3) & 7;
-    const uint8_t sub=(rm & 7);
-	switch (group){
-	case 0x00:		/* FADD ST,STi */
-		FPU_FADD(TOP,STV(sub));
-		break;
-	case 0x01:		/* FMUL  ST,STi */
-		FPU_FMUL(TOP,STV(sub));
-		break;
+	const uint8_t group = (rm >> 3) & 7;
+	const uint8_t sub   = (rm & 7);
+	switch (group) {
+	case 0x00: /* FADD ST,STi */ FPU_FADD(TOP, STV(sub)); break;
+	case 0x01: /* FMUL  ST,STi */ FPU_FMUL(TOP, STV(sub)); break;
 	case 0x02:		/* FCOM  STi */
 		FPU_FCOM(TOP,STV(sub));
 		break;
@@ -151,56 +147,39 @@ void FPU_ESC0_Normal(Bitu rm) {
 }
 
 void FPU_ESC1_EA(Bitu rm,PhysPt addr) {
-// floats
-    const uint8_t group=(rm >> 3) & 7;
-    const uint8_t sub=(rm & 7);
-	switch(group){
+	const uint8_t group = (rm >> 3) & 7;
+	const uint8_t sub   = (rm & 7);
+	switch (group) {
 	case 0x00: /* FLD float*/
 		FPU_PREP_PUSH();
-		FPU_FLD_F32(addr,TOP);
+		FPU_FLD_F32(addr, TOP);
 		break;
-	case 0x01: /* UNKNOWN */
-		FPU_LOG_WARN(1,true,group,sub);
-		break;
-	case 0x02: /* FST float*/
-		FPU_FST_F32(addr);
-		break;
+	case 0x01: /* UNKNOWN */ FPU_LOG_WARN(1, true, group, sub); break;
+	case 0x02: /* FST float*/ FPU_FST_F32(addr); break;
 	case 0x03: /* FSTP float*/
 		FPU_FST_F32(addr);
 		FPU_FPOP();
 		break;
-	case 0x04: /* FLDENV */
-		FPU_FLDENV(addr);
-		break;
-	case 0x05: /* FLDCW */
-		FPU_FLDCW(addr);
-		break;
-	case 0x06: /* FSTENV */
-		FPU_FSTENV(addr);
-		break;
-	case 0x07:  /* FNSTCW*/
-		mem_writew(addr,fpu.cw);
-		break;
-	default:
-		FPU_LOG_WARN(1,true,group,sub);
-		break;
+	case 0x04: /* FLDENV */ FPU_FLDENV(addr); break;
+	case 0x05: /* FLDCW */ FPU_FLDCW(addr); break;
+	case 0x06: /* FSTENV */ FPU_FSTENV(addr); break;
+	case 0x07: /* FNSTCW*/ mem_writew(addr, fpu.cw); break;
+	default: FPU_LOG_WARN(1, true, group, sub); break;
 	}
 }
 
 void FPU_ESC1_Normal(Bitu rm) {
-    const uint8_t group=(rm >> 3) & 7;
-    const uint8_t sub=(rm & 7);
-	switch (group){
+	const uint8_t group = (rm >> 3) & 7;
+	const uint8_t sub   = (rm & 7);
+	switch (group) {
 	case 0x00: /* FLD STi */
-		{
-			Bitu reg_from=STV(sub);
-			FPU_PREP_PUSH();
-			FPU_FST(reg_from, TOP);
-			break;
-		}
-	case 0x01: /* FXCH STi */
-		FPU_FXCH(TOP,STV(sub));
+	{
+		Bitu reg_from = STV(sub);
+		FPU_PREP_PUSH();
+		FPU_FST(reg_from, TOP);
 		break;
+	}
+	case 0x01: /* FXCH STi */ FPU_FXCH(TOP, STV(sub)); break;
 	case 0x02: /* FNOP */
 		FPU_FNOP();
 		break;
@@ -325,7 +304,7 @@ void FPU_ESC1_Normal(Bitu rm) {
 		default:
 			FPU_LOG_WARN(1,false,group,sub);
 			break;
-	}
+	        }
 }
 
 
@@ -336,9 +315,9 @@ void FPU_ESC2_EA(Bitu rm,PhysPt addr) {
 }
 
 void FPU_ESC2_Normal(Bitu rm) {
-    const uint8_t group=(rm >> 3) & 7;
-    const uint8_t sub=(rm & 7);
-	switch(group){
+	const uint8_t group = (rm >> 3) & 7;
+	const uint8_t sub   = (rm & 7);
+	switch (group) {
 	case 0x05:
 		switch(sub){
 		case 0x01:		/* FUCOMPP */
@@ -359,10 +338,10 @@ void FPU_ESC2_Normal(Bitu rm) {
 
 
 void FPU_ESC3_EA(Bitu rm,PhysPt addr) {
-    const uint8_t group=(rm >> 3) & 7;
-    const uint8_t sub=(rm & 7);
-	switch(group){
-	case 0x00:	/* FILD */
+	const uint8_t group = (rm >> 3) & 7;
+	const uint8_t sub   = (rm & 7);
+	switch (group) {
+	case 0x00: /* FILD */
 		FPU_PREP_PUSH();
 		FPU_FLD_I32(addr,TOP);
 		break;
@@ -391,8 +370,8 @@ void FPU_ESC3_EA(Bitu rm,PhysPt addr) {
 }
 
 void FPU_ESC3_Normal(Bitu rm) {
-    const uint8_t group = (rm >> 3) & 7;
-    const uint8_t sub = (rm & 7);
+	const uint8_t group = (rm >> 3) & 7;
+	const uint8_t sub   = (rm & 7);
 	switch (group) {
 	case 0x04:
 		switch (sub) {
@@ -429,15 +408,11 @@ void FPU_ESC4_EA(Bitu rm,PhysPt addr) {
 
 void FPU_ESC4_Normal(Bitu rm) {
 	/* LOOKS LIKE number 6 without popping */
-    const uint8_t group=(rm >> 3) & 7;
-    const uint8_t sub=(rm & 7);
-	switch(group){
-	case 0x00:	/* FADD STi,ST*/
-		FPU_FADD(STV(sub),TOP);
-		break;
-	case 0x01:	/* FMUL STi,ST*/
-		FPU_FMUL(STV(sub),TOP);
-		break;
+	const uint8_t group = (rm >> 3) & 7;
+	const uint8_t sub   = (rm & 7);
+	switch (group) {
+	case 0x00: /* FADD STi,ST*/ FPU_FADD(STV(sub), TOP); break;
+	case 0x01: /* FMUL STi,ST*/ FPU_FMUL(STV(sub), TOP); break;
 	case 0x02:  /* FCOM*/
 		FPU_FCOM(TOP,STV(sub));
 		break;
@@ -463,10 +438,10 @@ void FPU_ESC4_Normal(Bitu rm) {
 }
 
 void FPU_ESC5_EA(Bitu rm,PhysPt addr) {
-    const uint8_t group=(rm >> 3) & 7;
-    const uint8_t sub=(rm & 7);
-	switch(group){
-	case 0x00:  /* FLD double real*/
+	const uint8_t group = (rm >> 3) & 7;
+	const uint8_t sub   = (rm & 7);
+	switch (group) {
+	case 0x00: /* FLD double real*/
 		FPU_PREP_PUSH();
 		FPU_FLD_F64(addr,TOP);
 		break;
@@ -498,14 +473,13 @@ void FPU_ESC5_EA(Bitu rm,PhysPt addr) {
 }
 
 void FPU_ESC5_Normal(Bitu rm) {
-    const uint8_t group=(rm >> 3) & 7;
-    const uint8_t sub=(rm & 7);
-	switch(group){
-	case 0x00: /* FFREE STi */
-		fpu.tags[STV(sub)] = TAG_Empty;
-#if !C_FPU_X86
-		fpu.use_regs_memcpy[STV(sub)] = false;
-#endif
+	const uint8_t group = (rm >> 3) & 7;
+	const uint8_t sub   = (rm & 7);
+	switch (group) {
+	case 0x00: /* FFREE STi */ fpu.tags[STV(sub)] = TAG_Empty;
+	#if !C_FPU_X86
+		fpu.regs_memcpy[STV(sub)].reset();
+	#endif
 		break;
 	case 0x01: /* FXCH STi*/
 		FPU_FXCH(TOP,STV(sub));
@@ -539,15 +513,11 @@ void FPU_ESC6_EA(Bitu rm,PhysPt addr) {
 void FPU_ESC6_Normal(Bitu rm) {
 	/* all P variants working only on registers */
 	/* get top before switch and pop afterwards */
-    const uint8_t group=(rm >> 3) & 7;
-    const uint8_t sub=(rm & 7);
-	switch(group){
-	case 0x00:	/*FADDP STi,ST*/
-		FPU_FADD(STV(sub),TOP);
-		break;
-	case 0x01:	/* FMULP STi,ST*/
-		FPU_FMUL(STV(sub),TOP);
-		break;
+	const uint8_t group = (rm >> 3) & 7;
+	const uint8_t sub   = (rm & 7);
+	switch (group) {
+	case 0x00: /*FADDP STi,ST*/ FPU_FADD(STV(sub), TOP); break;
+	case 0x01: /* FMULP STi,ST*/ FPU_FMUL(STV(sub), TOP); break;
 	case 0x02:  /* FCOMP5*/
 		FPU_FCOM(TOP,STV(sub));
 		break;	/* TODO IS THIS ALLRIGHT ????????? */
@@ -579,10 +549,10 @@ void FPU_ESC6_Normal(Bitu rm) {
 
 
 void FPU_ESC7_EA(Bitu rm,PhysPt addr) {
-    const uint8_t group=(rm >> 3) & 7;
-    const uint8_t sub=(rm & 7);
-	switch(group){
-	case 0x00:  /* FILD int16_t */
+	const uint8_t group = (rm >> 3) & 7;
+	const uint8_t sub   = (rm & 7);
+	switch (group) {
+	case 0x00: /* FILD int16_t */
 		FPU_PREP_PUSH();
 		FPU_FLD_I16(addr,TOP);
 		break;
@@ -619,14 +589,13 @@ void FPU_ESC7_EA(Bitu rm,PhysPt addr) {
 }
 
 void FPU_ESC7_Normal(Bitu rm) {
-    const uint8_t group=(rm >> 3) & 7;
-    const uint8_t sub=(rm & 7);
-	switch (group){
-	case 0x00: /* FFREEP STi*/
-		fpu.tags[STV(sub)] = TAG_Empty;
-#if !C_FPU_X86
-		fpu.use_regs_memcpy[STV(sub)] = false;
-#endif
+	const uint8_t group = (rm >> 3) & 7;
+	const uint8_t sub   = (rm & 7);
+	switch (group) {
+	case 0x00: /* FFREEP STi*/ fpu.tags[STV(sub)] = TAG_Empty;
+	#if !C_FPU_X86
+		fpu.regs_memcpy[STV(sub)].reset();
+	#endif
 		FPU_FPOP();
 		break;
 	case 0x01: /* FXCH STi*/

--- a/src/fpu/fpu.cpp
+++ b/src/fpu/fpu.cpp
@@ -36,7 +36,7 @@ void FPU_FLDCW(PhysPt addr){
 uint16_t FPU_GetTag()
 {
 	uint16_t tag = 0;
-	for (Bitu i = 0; i < 8; i++) {
+	for (int i = 0; i < 8; i++) {
 		tag |= ((fpu.tags[i] & 3) << (2 * i));
 	}
 	return tag;
@@ -78,7 +78,7 @@ void FPU_GetPRegsTo(uint8_t dyn_regs[8][10])
 			*/
 
 static void EATREE(Bitu _rm){
-	Bitu group=(_rm >> 3) & 7;
+	const uint8_t group=(_rm >> 3) & 7;
 	switch(group){
 		case 0x00:	/* FADD */
 			FPU_FADD_EA(TOP);
@@ -117,8 +117,8 @@ void FPU_ESC0_EA(Bitu rm,PhysPt addr) {
 }
 
 void FPU_ESC0_Normal(Bitu rm) {
-	Bitu group=(rm >> 3) & 7;
-	Bitu sub=(rm & 7);
+	const uint8_t group=(rm >> 3) & 7;
+    const uint8_t sub=(rm & 7);
 	switch (group){
 	case 0x00:		/* FADD ST,STi */
 		FPU_FADD(TOP,STV(sub));
@@ -152,8 +152,8 @@ void FPU_ESC0_Normal(Bitu rm) {
 
 void FPU_ESC1_EA(Bitu rm,PhysPt addr) {
 // floats
-	Bitu group=(rm >> 3) & 7;
-	Bitu sub=(rm & 7);
+    const uint8_t group=(rm >> 3) & 7;
+    const uint8_t sub=(rm & 7);
 	switch(group){
 	case 0x00: /* FLD float*/
 		FPU_PREP_PUSH();
@@ -188,8 +188,8 @@ void FPU_ESC1_EA(Bitu rm,PhysPt addr) {
 }
 
 void FPU_ESC1_Normal(Bitu rm) {
-	Bitu group=(rm >> 3) & 7;
-	Bitu sub=(rm & 7);
+    const uint8_t group=(rm >> 3) & 7;
+    const uint8_t sub=(rm & 7);
 	switch (group){
 	case 0x00: /* FLD STi */
 		{
@@ -336,8 +336,8 @@ void FPU_ESC2_EA(Bitu rm,PhysPt addr) {
 }
 
 void FPU_ESC2_Normal(Bitu rm) {
-	Bitu group=(rm >> 3) & 7;
-	Bitu sub=(rm & 7);
+    const uint8_t group=(rm >> 3) & 7;
+    const uint8_t sub=(rm & 7);
 	switch(group){
 	case 0x05:
 		switch(sub){
@@ -359,8 +359,8 @@ void FPU_ESC2_Normal(Bitu rm) {
 
 
 void FPU_ESC3_EA(Bitu rm,PhysPt addr) {
-	Bitu group=(rm >> 3) & 7;
-	Bitu sub=(rm & 7);
+    const uint8_t group=(rm >> 3) & 7;
+    const uint8_t sub=(rm & 7);
 	switch(group){
 	case 0x00:	/* FILD */
 		FPU_PREP_PUSH();
@@ -391,8 +391,8 @@ void FPU_ESC3_EA(Bitu rm,PhysPt addr) {
 }
 
 void FPU_ESC3_Normal(Bitu rm) {
-	const auto group = static_cast<unsigned>((rm >> 3) & 7);
-	const auto sub = static_cast<unsigned>(rm & 7);
+    const uint8_t group = (rm >> 3) & 7;
+    const uint8_t sub = (rm & 7);
 	switch (group) {
 	case 0x04:
 		switch (sub) {
@@ -429,8 +429,8 @@ void FPU_ESC4_EA(Bitu rm,PhysPt addr) {
 
 void FPU_ESC4_Normal(Bitu rm) {
 	/* LOOKS LIKE number 6 without popping */
-	Bitu group=(rm >> 3) & 7;
-	Bitu sub=(rm & 7);
+    const uint8_t group=(rm >> 3) & 7;
+    const uint8_t sub=(rm & 7);
 	switch(group){
 	case 0x00:	/* FADD STi,ST*/
 		FPU_FADD(STV(sub),TOP);
@@ -463,8 +463,8 @@ void FPU_ESC4_Normal(Bitu rm) {
 }
 
 void FPU_ESC5_EA(Bitu rm,PhysPt addr) {
-	Bitu group=(rm >> 3) & 7;
-	Bitu sub=(rm & 7);
+    const uint8_t group=(rm >> 3) & 7;
+    const uint8_t sub=(rm & 7);
 	switch(group){
 	case 0x00:  /* FLD double real*/
 		FPU_PREP_PUSH();
@@ -498,8 +498,8 @@ void FPU_ESC5_EA(Bitu rm,PhysPt addr) {
 }
 
 void FPU_ESC5_Normal(Bitu rm) {
-	Bitu group=(rm >> 3) & 7;
-	Bitu sub=(rm & 7);
+    const uint8_t group=(rm >> 3) & 7;
+    const uint8_t sub=(rm & 7);
 	switch(group){
 	case 0x00: /* FFREE STi */
 		fpu.tags[STV(sub)] = TAG_Empty;
@@ -539,8 +539,8 @@ void FPU_ESC6_EA(Bitu rm,PhysPt addr) {
 void FPU_ESC6_Normal(Bitu rm) {
 	/* all P variants working only on registers */
 	/* get top before switch and pop afterwards */
-	Bitu group=(rm >> 3) & 7;
-	Bitu sub=(rm & 7);
+    const uint8_t group=(rm >> 3) & 7;
+    const uint8_t sub=(rm & 7);
 	switch(group){
 	case 0x00:	/*FADDP STi,ST*/
 		FPU_FADD(STV(sub),TOP);
@@ -579,8 +579,8 @@ void FPU_ESC6_Normal(Bitu rm) {
 
 
 void FPU_ESC7_EA(Bitu rm,PhysPt addr) {
-	Bitu group=(rm >> 3) & 7;
-	Bitu sub=(rm & 7);
+    const uint8_t group=(rm >> 3) & 7;
+    const uint8_t sub=(rm & 7);
 	switch(group){
 	case 0x00:  /* FILD int16_t */
 		FPU_PREP_PUSH();
@@ -619,8 +619,8 @@ void FPU_ESC7_EA(Bitu rm,PhysPt addr) {
 }
 
 void FPU_ESC7_Normal(Bitu rm) {
-	Bitu group=(rm >> 3) & 7;
-	Bitu sub=(rm & 7);
+    const uint8_t group=(rm >> 3) & 7;
+    const uint8_t sub=(rm & 7);
 	switch (group){
 	case 0x00: /* FFREEP STi*/
 		fpu.tags[STV(sub)] = TAG_Empty;

--- a/src/fpu/fpu_instructions.h
+++ b/src/fpu/fpu_instructions.h
@@ -374,7 +374,7 @@ static void FPU_FADD(Bitu op1, Bitu op2){
 }
 
 static void FPU_FSIN(void){
-	fpu.regs[TOP].d = sin(fpu.regs[TOP].d);
+	fpu.regs[TOP].d = std::sin(fpu.regs[TOP].d);
 	FPU_SET_C2(0);
 	//flags and such :)
 	return;
@@ -382,33 +382,33 @@ static void FPU_FSIN(void){
 
 static void FPU_FSINCOS(void){
 	Real64 temp = fpu.regs[TOP].d;
-	fpu.regs[TOP].d = sin(temp);
-	FPU_PUSH(cos(temp));
+	fpu.regs[TOP].d = std::sin(temp);
+	FPU_PUSH(std::cos(temp));
 	FPU_SET_C2(0);
 	//flags and such :)
 	return;
 }
 
 static void FPU_FCOS(void){
-	fpu.regs[TOP].d = cos(fpu.regs[TOP].d);
+	fpu.regs[TOP].d = std::cos(fpu.regs[TOP].d);
 	FPU_SET_C2(0);
 	//flags and such :)
 	return;
 }
 
 static void FPU_FSQRT(void){
-	fpu.regs[TOP].d = sqrt(fpu.regs[TOP].d);
+	fpu.regs[TOP].d = std::sqrt(fpu.regs[TOP].d);
 	//flags and such :)
 	return;
 }
 static void FPU_FPATAN(void){
-	fpu.regs[STV(1)].d = atan2(fpu.regs[STV(1)].d,fpu.regs[TOP].d);
+	fpu.regs[STV(1)].d = std::atan2(fpu.regs[STV(1)].d, fpu.regs[TOP].d);
 	FPU_FPOP();
 	//flags and such :)
 	return;
 }
 static void FPU_FPTAN(void){
-	fpu.regs[TOP].d = tan(fpu.regs[TOP].d);
+	fpu.regs[TOP].d = std::tan(fpu.regs[TOP].d);
 	FPU_PUSH(1.0);
 	FPU_SET_C2(0);
 	//flags and such :)
@@ -551,24 +551,24 @@ static void FPU_FXAM(void){
 
 
 static void FPU_F2XM1(void){
-	fpu.regs[TOP].d = pow(2.0,fpu.regs[TOP].d) - 1;
+	fpu.regs[TOP].d = std::pow(2.0, fpu.regs[TOP].d) - 1.0;
 	return;
 }
 
 static void FPU_FYL2X(void){
-	fpu.regs[STV(1)].d*=log(fpu.regs[TOP].d)/log(static_cast<Real64>(2.0));
+	fpu.regs[STV(1)].d *= std::log2(fpu.regs[TOP].d);
 	FPU_FPOP();
 	return;
 }
 
 static void FPU_FYL2XP1(void){
-	fpu.regs[STV(1)].d*=log(fpu.regs[TOP].d+1.0)/log(static_cast<Real64>(2.0));
+	fpu.regs[STV(1)].d *= std::log2(fpu.regs[TOP].d + 1.0);
 	FPU_FPOP();
 	return;
 }
 
 static void FPU_FSCALE(void){
-	fpu.regs[TOP].d *= pow(2.0,static_cast<Real64>(static_cast<int64_t>(fpu.regs[STV(1)].d)));
+	fpu.regs[TOP].d *= std::pow(2.0, std::trunc(fpu.regs[STV(1)].d));
 	//FPU_SET_C1(0);
 	return; //2^x where x is chopped.
 }
@@ -596,7 +596,7 @@ static void FPU_FLDENV(PhysPt addr){
 		tag    = mem_readw(addr+4);
 	} else { 
 		cw     = mem_readd(addr+0);
-		fpu.sw = (uint16_t)mem_readd(addr+4);
+		fpu.sw = static_cast<uint16_t>(mem_readd(addr+4));
 		tagbig = mem_readd(addr+8);
 		tag    = static_cast<uint16_t>(tagbig);
 	}
@@ -607,8 +607,8 @@ static void FPU_FLDENV(PhysPt addr){
 
 static void FPU_FSAVE(PhysPt addr){
 	FPU_FSTENV(addr);
-	Bitu start = (cpu.code.big?28:14);
-	for(Bitu i = 0;i < 8;i++){
+    PhysPt start = (cpu.code.big?28:14);
+	for(int i = 0;i < 8;i++){
 		FPU_ST80(addr+start,STV(i));
 		start += 10;
 	}
@@ -617,8 +617,8 @@ static void FPU_FSAVE(PhysPt addr){
 
 static void FPU_FRSTOR(PhysPt addr){
 	FPU_FLDENV(addr);
-	Bitu start = (cpu.code.big?28:14);
-	for(Bitu i = 0;i < 8;i++){
+	PhysPt start = (cpu.code.big?28:14);
+	for(int i = 0;i < 8;i++){
 		fpu.regs[STV(i)].d = FPU_FLD80(addr+start);
 		start += 10;
 	}
@@ -632,17 +632,17 @@ static void FPU_FXTRACT(void) {
 	FPU_Reg test = fpu.regs[TOP];
 	int64_t exp80 =  test.ll&LONGTYPE(0x7ff0000000000000);
 	int64_t exp80final = (exp80>>52) - BIAS64;
-	Real64 mant = test.d / (pow(2.0,static_cast<Real64>(exp80final)));
+	Real64 mant = test.d / (std::pow(2.0, static_cast<Real64>(exp80final)));
 	fpu.regs[TOP].d = static_cast<Real64>(exp80final);
 	FPU_PUSH(mant);
 }
 
 static void FPU_FCHS(void){
-	fpu.regs[TOP].d = -1.0*(fpu.regs[TOP].d);
+	fpu.regs[TOP].d = -(fpu.regs[TOP].d);
 }
 
 static void FPU_FABS(void){
-	fpu.regs[TOP].d = fabs(fpu.regs[TOP].d);
+	fpu.regs[TOP].d = std::fabs(fpu.regs[TOP].d);
 }
 
 static void FPU_FTST(void){


### PR DESCRIPTION
# Description

I wasn't able to fix the Critical Path issue (#610) yet, but I was reminded of a few things in the FPU code that annoyed me. This is a largely non-functional cleanup, but there a few small optimizations and one fix. 

I extended the single precision rounding fix to all rounding modes, instead of just `ROUND_Chop`. This is really only noticeable when logging the output, as I didn't notice any visible differences during e.g. Quake gameplay or any of the demos that heavily use single precision mode, but for consistency it should be done for all modes.

The minor optimizations are to the log-related functions.

The cleanup is mostly `std::` prefixing, some more de-Bitu-ing, and the bigger change of using `std::optional` for the array of the 64-bit FILD/FIST memcpy trick, thus eliminating the corresponding array of `bool` used to track the memcpy state.

# Manual testing

MCPDIAG gives the same result:

![CleanShot 2024-07-24 at 21 47 27@2x](https://github.com/user-attachments/assets/d6c36527-92ef-4cc4-bc9c-13813d624531)

 as `main`:

![CleanShot 2024-07-24 at 21 48 05@2x](https://github.com/user-attachments/assets/9c8e145d-d02d-4e23-8967-724c59d6e07d)

The Quake screen size option slider still works:

![CleanShot 2024-07-24 at 21 49 27@2x](https://github.com/user-attachments/assets/93db4db7-aff5-4408-b763-c20a64415035)

I also tested:

- Sunflower
- Carmageddon
- moralhardcandy
- Heaven 7
- Quake (QTD for performance)
- multikolor
- toontown
- Z.A.R. demo (MMX mode)
- matrix (MMX demo https://www.pouet.net/prod.php?which=1100)

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

