### PR TITLE
Fix `IMGMOUNT` command error message

### DIFF
--- a/contrib/resources/translations/br.lng
+++ b/contrib/resources/translations/br.lng
@@ -2362,7 +2362,7 @@ Arquivo de imagem não encontrado.
 
 .
 :PROGRAM_IMGMOUNT_MOUNT
-Para montar pastas, use o comando [color=light-green]MOUNT[reset], não o comando [color=green-blue]IMGMOUNT[reset].
+Para montar pastas, use o comando [color=light-green]MOUNT[reset], não o comando [color=light-green]IMGMOUNT[reset].
 
 .
 :PROGRAM_IMGMOUNT_ALREADY_MOUNTED

--- a/contrib/resources/translations/en.lng
+++ b/contrib/resources/translations/en.lng
@@ -2277,7 +2277,7 @@ Image file not found.
 
 .
 :PROGRAM_IMGMOUNT_MOUNT
-To mount directories, use the [color=light-green]MOUNT[reset] command, not the [color=green-blue]IMGMOUNT[reset] command.
+To mount directories, use the [color=light-green]MOUNT[reset] command, not the [color=light-green]IMGMOUNT[reset] command.
 
 .
 :PROGRAM_IMGMOUNT_ALREADY_MOUNTED

--- a/contrib/resources/translations/es.lng
+++ b/contrib/resources/translations/es.lng
@@ -2490,7 +2490,7 @@ Archivo de imagen no encontrado.
 
 .
 :PROGRAM_IMGMOUNT_MOUNT
-Para montar directorios, use el comando [color=light-green]MOUNT[reset], no [color=green-blue]IMGMOUNT[reset].
+Para montar directorios, use el comando [color=light-green]MOUNT[reset], no [color=light-green]IMGMOUNT[reset].
 
 .
 :PROGRAM_IMGMOUNT_ALREADY_MOUNTED

--- a/src/dos/program_imgmount.cpp
+++ b/src/dos/program_imgmount.cpp
@@ -683,7 +683,7 @@ void IMGMOUNT::AddMessages()
 	MSG_Add("PROGRAM_IMGMOUNT_FILE_NOT_FOUND", "Image file not found.\n");
 
 	MSG_Add("PROGRAM_IMGMOUNT_MOUNT",
-	        "To mount directories, use the [color=light-green]MOUNT[reset] command, not the [color=green-blue]IMGMOUNT[reset] command.\n");
+	        "To mount directories, use the [color=light-green]MOUNT[reset] command, not the [color=light-green]IMGMOUNT[reset] command.\n");
 
 	MSG_Add("PROGRAM_IMGMOUNT_ALREADY_MOUNTED",
 	        "Drive already mounted at that letter.\n");


### PR DESCRIPTION
# Description

As it says on the tin.

Fixes https://github.com/dosbox-staging/dosbox-staging/issues/3860.

# Manual testing

<img width="986" alt="image" src="https://github.com/user-attachments/assets/ed41e6ec-28fd-4d7d-b78b-1cd07ff0f33e">

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

