### PR TITLE
Fix ZMBV CompareBlock function returning a negative value for 24/32bpp types

### DIFF
--- a/src/libs/zmbv/zmbv.cpp
+++ b/src/libs/zmbv/zmbv.cpp
@@ -181,19 +181,18 @@ int VideoCodec::PossibleBlock(const int vx, const int vy, const FrameBlock & blo
 template <class P>
 int VideoCodec::CompareBlock(const int vx, const int vy, const FrameBlock & block)
 {
-	int ret = 0;
+	int diff_count = 0;
 	P *pold = reinterpret_cast<P *>(oldframe) + block.start + (vy * pitch) + vx;
 	P *pnew = reinterpret_cast<P *>(newframe) + block.start;
-	;
+
 	for (auto y = 0; y < block.dy; y++) {
 		for (auto x = 0; x < block.dx; x++) {
-			const auto test = 0 - ((pold[x] - pnew[x]) & 0x00ffffff);
-			ret -= check_cast<int>(test >> 31);
+			diff_count += ((pold[x] ^ pnew[x]) & 0x00ffffff) != 0;
 		}
 		pold += pitch;
 		pnew += pitch;
 	}
-	return ret;
+	return diff_count;
 }
 
 template <class P>


### PR DESCRIPTION
# Description

Regression from 6892f70c8502d9ef790059756a7b33d2faa7f880
Above commit changed a variable from int to auto
This resulted in a logical right shift instead of the expected arithmatic right shift

This bug caused the motion vector to always be (0, 0) resulting in more inefficient compression

Found this bug while I was writing a ZMBV decoder for a video player I'm working on.

The logic is kind of hard to follow but form what I can tell `CompareBlock()` is supposed to return a positive value indicating how closely the two blocks match with 0 being (mostly?) identical and a large number meaning very different.

The bug made this function always return a negative number when in 24 or 32 bit per pixel mode.  It's a templated function so it happened when `P` is `uint32_t`.  This made the logic in `AddXorFrame()` think it always found a good match on the first try so it didn't try other motion vector possibilities.

This doesn't result in any visual glitches in the output video file so it went un-noticed for a long time.  Only observable affect is a slightly larger file size.

# Release notes

Fixed a bug with video capture that resulted in slightly larger file sizes.

# Manual testing

Recorded about 9 seconds of Crystal Caves from level 1 start to the hole in the ground.  Stubbed out audio capture as that was the bulk of the file size otherwise as audio is uncompressed.

Result was 1.49MB on this branch and 1.62MB on main

For a more scientific test, I would need to rip out the encoder and compress the exact same video but this was as close as I could get it without doing a bunch of extra work.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

