### PR TITLE
Reinstate creating the Windows installer package in CI

### DIFF
--- a/.github/workflows/windows-msvc.yml
+++ b/.github/workflows/windows-msvc.yml
@@ -35,12 +35,12 @@ jobs:
     strategy:
       matrix:
         conf:
-          - name: MS Clang/LLVM 64-bit
+          - name: MS Clang/LLVM (x64)
             arch: x64
             max_warnings: 30
 
     steps:
-      - name: Checkout repository
+      - name: Check out repository
         uses: actions/checkout@v4
         with:
           submodules: false
@@ -89,11 +89,12 @@ jobs:
           MAX_WARNINGS: ${{ matrix.conf.max_warnings }}
         run: python scripts\count-warnings.py -f --msclang vs\build.log
 
+
   build_windows_vs_release:
     name: Release ${{ matrix.debugger && 'w/ debugger' || '' }} (${{ matrix.arch }})
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     outputs:
-      dosbox_version: ${{ steps.set_dosbox_vers.outputs.dosbox_vers }}
+      dosbox_version: ${{ steps.set_vars.outputs.dosbox_version }}
 
     runs-on: windows-2022
     strategy:
@@ -102,7 +103,7 @@ jobs:
         debugger: [false, true]
 
     steps:
-      - name: Checkout repository
+      - name: Check out repository
         uses: actions/checkout@v4
         with:
           submodules: false
@@ -133,17 +134,23 @@ jobs:
         shell: pwsh
         run:   .\scripts\log-env.ps1
 
-      - name:  Set version
-        id:    set_dosbox_vers
+      - name:  Set variables
+        id:    set_vars
+        shell: bash
+        run: |
+          set -x
+          echo "build_dir=vs/${{ matrix.arch }}/Release" >> $GITHUB_OUTPUT
+
+          VERSION=$(./scripts/get-version.sh version-and-hash)
+          echo "pkg_dir=dosbox-staging-windows-${{ matrix.arch }}-${VERSION}" >> $GITHUB_OUTPUT
+          echo "dosbox_version=${VERSION}" >> $GITHUB_OUTPUT
+
+      - name:  Set the Git hash in config.h
         shell: bash
         run: |
           set -x
           GIT_HASH=$(./scripts/get-version.sh hash)
           sed -i "s|BUILD_GIT_HASH \"git\"|BUILD_GIT_HASH \"$GIT_HASH\"|" src/platform/visualc/config.h
-
-          VERSION=$(./scripts/get-version.sh version-and-hash)
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
-          echo "dosbox_vers=${VERSION}" >> $GITHUB_OUTPUT
 
       - name:  Enable the debugger in config.h
         if: ${{ matrix.debugger }}
@@ -159,19 +166,15 @@ jobs:
           cd vs
           MSBuild -m dosbox.sln -t:dosbox:Rebuild -p:Configuration=Release -p:Platform=${{ matrix.arch }}
 
-      - name:  Set packaging names
-        id:    set_pkg_dir
-        shell: bash
-        run: |
-          echo "pkg_dir=dosbox-staging-windows-${{ matrix.arch }}-${{ env.VERSION }}" >> $GITHUB_OUTPUT
-
       - name: Package standard build
         if: ${{ !matrix.debugger }}
         shell: bash
         run: |
+          set -x
           # Construct VC_REDIST_DIR
           readonly VC_REDIST_BASE="C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Redist/MSVC"
           readonly VC_REDIST_CRT_VERSION="Microsoft.VC143.CRT"
+
           for ENTRY in "$VC_REDIST_BASE"/*
           do
               ENTRY=$ENTRY/${{ matrix.arch }}/$VC_REDIST_CRT_VERSION
@@ -188,46 +191,112 @@ jobs:
           # Package
           ./scripts/create-package.sh \
             -p msvc \
-            vs/${{ matrix.arch }}/Release \
-            "${{ steps.set_pkg_dir.outputs.pkg_dir }}"
-
-      - name:  Package the debugger
-        if:    ${{ matrix.debugger }}
-        shell: bash
-        run: |
-          set -x
-          mkdir -p ${{ steps.set_pkg_dir.outputs.pkg_dir }}
-          # Move the debugger build into the release area
-          readonly RELEASE_DIR=${{ matrix.arch }}/Release
-          ls "vs/$RELEASE_DIR"
-          cp vs/$RELEASE_DIR/dosbox.exe   ${{ steps.set_pkg_dir.outputs.pkg_dir }}/dosbox_with_debugger.exe
+            ${{ steps.set_vars.outputs.build_dir }} \
+            ${{ steps.set_vars.outputs.pkg_dir }}
 
       - name: Upload package
         if:   ${{ !matrix.debugger }}
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ steps.set_pkg_dir.outputs.pkg_dir }}-without-debugger
-          path: ${{ steps.set_pkg_dir.outputs.pkg_dir }}
+          name: ${{ steps.set_vars.outputs.pkg_dir }}-without-debugger
+          path: ${{ steps.set_vars.outputs.pkg_dir }}
           overwrite: true
+
+
+      - name:  Package the debugger build
+        if:    ${{ matrix.debugger }}
+        shell: bash
+        run: |
+          set -x
+          mkdir -p ${{ steps.set_vars.outputs.pkg_dir }}
+          # Move the debugger build into the release area
+          ls ${{ steps.set_vars.outputs.build_dir }}
+          cp ${{ steps.set_vars.outputs.build_dir }}/dosbox.exe ${{ steps.set_vars.outputs.pkg_dir }}/dosbox_with_debugger.exe
 
       - name: Upload debugger artifact
         if:   ${{ matrix.debugger }}
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ steps.set_pkg_dir.outputs.pkg_dir }}-with-debugger
-          path: ${{ steps.set_pkg_dir.outputs.pkg_dir }}/dosbox_with_debugger.exe
+          name: ${{ steps.set_vars.outputs.pkg_dir }}-with-debugger
+          path: ${{ steps.set_vars.outputs.pkg_dir }}/dosbox_with_debugger.exe
           overwrite: true
 
-  merge:
-    runs-on: ubuntu-latest
+
+  merge_artifacts:
+    name: Merge release & debugger artifacts (${{ matrix.arch }} )
     needs: build_windows_vs_release
+    outputs:
+      dosbox_version: ${{ needs.build_windows_vs_release.outputs.dosbox_version }}
+
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         arch: [x64, ARM64]
     steps:
-      - name: Merge ${{ matrix.arch }} artifacts
+      - name: Merge artifacts (${{ matrix.arch }} )
         uses: actions/upload-artifact/merge@v4
         with:
           name:    dosbox-staging-windows-${{ matrix.arch }}-${{ needs.build_windows_vs_release.outputs.dosbox_version }}
           pattern: dosbox-staging-windows-${{ matrix.arch }}-*
           delete-merged: 'true'
+
+
+  build_installer:
+    name: Build installer (${{ matrix.arch }} )
+    needs: merge_artifacts
+    runs-on: windows-2022
+    strategy:
+      matrix:
+        # We only provide x64 installers as ARM64 support is experimental
+        arch: [x64]
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          submodules: false
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+
+      - name:  Set variables
+        id:    set_vars
+        shell: bash
+        run: |
+          set -x
+          VERSION=${{ needs.merge_artifacts.outputs.dosbox_version }}
+          echo "pkg_dir=dosbox-staging-windows-${{ matrix.arch }}-${VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Prepare Windows installer
+        shell: bash
+        run: |
+          set -x
+          VERSION=${{ needs.merge_artifacts.outputs.dosbox_version }}
+          PACKAGE_INFO="release ${VERSION}"
+
+          mkdir -p out/program
+
+          sed -e "s|%PACKAGE_INFORMATION%|${PACKAGE_INFO}|;s|%GITHUB_REPO%|${{ github.repository }}|" docs/README.template >out/setup_preamble.txt
+          sed -i "s|DOSBOX-STAGING-VERSION|${VERSION}|" contrib/windows_installer/DOSBox-Staging-setup.iss
+
+          cp contrib/windows_installer/*                   out
+          cp contrib/icons/windows/dosbox-staging.ico      out
+          cp contrib/icons/windows/dosbox-staging.bmp      out
+          cp contrib/icons/windows/dosbox-staging-side.bmp out
+
+          mv ${{ steps.set_vars.outputs.pkg_dir }}/*       out/program
+          mv out/program/dosbox*.exe                       out
+
+      - name: Build Windows installer
+        shell: pwsh
+        run: |
+          cd out
+          C:\PROGRA~2\INNOSE~1\ISCC.exe DOSBox-Staging-setup.iss
+          dir
+
+      - name: Upload Windows installer
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.set_vars.outputs.pkg_dir }}-setup
+          path: ${{ github.workspace }}\out\${{ steps.set_vars.outputs.pkg_dir }}-setup.exe
+          overwrite: true

--- a/contrib/windows_installer/.gitattributes
+++ b/contrib/windows_installer/.gitattributes
@@ -1,0 +1,1 @@
+*	text eol=crlf

--- a/contrib/windows_installer/DOSBox-Staging-setup.iss
+++ b/contrib/windows_installer/DOSBox-Staging-setup.iss
@@ -5,8 +5,6 @@
 #define DOSBoxAppURL "https://www.dosbox-staging.org/"
 #define DOSBoxAppExeName "dosbox.exe"
 #define DOSBoxAppExeDebuggerName "dosbox_with_debugger.exe"
-#define DOSBoxAppExeMSVCName "dosbox_msvc.exe"
-#define DOSBoxAppExeMSVCDebuggerName "dosbox_msvc_with_debugger.exe"
 #define DOSBoxAppExeConsoleName "dosbox_with_console.bat"
 #define DOSBoxAppBuildDate GetDateTimeString('yyyymmdd_hhnnss', '', '')
 
@@ -25,7 +23,7 @@ DisableWelcomePage=no
 DisableProgramGroupPage=yes
 InfoBeforeFile=setup_preamble.txt
 OutputDir=.\
-OutputBaseFilename={#DOSBoxAppInternal}-{#DOSBoxAppVersion}-setup
+OutputBaseFilename={#DOSBoxAppInternal}-windows-x64-{#DOSBoxAppVersion}-setup
 SetupIconFile={#DOSBoxAppInternal}.ico
 Compression=lzma
 SolidCompression=yes
@@ -68,15 +66,12 @@ Name: "ukrainian"; MessagesFile: "compiler:Languages\Ukrainian.isl"
 
 [Tasks]
 Name: "contextmenu"; Description: "Add ""Run/Open with {#DOSBoxAppName}"" context menu for Windows Explorer"
-Name: "defaultmsvc"; Description: "Run MSVC release binary (instead of MSYS2 binary) as the default binary"; Flags: unchecked
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"
 
 [Files]
 Source: "program\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
-Source: "{#DOSBoxAppExeName}"; DestDir: "{app}"; DestName: "{#DOSBoxAppExeName}"; Flags: ignoreversion; Tasks: not defaultmsvc
-Source: "{#DOSBoxAppExeDebuggerName}"; DestDir: "{app}"; DestName: "{#DOSBoxAppExeDebuggerName}"; Flags: ignoreversion; Tasks: not defaultmsvc
-Source: "{#DOSBoxAppExeMSVCName}"; DestDir: "{app}"; DestName: "{#DOSBoxAppExeName}"; Flags: ignoreversion; Tasks: defaultmsvc
-Source: "{#DOSBoxAppExeMSVCDebuggerName}"; DestDir: "{app}"; DestName: "{#DOSBoxAppExeDebuggerName}"; Flags: ignoreversion; Tasks: defaultmsvc
+Source: "{#DOSBoxAppExeName}"; DestDir: "{app}"; DestName: "{#DOSBoxAppExeName}"; Flags: ignoreversion
+Source: "{#DOSBoxAppExeDebuggerName}"; DestDir: "{app}"; DestName: "{#DOSBoxAppExeDebuggerName}"; Flags: ignoreversion
 Source: "{#DOSBoxAppExeConsoleName}"; DestDir: "{app}"; DestName: "{#DOSBoxAppExeConsoleName}"; Flags: ignoreversion
 Source: "{#DOSBoxAppInternal}.ico"; DestDir: "{app}"; DestName: "{#DOSBoxAppInternal}.ico"; Flags: ignoreversion
 

--- a/contrib/windows_installer/dosbox_with_console.bat
+++ b/contrib/windows_installer/dosbox_with_console.bat
@@ -1,0 +1,4 @@
+@echo off
+"%~dp0\dosbox.exe" %*
+if errorlevel 1 pause
+


### PR DESCRIPTION
# Description

As per title. Also cleaned up the MSVC workflow somewhat.

We only provide x64 installers as ARM64 support is experimental

I've also fixed the Windows Explorer context-menu icon (previously, a blank document icon was displayed because the "Icon" registry entry erroneously referenced the `.bat` launcher file instead of the `.exe` file)

![image](https://github.com/user-attachments/assets/ab0417ec-8f67-47a0-8b88-ace2f247b573)

# Manual testing

- Confirmed that all the other x64 and ARM64 artifacts are still built.
- Tested the generated installer, it works as it should.
- Tested the right-click context menus and the uninstaller as well.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

