### PR TITLE
Ensure logs are UTF-8 on Windows, improve deprecated config warning log

### DIFF
--- a/include/cross.h
+++ b/include/cross.h
@@ -158,27 +158,4 @@ bool get_expanded_files(const std::string &path,
 
 std::string get_language_from_os();
 
-// A printf variant outputting UTF-8 strings
-template <typename... Arguments>
-void printf_utf8(const char* format, Arguments... arguments)
-{
-#ifdef WIN32
-	constexpr uint16_t CodePageUtf8 = 65001;
-
-	const auto old_code_page = GetConsoleOutputCP();
-	SetConsoleOutputCP(CodePageUtf8);
-	try {
-		printf(format, arguments...);
-	} catch (...) {
-		SetConsoleOutputCP(old_code_page);
-		throw;
-	}
-
-	SetConsoleOutputCP(old_code_page);
-#else
-	// Assume any OS without special support uses UTF-8 as console encoding
-	printf(format, arguments...);
-#endif
-}
-
 #endif

--- a/include/sdlmain.h
+++ b/include/sdlmain.h
@@ -180,6 +180,10 @@ struct SDL_Block {
 
 	uint32_t start_event_id = UINT32_MAX;
 
+#ifdef WIN32
+	uint16_t original_code_page = 0;
+#endif
+
 	bool is_paused = false;
 
 	RenderingBackend rendering_backend      = RenderingBackend::Texture;

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -1036,8 +1036,9 @@ bool Section_prop::HandleInputline(const std::string& line)
 		}
 
 		if (p->IsDeprecated()) {
-			LOG_WARNING("CONFIG: Deprecated option '%s'", name.c_str());
-			LOG_WARNING("CONFIG: %s", p->GetHelp().c_str());
+			LOG_WARNING("CONFIG: Deprecated option '%s'\n\n%s\n",
+			            name.c_str(),
+			            p->GetHelpUtf8().c_str());
 
 			if (!p->IsDeprecatedButAllowed()) {
 				return false;


### PR DESCRIPTION
# Description

Test case:
- set `language = pl` in the config file
- run DOSBox
- execute `keyb pl`
- execute `config -set cycles=max`

Result on Linux and possibly other systems:

![Log-Before](https://github.com/user-attachments/assets/5a0ab2b2-7c6e-43f4-91e0-2677c62d01a8)

Result after the change:

![Log-After](https://github.com/user-attachments/assets/a7505ae8-aaf7-4fe6-9a9b-1a5b1fc96e37)


# Manual testing

- tried to reproduce the problem from the description
- executed DOSBox with `--list-countries` switch, with language set to `pl` in the configuration file


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

