### PR TITLE
Fix assert failure from incorrectly mapping result of SDL_GL_SwapInterval()

### DIFF
--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -2210,8 +2210,20 @@ uint8_t GFX_SetSize(const int render_width_px, const int render_height_px,
 	if (sdl.rendering_backend == RenderingBackend::OpenGl) {
 		static auto last_vsync_mode = VsyncMode::Unset;
 
-		const auto vsync_mode = static_cast<VsyncMode>(
-		        SDL_GL_GetSwapInterval());
+		auto vsync_mode = VsyncMode::Unset;
+		switch (SDL_GL_GetSwapInterval()) {
+		case -1:
+			vsync_mode = VsyncMode::Adaptive;
+			break;
+		case 0:
+			vsync_mode = VsyncMode::Off;
+			break;
+		case 1:
+			vsync_mode = VsyncMode::On;
+			break;
+		default:
+			assertm(false, "SDL_GL_GetSwapInterval() returned invalid result");
+		}
 
 		if (last_vsync_mode != vsync_mode) {
 			last_vsync_mode = vsync_mode;


### PR DESCRIPTION
# Description

Regression from https://github.com/dosbox-staging/dosbox-staging/commit/77e11e1dba0957ae33b90ef3304d56e4877a64b8

Result of `SDL_GL_SwapInterval()` was being cast to an enum but the SDL call can return a negative value.  Added a switch statement to explicitly map the result to a valid enum value.

## Related issues

Fixes #3843

# Manual testing

Crash was only reproducible for me when running with `SDL_VIDEODRIVER=x11`.  No longer crashes after this commit.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

