### PR TITLE
DYN_LOG: Fix formatting type mismatch

### DIFF
--- a/src/cpu/core_dyn_x86/decoder.h
+++ b/src/cpu/core_dyn_x86/decoder.h
@@ -2424,7 +2424,7 @@ restart_prefix:
 
 			default:
 #if DYN_LOG
-				LOG_MSG("Unhandled dual opcode 0F%02X",dual_code);
+				LOG_MSG("Unhandled dual opcode 0F%02" PRIXPTR, dual_code);
 #endif
 				goto illegalopcode;
 			}
@@ -3006,7 +3006,7 @@ restart_prefix:
 			break;
 		default:
 #if DYN_LOG
-//			LOG_MSG("Dynamic unhandled opcode %X",opcode);
+//			LOG_MSG("Dynamic unhandled opcode %" PRIXPTR, opcode);
 #endif
 			goto illegalopcode;
 		}

--- a/src/cpu/core_dynrec/decoder.h
+++ b/src/cpu/core_dynrec/decoder.h
@@ -621,7 +621,7 @@ static CacheBlock *CreateCacheBlock(CodePageHandler *codepage, PhysPt start, Bit
 				        break;
 			        default:
 #if DYN_LOG
-//					LOG_MSG("Unhandled dual opcode 0F%02X",dual_code);
+//					LOG_MSG("Unhandled dual opcode 0F%02" PRIXPTR, dual_code);
 #endif
 				goto illegalopcode;
 			}
@@ -973,7 +973,7 @@ static CacheBlock *CreateCacheBlock(CodePageHandler *codepage, PhysPt start, Bit
 
 		default:
 #if DYN_LOG
-//			LOG_MSG("Dynrec unhandled opcode %X",opcode);
+//			LOG_MSG("Dynrec unhandled opcode %" PRIXPTR, opcode);
 #endif
 			goto illegalopcode;
 		}


### PR DESCRIPTION
# Description

This is the complaint from the compiler:

```
In file included from ../../src/cpu/core_dyn_x86.cpp:257: ../../src/cpu/core_dyn_x86/decoder.h: In function ‘CacheBlock* CreateCacheBlock(CodePageHandler*, PhysPt, Bitu)’: ../../src/cpu/core_dyn_x86/decoder.h:2427:69: warning: format ‘%X’ expects argument of type ‘unsigned int’, but argument 2 has type ‘Bitu’ {aka ‘long unsigned int’} [-Wformat=]
 2427 |                                 LOG_MSG("Unhandled dual opcode 0F%02X",dual_code);
      |                                                                  ~~~^  ~~~~~~~~~
      |                                                                     |  |
      |                                                                     |  Bitu {aka long unsigned int}
      |                                                                     unsigned int
      |                                                                  %02lX
```

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [ ] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.