### PR TITLE
Improve redirection handling in the DOS shell

### DIFF
--- a/include/shell.h
+++ b/include/shell.h
@@ -131,11 +131,19 @@ public:
 
 	/* A load of subfunctions */
 	void ParseLine(char* line);
-	void GetRedirection(char* s, std::string& ifn, std::string& ofn,
-	                    std::string& pipe, bool* append);
 	void InputCommand(char* line);
 	void ShowPrompt();
 	void DoCommand(char* cmd);
+
+	// Returned by the GetRedirection(...) member function
+	struct RedirectionResults {
+		std::string processed_line = {};
+		std::string in_file        = {};
+		std::string out_file       = {};
+		std::string pipe_target    = {};
+		bool is_appending          = false;
+	};
+	static std::optional<RedirectionResults> GetRedirection(const std::string_view line);
 
 	// Execute external shell command / program / configuration change
 	// 'virtual' needed for unit tests


### PR DESCRIPTION
# Description

This fixes and improves the redirection handling in the DOS Shell.

- Adds many more unit tests based on real MS-DOS behavior.
    
- Now generates syntax errors when illegal combinations of redirection characters are used. For example, previously things like: `echo || dir`, `echo |< > hi`, and so on were processed but real MS-DOS genrates a syntax error and returns `ERRORLEVEL` `0`. Now we match this behavior.
    
- Fixes whitespace handling around output targets to match real MS-DOS. (See unit tests for details).
    
- Fixes multiple target handling to match real MS-DOS. For example, `echo hi>1>2>3` should only write to the file 3 but previously we couldn't handle this.
    
- Replaces all of the previous C-string code with a loop that iterates over regular expression matches.
    
- Refactors the function's previous style of modifying its arguments with a return struct of values.

## Related issues

Fixes #3829

# Manual testing

Tested X-Wing + B-Wing installation and compared countless variations of shell redirection handling against real MS-DOS.

Also tested (and ran unit tests) w/ sanitiser builds.

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [x] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

