### PR TITLE
Fix CD audio support on physical USB drives on Windows

### DIFF
--- a/src/dos/cdrom_win32.cpp
+++ b/src/dos/cdrom_win32.cpp
@@ -356,7 +356,11 @@ bool CDROM_Interface_Win32::HasDataTrack() const
 std::vector<int16_t> CDROM_Interface_Win32::ReadAudio(const uint32_t sector,
                                                       const uint32_t frames_requested)
 {
-	constexpr uint32_t MaximumFramesPerCall = 55;
+	// According to testing done so far:
+	// - 55 is the maximum for SerialATA drives
+	// - 27 is the maximum for USB drives
+	// Higher values makes the IOCTL_CDROM_RAW_READ fail.
+	constexpr uint32_t MaximumFramesPerCall = 27;
 	const uint32_t num_frames = std::min(frames_requested, MaximumFramesPerCall);
 
 	std::vector<int16_t> audio_frames(num_frames * SAMPLES_PER_REDBOOK_FRAME);


### PR DESCRIPTION
# Description

There is a problem with CD audio support under Windows if using a physical USB CD drive (SATA drives work fine), the CD audio does not play at all. Cause:
- IOCTL used to read audio tracks only accepts requests up to certain number of frames per call, value depending on the drive interface used
- previous implementation used a constant value which was thought to be good for any CD drive, but was found to be too high for USB drives

This PR lowers the value. Some auto-detection routines were discussed, but they were considered too complex. Example code attached below, in case anyone needs it in the future:

[old_solution.tar.gz](https://github.com/user-attachments/files/16402733/old_solution.tar.gz)

## Related issues

Fixes https://github.com/dosbox-staging/dosbox-staging/issues/3836


# Manual testing

I have used Windows 11 and different CD drives (change is irrelevant for non-Windows platforms).

Insert _Alone in the Dark 3_ game CD, mounted it using command `mount D X: -t cdrom`, try to play the game a little, try to play audio tracks using _DOS Navigator OSP 6.4.0_ (from the main menu  select: _Utilities_ -> _CD Player_).

Make sure to test both cases:
- audio track plays till the end and only then another one starts playing
- audio track is interrupted and another one starts playing

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

