### PR TITLE
Fix SoundBlaster DMA stuttering in The Rocketeer

### DIFF
--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -2965,7 +2965,7 @@ static void sblaster_pic_callback()
 		generate_frames(total_frames - frames_added_this_tick);
 	}
 
-	frames_added_this_tick = 0;
+	frames_added_this_tick -= total_frames;
 }
 
 static SbType determine_sb_type(const std::string& pref)


### PR DESCRIPTION
# Description

Regression from d75e1057f5c6f7854b7ab1d9b3874cc8a6b8afce

The Rocketeer runs the SoundBlaster an odd sample rate of 13,888hz
This revealed a bug where we would request too many frames inside the PIC callback

It is possible for DMA to output more frames than needed for the current tick.
When this happens, we need to request less frames on the next tick.
DMA outputs inside the main emulator loop, not just in the PIC callback.

The fix is to remember how much we overflowed in the frames_added_this_tick counter and not zero it out every tick


## Related issues

Fixes #3913


# Release notes

Fix audio stuttering in The Rocketeer (regression from 0.82.0 RC1)


# Manual testing

- The Rocketeer
- Quake
- Doom
- Tyrian
- Alone in the Dark (DMA and DAC modes)


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [x] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

