### PR TITLE
Fix shell redirection for appending to the end of a file

### DIFF
--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -204,7 +204,6 @@ static uint16_t get_output_redirection(const char *out_file,
 	constexpr bool fcb = true;
 	FatAttributeFlags fattr = {};
 	uint16_t file_handle = InvalidFileHandle;
-	uint32_t bigdummy = 0;
 	bool success = true;
 	/* Create if not exist. Open if exist. Both in read/write mode */
 	if (!pipe_file && append) {
@@ -212,7 +211,8 @@ static uint16_t get_output_redirection(const char *out_file,
 			DOS_SetError(DOSERR_ACCESS_DENIED);
 			success = false;
 		} else if ((success = DOS_OpenFile(out_file, OPEN_READWRITE, &file_handle, fcb))) {
-			DOS_SeekFile(1, &bigdummy, DOS_SEEK_END, fcb);
+			uint32_t seek_pos = 0;
+			DOS_SeekFile(file_handle, &seek_pos, DOS_SEEK_END, fcb);
 		} else {
 			// Create if not exists.
 			success = DOS_CreateFile(out_file,


### PR DESCRIPTION
# Description

Regression from d4509f9ff7661aa83ab208c2e39e02b6c51343f9
Previous code had an assumption that the output file would be at file handle 1
That assumption was broken in my refactor
We obviously want to seek to the end of the file we just opened


## Related issues

Fixes #3872


# Manual testing

Copied test .bat file from the issue ticket:

```
if %VIDEO%==VGA echo  videoDrv  = VGA320.DRV>>resource.cfg
if %VIDEO%==EGA echo  videoDrv  = EGA640.DRV>>resource.cfg
if %SOUND%==SB echo  soundDrv  = SBPRO.DRV>>resource.cfg
if %SOUND%==SB echo  audioDrv  = AUDBLAST.DRV>>resource.cfg
if %SOUND%==MT32 echo  soundDrv  = MT32.DRV>>resource.cfg
if %SOUND%==MT32 echo  audioDrv  = AUDBLAST.DRV>>resource.cfg
if %SOUND%==SC echo  soundDrv  = GENMIDI.DRV>>resource.cfg
if %SOUND%==SC echo  audioDrv  = AUDBLAST.DRV>>resource.cfg
echo  joyDrv    = NO>>resource.cfg
echo  kbdDrv    = IBMKBD.DRV>>resource.cfg
echo  mouseDrv  = STDMOUSE.DRV>>resource.cfg
echo  memoryDrv = ARM.DRV>>resource.cfg
echo  minHunk   = 204k>>resource.cfg
echo  language  = 1>>resource.cfg
echo  cd        = YES>>resource.cfg
echo  cmd       = FPFPCD>>resource.cfg
echo  audioSize = 16k>>resource.cfg
echo  patchDir  = C:\;D:\freddy\audio>>resource.cfg 
echo  resAUD    = C:\audio>>resource.cfg 
```
Ran the following commands.  The set commands are needed or the output for lines checking for environment variables is "Incorrect command syntax".  I believe this is expected behavior.

```
set VIDEO=VGA
set SOUND=SB
test.bat
```

Verified `RESOURCE.CFG` file it output looks correct.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

