### PR TITLE
Improve the GUS config setting descriptions

### DIFF
--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -1740,10 +1740,11 @@ void init_gus_dosbox_settings(Section_prop& secprop)
 	assert(bool_prop);
 	bool_prop->Set_help(
 	        "Enable Gravis UltraSound emulation (disabled by default).\n"
-	        "The default settings of base address 240, IRQ 5, and DMA 3 have been chosen\n"
-	        "so the GUS can coexist with a Sound Blaster card. This works fine for the\n"
-	        "majority of programs, but some games and demos expect the GUS factory\n"
-	        "defaults of base address 220, IRQ 11, and DMA 1.");
+	        "The default settings of base address 240, IRQ 5, and DMA 3 have been chosen so\n"
+	        "the GUS can coexist with a Sound Blaster card. This works fine for the majority\n"
+	        "of programs, but some games and demos expect the GUS factory defaults of base\n"
+	        "address 220, IRQ 11, and DMA 1. The default IRQ 11 is also problematic with\n"
+	        "specific versions of the DOS4GW extender that cannot handle IRQs above 7.");
 
 	auto* hex_prop = secprop.Add_hex("gusbase", when_idle, 0x240);
 	assert(hex_prop);
@@ -1772,7 +1773,7 @@ void init_gus_dosbox_settings(Section_prop& secprop)
 	assert(str_prop);
 	str_prop->Set_help(
 	        "Path to UltraSound directory ('C:\\ULTRASND' by default).\n"
-	        "In this directory there should be a 'MIDI' directory that contains the patch\n"
+	        "In this directory, there should be a 'MIDI' directory that contains the patch\n"
 	        "files for GUS playback.");
 }
 


### PR DESCRIPTION
# Description

As per title.

# Manual testing

<img width="1089" alt="image" src="https://github.com/user-attachments/assets/81a08c2a-6189-44d4-ad64-a4c4e35622d0">


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

