### PR TITLE
Make the `impulse` PC speaker model the default

### DIFF
--- a/include/timer.h
+++ b/include/timer.h
@@ -89,7 +89,7 @@ union PpiPortB {
 
 const char *pit_mode_to_string(const PitMode mode);
 
-/* PC Speakers functions, tightly related to the timer functions */
+// PC speaker functions, tightly related to the timer functions
 void PCSPEAKER_SetCounter(const int count, const PitMode pit_mode);
 void PCSPEAKER_SetType(const PpiPortB &port_b);
 void PCSPEAKER_SetPITControl(const PitMode pit_mode);

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -899,7 +899,7 @@ void DOSBOX_Init()
 
 	pstring = secprop->Add_string("pcspeaker_filter", when_idle, "on");
 	pstring->Set_help(
-	        "Filter for the PC Speaker output:\n"
+	        "Filter for the PC speaker output:\n"
 	        "  on:        Filter the output (default).\n"
 	        "  off:       Don't filter the output.\n"
 	        "  <custom>:  Custom filter definition; see 'sb_filter' for details.");

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -886,7 +886,7 @@ void DOSBOX_Init()
 	                                   &PCSPEAKER_Init,
 	                                   changeable_at_runtime);
 
-	pstring = secprop->Add_string("pcspeaker", when_idle, "discrete");
+	pstring = secprop->Add_string("pcspeaker", when_idle, "impulse");
 	pstring->Set_help(
 	        "PC speaker emulation model:\n"
 	        "  discrete:  Waveform is created using discrete steps (default).\n"

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -889,13 +889,13 @@ void DOSBOX_Init()
 	pstring = secprop->Add_string("pcspeaker", when_idle, "impulse");
 	pstring->Set_help(
 	        "PC speaker emulation model:\n"
-	        "  discrete:  Waveform is created using discrete steps (default).\n"
-	        "             Works well for games that use RealSound-type effects.\n"
-	        "  impulse:   Waveform is created using sinc impulses.\n"
-	        "             Recommended for square-wave games, like Commander Keen.\n"
-	        "             While improving accuracy, it is more CPU intensive.\n"
-	        "  none/off:  Don't use the PC Speaker.");
-	pstring->Set_values({"discrete", "impulse", "none", "off"});
+	        "  impulse:   A very faithful emulation of the PC speaker's output (default).\n"
+	        "             Works with most games, but may result in garbled sound or silence\n"
+	        "             in a small number of programs.\n"
+	        "  discrete:  Legacy simplified PC speaker emulation; only use this on specific\n"
+	        "             titles that give you problems with the 'impulse' model.\n"
+	        "  none/off:  Don't emulate the PC speaker.");
+	pstring->Set_values({"impulse", "discrete", "none", "off"});
 
 	pstring = secprop->Add_string("pcspeaker_filter", when_idle, "on");
 	pstring->Set_help(

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -3117,7 +3117,7 @@ static void init_mixer_dosbox_settings(Section_prop& sec_prop)
 	        "  on:      Enable reverb (medium preset).\n"
 	        "  tiny:    Simulates the sound of a small integrated speaker in a room;\n"
 	        "           specifically designed for small-speaker audio systems\n"
-	        "           (PC Speaker, Tandy, PS/1 Audio, and LPT DAC devices).\n"
+	        "           (PC speaker, Tandy, PS/1 Audio, and LPT DAC devices).\n"
 	        "  small:   Adds a subtle sense of space; good for games that use a single\n"
 	        "           synth channel (typically OPL) for both music and sound effects.\n"
 	        "  medium:  Medium room preset that works well with a wide variety of games.\n"

--- a/src/hardware/pcspeaker.cpp
+++ b/src/hardware/pcspeaker.cpp
@@ -24,7 +24,7 @@
 #include "pcspeaker_discrete.h"
 #include "pcspeaker_impulse.h"
 
-// The PC Speaker managed pointer
+// The PC speaker managed pointer
 std::unique_ptr<PcSpeaker> pc_speaker = {};
 
 void PCSPEAKER_ShutDown([[maybe_unused]] Section *sec)
@@ -40,7 +40,7 @@ void PCSPEAKER_Init(Section *section)
 	assert(section);
 	const auto prop = static_cast<Section_prop *>(section);
 
-	// Get the user's PC Speaker model choice
+	// Get the user's PC speaker model choice
 	const std::string model_choice = prop->Get_string("pcspeaker");
 
 	const auto model_choice_has_bool = parse_bool_setting(model_choice);
@@ -83,7 +83,7 @@ void PCSPEAKER_Init(Section *section)
 	section->AddDestroyFunction(&PCSPEAKER_ShutDown, changeable_at_runtime);
 }
 
-// PC Speaker external API, used by the PIT timer and keyboard
+// PC speaker external API, used by the PIT timer and keyboard
 void PCSPEAKER_SetCounter(const int counter, const PitMode pit_mode)
 {
 	if (pc_speaker)

--- a/src/hardware/pcspeaker.cpp
+++ b/src/hardware/pcspeaker.cpp
@@ -55,7 +55,7 @@ void PCSPEAKER_Init(Section *section)
 		pc_speaker = std::make_unique<PcSpeakerImpulse>();
 
 	} else {
-		LOG_ERR("PCSPEAKER: Invalid PC Speaker model: %s",
+		LOG_ERR("PCSPEAKER: Invalid PC speaker model: %s",
 		        model_choice.c_str());
 		return;
 	}

--- a/src/hardware/pcspeaker_discrete.h
+++ b/src/hardware/pcspeaker_discrete.h
@@ -54,7 +54,7 @@ private:
 	static constexpr auto model_name  = "discrete";
 
 	// The discrete PWM scalar was manually adjusted to roughly match
-	// voltage levels recorded from a hardware PC Speaker
+	// voltage levels recorded from a hardware PC speaker
 	// Ref:https://github.com/dosbox-staging/dosbox-staging/files/9494469/3.audio.samples.zip
 	static constexpr float pwm_scalar = 0.75f;
 	static constexpr float sqw_scalar = pwm_scalar / 2.0f;

--- a/src/hardware/pcspeaker_impulse.h
+++ b/src/hardware/pcspeaker_impulse.h
@@ -56,7 +56,7 @@ private:
 	// Amplitude constants
 
 	// The impulse PWM scalar was manually adjusted to roughly match voltage
-	// levels recorded from a hardware PC Speaker
+	// levels recorded from a hardware PC speaker
 	// Ref:https://github.com/dosbox-staging/dosbox-staging/files/9494469/3.audio.samples.zip
 	static constexpr float pwm_scalar = 0.5f;
 


### PR DESCRIPTION
# Description

This change sets the `impulse` PC speaker model as the default instead of the legacy `discrete` model. The impulse model emulates the PC speaker in a theoretically-correct way, so it's generally more accurate than the legacy model.

The catch is that the impulse model has some bugs, so in a handful of games, the `discrete` model is still preferable.

There is an [open ticket](https://github.com/dosbox-staging/dosbox-staging/issues/3819) to address the shortcomings of the `impulse` model and retire the legacy `discrete` model altogether, but that's a bigger job.

To my knowledge, other DOSBox forks such as ECE and Daum have been defaulting to the `impulse` model for ages, so we know it works well for most games, making this a safe change.

<img width="1426" alt="image" src="https://github.com/user-attachments/assets/b9812cf6-9a25-4664-8ac8-804f2f5736d1">

## Related issues

- https://github.com/dosbox-staging/dosbox-staging/issues/3819

# Manual testing

- Tested Windwalker (always uses the PC speaker to play sampled sound effects, regardless of the selected sound option).

- Tested Fast Tracker II with the "impulse" and "discrete" options in the program's sound preferences screen.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

