### PR TITLE
Minor fix to x87 64-bit memcpy

### DIFF
--- a/src/fpu/fpu_instructions.h
+++ b/src/fpu/fpu_instructions.h
@@ -231,8 +231,10 @@ static void FPU_FLD_I32(PhysPt addr,Bitu store_to) {
 }
 
 static void FPU_FLD_I64(PhysPt addr,Bitu store_to) {
-	constexpr int64_t int53_min = -(1LL << 53);
-	constexpr int64_t int53_max = (1LL << 53) - 1;
+	// The range of integers that can fit in the mantissa of a double.
+	// https://en.wikipedia.org/wiki/Double-precision_floating-point_format
+	constexpr int64_t MantissaMin = -(1LL << 53);
+	constexpr int64_t MantissaMax = (1LL << 53);
 
 	FPU_Reg temp_reg;
 	temp_reg.ll = mem_readq(addr);
@@ -242,10 +244,10 @@ static void FPU_FLD_I64(PhysPt addr,Bitu store_to) {
 	// use FILD/FIST as a fast 64-bit integer memcpy, such as Carmageddon,
 	// Motor Mash, and demos like Sunflower and Multikolor.
 
-	// If the value won't fit in the 53-bit mantissa of a double, save the
+	// If the value won't fit in the mantissa of a double, save the
 	// value into the regs_memcpy register to indicate that the integer
 	// value should be read out by the FPU_FST_I64 function instead.
-	if (temp_reg.ll > int53_max || temp_reg.ll < int53_min) {
+	if (temp_reg.ll > MantissaMax || temp_reg.ll < MantissaMin) {
 		fpu.regs_memcpy[store_to] = temp_reg.ll;
 	} else {
 		fpu.regs_memcpy[store_to].reset();


### PR DESCRIPTION
# Description

This is a very minor cleanup to the x87 64-bit memcpy trick, giving the variables better names and using the correct range.


# Manual testing

Tested the games and demos that use the code:

- sunflower demo
- Carmageddon
- multikolor demo
- toontown demo

Also ran the following code to verify the range:

```cpp
#include <cstdio>
#include <cstdint>

constexpr int64_t mantissa_min = -(1LL << 53);
constexpr int64_t mantissa_max = (1LL << 53);

int main() {
    for (int i = -10; i < 10; i++) {
        int64_t max_test = mantissa_max + i;
        int64_t min_test = mantissa_min - i;
        double max_dval = static_cast<double>(max_test);
        double min_dval = static_cast<double>(min_test);
        int64_t max_ival = static_cast<int64_t>(max_dval);
        int64_t min_ival = static_cast<int64_t>(min_dval);
        printf("(max) %s (i=%d) before: %lld, after: %lld\n", max_ival == max_test ? "RIGHT!" : "WRONG!", i, max_test, max_ival);
        printf("(min) %s (i=%d) before: %lld, after: %lld\n", min_ival == min_test ? "RIGHT!" : "WRONG!", i, min_test, min_ival);
    }
}
```


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

](https://en.wikipedia.org/wiki/Double-precision_floating-point_format)