### PR TITLE
Fix data race in the mapper when using `autotype`

### DIFF
--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -24,18 +24,15 @@
 #include <algorithm>
 #include <cassert>
 #include <cctype>
-#include <chrono>
 #include <cstdarg>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
-#include <atomic>
 #include <list>
-#include <thread>
+#include <queue>
 #include <vector>
 
 #include <SDL.h>
-#include <SDL_thread.h>
 
 #include "control.h"
 #include "joystick.h"
@@ -107,6 +104,7 @@ static std::vector<std::unique_ptr<CButton>> buttons;
 static std::vector<CBindGroup *> bindgroups;
 static std::vector<CHandlerEvent *> handlergroup;
 static std::list<CBind *> all_binds;
+static std::queue<std::string> auto_type_queue = {};
 
 typedef std::list<CBind *> CBindList;
 typedef std::list<CBind *>::iterator CBindList_it;
@@ -1342,125 +1340,65 @@ void MAPPER_TriggerEvent(const CEvent *event, const bool deactivation_state) {
 	}
 }
 
-class Typer {
-public:
-	Typer() = default;
-	Typer(const Typer &) = delete;            // prevent copy
-	Typer &operator=(const Typer &) = delete; // prevent assignment
-	~Typer() { Stop(); }
-	void Start(std::vector<std::unique_ptr<CEvent>> *ext_events,
-	           std::vector<std::string> &ext_sequence,
-	           const uint32_t wait_ms,
-	           const uint32_t pace_ms)
-	{
-		// Guard against empty inputs
-		if (!ext_events || ext_sequence.empty())
-			return;
-		Wait();
-		m_events = ext_events;
-		m_sequence = std::move(ext_sequence);
-		m_wait_ms = wait_ms;
-		m_pace_ms = pace_ms;
-		m_stop_requested = false;
-		m_instance = std::thread(&Typer::Callback, this);
-		set_thread_name(m_instance, "dosbox:autotype");
+// Presses or releases the next button in AUTOTYPE's queue. When the button is
+// released it's popped from the queue.
+static void auto_type_queued_button(uint32_t type_action_value)
+{
+	if (auto_type_queue.empty()) {
+		return;
 	}
-	void Wait()
-	{
-		if (m_instance.joinable())
-			m_instance.join();
-	}
-	void Stop()
-	{
-		m_stop_requested = true;
-		Wait();
-	}
-	void StopImmediately()
-	{
-		m_stop_requested = true;
-		if (m_instance.joinable())
-			m_instance.detach();
-	}
+	auto button = auto_type_queue.front();
 
-private:
-	// find the event for the lshift key and return it
-	CEvent *GetLShiftEvent()
-	{
-		static CEvent *lshift_event = nullptr;
-		for (auto &event : *m_events) {
-			if (std::string("key_lshift") == event->GetName()) {
-				lshift_event = event.get();
-				break;
-			}
+	const auto is_upper_case = button.length() == 1 &&
+	                           std::isupper(button.front());
+
+	const auto action = static_cast<TypeAction>(type_action_value);
+
+	// Upper case buttons are input using shift + lower case button
+	if (is_upper_case) {
+		type_button("lshift", action);
+		button.front() = std::tolower(button.front());
+	}
+	type_button(button, action);
+
+	if (action == TypeAction::Release) {
+		auto_type_queue.pop();
+	}
+}
+
+// Add each of the given buttons with a corresponding pair of press and release
+// PIC-timed events delayed into the future based on the given wait and pace times.
+void MAPPER_AutoType(std::vector<std::string>& buttons, uint32_t wait_ms,
+                     uint32_t pace_ms)
+{
+	uint32_t running_delay_ms = wait_ms;
+
+	for (auto& button : buttons) {
+		if (button == ",") {
+			running_delay_ms += pace_ms;
+		} else {
+			auto_type_queue.emplace(std::move(button));
+
+			PIC_AddEvent(auto_type_queued_button,
+			             running_delay_ms,
+			             static_cast<uint32_t>(TypeAction::Press));
+
+			constexpr auto ReleaseDelayMs = 50;
+			running_delay_ms += ReleaseDelayMs;
+
+			PIC_AddEvent(auto_type_queued_button,
+			             running_delay_ms,
+			             static_cast<uint32_t>(TypeAction::Release));
 		}
-		assert(lshift_event);
-		return lshift_event;
+		running_delay_ms += pace_ms;
 	}
+}
 
-	void Callback()
-	{
-		// quit before our initial wait time
-		if (m_stop_requested)
-			return;
-		std::this_thread::sleep_for(std::chrono::milliseconds(m_wait_ms));
-		for (const auto &button : m_sequence) {
-			if (m_stop_requested)
-				return;
-			bool found = false;
-			// comma adds an extra pause, similar to on phones
-			if (button == ",") {
-				found = true;
-				// quit before the pause
-				if (m_stop_requested)
-					return;
-				std::this_thread::sleep_for(std::chrono::milliseconds(m_pace_ms));
-				// Otherwise trigger the matching button if we have one
-			} else {
-				// is the button an upper case letter?
-				const auto is_cap = button.length() == 1 && isupper(button[0]);
-				const auto maybe_lshift = is_cap ? GetLShiftEvent() : nullptr;
-				const std::string lbutton = is_cap ? std::string{int_to_char(
-				                                             tolower(button[0]))}
-				                                   : button;
-				const std::string bind_name = "key_" + lbutton;
-				for (auto &event : *m_events) {
-					if (bind_name == event->GetName()) {
-						found = true;
-						if (maybe_lshift)
-							maybe_lshift->Active(true);
-						event->Active(true);
-						std::this_thread::sleep_for(
-						        std::chrono::milliseconds(50));
-						event->Active(false);
-						if (maybe_lshift)
-							maybe_lshift->Active(false);
-						break;
-					}
-				}
-			}
-			/*
-			 *  Terminate the sequence for safety reasons if we can't find
-			 * a button. For example, we don't wan't DEAL becoming DEL, or
-			 * 'rem' becoming 'rm'
-			 */
-			if (!found) {
-				LOG_MSG("MAPPER: Couldn't find a button named '%s', stopping.",
-				        button.c_str());
-				return;
-			}
-			if (m_stop_requested) // quit before the pacing delay
-				return;
-			std::this_thread::sleep_for(std::chrono::milliseconds(m_pace_ms));
-		}
-	}
-
-	std::thread m_instance = {};
-	std::vector<std::string> m_sequence = {};
-	std::vector<std::unique_ptr<CEvent>>* m_events = nullptr;
-	uint32_t m_wait_ms = 0;
-	uint32_t m_pace_ms = 0;
-	std::atomic_bool m_stop_requested{false};
-};
+void MAPPER_StopAutoTyping()
+{
+	auto_type_queue = {};
+	PIC_RemoveEvents(auto_type_queued_button);
+}
 
 static struct CMapper {
 	SDL_Window *window = nullptr;
@@ -1477,8 +1415,7 @@ static struct CMapper {
 		CStickBindGroup *stick[MAXSTICKS] = {nullptr};
 		unsigned int num = 0;
 		unsigned int num_groups = 0;
-	} sticks = {};
-	Typer typist = {};
+	} sticks             = {};
 	std::string filename = "";
 } mapper;
 
@@ -2688,9 +2625,9 @@ static struct {
 
                    {nullptr, SDL_SCANCODE_UNKNOWN}};
 
-static void ClearAllBinds() {
-	// wait for the auto-typer to complete because it might be accessing events
-	mapper.typist.Wait();
+static void ClearAllBinds()
+{
+	MAPPER_StopAutoTyping();
 
 	for (const auto& event : events) {
 		event->ClearBinds();
@@ -3279,8 +3216,7 @@ static void MAPPER_Destroy(Section *sec) {
 	(void) sec; // unused but present for API compliance
 
 	// Stop any ongoing typing as soon as possible (because it access events)
-	mapper.typist.Stop();
-
+	MAPPER_StopAutoTyping();
 	// Release all the accumulated allocations by the mapper
 	events.clear();
 
@@ -3385,17 +3321,6 @@ std::vector<std::string> MAPPER_GetEventNames(const std::string &prefix) {
 		}
 	}
 	return key_names;
-}
-
-void MAPPER_AutoType(std::vector<std::string> &sequence,
-                     const uint32_t wait_ms,
-                     const uint32_t pace_ms) {
-	mapper.typist.Start(&events, sequence, wait_ms, pace_ms);
-}
-
-void MAPPER_AutoTypeStopImmediately()
-{
-	mapper.typist.StopImmediately();
 }
 
 void MAPPER_StartUp(Section* sec)

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -206,6 +206,26 @@ public:
 	virtual void RepostActivity() {}
 };
 
+enum TypeAction : bool { Press, Release };
+
+// A helper function that either presses or releases the named button.
+static void type_button(const std::string& button, const TypeAction action)
+{
+	const auto button_name = "key_" + button;
+
+	// Find the button's event in the mapper's global events vector
+	auto it = std::find_if(events.begin(), events.end(), [&](const auto& event) {
+		return event->GetName() == button_name;
+	});
+	if (it != events.end()) {
+		(*it)->Active(action == TypeAction::Press);
+	} else {
+		LOG_ERR("MAPPER: Couldn't find a button named '%s' to %s",
+		        button.c_str(),
+		        action == TypeAction::Press ? "press" : "release");
+	}
+}
+
 class CBind {
 public:
 	CBind(CBindList *binds)

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -1966,7 +1966,7 @@ void DOS_Shell::CMD_LOADHIGH(char *args){
 void MAPPER_AutoType(std::vector<std::string> &sequence,
                      const uint32_t wait_ms,
                      const uint32_t pacing_ms);
-void MAPPER_AutoTypeStopImmediately();
+void MAPPER_StopAutoTyping();
 void DOS_21Handler();
 
 void DOS_Shell::CMD_CHOICE(char * args){
@@ -2064,7 +2064,7 @@ void DOS_Shell::CMD_CHOICE(char * args){
 		if (always_capitalize)
 			choice = static_cast<char>(toupper(choice));
 		if (using_auto_type)
-			MAPPER_AutoTypeStopImmediately();
+			MAPPER_StopAutoTyping();
 		if (shutdown_requested)
 			break;
 		if (choice == ctrl_c)


### PR DESCRIPTION
# Description

When testing older TSAN builds, I had trouble automating some intro steps with `AUTOTYPE` because TSAN threw data race warnings from the mapper and PIC system.  For example:

```
WARNING: ThreadSanitizer: data race (pid=1810861)
  Write of size 8 at 0x00000319d118 by main thread:
    #0 PIC_RunQueue() ../../src/hardware/pic.cpp:560
    #1 Normal_Loop ../../src/dosbox.cpp:168
    #2 DOSBOX_RunMachine() ../../src/dosbox.cpp:450
    #3 CALLBACK_RunRealInt(unsigned char) ../../src/cpu/callback.cpp:117
    #4 device_CON::Read(unsigned char*, unsigned short*) ../../src/dos/dev_con.h:89
    ...

  Previous write of size 8 at 0x00000319d118 by thread T18:
    #0 AddEntry ../../src/hardware/pic.cpp:442
    #1 PIC_AddEvent(void (*)(unsigned int), double, unsigned int) ../../src/hardware/pic.cpp:484
    #2 restart_delay_timer ../../src/hardware/input/intel8042.cpp:452
    #3 maybe_transfer_buffer ../../src/hardware/input/intel8042.cpp:480
    ...
```

This PR fixes those warnings by refactoring the 'Typist' class in the mapper.

## Related issues

Here's a full log of all TSAN issues hit when using `AUTOTYPE`:

[autotype-tsan-multiple.txt.gz](https://github.com/user-attachments/files/16989177/autotype-tsan-multiple.txt.gz)

# Manual testing

Tested normal builds, TSAN builds, with normal and missing/bad AUTOTYPE buttons. It's working as expected with the same wait and pause timings as before.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

