### PR TITLE
Handle double-quotes in the shell similar to real MS-DOS

### DIFF
--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -172,11 +172,12 @@ bool DOS_Shell::ExecuteShellCommand(const char* const name, char* arguments)
 	return true;
 }
 
-void DOS_Shell::DoCommand(char * line) {
-/* First split the line into command and arguments */
-	line=trim(line);
+void DOS_Shell::DoCommand(char* line)
+{
+	// First split the line into command and arguments
+	line = trim(line);
 	char cmd_buffer[CMD_MAXLINE];
-	char * cmd_write=cmd_buffer;
+	char* cmd_write = cmd_buffer;
 
 	auto is_cli_delimiter = [](const char c) {
 		constexpr std::array<char, 6> Delimiters = {'\0', ' ', '/', '\t', '='};
@@ -187,15 +188,19 @@ void DOS_Shell::DoCommand(char * line) {
 
 	// Scan forward until we hit the first delimiter
 	while (!is_cli_delimiter(line[0])) {
-		if ((*line == '.') ||(*line == '\\')) {  //allow stuff like cd.. and dir.exe cd\kees
-			*cmd_write=0;
+		// Handle squashed . and \ syntax like real MS-DOS:
+		//   C:\> cd\keen
+		//   C:\KEEN> cd..
+		//   C:\> dir.exe
+		if ((*line == '.') || (*line == '\\')) {
+			*cmd_write = 0;
 			if (ExecuteShellCommand(cmd_buffer, line)) {
 				return;
 			}
 		}
-		*cmd_write++=*line++;
+		*cmd_write++ = *line++;
 	}
-	*cmd_write=0;
+	*cmd_write = 0;
 	if (is_empty(cmd_buffer)) {
 		return;
 	}

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -180,7 +180,7 @@ void DOS_Shell::DoCommand(char* line)
 	char* cmd_write = cmd_buffer;
 
 	auto is_cli_delimiter = [](const char c) {
-		constexpr std::array<char, 6> Delimiters = {'\0', ' ', '/', '\t', '='};
+		constexpr std::array<char, 7> Delimiters = {'\0', ' ', '/', '\t', '=', '"'};
 		// Note: ':' is also a delimiter, but handling it here breaks
 		//       drive switching as that is handled at a later stage.
 		return contains(Delimiters, c);

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -178,12 +178,15 @@ void DOS_Shell::DoCommand(char * line) {
 	char cmd_buffer[CMD_MAXLINE];
 	char * cmd_write=cmd_buffer;
 
-	while (*line) {
-		if (*line == 32) break;
-		if (*line == '/') break;
-		if (*line == '\t') break;
-		if (*line == '=') break;
-//		if (*line == ':') break; //This breaks drive switching as that is handled at a later stage.
+	auto is_cli_delimiter = [](const char c) {
+		constexpr std::array<char, 6> Delimiters = {'\0', ' ', '/', '\t', '='};
+		// Note: ':' is also a delimiter, but handling it here breaks
+		//       drive switching as that is handled at a later stage.
+		return contains(Delimiters, c);
+	};
+
+	// Scan forward until we hit the first delimiter
+	while (!is_cli_delimiter(line[0])) {
 		if ((*line == '.') ||(*line == '\\')) {  //allow stuff like cd.. and dir.exe cd\kees
 			*cmd_write=0;
 			if (ExecuteShellCommand(cmd_buffer, line)) {

--- a/tests/shell_cmds_tests.cpp
+++ b/tests/shell_cmds_tests.cpp
@@ -100,6 +100,7 @@ TEST_F(DOS_Shell_CMDSTest, DoCommand_Separating_Chars)
 	        '/',
 	        '\t',
 	        '=',
+	        '"',
 	};
 	for (auto end_chr : end_chars) {
 		MockDOS_Shell shell;
@@ -153,6 +154,17 @@ TEST_F(DOS_Shell_CMDSTest, DoCommand_Nospace_Slash_Handling)
 {
 	assert_DoCommand("CD\\DIRECTORY", "CD", "\\DIRECTORY");
 	assert_DoCommand("CD\\", "CD", "\\");
+}
+
+TEST_F(DOS_Shell_CMDSTest, DoCommand_Nospace_Echo_DoubleQuotes)
+{
+	assert_DoCommand("ECHO\"", "ECHO", "\"");
+	assert_DoCommand("ECHO\"\"", "ECHO", "\"\"");
+}
+
+TEST_F(DOS_Shell_CMDSTest, DoCommand_Nospace_If_DoubleQuotes)
+{
+	assert_DoCommand("IF\"1\"==\"1\"", "IF", "\"1\"==\"1\"");
 }
 
 TEST_F(DOS_Shell_CMDSTest, CMD_ECHO_off_on)


### PR DESCRIPTION
# Description

Real MS-DOS handles the first double quote as a delimiter, for example:

```
C:\> echo"

C:\> echo""
"

C:\> echo "hi"
"hi"

C:\> if"1"=="1" echo matched
matched
```

Where as DOSBox Staging wasn't able to handle this as mentioned in #3921 as well as mentioned by darksky on Discord:

> Does the current version support the `if"` clause and `%1` in batch files? I've noticed quite a few issues with it in the past month but generally assumed it's the game, but now I'm looking into it and I'm noticing potential bugs for example, `if"%1"=="1" goto adlib` results in `Illegal command: if"1"`
> it might not be the cleanest batch file but I believe that worked in DOS

I tested **darksky**'s command and indeed, `if"%1"=="1"` does work in real MS-DOS.

## Related issues

Fixes #3921 as well as the strange space-less format in statements like `if"%1"=="1"`

# Release notes

The command shell now handles double-quotes without preceding spaces similar to real DOS. For example, `ECHO"` will now print an empty line and .BAT files that use squashed syntax, like `if"%1"=="1" goto adlib` will also now work.

# Manual testing

Tested manually against real MS-DOS 6.22 `COMMAND.COM` and also added unit tests.

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [x] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [x] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

