### PR TITLE
Fix data race on mixer volume change

### DIFF
--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -815,6 +815,7 @@ void MixerChannel::Set0dbScalar(const float scalar)
 
 void MixerChannel::UpdateCombinedVolume()
 {
+	std::lock_guard lock(mutex);
 	// TODO Now that we use floats, we should apply the master volume at the
 	// very end as it has no risk of overloading the 16-bit range
 	combined_volume_gain = user_volume_gain * app_volume_gain *


### PR DESCRIPTION
# Description

Add a lock to `UpdateCombinedVolume()` to ensure we finish rendering the current block before changing volume to avoid a data race.

## Related issues

Fixes #3922

# Manual testing

Ran TSAN build and confirmed this fixes the thread sanitizer warning

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

