### PR TITLE
Fix CI to create Debian package on `main` push

### DIFF
--- a/.github/workflows/debian-package.yml
+++ b/.github/workflows/debian-package.yml
@@ -1,9 +1,9 @@
 name: Debian package build
 
 on:
-  pull_request:
-    branches: [ main ]
-    types: [ closed ]
+  push:
+    branches:
+      - main
     paths-ignore:
       - '.clang-format'
       - '.mdl-styles'


### PR DESCRIPTION
# Description

The Debian packager workflow runs on branches at the time they're merged to `main`, however we originally wanted it to run on `main` (_after_ branches are merged).  This fixes that criteria.

(If we want to include it for 0.82, then we can attach the CI .deb to the release binaries, too).

# Manual testing

None, because the adjustment is only to the CI workflow.

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [ ] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

