### PR TITLE
Update SDL wrap to 2.30.6

### DIFF
--- a/subprojects/sdl2.wrap
+++ b/subprojects/sdl2.wrap
@@ -1,13 +1,13 @@
 [wrap-file]
-directory = SDL2-2.28.5
-source_url = https://github.com/libsdl-org/SDL/releases/download/release-2.28.5/SDL2-2.28.5.tar.gz
-source_filename = SDL2-2.28.5.tar.gz
-source_hash = 332cb37d0be20cb9541739c61f79bae5a477427d79ae85e352089afdaf6666e4
-patch_filename = sdl2_2.28.5-2_patch.zip
-patch_url = https://wrapdb.mesonbuild.com/v2/sdl2_2.28.5-2/get_patch
-patch_hash = 8a5d7e7cd58932e0231963d42aa79776c2af1aceea6506a06be25a56935121eb
-source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/sdl2_2.28.5-2/SDL2-2.28.5.tar.gz
-wrapdb_version = 2.28.5-2
+directory = SDL2-2.30.6
+source_url = https://github.com/libsdl-org/SDL/releases/download/release-2.30.6/SDL2-2.30.6.tar.gz
+source_filename = SDL2-2.30.6.tar.gz
+source_hash = c6ef64ca18a19d13df6eb22df9aff19fb0db65610a74cc81dae33a82235cacd4
+patch_filename = sdl2_2.30.6-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/sdl2_2.30.6-1/get_patch
+patch_hash = 9c143c81d02ac33fe4d50b320ee2860e59552a30e087630de298af44a16ed015
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/sdl2_2.30.6-1/SDL2-2.30.6.tar.gz
+wrapdb_version = 2.30.6-1
 
 [provide]
 sdl2 = sdl2_dep


### PR DESCRIPTION
# Description

Let's get the SDL wrap bumped to the latest version with enough time to test for 0.82.

# Manual testing

I've run the usual suspects:

- Quake (including QTD)
- Doom
- Future Crew Panic
- Future Crew Unreal
- Sierra Games (KQ1/2/3, SQ1/2/3)
- moralhardcandy
- sunflower
- multikolor
- toontown

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

