### PR TITLE
Use inline memory routines for MMX

### DIFF
--- a/src/cpu/core_dyn_x86/dyn_mmx.h
+++ b/src/cpu/core_dyn_x86/dyn_mmx.h
@@ -19,26 +19,39 @@
 
 #include "mmx.h"
 
+extern uint32_t* lookupRMEAregd[256];
+
+#define LoadMd(off)      mem_readd_inline(off)
+#define LoadMq(off)      mem_readq_inline(off)
+#define SaveMd(off, val) mem_writed_inline(off, val)
+#define SaveMq(off, val) mem_writeq_inline(off, val)
+
+#define CASE_0F_MMX(opcode) case (opcode):
+#define GetRM
+#define GetEAa
+#define Fetchb() imm
+#define GetEArd  uint32_t* eard = lookupRMEAregd[rm];
+
 static MMX_reg mmxtmp{};
 
 static void MMX_LOAD_32(PhysPt addr)
 {
-	mmxtmp.ud.d0 = mem_readd(addr);
+	mmxtmp.ud.d0 = LoadMd(addr);
 }
 
 static void MMX_STORE_32(PhysPt addr)
 {
-	mem_writed(addr, mmxtmp.ud.d0);
+	SaveMd(addr, mmxtmp.ud.d0);
 }
 
 static void MMX_LOAD_64(PhysPt addr)
 {
-	mmxtmp.q = mem_readq(addr);
+	mmxtmp.q = LoadMq(addr);
 }
 
 static void MMX_STORE_64(PhysPt addr)
 {
-	mem_writeq(addr, mmxtmp.q);
+	SaveMq(addr, mmxtmp.q);
 }
 
 // add simple instruction (that operates only with mm regs)
@@ -66,19 +79,6 @@ static void dyn_mmx_mem(Bitu op, Bitu reg = decode.modrm.reg, void* mem = &mmxtm
 	opcode((int)reg).setabsaddr(mem).Emit16((uint16_t)(0x0F | (op << 8)));
 #endif
 }
-
-extern uint32_t* lookupRMEAregd[256];
-
-#define LoadMd(off) mem_readd_inline(off)
-#define LoadMq(off) mem_readq_inline(off)
-#define SaveMd(off,val)	mem_writed_inline(off,val)
-#define SaveMq(off,val) mem_writeq_inline(off,val)
-
-#define CASE_0F_MMX(opcode) case(opcode):
-#define GetRM
-#define GetEAa
-#define Fetchb() imm
-#define GetEArd	uint32_t * eard=lookupRMEAregd[rm];
 
 static void dyn_mmx_op(Bitu op)
 {

--- a/src/cpu/core_dynrec/dyn_mmx.h
+++ b/src/cpu/core_dynrec/dyn_mmx.h
@@ -21,14 +21,14 @@
 
 extern uint32_t* lookupRMEAregd[256];
 
-#define LoadMb(off)      mem_readb(off)
-#define LoadMw(off)      mem_readw(off)
-#define LoadMd(off)      mem_readd(off)
-#define LoadMq(off)      mem_readq(off)
-#define SaveMb(off, val) mem_writeb(off, val)
-#define SaveMw(off, val) mem_writew(off, val)
-#define SaveMd(off, val) mem_writed(off, val)
-#define SaveMq(off, val) mem_writeq(off, val)
+#define LoadMb(off)      mem_readb_inline(off)
+#define LoadMw(off)      mem_readw_inline(off)
+#define LoadMd(off)      mem_readd_inline(off)
+#define LoadMq(off)      mem_readq_inline(off)
+#define SaveMb(off, val) mem_writeb_inline(off, val)
+#define SaveMw(off, val) mem_writew_inline(off, val)
+#define SaveMd(off, val) mem_writed_inline(off, val)
+#define SaveMq(off, val) mem_writeq_inline(off, val)
 
 static void mmx_movd_pqed(const Bitu rm, const PhysPt eaa = 0)
 {


### PR DESCRIPTION
# Description

Switching to the inline memory functions for MMX shows a significant increase in synthetic MMX benchmark scores:

`main`:
```log

       MMX Speed Test DOS Version 1.1 Mon Jul 29 17:36:25 2024
                 Copyright (C) 1997, Roy Longbottom

  Via Watcom Version 11, M = Standard Macros, E = Extended Macros

   Array Dimensions 512 64 bit words x 2, log file MMXres.txt

Test                        Passes   Secs     MOPS     MB/S    Result

Compare bytes pcmpeqb  M    550537   5.06    55.71    891.3  ff0000ff
Compare bytes pcmpeqb  E   1948051   5.11   195.19   3123.0  ff0000ff
Multiply add  pmaddwd  M    507936   4.89    53.18    850.9  00000020
Multiply add  pmaddwd  E   1886792   4.89   197.55   3160.9  00000020
Pack bytes    packuswb M    556521   5.22    54.59    873.4  efffff00
Pack bytes    packuswb E   1886792   4.94   195.55   3128.9  efffff00
Shift right   psrawi   M    680851   4.99    69.86    558.9  ffffffff
Shift right   psrawi   E   2272727   4.83   240.92   1927.3  ffffffff
Or 64 bits    por      M    551724   5.05    55.94    895.0  fff0f0ff
Or 64 bits    por      E   1807228   4.67   198.14   3170.2  fff0f0ff
42 ops plus moves      E    172043   4.78   773.98           01010101
```

branch:
```log
       MMX Speed Test DOS Version 1.1 Mon Jul 29 17:38:21 2024
                 Copyright (C) 1997, Roy Longbottom

  Via Watcom Version 11, M = Standard Macros, E = Extended Macros

   Array Dimensions 512 64 bit words x 2, log file MMXres.txt

Test                        Passes   Secs     MOPS     MB/S    Result

Compare bytes pcmpeqb  M    581818   4.99    59.70    955.2  ff0000ff
Compare bytes pcmpeqb  E   2479338   4.94   256.97   4111.5  ff0000ff
Multiply add  pmaddwd  M    556521   5.00    56.99    911.8  00000020
Multiply add  pmaddwd  E   2479338   5.00   253.88   4062.1  00000020
Pack bytes    packuswb M    556521   4.89    58.27    932.3  efffff00
Pack bytes    packuswb E   2380952   5.11   238.56   3817.0  efffff00
Shift right   psrawi   M    680851   4.78    72.93    583.4  ffffffff
Shift right   psrawi   E   3030303   5.22   297.23   2377.8  ffffffff
Or 64 bits    por      M    581818   4.95    60.18    962.9  fff0f0ff
Or 64 bits    por      E   2479338   4.95   256.45   4103.2  fff0f0ff
42 ops plus moves      E    183908   5.11   773.93           01010101

```

Low risk, low effort, high gain - my kind of tweak.

# Manual testing

Tested several MMX games and demos under ARM and x64:

- moralhardcandy
- matrix
- Z.A.R. demo (zarmmx.exe)
- Heaven 7

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

