### PR TITLE
Move mixer to a seperate thread

### DIFF
--- a/include/audio_vector.h
+++ b/include/audio_vector.h
@@ -1,0 +1,199 @@
+/*
+ *  Copyright (C) 2024-2024  The DOSBox Staging Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#ifndef AUDIO_VECTOR_H
+#define AUDIO_VECTOR_H
+
+#include <cstdint>
+#include <vector>
+
+#include "config.h"
+#include "mixer.h"
+
+// The producer constructs the object and the consumer calls AddSamples()
+
+// Currently only used by SoundBlaster
+// Think before using this for other audio devices
+// Usage of this class causes more heap allocations than adding samples directly to an RWQueue
+// SoundBlaster needs this because it can switch between different formats at runtime
+
+// Suitable where incoming samples are guaranteed to be little-endian,
+// such as DOS 16-bit DMA (SB and GUS), as well as raw bin+cue CDDA.
+// (Not suitable for synths that output 16-bit samples or the audio
+//  codecs, which produce host-endian samples)
+
+class AudioVector
+{
+public:
+	AudioVector(int _num_frames) : num_frames(_num_frames) {}
+	virtual ~AudioVector() = default;
+	virtual void AddSamples(MixerChannel* channel) = 0;
+	int num_frames = 0;
+};
+
+class AudioVectorM8 final : public AudioVector
+{
+public:
+	AudioVectorM8(int _num_frames, const uint8_t* _data)
+		: AudioVector(_num_frames),
+		  data(_data, _data + _num_frames) {}
+
+	void AddSamples(MixerChannel* channel) final
+	{
+		channel->AddSamples_m8(num_frames, data.data());
+	}
+private:
+	std::vector<uint8_t> data = {};
+};
+
+class AudioVectorM8S final : public AudioVector
+{
+public:
+	AudioVectorM8S(int _num_frames, const int8_t* _data)
+		: AudioVector(_num_frames),
+		  data(_data, _data + _num_frames) {}
+
+	void AddSamples(MixerChannel* channel) final
+	{
+		channel->AddSamples_m8s(num_frames, data.data());
+	}
+private:
+	std::vector<int8_t> data = {};
+};
+
+class AudioVectorS8 final : public AudioVector
+{
+public:
+	AudioVectorS8(int _num_frames, const uint8_t* _data)
+		: AudioVector(_num_frames),
+		  data(_data, _data + (_num_frames * 2)) {}
+
+	void AddSamples(MixerChannel* channel) final
+	{
+		channel->AddSamples_s8(num_frames, data.data());
+	}
+private:
+	std::vector<uint8_t> data = {};
+};
+
+class AudioVectorS8S final : public AudioVector
+{
+public:
+	AudioVectorS8S(int _num_frames, const int8_t* _data)
+		: AudioVector(_num_frames),
+		  data(_data, _data + (_num_frames * 2)) {}
+
+	void AddSamples(MixerChannel* channel) final
+	{
+		channel->AddSamples_s8s(num_frames, data.data());
+	}
+private:
+	std::vector<int8_t> data = {};
+};
+
+class AudioVectorS16 final : public AudioVector
+{
+public:
+	AudioVectorS16(int _num_frames, const int16_t* _data)
+		: AudioVector(_num_frames),
+		  data(_data, _data + (_num_frames * 2)) {}
+
+	void AddSamples(MixerChannel* channel) final
+	{
+		#if defined(WORDS_BIGENDIAN)
+		channel->AddSamples_s16_nonnative(num_frames, data.data());
+		#else
+		channel->AddSamples_s16(num_frames, data.data());
+		#endif
+	}
+private:
+	std::vector<int16_t> data = {};
+};
+
+class AudioVectorS16U final : public AudioVector
+{
+public:
+	AudioVectorS16U(int _num_frames, const uint16_t* _data)
+		: AudioVector(_num_frames),
+		  data(_data, _data + (_num_frames * 2)) {}
+
+	void AddSamples(MixerChannel* channel) final
+	{
+		#if defined(WORDS_BIGENDIAN)
+		channel->AddSamples_s16u_nonnative(num_frames, data.data());
+		#else
+		channel->AddSamples_s16u(num_frames, data.data());
+		#endif
+	}
+private:
+	std::vector<uint16_t> data = {};
+};
+
+class AudioVectorM16 final : public AudioVector
+{
+public:
+	AudioVectorM16(int _num_frames, const int16_t* _data)
+		: AudioVector(_num_frames),
+		  data(_data, _data + _num_frames) {}
+
+	void AddSamples(MixerChannel* channel) final
+	{
+		#if defined(WORDS_BIGENDIAN)
+		channel->AddSamples_m16_nonnative(num_frames, data.data());
+		#else
+		channel->AddSamples_m16(num_frames, data.data());
+		#endif
+	}
+private:
+	std::vector<int16_t> data = {};
+};
+
+class AudioVectorM16U final : public AudioVector
+{
+public:
+	AudioVectorM16U(int _num_frames, const uint16_t* _data)
+		: AudioVector(_num_frames),
+		  data(_data, _data + _num_frames) {}
+
+	void AddSamples(MixerChannel* channel) final
+	{
+		#if defined(WORDS_BIGENDIAN)
+		channel->AddSamples_m16u_nonnative(num_frames, data.data());
+		#else
+		channel->AddSamples_m16u(num_frames, data.data());
+		#endif
+	}
+private:
+	std::vector<uint16_t> data = {};
+};
+
+class AudioVectorStretched final : public AudioVector {
+public:
+	AudioVectorStretched(int _num_frames, const int16_t* _data)
+		: AudioVector(_num_frames),
+		  data(_data, _data + _num_frames) {}
+
+	void AddSamples(MixerChannel* channel) final
+	{
+		channel->AddStretched(num_frames, data.data());
+	}
+private:
+	std::vector<int16_t> data = {};
+};
+
+#endif

--- a/include/cpu.h
+++ b/include/cpu.h
@@ -54,13 +54,18 @@ enum class ArchitectureType {
 	Mixed           = 0xff,
 };
 
+// PIC_FullIndex() is used by the mixer thread for determining timing
+// Variables used in this calculation must be atomic or Clang's thread sanitizer complains
+// This includes CPU_Cycles, CPU_CycleLeft, and CPU_CycleMax
+// The rest can be left as normal variables
+
 // Current cycles values
-extern int CPU_Cycles;
-extern int CPU_CycleLeft;
+extern std::atomic<int> CPU_Cycles;
+extern std::atomic<int> CPU_CycleLeft;
 
 // Cycles settings for both "legacy" and "modern" modes
 extern bool CPU_CycleAutoAdjust;
-extern int CPU_CycleMax;
+extern std::atomic<int> CPU_CycleMax;
 extern int CPU_CyclePercUsed;
 extern int CPU_CycleLimit;
 

--- a/include/midi.h
+++ b/include/midi.h
@@ -211,7 +211,7 @@ void MIDI_Unmute();
 
 struct MidiWork {
 	std::vector<uint8_t> message      = {};
-	uint16_t num_pending_audio_frames = 0;
+	int num_pending_audio_frames      = 0;
 	MessageType message_type          = {};
 
 	// Default value constructor
@@ -221,7 +221,7 @@ struct MidiWork {
 
 	// Construct from movable values
 	MidiWork(std::vector<uint8_t>&& _message,
-	         const uint16_t _num_audio_frames_pending,
+	         const int _num_audio_frames_pending,
 	         const MessageType _message_type)
 	        : message(std::move(_message)),
 	          num_pending_audio_frames(_num_audio_frames_pending),

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -110,8 +110,8 @@ struct StereoLine {
 	bool operator==(const StereoLine other) const;
 };
 
-static constexpr StereoLine Stereo  = {Left, Right};
-static constexpr StereoLine Reverse = {Right, Left};
+static constexpr StereoLine StereoMap  = {Left, Right};
+static constexpr StereoLine ReverseMap = {Right, Left};
 
 enum class ChannelFeature {
 	ChorusSend,
@@ -345,11 +345,11 @@ private:
 
 	// User-configurable that defines how the channel's Stereo line maps
 	// into the mixer.
-	StereoLine output_map = Stereo;
+	StereoLine output_map = StereoMap;
 
 	// DOS application-configurable that maps the channels own "left" or
 	// "right" as themselves or vice-versa.
-	StereoLine channel_map = Stereo;
+	StereoLine channel_map = StereoMap;
 
 	bool last_samples_were_stereo  = false;
 	bool last_samples_were_silence = true;

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -322,7 +322,7 @@ private:
 	AudioFrame ConvertNextFrame(const Type* data, const int pos);
 
 	template <class Type, bool stereo, bool signeddata, bool nativeorder>
-	std::vector<AudioFrame> ConvertSamplesAndMaybeZohUpsample(const Type* data, const int frames);
+	void ConvertSamplesAndMaybeZohUpsample(const Type* data, const int frames);
 
 	void ConfigureResampler();
 	void ClearResampler();
@@ -334,6 +334,8 @@ private:
 	std::string name = {};
 	Envelope envelope;
 	MIXER_Handler handler = nullptr;
+
+	std::vector<AudioFrame> convert_buffer = {};
 
 	std::set<ChannelFeature> features = {};
 

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -456,6 +456,9 @@ void MIXER_DeregisterChannel(MixerChannelPtr& channel);
 void MIXER_AddConfigSection(const ConfigPtr& conf);
 int MIXER_GetSampleRate();
 int MIXER_GetPreBufferMs();
+
+void MIXER_EnableFastForwardMode();
+void MIXER_DisableFastForwardMode();
 bool MIXER_FastForwardModeEnabled();
 
 const AudioFrame MIXER_GetMasterVolume();

--- a/include/pic.h
+++ b/include/pic.h
@@ -19,14 +19,12 @@
 #ifndef DOSBOX_PIC_H
 #define DOSBOX_PIC_H
 
+#include <atomic>
 #include <cassert>
 #include <cmath>
 #include <cstdint>
 
-/* CPU Cycle Timing */
-extern int32_t CPU_Cycles;
-extern int32_t CPU_CycleLeft;
-extern int32_t CPU_CycleMax;
+#include "cpu.h"
 
 typedef void(PIC_EOIHandler)();
 typedef void (*PIC_EventHandler)(uint32_t val);
@@ -35,7 +33,7 @@ extern uint32_t PIC_IRQCheck;
 
 // Elapsed milliseconds since starting DOSBox
 // Holds ~4.2 B milliseconds or ~48 days before rolling over
-extern uint32_t PIC_Ticks;
+extern std::atomic<uint32_t> PIC_Ticks;
 
 // The number of cycles not done yet (ND)
 static inline int32_t PIC_TickIndexND()

--- a/include/rwqueue.h
+++ b/include/rwqueue.h
@@ -99,6 +99,10 @@ public:
 	//  return false and the item will not be queued.
 	bool Enqueue(T&& item);
 
+	// Returns false and does nothing if the queue is at capacity or the queue is not running
+	// Otherwise the item gets moved into the queue and it returns true
+	bool NonblockingEnqueue(T&& item);
+
 	// The method potentially blocks until there is at least a single item
 	// in the queue to dequeue.
 
@@ -130,6 +134,13 @@ public:
 	// stopping will be available in the queue however the items that came
 	// after stopping will not be queued.
 	bool BulkEnqueue(std::vector<T>& from_source, const size_t num_requested);
+
+	// Does nothing if queue is at capacity or queue is not running.
+	// Otherwise, enqueues as many elements as possible until the queue is at capacity.
+	// Moved elements will be erased from the source vector.
+	// Elements not enqueued will be left in the source vector.
+	// Returns the number of elements enqueued.
+	size_t NonblockingBulkEnqueue(std::vector<T>& from_source, const size_t num_requested);
 
 	// The target vector will be resized to accomodate, if needed. The
 	// method potentially blocks until the requested number of items have

--- a/src/dos/cdrom.cpp
+++ b/src/dos/cdrom.cpp
@@ -86,7 +86,7 @@ void CDROM_Interface::LagDriveResponse() const
 
 	// Handle tick-rollover
 	static decltype(PIC_Ticks) prev_ticks = 0;
-	prev_ticks = std::min(PIC_Ticks, prev_ticks);
+	prev_ticks = std::min(PIC_Ticks.load(), prev_ticks.load());
 
 	// Ensure results a monotonically increasing
 	auto since_last_response_ms = [=]() { return PIC_Ticks - prev_ticks; };
@@ -95,7 +95,7 @@ void CDROM_Interface::LagDriveResponse() const
 		CALLBACK_Idle();
 	}
 
-	prev_ticks = PIC_Ticks;
+	prev_ticks = PIC_Ticks.load();
 }
 
 void CDROM_Interface_Physical::CdReaderLoop()

--- a/src/dos/cdrom.cpp
+++ b/src/dos/cdrom.cpp
@@ -184,7 +184,7 @@ void CDROM_Interface_Physical::InitAudio()
 	thread = std::thread(&CDROM_Interface_Physical::CdReaderLoop, this);
 }
 
-void CDROM_Interface_Physical::CdAudioCallback(const uint16_t requested_frames)
+void CDROM_Interface_Physical::CdAudioCallback(const int requested_frames)
 {
 	assert(requested_frames > 0);
 

--- a/src/dos/cdrom.cpp
+++ b/src/dos/cdrom.cpp
@@ -172,6 +172,7 @@ void CDROM_Interface_Physical::InitAudio()
 		return;
 	}
 
+	MIXER_LockMixerThread();
 	auto callback = std::bind(&CDROM_Interface_Physical::CdAudioCallback,
 	                          this,
 	                          std::placeholders::_1);
@@ -182,6 +183,7 @@ void CDROM_Interface_Physical::InitAudio()
 	                                  ChannelFeature::DigitalAudio});
 
 	thread = std::thread(&CDROM_Interface_Physical::CdReaderLoop, this);
+	MIXER_UnlockMixerThread();
 }
 
 void CDROM_Interface_Physical::CdAudioCallback(const int requested_frames)

--- a/src/dos/cdrom.h
+++ b/src/dos/cdrom.h
@@ -363,7 +363,7 @@ private:
 	                 const uint16_t sectorSize,
 	                 const bool mode2);
 	std::vector<Track>::iterator GetTrack(const uint32_t sector);
-	void CDAudioCallBack(uint16_t desired_frames);
+	void CDAudioCallBack(const int desired_track_frames);
 
 	// Private functions for cue sheet processing
 	bool  LoadCueSheet(const char *cuefile);
@@ -398,7 +398,7 @@ protected:
 
 private:
 	virtual std::vector<int16_t> ReadAudio(const uint32_t sector, const uint32_t frames_requested) = 0;
-	void CdAudioCallback(const uint16_t requested_frames);
+	void CdAudioCallback(const int requested_frames);
 	void CdReaderLoop();
 
 	MixerChannelPtr mixer_channel  = {};

--- a/src/dos/cdrom_image.cpp
+++ b/src/dos/cdrom_image.cpp
@@ -488,6 +488,7 @@ CDROM_Interface_Image::CDROM_Interface_Image()
 {
 	if (refCount == 0) {
 		if (!player.channel) {
+			MIXER_LockMixerThread();
 			const auto mixer_callback = std::bind(&CDROM_Interface_Image::CDAudioCallBack,
 			                                      this, std::placeholders::_1);
 
@@ -498,6 +499,7 @@ CDROM_Interface_Image::CDROM_Interface_Image()
 			                                   ChannelFeature::DigitalAudio});
 
 			player.channel->Enable(false); // only enabled during playback periods
+			MIXER_UnlockMixerThread();
 		}
 #ifdef DEBUG
 		LOG_MSG("CDROM: Initialised the %s audio channel", ChannelName::CdAudio);
@@ -508,6 +510,7 @@ CDROM_Interface_Image::CDROM_Interface_Image()
 
 CDROM_Interface_Image::~CDROM_Interface_Image()
 {
+	MIXER_LockMixerThread();
 	refCount--;
 
 	// Stop playback before wiping out the CD Player
@@ -523,6 +526,7 @@ CDROM_Interface_Image::~CDROM_Interface_Image()
 	if (player.cd == this) {
 		player.cd = nullptr;
 	}
+	MIXER_UnlockMixerThread();
 }
 
 bool CDROM_Interface_Image::SetDevice(const char* path)

--- a/src/dos/cdrom_image.cpp
+++ b/src/dos/cdrom_image.cpp
@@ -997,7 +997,7 @@ bool CDROM_Interface_Image::ReadSectorsHost(void *buffer, bool raw, unsigned lon
 	return success;
 }
 
-void CDROM_Interface_Image::CDAudioCallBack(uint16_t desired_track_frames)
+void CDROM_Interface_Image::CDAudioCallBack(const int desired_track_frames)
 {
 	/**
 	 *  This callback runs in SDL's mixer thread, so there's a risk

--- a/src/dos/program_mixer.cpp
+++ b/src/dos/program_mixer.cpp
@@ -757,8 +757,6 @@ void MIXER::Run()
 
 	const auto args = cmd->GetArguments();
 
-	MIXER_LockAudioDevice();
-
 	auto result = MixerCommand::ParseCommands(args,
 	                                          create_channel_infos(),
 	                                          AllChannelNames);
@@ -788,8 +786,6 @@ void MIXER::Run()
 		LOG_WARNING("MIXER: Incorrect MIXER command invocation; "
 		            "run MIXER /? for help");
 	}
-
-	MIXER_UnlockAudioDevice();
 }
 
 void MIXER::AddMessages()
@@ -929,8 +925,6 @@ void MIXER::ShowMixerStatus()
 	const auto off_value      = MSG_Get("SHELL_CMD_MIXER_CHANNEL_OFF");
 	constexpr auto none_value = "-";
 
-	MIXER_LockAudioDevice();
-
 	constexpr auto master_channel_string = "[color=light-cyan]MASTER[reset]";
 
 	show_channel(convert_ansi_markup(master_channel_string),
@@ -984,6 +978,4 @@ void MIXER::ShowMixerStatus()
 		             reverb,
 		             chorus);
 	}
-
-	MIXER_UnlockAudioDevice();
 }

--- a/src/dos/program_mixer.cpp
+++ b/src/dos/program_mixer.cpp
@@ -309,10 +309,10 @@ static std::variant<Error, Command> parse_volume_command(const std::string& s,
 static std::optional<StereoLine> parse_stereo_mode(const std::string& s)
 {
 	if (s == "STEREO") {
-		return Stereo;
+		return StereoMap;
 	}
 	if (s == "REVERSE") {
-		return Reverse;
+		return ReverseMap;
 	}
 	return {};
 }

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -297,7 +297,7 @@ static void increase_ticks()
 		auto ratio = (ticks.scheduled * (CPU_CyclePercUsed * 1024 / 100)) /
 		             ticks.done;
 
-		auto new_cycle_max = CPU_CycleMax;
+		auto new_cycle_max = CPU_CycleMax.load();
 
 		auto cproc = static_cast<int64_t>(CPU_CycleMax) *
 		             static_cast<int64_t>(ticks.scheduled);
@@ -417,7 +417,7 @@ static void increase_ticks()
 		// ticks.added > 15 but ticks.scheduled < 5, lower the cycles
 		// but do not reset the scheduled/done ticks to take them into
 		// account during the next auto cycle adjustment.
-		CPU_CycleMax /= 3;
+		CPU_CycleMax = CPU_CycleMax / 3;
 
 		if (CPU_CycleMax < auto_cpu_cycles_min) {
 			CPU_CycleMax = auto_cpu_cycles_min;
@@ -461,7 +461,7 @@ static void DOSBOX_UnlockSpeed( bool pressed ) {
 		if (CPU_CycleAutoAdjust) {
 			autoadjust = true;
 			CPU_CycleAutoAdjust = false;
-			CPU_CycleMax /= 3;
+			CPU_CycleMax = CPU_CycleMax / 3;
 			if (CPU_CycleMax<1000) CPU_CycleMax=1000;
 		}
 	} else {

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -457,6 +457,7 @@ static void DOSBOX_UnlockSpeed( bool pressed ) {
 	if (pressed) {
 		LOG_MSG("Fast Forward ON");
 		ticks.locked = true;
+		MIXER_EnableFastForwardMode();
 
 		if (CPU_CycleAutoAdjust) {
 			autoadjust = true;
@@ -467,6 +468,7 @@ static void DOSBOX_UnlockSpeed( bool pressed ) {
 	} else {
 		LOG_MSG("Fast Forward OFF");
 		ticks.locked = false;
+		MIXER_DisableFastForwardMode();
 
 		if (autoadjust) {
 			autoadjust = false;

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -4544,8 +4544,6 @@ static int edit_primary_config()
 extern void DEBUG_ShutDown(Section * /*sec*/);
 #endif
 
-void MIXER_CloseAudioDevice();
-
 void restart_dosbox(std::vector<std::string> &parameters) {
 #ifdef WIN32
 	std::string command_line = {};

--- a/src/hardware/gameblaster.h
+++ b/src/hardware/gameblaster.h
@@ -83,6 +83,8 @@ private:
 
 	std::queue<AudioFrame> fifo = {};
 
+	std::mutex mutex = {};
+
 	// Static rate-related configuration
 	static constexpr auto ChipClockHz   = 14318180 / 2;
 	static constexpr auto RenderDivisor = 32;

--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -254,7 +254,7 @@ private:
 	Gus& operator=(const Gus&) = delete; // prevent assignment
 
 	void ActivateVoices(uint8_t requested_voices);
-	void AudioCallback(uint16_t requested_frames);
+	void AudioCallback(const int requested_frames);
 	void CheckIrq();
 	void CheckVoiceIrq();
 	uint32_t GetDmaOffset() noexcept;
@@ -757,7 +757,7 @@ void Gus::RenderUpToNow()
 	}
 }
 
-void Gus::AudioCallback(const uint16_t num_requested_frames)
+void Gus::AudioCallback(const int num_requested_frames)
 {
 	assert(audio_channel);
 

--- a/src/hardware/imfc.cpp
+++ b/src/hardware/imfc.cpp
@@ -13359,6 +13359,7 @@ static void IMFC_Mixer_Callback(const int requested_frames)
 
 void imfc_destroy(Section* /*sec*/)
 {
+	MIXER_LockMixerThread();
 	imfc = {};
 
 #if IMFC_VERBOSE_LOGGING
@@ -13366,6 +13367,7 @@ void imfc_destroy(Section* /*sec*/)
 	SDL_DestroyMutex(m_loggerMutex);
 	m_loggerMutex = nullptr;
 #endif
+	MIXER_UnlockMixerThread();
 }
 
 static void imfc_init(Section* sec)
@@ -13375,6 +13377,8 @@ static void imfc_init(Section* sec)
 	if (!conf || !conf->Get_bool("imfc")) {
 		return;
 	}
+
+	MIXER_LockMixerThread();
 
 #if IMFC_VERBOSE_LOGGING
 	m_loggerMutex = SDL_CreateMutex();
@@ -13438,6 +13442,8 @@ static void imfc_init(Section* sec)
 
 	constexpr auto changeable_at_runtime = true;
 	sec->AddDestroyFunction(&imfc_destroy, changeable_at_runtime);
+
+	MIXER_UnlockMixerThread();
 }
 
 void init_imfc_dosbox_settings(Section_prop& secprop)

--- a/src/hardware/imfc.cpp
+++ b/src/hardware/imfc.cpp
@@ -3134,7 +3134,7 @@ public:
 	void device_clock_changed();
 
 	// sound stream update overrides
-	void sound_stream_update(const uint16_t requested_frames);
+	void sound_stream_update(const int requested_frames);
 
 private:
 	AudioFrame RenderFrame();
@@ -5006,7 +5006,7 @@ void ym2151_device::RenderUpToNow()
 //  sound_stream_update - handle a stream update
 //-------------------------------------------------
 
-void ym2151_device::sound_stream_update(const uint16_t requested_frames)
+void ym2151_device::sound_stream_update(const int requested_frames)
 {
 	assert(audio_channel);
 
@@ -13216,7 +13216,7 @@ public:
 		SDL_UnlockMutex(m_hardwareMutex);
 	}
 
-	void mixerCallback(const uint16_t requested_frames)
+	void mixerCallback(const int requested_frames)
 	{
 		SDL_LockMutex(m_hardwareMutex);
 		m_ya2151.sound_stream_update(requested_frames);
@@ -13352,7 +13352,7 @@ static void Intel8253_TimerEvent(const uint32_t val)
 	imfc->onTimerEvent(val);
 }
 
-static void IMFC_Mixer_Callback(const uint16_t requested_frames)
+static void IMFC_Mixer_Callback(const int requested_frames)
 {
 	imfc->mixerCallback(requested_frames);
 }

--- a/src/hardware/innovation.cpp
+++ b/src/hardware/innovation.cpp
@@ -221,7 +221,7 @@ bool Innovation::MaybeRenderFrame(float &frame)
 	return frame_is_ready;
 }
 
-void Innovation::AudioCallback(const uint16_t requested_frames)
+void Innovation::AudioCallback(const int requested_frames)
 {
 	assert(channel);
 

--- a/src/hardware/innovation.h
+++ b/src/hardware/innovation.h
@@ -59,6 +59,7 @@ private:
 	IO_WriteHandleObject write_handler    = {};
 	std::unique_ptr<reSIDfp::SID> service = {};
 	std::queue<float> fifo                = {};
+	std::mutex mutex                      = {};
 
 	// Initial configuration
 	double chip_clock            = 0.0;

--- a/src/hardware/innovation.h
+++ b/src/hardware/innovation.h
@@ -47,7 +47,7 @@ public:
 
 private:
 	bool MaybeRenderFrame(float &frame);
-	void AudioCallback(const uint16_t requested_frames);
+	void AudioCallback(const int requested_frames);
 	uint8_t ReadFromPort(io_port_t port, io_width_t width);
 	void RenderUpToNow();
 	int16_t TallySilence(const int16_t sample);

--- a/src/hardware/input/mouse_manymouse.cpp
+++ b/src/hardware/input/mouse_manymouse.cpp
@@ -240,7 +240,7 @@ bool ManyMouseGlue::ProbeForMapping(uint8_t &physical_device_idx)
 
 	// Wait a little to speedup screen update
 	constexpr uint32_t ticks_threshold = 50; // time to wait idle in PIC ticks
-	const auto pic_ticks_start = PIC_Ticks;
+	const auto pic_ticks_start = PIC_Ticks.load();
 	while (PIC_Ticks >= pic_ticks_start &&
 	       PIC_Ticks - pic_ticks_start < ticks_threshold)
 		CALLBACK_Idle();

--- a/src/hardware/input/mouseif_ps2_bios.cpp
+++ b/src/hardware/input/mouseif_ps2_bios.cpp
@@ -825,7 +825,7 @@ static void bios_flush_aux()
 			IO_ReadB(port_num_i8042_data);
 		}
 
-		const auto start_ticks = PIC_Ticks;
+		const auto start_ticks = PIC_Ticks.load();
 		while (PIC_Ticks - start_ticks <= max_wait_ms) {
 			CALLBACK_Idle();
 			has_more = bios_is_aux_byte_waiting();

--- a/src/hardware/lpt_dac.cpp
+++ b/src/hardware/lpt_dac.cpp
@@ -23,9 +23,11 @@
 
 #include "dosbox.h"
 
+#include "math_utils.h"
 #include "pic.h"
 #include "setup.h"
 #include "support.h"
+#include "timer.h"
 
 #include "covox.h"
 #include "disney.h"
@@ -38,7 +40,13 @@ LptDac::LptDac(const std::string_view name, const int channel_rate_hz,
 	using namespace std::placeholders;
 
 	assert(!dac_name.empty());
-	const auto audio_callback = std::bind(&LptDac::AudioCallback, this, _1);
+
+	constexpr bool Stereo = true;
+	constexpr bool SignedData = true;
+	constexpr bool NativeOrder = true;
+	const auto audio_callback = std::bind(MIXER_PullFromQueueCallback<LptDac, AudioFrame, Stereo, SignedData, NativeOrder>,
+	                                      std::placeholders::_1,
+	                                      this);
 
 	std::set<ChannelFeature> features = {ChannelFeature::Sleep,
 	                                     ChannelFeature::ReverbSend,
@@ -93,29 +101,23 @@ void LptDac::RenderUpToNow()
 	assert(ms_per_frame > 0.0);
 	while (last_rendered_ms < now) {
 		last_rendered_ms += ms_per_frame;
-		render_queue.emplace(Render());
+		++frames_rendered_this_tick;
+		output_queue.NonblockingEnqueue(Render());
 	}
 }
 
-void LptDac::AudioCallback(const int requested_frames)
+void LptDac::PicCallback(const int requested_frames)
 {
 	assert(channel);
 
-	auto frames_remaining = requested_frames;
+	const auto frames_remaining = requested_frames - frames_rendered_this_tick;
 
-	// First, add any frames we've queued since the last callback
-	while (frames_remaining && render_queue.size()) {
-		channel->AddSamples_sfloat(1, &render_queue.front()[0]);
-		render_queue.pop();
-		--frames_remaining;
-	}
 	// If the queue's run dry, render the remainder and sync-up our time datum
-	while (frames_remaining) {
-		const auto frame = Render();
-		channel->AddSamples_sfloat(1, &frame[0]);
-		--frames_remaining;
+	for (int i = 0; i < frames_remaining; ++i) {
+		output_queue.NonblockingEnqueue(Render());
 	}
 	last_rendered_ms = PIC_FullIndex();
+	frames_rendered_this_tick = 0;
 }
 
 LptDac::~LptDac()
@@ -134,15 +136,27 @@ LptDac::~LptDac()
 	// Deregister the mixer channel, after which it's cleaned up
 	assert(channel);
 	MIXER_DeregisterChannel(channel);
-
-	render_queue = {};
 }
 
 std::unique_ptr<LptDac> lpt_dac = {};
 
+static void LPT_DAC_PicCallback()
+{
+	if (!lpt_dac || !lpt_dac->channel->is_enabled) {
+		return;
+	}
+	lpt_dac->frame_counter += lpt_dac->channel->GetFramesPerTick();
+	const auto requested_frames = ifloor(lpt_dac->frame_counter);
+	lpt_dac->frame_counter -= static_cast<float>(requested_frames);
+	lpt_dac->PicCallback(requested_frames);
+}
+
 void LPT_DAC_ShutDown([[maybe_unused]] Section *sec)
 {
+	MIXER_LockMixerThread();
+	TIMER_DelTickHandler(LPT_DAC_PicCallback);
 	lpt_dac.reset();
+	MIXER_UnlockMixerThread();
 }
 
 void LPT_DAC_Init(Section* section)
@@ -159,10 +173,13 @@ void LPT_DAC_Init(Section* section)
 	const std::string dac_choice = prop->Get_string("lpt_dac");
 
 	if (dac_choice == "disney") {
+		MIXER_LockMixerThread();
 		lpt_dac = std::make_unique<Disney>();
 	} else if (dac_choice == "covox") {
+		MIXER_LockMixerThread();
 		lpt_dac = std::make_unique<Covox>();
 	} else if (dac_choice == "ston1") {
+		MIXER_LockMixerThread();
 		lpt_dac = std::make_unique<StereoOn1>();
 	} else {
 		// The remaining setting is to turn the LPT DAC off
@@ -197,4 +214,11 @@ void LPT_DAC_Init(Section* section)
 
 	constexpr auto changeable_at_runtime = true;
 	section->AddDestroyFunction(&LPT_DAC_ShutDown, changeable_at_runtime);
+
+	// Size to 2x blocksize. The mixer callback will request 1x blocksize.
+	// This provides a good size to avoid over-runs and stalls.
+	lpt_dac->output_queue.Resize(iceil(lpt_dac->channel->GetFramesPerBlock() * 2.0f));
+	TIMER_AddTickHandler(LPT_DAC_PicCallback);
+
+	MIXER_UnlockMixerThread();
 }

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -2582,8 +2582,9 @@ static void mixer_thread_loop()
 			continue;
 		} else if (mixer.state == MixerState::Muted) {
 			// SDL callback remains active. Enqueue silence.
-			std::vector<AudioFrame> silence(mixer.blocksize);
-			mixer.final_output.BulkEnqueue(silence, silence.size());
+			mixer.output_buffer.clear();
+			mixer.output_buffer.resize(mixer.blocksize);
+			mixer.final_output.BulkEnqueue(mixer.output_buffer, mixer.output_buffer.size());
 			continue;
 		}
 

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -701,7 +701,7 @@ MixerChannelPtr MIXER_AddChannel(MIXER_Handler handler,
 
 		// We're only dealing with stereo channels internally, so we
 		// need to set the "stereo" line-out even for mono content.
-		chan->SetChannelMap(Stereo);
+		chan->SetChannelMap(StereoMap);
 
 		set_global_crossfeed(chan);
 		set_global_reverb(chan);
@@ -2298,10 +2298,10 @@ std::string MixerChannel::DescribeLineout() const
 	if (!HasFeature(ChannelFeature::Stereo)) {
 		return MSG_Get("SHELL_CMD_MIXER_CHANNEL_MONO");
 	}
-	if (output_map == Stereo) {
+	if (output_map == StereoMap) {
 		return MSG_Get("SHELL_CMD_MIXER_CHANNEL_STEREO");
 	}
-	if (output_map == Reverse) {
+	if (output_map == ReverseMap) {
 		return MSG_Get("SHELL_CMD_MIXER_CHANNEL_REVERSE");
 	}
 

--- a/src/hardware/opl.h
+++ b/src/hardware/opl.h
@@ -119,6 +119,7 @@ private:
 	IO_WriteHandleObject WriteHandler[3];
 
 	std::queue<AudioFrame> fifo = {};
+	std::mutex mutex = {};
 
 	OplChip chip[2]  = {};
 

--- a/src/hardware/pcspeaker.h
+++ b/src/hardware/pcspeaker.h
@@ -26,10 +26,15 @@
 #include <string_view>
 
 #include "mixer.h"
+#include "rwqueue.h"
 #include "timer.h"
 
 class PcSpeaker {
 public:
+	RWQueue<float> output_queue{1};
+	MixerChannelPtr channel = nullptr;
+	float frame_counter = 0.0f;
+
 	virtual ~PcSpeaker() = default;
 
 	virtual void SetFilterState(const FilterState filter_state) = 0;
@@ -37,6 +42,9 @@ public:
 	virtual void SetCounter(const int cntr, const PitMode pit_mode) = 0;
 	virtual void SetPITControl(const PitMode pit_mode)              = 0;
 	virtual void SetType(const PpiPortB &port_b)                    = 0;
+	virtual void PicCallback(const int requested_frames)            = 0;
 };
+
+extern std::unique_ptr<PcSpeaker> pc_speaker;
 
 #endif

--- a/src/hardware/pcspeaker_discrete.cpp
+++ b/src/hardware/pcspeaker_discrete.cpp
@@ -25,6 +25,7 @@
 #include <array>
 #include <cmath>
 #include <limits>
+#include <mutex>
 
 #include "checks.h"
 
@@ -339,16 +340,16 @@ void PcSpeakerDiscrete::SetType(const PpiPortB &b)
 	(void)channel->WakeUp();
 }
 
-void PcSpeakerDiscrete::ChannelCallback(const int frames)
+void PcSpeakerDiscrete::PicCallback(const int requested_frames)
 {
 	std::vector<float> output = {};
-	output.reserve(frames);
+	output.reserve(requested_frames);
 
 	ForwardPIT(1);
 	last_index       = 0.0f;
 	auto sample_base = 0.0f;
 
-	const auto period_per_frame_ms = FLT_EPSILON + 1.0f / static_cast<float>(frames);
+	const auto period_per_frame_ms = FLT_EPSILON + 1.0f / static_cast<float>(requested_frames);
 	// The addition of epsilon ensures that queued entries
 	// having time indexes at the end of the tick cycle (ie: .index == ~1.0)
 	// will still be accepted in the comparison below:
@@ -367,7 +368,7 @@ void PcSpeakerDiscrete::ChannelCallback(const int frames)
 	// Therefore, it's better to err on the side of accepting and processing
 	// entries versus queuing, to keep the queue under control.
 
-	for (auto i = 0; i < frames; ++i) {
+	for (auto i = 0; i < requested_frames; ++i) {
 		auto index = sample_base;
 		sample_base += period_per_frame_ms;
 		const auto end = sample_base;
@@ -423,7 +424,7 @@ void PcSpeakerDiscrete::ChannelCallback(const int frames)
 		output.push_back(value / period_per_frame_ms);
 	}
 
-	channel->AddSamples_mfloat(check_cast<int>(output.size()), output.data());
+	output_queue.NonblockingBulkEnqueue(output, output.size());
 }
 
 void PcSpeakerDiscrete::SetFilterState(const FilterState filter_state)
@@ -461,9 +462,12 @@ bool PcSpeakerDiscrete::TryParseAndSetCustomFilter(const std::string& filter_cho
 PcSpeakerDiscrete::PcSpeakerDiscrete()
 {
 	// Register the sound channel
-	const auto callback = std::bind(&PcSpeakerDiscrete::ChannelCallback,
-	                                this,
-	                                std::placeholders::_1);
+	constexpr bool Stereo = false;
+	constexpr bool SignedData = true;
+	constexpr bool NativeOrder = true;
+	const auto callback = std::bind(MIXER_PullFromQueueCallback<PcSpeakerDiscrete, float, Stereo, SignedData, NativeOrder>,
+	                                std::placeholders::_1,
+	                                this);
 
 	channel = MIXER_AddChannel(callback,
 	                           UseMixerRate,

--- a/src/hardware/pcspeaker_discrete.cpp
+++ b/src/hardware/pcspeaker_discrete.cpp
@@ -339,7 +339,7 @@ void PcSpeakerDiscrete::SetType(const PpiPortB &b)
 	(void)channel->WakeUp();
 }
 
-void PcSpeakerDiscrete::ChannelCallback(const uint16_t frames)
+void PcSpeakerDiscrete::ChannelCallback(const int frames)
 {
 	std::vector<float> output = {};
 	output.reserve(frames);
@@ -348,7 +348,7 @@ void PcSpeakerDiscrete::ChannelCallback(const uint16_t frames)
 	last_index       = 0.0f;
 	auto sample_base = 0.0f;
 
-	const auto period_per_frame_ms = FLT_EPSILON + 1.0f / frames;
+	const auto period_per_frame_ms = FLT_EPSILON + 1.0f / static_cast<float>(frames);
 	// The addition of epsilon ensures that queued entries
 	// having time indexes at the end of the tick cycle (ie: .index == ~1.0)
 	// will still be accepted in the comparison below:

--- a/src/hardware/pcspeaker_discrete.h
+++ b/src/hardware/pcspeaker_discrete.h
@@ -40,9 +40,9 @@ public:
 	void SetCounter(const int cntr, const PitMode m) final;
 	void SetPITControl(const PitMode) final {}
 	void SetType(const PpiPortB& b) final;
+	void PicCallback(const int requested_frames) final;
 
 private:
-	void ChannelCallback(const int frames);
 	void AddDelayEntry(const float index, float vol);
 	void ForwardPIT(const float newindex);
 	bool IsWaveSquare() const;
@@ -70,8 +70,6 @@ private:
 	};
 
 	std::queue<DelayEntry> entries = {};
-
-	MixerChannelPtr channel = nullptr;
 
 	PpiPortB port_b      = {};
 	PpiPortB prev_port_b = {};

--- a/src/hardware/pcspeaker_discrete.h
+++ b/src/hardware/pcspeaker_discrete.h
@@ -42,7 +42,7 @@ public:
 	void SetType(const PpiPortB& b) final;
 
 private:
-	void ChannelCallback(const uint16_t len);
+	void ChannelCallback(const int frames);
 	void AddDelayEntry(const float index, float vol);
 	void ForwardPIT(const float newindex);
 	bool IsWaveSquare() const;

--- a/src/hardware/pcspeaker_impulse.h
+++ b/src/hardware/pcspeaker_impulse.h
@@ -40,11 +40,11 @@ public:
 	void SetCounter(const int cntr, const PitMode pit_mode) final;
 	void SetPITControl(const PitMode pit_mode) final;
 	void SetType(const PpiPortB& port_b) final;
+	void PicCallback(const int requested_frames) final;
 
 private:
 	void AddImpulse(float index, const int16_t amplitude);
 	void AddPITOutput(const float index);
-	void ChannelCallback(int requested_frames);
 	void ForwardPIT(const float new_index);
 	float CalcImpulse(const double t) const;
 	void InitializeImpulseLUT();
@@ -113,8 +113,6 @@ private:
 	std::deque<float> waveform_deque = {};
 
 	std::array<float, sinc_filter_width> impulse_lut = {};
-
-	MixerChannelPtr channel = nullptr;
 
 	PpiPortB prev_port_b = {};
 

--- a/src/hardware/pic.cpp
+++ b/src/hardware/pic.cpp
@@ -134,7 +134,7 @@ struct PIC_Controller {
 static PIC_Controller pics[2];
 static PIC_Controller &primary_controller = pics[0];
 static PIC_Controller &secondary_controller = pics[1];
-uint32_t PIC_Ticks = 0;
+std::atomic<uint32_t> PIC_Ticks = 0;
 uint32_t PIC_IRQCheck = 0; // x86 dynamic core expects a 32 bit variable size
 
 void PIC_Controller::set_imr(uint8_t val) {
@@ -563,9 +563,9 @@ bool PIC_RunQueue(void) {
 		if (cycles < CPU_CycleLeft) {
 			CPU_Cycles = cycles;
 		} else {
-			CPU_Cycles=CPU_CycleLeft;
+			CPU_Cycles = CPU_CycleLeft.load();
 		}
-	} else CPU_Cycles=CPU_CycleLeft;
+	} else CPU_Cycles = CPU_CycleLeft.load();
 	CPU_CycleLeft-=CPU_Cycles;
 	if (PIC_IRQCheck) PIC_runIRQs();
 	return true;
@@ -603,8 +603,8 @@ void TIMER_AddTickHandler(TIMER_TickHandler handler) {
 
 void TIMER_AddTick(void) {
 	/* Setup new amount of cycles for PIC */
-	CPU_CycleLeft=CPU_CycleMax;
-	CPU_Cycles=0;
+	CPU_CycleLeft = CPU_CycleMax.load();
+	CPU_Cycles = 0;
 	PIC_Ticks++;
 	/* Go through the list of scheduled events and lower their index with 1000 */
 	PICEntry * entry=pic_queue.next_entry;

--- a/src/hardware/ps1audio.cpp
+++ b/src/hardware/ps1audio.cpp
@@ -2,7 +2,6 @@
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *
  *  Copyright (C) 2021-2024  The DOSBox Staging Team
- *  Copyright (C) 2002-2021  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/hardware/ps1audio.cpp
+++ b/src/hardware/ps1audio.cpp
@@ -65,7 +65,7 @@ public:
 private:
 	uint8_t CalcStatus() const;
 	void Reset(bool should_clear_adder);
-	void Update(uint16_t samples);
+	void Update(const int samples);
 
 	uint8_t ReadPresencePort02F(io_port_t port, io_width_t);
 	uint8_t ReadCmdResultPort200(io_port_t port, io_width_t);
@@ -373,14 +373,14 @@ uint8_t Ps1Dac::ReadJoystickPorts204To207(io_port_t, io_width_t)
 	return 0;
 }
 
-void Ps1Dac::Update(uint16_t samples)
+void Ps1Dac::Update(const int samples)
 {
 	uint8_t* buffer = MixTemp;
 
 	int32_t pending = 0;
 	uint32_t add    = 0;
 	uint32_t pos    = read_index_high;
-	uint16_t count  = samples;
+	int count       = samples;
 
 	if (is_playing) {
 		regs.status = CalcStatus();
@@ -394,7 +394,7 @@ void Ps1Dac::Update(uint16_t samples)
 		}
 	}
 
-	while (count) {
+	while (count > 0) {
 		uint8_t out = 0;
 		if (pending <= 0) {
 			pending = 0;
@@ -453,7 +453,7 @@ private:
 	Ps1Synth(const Ps1Synth&)            = delete;
 	Ps1Synth& operator=(const Ps1Synth&) = delete;
 
-	void AudioCallback(uint16_t requested_frames);
+	void AudioCallback(const int requested_frames);
 	float RenderSample();
 	void RenderUpToNow();
 
@@ -558,7 +558,7 @@ void Ps1Synth::WriteSoundGeneratorPort205(io_port_t, io_val_t value, io_width_t)
 	device.write(data);
 }
 
-void Ps1Synth::AudioCallback(const uint16_t requested_frames)
+void Ps1Synth::AudioCallback(const int requested_frames)
 {
 	assert(channel);
 

--- a/src/hardware/ps1audio.h
+++ b/src/hardware/ps1audio.h
@@ -1,0 +1,120 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2021-2024  The DOSBox Staging Team
+ *  Copyright (C) 2002-2021  The DOSBox Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+ #ifndef PS1AUDIO_H
+ #define PS1AUDIO_H
+
+ #include "inout.h"
+ #include "mixer.h"
+ #include "math_utils.h"
+ #include "rwqueue.h"
+
+ struct Ps1Registers {
+	// Read via port 0x202 control status
+	uint8_t status = 0;
+
+	// Written via port 0x202 for control, read via 0x200 for DAC
+	uint8_t command = 0;
+
+	// Read via port 0x203 for FIFO timing
+	uint8_t divisor = 0;
+
+	// Written via port 0x204 when FIFO is almost empty
+	uint8_t fifo_level = 0;
+};
+
+class Ps1Dac {
+public:
+	Ps1Dac(const std::string& filter_choice);
+	~Ps1Dac();
+	void PicCallback(const int frames_requested);
+
+	RWQueue<uint8_t> output_queue {1};
+	MixerChannelPtr channel = nullptr;
+	float frame_counter = 0.0f;
+
+private:
+	uint8_t CalcStatus() const;
+	void Reset(bool should_clear_adder);
+
+	uint8_t ReadPresencePort02F(io_port_t port, io_width_t);
+	uint8_t ReadCmdResultPort200(io_port_t port, io_width_t);
+	uint8_t ReadStatusPort202(io_port_t port, io_width_t);
+	uint8_t ReadTimingPort203(io_port_t port, io_width_t);
+	uint8_t ReadJoystickPorts204To207(io_port_t port, io_width_t);
+
+	void WriteDataPort200(io_port_t port, io_val_t value, io_width_t);
+	void WriteControlPort202(io_port_t port, io_val_t value, io_width_t);
+	void WriteTimingPort203(io_port_t port, io_val_t value, io_width_t);
+	void WriteFifoLevelPort204(io_port_t port, io_val_t value, io_width_t);
+
+	// Constants
+	static constexpr auto ClockRateHz        = 1'000'000;
+	static constexpr auto FifoSize           = 2048;
+	static constexpr auto FifoMaskSize       = FifoSize - 1;
+	static constexpr auto FifoNearlyEmptyVal = 128;
+
+	// Fixed precision
+	static constexpr auto FracShift = 12;
+
+	static constexpr auto FifoStatusReadyFlag = 0x10;
+	static constexpr auto FifoFullFlag        = 0x08;
+
+	static constexpr auto FifoEmptyFlag = 0x04;
+	// >= 1792 bytes free
+	static constexpr auto FifoNearlyEmptyFlag = 0x02;
+
+	// IRQ triggered by DAC
+	static constexpr auto FifoIrqFlag = 0x01;
+
+	static constexpr auto FifoMidline = ceil_udivide(static_cast<uint8_t>(UINT8_MAX),
+	                                                 2u);
+
+	static constexpr auto IrqNumber = 7;
+
+	static constexpr auto BytesPendingLimit = FifoSize << FracShift;
+
+	IO_ReadHandleObject read_handlers[5]   = {};
+	IO_WriteHandleObject write_handlers[4] = {};
+
+	Ps1Registers regs = {};
+
+	uint8_t fifo[FifoSize] = {};
+
+	// Counters
+	size_t last_write        = 0;
+	uint32_t adder           = 0;
+	uint32_t bytes_pending   = 0;
+	uint32_t read_index_high = 0;
+	uint32_t sample_rate_hz  = 0;
+	uint16_t read_index      = 0;
+	uint16_t write_index     = 0;
+	int8_t signal_bias       = 0;
+
+	// States
+	bool is_new_transfer = true;
+	bool is_playing      = false;
+	bool can_trigger_irq = false;
+};
+
+extern std::unique_ptr<Ps1Dac> ps1_dac;
+
+#endif

--- a/src/hardware/ps1audio.h
+++ b/src/hardware/ps1audio.h
@@ -2,7 +2,6 @@
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *
  *  Copyright (C) 2021-2024  The DOSBox Staging Team
- *  Copyright (C) 2002-2021  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/hardware/reelmagic/player.cpp
+++ b/src/hardware/reelmagic/player.cpp
@@ -761,7 +761,7 @@ static void DeactivatePlayerAudioFifo(AudioFifo& audio_fifo)
 	}
 }
 
-static void RMMixerChannelCallback(uint16_t frames_remaining)
+static void RMMixerChannelCallback(int frames_remaining)
 {
 	assert(active_fifo);
 	assert(mixer_channel);

--- a/src/hardware/reelmagic/player.h
+++ b/src/hardware/reelmagic/player.h
@@ -1,0 +1,32 @@
+/*
+ *  Copyright (C) 2022 Jon Dennis
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ */
+
+#ifndef REELMAGIC_PLAYER_H
+#define REELMAGIC_PLAYER_H
+
+#include "mixer.h"
+#include "rwqueue.h"
+
+struct ReelMagicAudio {
+	MixerChannelPtr channel = nullptr;
+	RWQueue<AudioFrame> output_queue{1};
+};
+
+extern ReelMagicAudio reel_magic_audio;
+
+#endif

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -2854,11 +2854,6 @@ static void sblaster_mixer_callback([[maybe_unused]]const int requested_frames)
 	// We can ignore requested frames as this function gets called in a loop until it gets what it needs
 	// Overflow is not a concern as extra frames will remain in the channel's buffer and get mixed on the next callback
 
-	// We must not block in fast-forward mode or the timings used by the mixer get confused
-	if (MIXER_FastForwardModeEnabled() && soundblaster_mixer_queue.IsEmpty()) {
-		sb.chan->AddSilence();
-		return;
-	}
 	const auto frames = soundblaster_mixer_queue.Dequeue();
 	if (!frames) {
 		// Queue must be stopped, otherwise Dequeue() will block until some frames are available

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -2894,9 +2894,9 @@ bool SB_GetAddress(uint16_t &sbaddr, uint8_t &sbirq, uint8_t &sbdma)
 	return (sbaddr != 0 && sbirq != 0 && sbdma != 0);
 }
 
-static void sblaster_callback(const uint32_t length)
+static void sblaster_callback(const int length)
 {
-	auto len = length;
+	uint32_t len = check_cast<uint32_t>(length);
 
 	switch (sb.mode) {
 	case DspMode::None:

--- a/src/hardware/tandy_sound.h
+++ b/src/hardware/tandy_sound.h
@@ -1,0 +1,91 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2019-2024  The DOSBox Staging Team
+ *  Copyright (C) 2002-2018  The DOSBox Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#ifndef TANDY_SOUND_H
+#define TANDY_SOUND_H
+
+#include "dma.h"
+#include "mixer.h"
+#include "rwqueue.h"
+
+enum class ConfigProfile {
+	TandySystem,
+	PcjrSystem,
+	SoundCardOnly,
+	SoundCardRemoved,
+};
+
+class TandyDAC {
+public:
+	struct IoConfig {
+		uint16_t base = 0;
+		uint8_t irq   = 0;
+		uint8_t dma   = 0;
+	};
+
+	struct Dma {
+		std::array<uint8_t, 128> fifo = {};
+		DmaChannel* channel           = nullptr;
+		bool is_done                  = false;
+	};
+
+	struct Registers {
+		uint16_t clock_divider = 0;
+		uint8_t mode           = 0;
+		uint8_t control        = 0;
+		uint8_t amplitude      = 0;
+		bool irq_activated     = false;
+	};
+
+    RWQueue<uint8_t> output_queue{1};
+	MixerChannelPtr channel = nullptr;
+	float frame_counter     = 0.0f;
+
+	// There's only one Tandy sound's IO configuration, so make it permanent
+	static constexpr IoConfig io = {0xc4, 7, 1};
+
+	TandyDAC(const ConfigProfile config_profile, const std::string& filter_choice);
+	~TandyDAC();
+
+	void PicCallback(const int requested);
+
+private:
+	void ChangeMode();
+
+	void DmaCallback(const DmaChannel* chan, DMAEvent event);
+	uint8_t ReadFromPort(io_port_t port, io_width_t);
+	void WriteToPort(io_port_t port, io_val_t value, io_width_t);
+
+	TandyDAC() = delete;
+
+	Dma dma = {};
+
+	IO_ReadHandleObject read_handler       = {};
+	IO_WriteHandleObject write_handlers[2] = {};
+
+	// States
+	Registers regs     = {};
+	int sample_rate_hz = 0;
+};
+
+extern std::unique_ptr<TandyDAC> tandy_dac;
+
+#endif

--- a/src/midi/midi_fluidsynth.cpp
+++ b/src/midi/midi_fluidsynth.cpp
@@ -738,7 +738,7 @@ void MidiHandlerFluidsynth::ApplySysexMessage(const std::vector<uint8_t>& msg)
 
 // The callback operates at the audio frame-level, steadily adding samples to
 // the mixer until the requested numbers of audio frames is met.
-void MidiHandlerFluidsynth::MixerCallBack(const uint16_t requested_audio_frames)
+void MidiHandlerFluidsynth::MixerCallBack(const int requested_audio_frames)
 {
 	assert(mixer_channel);
 
@@ -760,7 +760,7 @@ void MidiHandlerFluidsynth::MixerCallBack(const uint16_t requested_audio_frames)
 	                                                       requested_audio_frames);
 
 	if (has_dequeued) {
-		assert(audio_frames.size() == requested_audio_frames);
+		assert(check_cast<int>(audio_frames.size()) == requested_audio_frames);
 		mixer_channel->AddSamples_sfloat(requested_audio_frames,
 		                                 &audio_frames[0][0]);
 		last_rendered_ms = PIC_FullIndex();

--- a/src/midi/midi_fluidsynth.cpp
+++ b/src/midi/midi_fluidsynth.cpp
@@ -490,6 +490,8 @@ bool MidiHandlerFluidsynth::Open([[maybe_unused]] const char* conf)
 		        reverb_level);
 	}
 
+	MIXER_LockMixerThread();
+
 	// Setup the mixer callback
 	const auto mixer_callback = std::bind(&MidiHandlerFluidsynth::MixerCallBack,
 	                                      this,
@@ -564,6 +566,7 @@ bool MidiHandlerFluidsynth::Open([[maybe_unused]] const char* conf)
 
 	// Start playback
 	is_open = true;
+	MIXER_UnlockMixerThread();
 	return true;
 }
 
@@ -579,6 +582,8 @@ void MidiHandlerFluidsynth::Close()
 	}
 
 	LOG_MSG("FSYNTH: Shutting down");
+
+	MIXER_LockMixerThread();
 
 	if (had_underruns) {
 		LOG_WARNING("FSYNTH: Fix underruns by lowering CPU load, increasing "
@@ -614,6 +619,7 @@ void MidiHandlerFluidsynth::Close()
 	ms_per_audio_frame = 0.0;
 
 	is_open = false;
+	MIXER_UnlockMixerThread();
 }
 
 int MidiHandlerFluidsynth::GetNumPendingAudioFrames()

--- a/src/midi/midi_fluidsynth.cpp
+++ b/src/midi/midi_fluidsynth.cpp
@@ -616,7 +616,7 @@ void MidiHandlerFluidsynth::Close()
 	is_open = false;
 }
 
-uint16_t MidiHandlerFluidsynth::GetNumPendingAudioFrames()
+int MidiHandlerFluidsynth::GetNumPendingAudioFrames()
 {
 	const auto now_ms = PIC_FullIndex();
 
@@ -637,7 +637,7 @@ uint16_t MidiHandlerFluidsynth::GetNumPendingAudioFrames()
 	const auto num_audio_frames = iround(ceil(elapsed_ms / ms_per_audio_frame));
 	last_rendered_ms += (num_audio_frames * ms_per_audio_frame);
 
-	return check_cast<uint16_t>(num_audio_frames);
+	return num_audio_frames;
 }
 
 // The request to play the channel message is placed in the MIDI work FIFO
@@ -770,12 +770,12 @@ void MidiHandlerFluidsynth::MixerCallBack(const int requested_audio_frames)
 	}
 }
 
-void MidiHandlerFluidsynth::RenderAudioFramesToFifo(const uint16_t num_audio_frames)
+void MidiHandlerFluidsynth::RenderAudioFramesToFifo(const int num_audio_frames)
 {
 	static std::vector<AudioFrame> audio_frames = {};
 
 	// Maybe expand the vector
-	if (audio_frames.size() < num_audio_frames) {
+	if (check_cast<int>(audio_frames.size()) < num_audio_frames) {
 		audio_frames.resize(num_audio_frames);
 	}
 

--- a/src/midi/midi_fluidsynth.h
+++ b/src/midi/midi_fluidsynth.h
@@ -62,8 +62,8 @@ private:
 	void MixerCallBack(const int requested_audio_frames);
 	void ProcessWorkFromFifo();
 
-	uint16_t GetNumPendingAudioFrames();
-	void RenderAudioFramesToFifo(const uint16_t num_audio_frames = 1);
+	int GetNumPendingAudioFrames();
+	void RenderAudioFramesToFifo(const int num_audio_frames = 1);
 	void Render();
 
 	using FluidSynthSettingsPtr =

--- a/src/midi/midi_fluidsynth.h
+++ b/src/midi/midi_fluidsynth.h
@@ -59,7 +59,7 @@ public:
 private:
 	void ApplyChannelMessage(const std::vector<uint8_t>& msg);
 	void ApplySysexMessage(const std::vector<uint8_t>& msg);
-	void MixerCallBack(uint16_t requested_audio_frames);
+	void MixerCallBack(const int requested_audio_frames);
 	void ProcessWorkFromFifo();
 
 	uint16_t GetNumPendingAudioFrames();

--- a/src/midi/midi_mt32.cpp
+++ b/src/midi/midi_mt32.cpp
@@ -957,7 +957,7 @@ void MidiHandler_mt32::Close()
 	is_open = false;
 }
 
-uint16_t MidiHandler_mt32::GetNumPendingAudioFrames()
+int MidiHandler_mt32::GetNumPendingAudioFrames()
 {
 	const auto now_ms = PIC_FullIndex();
 
@@ -976,7 +976,7 @@ uint16_t MidiHandler_mt32::GetNumPendingAudioFrames()
 
 	const auto num_audio_frames = iround(ceil(elapsed_ms / ms_per_audio_frame));
 	last_rendered_ms += (num_audio_frames * ms_per_audio_frame);
-	return check_cast<uint16_t>(num_audio_frames);
+	return num_audio_frames;
 }
 
 // The request to play the channel message is placed in the MIDI work FIFO
@@ -1032,12 +1032,12 @@ void MidiHandler_mt32::MixerCallBack(const int requested_audio_frames)
 	}
 }
 
-void MidiHandler_mt32::RenderAudioFramesToFifo(const uint16_t num_frames)
+void MidiHandler_mt32::RenderAudioFramesToFifo(const int num_frames)
 {
 	static std::vector<AudioFrame> audio_frames = {};
 
 	// Maybe expand the vector
-	if (audio_frames.size() < num_frames) {
+	if (check_cast<int>(audio_frames.size()) < num_frames) {
 		audio_frames.resize(num_frames);
 	}
 

--- a/src/midi/midi_mt32.cpp
+++ b/src/midi/midi_mt32.cpp
@@ -826,6 +826,8 @@ bool MidiHandler_mt32::Open([[maybe_unused]] const char* conf)
 		return false;
 	}
 
+	MIXER_LockMixerThread();
+
 	const auto mixer_callback = std::bind(&MidiHandler_mt32::MixerCallBack,
 	                                      this,
 	                                      std::placeholders::_1);
@@ -900,6 +902,7 @@ bool MidiHandler_mt32::Open([[maybe_unused]] const char* conf)
 	set_thread_name(renderer, "dosbox:mt32");
 
 	is_open = true;
+	MIXER_UnlockMixerThread();
 	return true;
 }
 
@@ -921,6 +924,8 @@ void MidiHandler_mt32::Close()
 		            "or increasing your conf's prebuffer");
 		had_underruns = false;
 	}
+
+	MIXER_LockMixerThread();
 
 	// Stop playback
 	if (channel) {
@@ -955,6 +960,7 @@ void MidiHandler_mt32::Close()
 	ms_per_audio_frame = 0.0;
 
 	is_open = false;
+	MIXER_UnlockMixerThread();
 }
 
 int MidiHandler_mt32::GetNumPendingAudioFrames()

--- a/src/midi/midi_mt32.cpp
+++ b/src/midi/midi_mt32.cpp
@@ -999,7 +999,7 @@ void MidiHandler_mt32::PlaySysex(uint8_t* sysex, size_t len)
 
 // The callback operates at the audio frame-level, steadily adding samples to
 // the mixer until the requested numbers of audio frames is met.
-void MidiHandler_mt32::MixerCallBack(const uint16_t requested_audio_frames)
+void MidiHandler_mt32::MixerCallBack(const int requested_audio_frames)
 {
 	assert(channel);
 
@@ -1021,7 +1021,7 @@ void MidiHandler_mt32::MixerCallBack(const uint16_t requested_audio_frames)
 	                                                       requested_audio_frames);
 
 	if (has_dequeued) {
-		assert(audio_frames.size() == requested_audio_frames);
+		assert(check_cast<int>(audio_frames.size()) == requested_audio_frames);
 		channel->AddSamples_sfloat(requested_audio_frames,
 		                           &audio_frames[0][0]);
 

--- a/src/midi/midi_mt32.h
+++ b/src/midi/midi_mt32.h
@@ -79,8 +79,8 @@ private:
 	void MixerCallBack(const int requested_audio_frames);
 	void ProcessWorkFromFifo();
 
-	uint16_t GetNumPendingAudioFrames();
-	void RenderAudioFramesToFifo(const uint16_t num_frames = 1);
+	int GetNumPendingAudioFrames();
+	void RenderAudioFramesToFifo(const int num_frames = 1);
 	void Render();
 
 	// Managed objects

--- a/src/midi/midi_mt32.h
+++ b/src/midi/midi_mt32.h
@@ -76,7 +76,7 @@ public:
 
 private:
 	Mt32ServicePtr GetService();
-	void MixerCallBack(uint16_t len);
+	void MixerCallBack(const int requested_audio_frames);
 	void ProcessWorkFromFifo();
 
 	uint16_t GetNumPendingAudioFrames();

--- a/src/misc/meson.build
+++ b/src/misc/meson.build
@@ -26,6 +26,7 @@ libmisc_stubs_sources = libmisc_nomsg_sources + ['messages_stubs.cpp']
 libmisc_dependencies = [
     corefoundation_dep,
     ghc_dep,
+    libiir_dep,
     libloguru_dep,
     libslirp_dep,
     libwhereami_dep,

--- a/tests/program_mixer_tests.cpp
+++ b/tests/program_mixer_tests.cpp
@@ -298,7 +298,7 @@ TEST(ProgramMixer, Channel_SetVolumeChannelNameStartsWithLetterD)
 TEST(ProgramMixer, Channel_SetStereoModeStereo)
 {
 	auto expected = select_sb_channel();
-	expected.emplace(SetStereoMode{Stereo});
+	expected.emplace(SetStereoMode{StereoMap});
 
 	assert_success({"sb", "stereo"}, expected);
 }
@@ -306,7 +306,7 @@ TEST(ProgramMixer, Channel_SetStereoModeStereo)
 TEST(ProgramMixer, Channel_SetStereoModeReverse)
 {
 	auto expected = select_sb_channel();
-	expected.emplace(SetStereoMode{Reverse});
+	expected.emplace(SetStereoMode{ReverseMap});
 
 	assert_success({"sb", "reverse"}, expected);
 }
@@ -393,7 +393,7 @@ TEST(ProgramMixer, AllCommands)
 	expected.emplace(SelectChannel{"SB"});
 	expected.emplace(SetChorusLevel{0.09f});
 	expected.emplace(SetReverbLevel{0.20f});
-	expected.emplace(SetStereoMode{Reverse});
+	expected.emplace(SetStereoMode{ReverseMap});
 	expected.emplace(SetCrossfeedStrength{0.10f});
 	expected.emplace(SetVolume{AudioFrame(0.20f, 0.20f)});
 


### PR DESCRIPTION
# Description

The goal of this PR is to reduce the instances of audio stuttering that have been reported.  I've got it as one large commit right now.  I'm not sure it's really feasible to break it up.  The per-device changes don't make sense to do before I implement the thread and if I do them afterwards, you end up with a 1st commit that breaks a bunch of stuff that get fixed later (which ends up hurting more than it helps for bisecting purposes).

Previously, the mixer ran every 1ms inside a PIC callback on the main thread.  This causes stutters when something stalls the main thread causing the mixer to run late.  Now, the PIC callback has been removed and the mixer runs in a loop on a separate thread.

Per-channel audio callbacks are now run from the mixer thread.  In the "happy case" (OPL, MIDI, CDROM), I simply added some mutex locks and it just worked.

With the following devices, I had to add a PIC callback to generate audio on the main thread.  The PIC callback on these devices enqueues audio into an `RWQueue` for the mixer callback to read.  Some of these can be threaded at a later date.

- PC Speaker and LPT DAC (Disney and Covex) - Looks mostly thread safe but has assumptions about being called exactly once per ms.  These would probably be the easiest to thread in the future.
- SoundBlaster. Tandy DAC, and PS/1 DAC - Uses DMA which is not thread safe and I'm not familiar enough with DMA code to fix it.
- Reel Magic - This does MPEG audio and video decoding on the main thread.  Would probably require de-coupling the audio to make this thread-safe.

## Related issues

#3110

Probably more that I would need to search through the backlog for.

# Manual testing

All audio devices have been tested.

- OPL - Monkey Island 2, Doom, Tyrian
- SoundBlaster DMA - Doom, Quake, Tyrian
- SoundBlaster DAC - Alone in the Dark
- MT-32 - Eric the Unready, Space Quest 3
- Fluidsynth - Doom
- Gameblaster (CMS) - Silpheed
- GUS - Doom, Show (demoscene)
- IMFC - Police Quest 2
- Innovation - Red Storm Rising
- Disney Sound Source - Duke3D
- Covox - Heartlight
- PC Speaker (Impulse and Discrete) - Crystal Caves, Space Quest 1
- Reel Magic - The Horde
- Tandy (PSG and DAC) - Quest for Glory II - Trial by Combat
- PS/1 - Sierra Christmas Card
- Physical CDROM - Quake
- CDROM Image - Time Warriors

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

