### PR TITLE
Fix thread sanitizer warnings in threaded GUS code

### DIFF
--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -818,6 +818,7 @@ void Gus::CheckIrq()
 
 bool Gus::CheckTimer(const size_t t)
 {
+	std::lock_guard lock(mutex);
 	auto& timer = t == 0 ? timer_one : timer_two;
 	if (!timer.is_masked) {
 		timer.has_expired = true;

--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -737,8 +737,6 @@ const std::vector<AudioFrame>& Gus::RenderFrames(const int num_requested_frames)
 
 void Gus::RenderUpToNow()
 {
-	std::lock_guard lock(mutex);
-
 	const auto now = PIC_FullIndex();
 
 	// Wake up the channel and update the last rendered time datum.
@@ -1175,6 +1173,7 @@ void Gus::PrintStats()
 
 uint16_t Gus::ReadFromPort(const io_port_t port, io_width_t width)
 {
+	std::lock_guard lock(mutex);
 	//	LOG_MSG("GUS: Read from port %x", port);
 	switch (port - port_base) {
 	case 0x206: return irq_status;
@@ -1399,6 +1398,7 @@ void Gus::UpdateDmaAddress(const uint8_t new_address)
 
 void Gus::WriteToPort(io_port_t port, io_val_t value, io_width_t width)
 {
+	std::lock_guard lock(mutex);
 	RenderUpToNow();
 
 	const auto val = check_cast<uint16_t>(value);

--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -891,6 +891,7 @@ void Gus::UpdateDmaAddr(uint32_t offset) noexcept
 
 bool Gus::PerformDmaTransfer()
 {
+	std::lock_guard lock(mutex);
 	if (dma_channel->is_masked || !(dma_ctrl & 0x01)) {
 		return false;
 	}

--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -1129,6 +1129,7 @@ void Gus::MirrorAdLibCommandRegister(const uint8_t reg_value)
 
 void Gus::PrintStats()
 {
+	std::lock_guard lock(mutex);
 	// Aggregate stats from all voices
 	uint32_t combined_8bit_ms  = 0;
 	uint32_t combined_16bit_ms = 0;

--- a/src/hardware/pic.cpp
+++ b/src/hardware/pic.cpp
@@ -24,6 +24,8 @@
 #include "timer.h"
 #include "setup.h"
 
+#include <mutex>
+
 // PIC Controllers
 // ~~~~~~~~~~~~~~~
 // The sources here identify the two Programmable Interrupt Controllers
@@ -131,6 +133,7 @@ struct PIC_Controller {
 	void start_irq(uint8_t val);
 };
 
+static std::mutex pic_mutex = {};
 static PIC_Controller pics[2];
 static PIC_Controller &primary_controller = pics[0];
 static PIC_Controller &secondary_controller = pics[1];
@@ -321,6 +324,7 @@ static uint8_t read_data(io_port_t port, io_width_t)
 // DOS managed up to 15 IRQs
 void PIC_ActivateIRQ(const uint8_t irq)
 {
+	std::lock_guard lock(pic_mutex);
 	const uint8_t t = irq > 7 ? (irq - 8) : irq;
 	PIC_Controller *pic = &pics[irq > 7 ? 1 : 0];
 
@@ -347,6 +351,7 @@ void PIC_ActivateIRQ(const uint8_t irq)
 // DOS managed up to 15 IRQs
 void PIC_DeActivateIRQ(const uint8_t irq)
 {
+	std::lock_guard lock(pic_mutex);
 	const uint8_t t = irq > 7 ? (irq - 8) : irq;
 	PIC_Controller *pic = &pics[irq > 7 ? 1 : 0];
 	pic->lower_irq(t);
@@ -383,6 +388,7 @@ static void inline primary_startIRQ(uint8_t i)
 }
 
 void PIC_runIRQs(void) {
+	std::lock_guard lock(pic_mutex);
 	if (!GETFLAG(IF)) return;
 	if (!PIC_IRQCheck) {
 		return;

--- a/src/hardware/pic.cpp
+++ b/src/hardware/pic.cpp
@@ -208,6 +208,7 @@ static struct {
 
 static void write_command(io_port_t port, io_val_t value, io_width_t)
 {
+	std::lock_guard lock(pic_mutex);
 	const auto val = check_cast<uint8_t>(value);
 	PIC_Controller *pic = &pics[port == 0x20 ? 0 : 1];
 
@@ -264,6 +265,7 @@ static void write_command(io_port_t port, io_val_t value, io_width_t)
 
 static void write_data(io_port_t port, io_val_t value, io_width_t)
 {
+	std::lock_guard lock(pic_mutex);
 	const auto val = check_cast<uint8_t>(value);
 	PIC_Controller *pic = &pics[port == 0x21 ? 0 : 1];
 	switch (pic->icw_index) {
@@ -307,6 +309,7 @@ static void write_data(io_port_t port, io_val_t value, io_width_t)
 
 static uint8_t read_command(io_port_t port, io_width_t)
 {
+	std::lock_guard lock(pic_mutex);
 	PIC_Controller *pic = &pics[port == 0x20 ? 0 : 1];
 	if (pic->request_issr) {
 		return pic->isr;
@@ -317,6 +320,7 @@ static uint8_t read_command(io_port_t port, io_width_t)
 
 static uint8_t read_data(io_port_t port, io_width_t)
 {
+	std::lock_guard lock(pic_mutex);
 	PIC_Controller *pic = &pics[port == 0x21 ? 0 : 1];
 	return pic->imr;
 }

--- a/src/hardware/pic.cpp
+++ b/src/hardware/pic.cpp
@@ -567,7 +567,7 @@ bool PIC_RunQueue(void) {
 		}
 	} else CPU_Cycles = CPU_CycleLeft.load();
 	CPU_CycleLeft-=CPU_Cycles;
-	if (PIC_IRQCheck) PIC_runIRQs();
+	PIC_runIRQs();
 	return true;
 }
 


### PR DESCRIPTION
# Description

Previously, the main thread would aquire a mutex lock inside the RenderUpToNow() function
Move this lock up one level of the stack to WriteToPort() where RenderUpToNow() gets called
This function sets some additional state variables after it has rendered

Additionally, add a lock to ReadFromPort() to be safe
I did not see any thread sanitizer warnings from this but it modifies the irq_status variable


## Related issues

Fixes #3918

# Release notes

Probably no release notes needed as I couldn't find a user-facing issue.

# Manual testing

Ran thread sanitizer with the ambient demo


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

