### PR TITLE
  [post-0.82.0] Fix mouse support in Descent II with a Voodoo patch

### DIFF
--- a/src/hardware/input/mouseif_dos_driver.cpp
+++ b/src/hardware/input/mouseif_dos_driver.cpp
@@ -1620,12 +1620,20 @@ static Bitu int33_handler()
 		state.hidden    = 1;
 		// According to Ralf Brown Interrupt List it returns 0x20 if
 		// success,  but CuteMouse source code claims the code for
-		// success if 0x1f. Both agree that 0xffff means failure.
+		// success is 0x1f. Both agree that 0xffff means failure.
 		// Since reg_ax is 0x1f here, no need to change anything.
+		// [FeralChild64] My results:
+		// - MS driver 6.24 always returns 0xffff
+		// - MS driver 8.20 returns 0xffff if 'state.enabled == false'
+		// - 3rd party drivers I tested (A4Tech 8.04a, Genius 9.20,
+		//   Mouse Systems 8.00, DR-DOS driver 1.1) never return anything
 		break;
 	case 0x20: // MS MOUSE v6.0+ - enable mouse driver
 		state.enabled = true;
 		state.hidden  = state.oldhidden;
+		// At least Descent II with Voodoo patch expects this. Checked
+		// that MS driver alters AX this way starting from version 7.
+		reg_ax = 0xffff;
 		break;
 	case 0x22: // MS MOUSE v6.0+ - set language for messages
 		// 00h = English, 01h = French, 02h = Dutch, 03h = German, 04h =


### PR DESCRIPTION
# Description

A one-line fix + comments.

_Descent II_ version 1.2 with a _3Dfx Voodoo_ patch (the official one) is very picky regarding mouse driver. From my tests it only works with driver by Microsoft/IBM, version 7 or later - it doesn't work with _A4Tech_, _Genius_, _DR DOS_, _Mouse Systems_, _CuteMouse_, or _VBADOS_ drivers.

I've checked that with _DOSBox Staging_ the game the game just calls INT 33 function 0x00 (reset the driver and check it's capabilities), then function 0x20, afterwards there are no further mouse driver calls.

The game source code (https://github.com/OpenSourcedGames/Descent-2/blob/master/SOURCE/BIOS/MOUSE.C#L287) reveals:

```c
	// Enable mouse driver
	memset( &inregs, 0, sizeof(inregs) );
	inregs.w.ax = 0x0020;
	int386(0x33, &inregs, &outregs);
	if (outregs.w.ax != 0xffff )
		return 0;
```

despite all the documentation I have claims that function 0x20 returns nothing. I have checked with a test program (attached below) - and indeed, compatible mouse drivers return `AX=0xffff.

[TESTDESC.tar.gz](https://github.com/user-attachments/files/16735776/TESTDESC.tar.gz)


## Related issues

Fixes https://github.com/dosbox-staging/dosbox-staging/issues/3891


# Release notes

Fixed a problem with mouse not working in _Descent II_ version 1.2 with the official _3Dfx Voodoo_ patch.


# Manual testing

Tried to reproduce the PR, played a few games which are using a mouse.


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [x] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

