### PR TITLE
Improve `tiny` reverb preset for small-speaker emulation

### DIFF
--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -489,7 +489,7 @@ void MIXER_SetReverbPreset(const ReverbPreset new_preset)
 
 	// clang-format off
 	switch (r.preset) { //             PREDLY EARLY  SIZE   DENSITY BW_FREQ DECAY  DAMP_LV SYN_LV DIG_LV HIPASS_HZ
-	case ReverbPreset::Tiny:   r.Setup(0.00f, 1.00f, 0.05f, 0.50f,  0.50f,  0.00f, 1.00f,  0.87f, 0.87f, 200.0f, rate_hz); break;
+	case ReverbPreset::Tiny:   r.Setup(0.00f, 1.00f, 0.05f, 0.50f,  0.50f,  0.00f, 1.00f,  0.65f, 0.65f, 200.0f, rate_hz); break;
 	case ReverbPreset::Small:  r.Setup(0.00f, 1.00f, 0.17f, 0.42f,  0.50f,  0.50f, 0.70f,  0.40f, 0.08f, 200.0f, rate_hz); break;
 	case ReverbPreset::Medium: r.Setup(0.00f, 0.75f, 0.50f, 0.50f,  0.95f,  0.42f, 0.21f,  0.54f, 0.07f, 170.0f, rate_hz); break;
 	case ReverbPreset::Large:  r.Setup(0.00f, 0.75f, 0.75f, 0.50f,  0.95f,  0.52f, 0.21f,  0.70f, 0.05f, 140.0f, rate_hz); break;

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -485,26 +485,16 @@ void MIXER_SetReverbPreset(const ReverbPreset new_preset)
 
 	r.preset = new_preset;
 
-	// Pre-computed (negative) decibel scalars
-	constexpr auto __5_2dB = 0.87f;
-	constexpr auto __6_0dB = 0.85f;
-	constexpr auto _12_0dB = 0.70f;
-	constexpr auto _18_4dB = 0.54f;
-	constexpr auto _24_0dB = 0.40f;
-	constexpr auto _36_8dB = 0.08f;
-	constexpr auto _37_2dB = 0.07f;
-	constexpr auto _38_0dB = 0.05f;
-
 	const auto rate_hz = mixer.sample_rate_hz.load();
 
 	// clang-format off
-	switch (r.preset) { //             PDELAY EARLY   SIZE DNSITY BWFREQ  DECAY DAMPLV   -SYNLV   -DIGLV HIPASSHZ RATE_HZ
+	switch (r.preset) { //             PREDLY EARLY  SIZE   DENSITY BW_FREQ DECAY  DAMP_LV SYN_LV DIG_LV HIPASS_HZ
+	case ReverbPreset::Tiny:   r.Setup(0.00f, 1.00f, 0.05f, 0.50f,  0.50f,  0.00f, 1.00f,  0.87f, 0.87f, 200.0f, rate_hz); break;
+	case ReverbPreset::Small:  r.Setup(0.00f, 1.00f, 0.17f, 0.42f,  0.50f,  0.50f, 0.70f,  0.40f, 0.08f, 200.0f, rate_hz); break;
+	case ReverbPreset::Medium: r.Setup(0.00f, 0.75f, 0.50f, 0.50f,  0.95f,  0.42f, 0.21f,  0.54f, 0.07f, 170.0f, rate_hz); break;
+	case ReverbPreset::Large:  r.Setup(0.00f, 0.75f, 0.75f, 0.50f,  0.95f,  0.52f, 0.21f,  0.70f, 0.05f, 140.0f, rate_hz); break;
+	case ReverbPreset::Huge:   r.Setup(0.00f, 0.75f, 0.75f, 0.50f,  0.95f,  0.52f, 0.21f,  0.85f, 0.05f, 140.0f, rate_hz); break;
 	case ReverbPreset::None:   break;
-	case ReverbPreset::Tiny:   r.Setup(0.00f, 1.00f, 0.05f, 0.50f, 0.50f, 0.00f, 1.00f, __5_2dB, __5_2dB, 200.0f, rate_hz); break;
-	case ReverbPreset::Small:  r.Setup(0.00f, 1.00f, 0.17f, 0.42f, 0.50f, 0.50f, 0.70f, _24_0dB, _36_8dB, 200.0f, rate_hz); break;
-	case ReverbPreset::Medium: r.Setup(0.00f, 0.75f, 0.50f, 0.50f, 0.95f, 0.42f, 0.21f, _18_4dB, _37_2dB, 170.0f, rate_hz); break;
-	case ReverbPreset::Large:  r.Setup(0.00f, 0.75f, 0.75f, 0.50f, 0.95f, 0.52f, 0.21f, _12_0dB, _38_0dB, 140.0f, rate_hz); break;
-	case ReverbPreset::Huge:   r.Setup(0.00f, 0.75f, 0.75f, 0.50f, 0.95f, 0.52f, 0.21f, __6_0dB, _38_0dB, 140.0f, rate_hz); break;
 	}
 	// clang-format on
 
@@ -581,19 +571,14 @@ void MIXER_SetChorusPreset(const ChorusPreset new_preset)
 	assert(c.preset != new_preset);
 	c.preset = new_preset;
 
-	// Pre-computed (negative) decibel scalars
-	constexpr auto __6dB = 0.75f;
-	constexpr auto _11dB = 0.54f;
-	constexpr auto _16dB = 0.33f;
-
 	const auto rate_hz = mixer.sample_rate_hz.load();
 
 	// clang-format off
-	switch (c.preset) { //            -SYNLV -DIGLV  RATE_HZ
+	switch (c.preset) { //             SYN_LV  DIG_LV
+	case ChorusPreset::Light:  c.Setup(0.33f,  0.00f, rate_hz); break;
+	case ChorusPreset::Normal: c.Setup(0.54f,  0.00f, rate_hz); break;
+	case ChorusPreset::Strong: c.Setup(0.75f,  0.00f, rate_hz); break;
 	case ChorusPreset::None:   break;
-	case ChorusPreset::Light:  c.Setup(_16dB, 0.00f, rate_hz); break;
-	case ChorusPreset::Normal: c.Setup(_11dB, 0.00f, rate_hz); break;
-	case ChorusPreset::Strong: c.Setup(__6dB, 0.00f, rate_hz); break;
 	}
 	// clang-format on
 


### PR DESCRIPTION
# Description

The `tiny` reverb preset simulates the sound of a small integrated speaker in a room; it was specifically designed for small-speaker audio systems (PC speaker, Tandy, PCjr, PS/1 Audio, and LPT DAC devices) to make them sound _less bad_ than the raw output, especially in headphones (the analog output filter settings also greatly help with achieving this goal, taking off most of the ugly high-frequency content of the "digital only" emulation).

That's all good and well, but the `tiny` reverb preset was just too strong: it almost sounded as if your PC was in a tiled bathroom, not a domestic room 😆 So I'm correcting that by reducing the strength of the `tiny` preset by about 25% (from 87% to 65%).

## Audio examples

### Manhunter (Tandy)

- No reverb: https://drive.google.com/file/d/1XBhFGhuhC-POCII5xIJVhy5c3WwPBTUl/view?usp=drive_link
- Current reverb: https://drive.google.com/file/d/1jIOsMs9znaKfACER6I27nR3LNL1Sfsx8/view?usp=drive_link
- Reduced reverb: https://drive.google.com/file/d/1CXWKG_3DAQfDnJ4vuhoevgAEBhA8SVQF/view?usp=drive_link


### Space Quest 1 (PCjr)

- No reverb: https://drive.google.com/file/d/1VlmUY8u7egiTPbJw8Pb4OSG44yjUwXWH/view?usp=drive_link
- Current reverb: https://drive.google.com/file/d/1XFJuABZacuil31R77Z3bLBycn-9iSm50/view?usp=drive_link
- Reduced reverb: https://drive.google.com/file/d/1ATpHQep9vvVwtijoTdE9gbGXHWfBee2N/view?usp=drive_link

# Manual testing

I've made the above recordings. Another way to test is to confirm that `reverb = tiny` sets the reverb levels to 65 instead of 87:

<img width="1097" alt="image" src="https://github.com/user-attachments/assets/7bd16276-cba4-4a70-92d8-2eee61118833">


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

