### PR TITLE
Make the titlebar cycles display translatable again

### DIFF
--- a/contrib/resources/translations/pl.lng
+++ b/contrib/resources/translations/pl.lng
@@ -430,6 +430,9 @@ Składnia: [color=light-green]config [/reset]-set [color=light-cyan][SECTION][/r
 :TITLEBAR_CYCLES_MS
 cykli/ms
 .
+:TITLEBAR_CYCLES_THROTTLED
+ograniczone
+.
 :TITLEBAR_MUTED
 WYCISZONE
 .
@@ -1064,7 +1067,7 @@ Szybkość emulowanego procesora dla programów działających w trybie chronion
 Uwaga: Więcej informacji znajdziesz w opisie 'cpu_cycles'.
 .
 :CONFIG_CPU_THROTTLE
-Dynamicznie zmniejsza ilość emulowanych cykli procesora, jeśli system
+Dynamicznie ogranicza ilość emulowanych cykli procesora, jeśli system
 gospodarza nie jest w stanie emulować zadanej liczby (domyślnie wyłączone).
 Działa jedynie w przypadku ustawienia stałej liczby cykli. Po włączeniu
 ilość cykli na milisekundę będzie się zmieniać, może to powodować problemy

--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -2600,8 +2600,6 @@ void CPU_ResetAutoAdjust()
 
 std::string CPU_GetCyclesConfigAsString()
 {
-	static const auto CyclesPerMs = " cycles/ms";
-
 	if (legacy_cycles_mode) {
 		std::string s = {};
 
@@ -2616,7 +2614,9 @@ std::string CPU_GetCyclesConfigAsString()
 		} else {
 			s += format_str("%d", CPU_CycleMax.load());
 		}
-		return s += CyclesPerMs;
+
+		s += " ";
+		return s += MSG_GetRaw("TITLEBAR_CYCLES_MS");
 
 	} else {
 		// Modern mode
@@ -2647,10 +2647,13 @@ std::string CPU_GetCyclesConfigAsString()
 			format_cycles(conf.real_mode);
 		}
 
-		s += CyclesPerMs;
+		s += " ";
+		s += MSG_GetRaw("TITLEBAR_CYCLES_MS");
 
 		if (modern_cycles_config.throttle && !max_mode) {
-			s += " (throttled)";
+			s += " (";
+			s += MSG_GetRaw("TITLEBAR_CYCLES_THROTTLED");
+			s += ")";
 		}
 		return s;
 	}

--- a/src/gui/titlebar.cpp
+++ b/src/gui/titlebar.cpp
@@ -771,6 +771,7 @@ void TITLEBAR_AddConfig(Section_prop& secprop)
 void TITLEBAR_AddMessages()
 {
 	MSG_Add("TITLEBAR_CYCLES_MS", "cycles/ms");
+	MSG_Add("TITLEBAR_CYCLES_THROTTLED", "throttled");
 	MSG_Add("TITLEBAR_MUTED", "MUTED");
 	MSG_Add("TITLEBAR_PAUSED", "PAUSED");
 


### PR DESCRIPTION
# Description

Two more title bar strings are now translatable (one of them used to be translatable, but this was lost during development). See the problem below:

![Screenshot-NoTranslation](https://github.com/user-attachments/assets/0f96227e-422d-4a0e-818e-37a509de1cc3)

# Manual testing

Run DOSBox with `language = pl`, try also with cpu throttling enabled, observe the titlebar.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

