### PR TITLE
`MODE` command fixes & improvements

### DIFF
--- a/src/dos/program_mode.cpp
+++ b/src/dos/program_mode.cpp
@@ -242,7 +242,10 @@ void MODE::Run()
 		return isdigit(command[0]) && command.size() >= MinLength;
 	};
 
-	if (cmd->GetCount() == 1) {
+	if (cmd->GetCount() == 0) {
+		WriteOut(MSG_Get("SHELL_MISSING_PARAMETER"));
+
+	} else if (cmd->GetCount() == 1) {
 		const auto args    = cmd->GetArguments();
 		const auto command = args[0];
 

--- a/src/dos/program_mode.cpp
+++ b/src/dos/program_mode.cpp
@@ -293,14 +293,14 @@ void MODE::AddMessages()
 	        "  [color=light-green]mode[reset] [color=white]80x43[reset]\n"
 	        "  [color=light-green]mode[reset] rate=[color=white]32[reset] delay=[color=white]1[reset]");
 
-	MSG_Add("PROGRAM_MODE_INVALID_COMMAND", "Invalid mode command");
+	MSG_Add("PROGRAM_MODE_INVALID_COMMAND", "Invalid mode command.");
 
 	MSG_Add("PROGRAM_MODE_INVALID_DISPLAY_MODE",
-	        "Invalid display mode [color=white]%s[reset]");
+	        "Invalid display mode: [color=white]%s[reset]");
 
 	MSG_Add("PROGRAM_MODE_UNSUPPORTED_DISPLAY_MODE",
-	        "Display mode [color=white]%s[reset] is not supported on this graphics adapter");
+	        "Display mode [color=white]%s[reset] is not supported on this graphics adapter.");
 
 	MSG_Add("PROGRAM_MODE_INVALID_TYPEMATIC_RATE",
-	        "Invalid typematic rate setting");
+	        "Invalid typematic rate setting.");
 }

--- a/src/dos/program_mode.cpp
+++ b/src/dos/program_mode.cpp
@@ -253,13 +253,13 @@ void MODE::Run()
 			const auto& mode = command;
 			HandleSetDisplayMode(mode);
 		} else {
-			WriteOut(MSG_Get("PROGRAM_MODE_INVALID_COMMAND"));
+			WriteOut(MSG_Get("SHELL_SYNTAX_ERROR"));
 		}
 
 	} else if (cmd->GetCount() >= 2) {
 		// To allow 'MODE CON: RATE=32 DELAY=1' too with minimal effort
 		if (!HandleSetTypematicRate()) {
-			WriteOut(MSG_Get("PROGRAM_MODE_INVALID_COMMAND"));
+			WriteOut(MSG_Get("SHELL_SYNTAX_ERROR"));
 		}
 	}
 }
@@ -292,8 +292,6 @@ void MODE::AddMessages()
 	        "  [color=light-green]mode[reset] [color=white]132x50\n"
 	        "  [color=light-green]mode[reset] [color=white]80x43[reset]\n"
 	        "  [color=light-green]mode[reset] rate=[color=white]32[reset] delay=[color=white]1[reset]");
-
-	MSG_Add("PROGRAM_MODE_INVALID_COMMAND", "Invalid mode command.");
 
 	MSG_Add("PROGRAM_MODE_INVALID_DISPLAY_MODE",
 	        "Invalid display mode: [color=white]%s[reset]");


### PR DESCRIPTION
# Description

The `MODE` command now displays an error when it's invoked without arguments. The error messages have been slightly improved as well.

# Manual testing

Tested the command with various command line argument combinations.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

