### PR TITLE
Provide application name to SDL

### DIFF
--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -4941,6 +4941,17 @@ int sdl_main(int argc, char* argv[])
 		        SDL_GetCurrentVideoDriver(),
 		        SDL_GetCurrentAudioDriver());
 
+#if defined SDL_HINT_APP_NAME
+		// For KDE 6 volume applet and PipeWire audio driver; further
+		// SetHint calls have no effect in the GUI, only the first
+		// advertised name is used
+		SDL_SetHint(SDL_HINT_APP_NAME, DOSBOX_NAME);
+#endif
+#if defined SDL_HINT_AUDIO_DEVICE_STREAM_NAME
+		// Useful for 'pw-top' and possibly other PipeWire CLI tools
+		SDL_SetHint(SDL_HINT_AUDIO_DEVICE_STREAM_NAME, DOSBOX_NAME);
+#endif
+
 		for (auto line : arguments->set) {
 			trim(line);
 


### PR DESCRIPTION
# Description

When testing on Linux with:
- SDL 2.30.7 using PipeWire audio driver
- KDE Plasma 6.1 with KDE Frameworks 6.5

I have noticed the volume applet displays DOSBox as a mysterious _SDL Application_ (you might need to execute DOSBox using `SDL_AUDIODRIVER=pipewire dosbox` command to see the issue - depending on your OS configuration):

![Screenshot-Before](https://github.com/user-attachments/assets/7020048f-28ea-4640-8baf-9f0d5a0dd933)

This PR sets the name to _DOSBox Staging_:

![Screenshot-After](https://github.com/user-attachments/assets/8a24ee00-1c44-47a3-b0f2-bfdb9b5b94ca)

Unfortunately, changing the application name later on does not change the displayed name (only the first SDL hint is used) - so that adapting the name based on `window_titlebar` config option is not feasible, at least for now.

# Release notes

On _Linux_ systems using _PipeWire_ sound daemon, tools like `pw-top`, `pavucontrol`, or KDE volume applet now show the proper application name, _DOSBox Staging_, instead of the generic _SDL Application_.

# Manual testing

Execute DOSBox Staging with `SDL_AUDIODRIVER=pipewire dosbox` command, check the application name displayed in the KDE volume applet.

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

