### PR TITLE
Follow-up fix for Debian package on `main` push

### DIFF
--- a/.github/workflows/debian-package.yml
+++ b/.github/workflows/debian-package.yml
@@ -18,7 +18,6 @@ concurrency:
 
 jobs:
   build:
-    if: ${{ github.event.pull_request.merged }}
     name: Release package ${{ matrix.arch }}
     runs-on: ubuntu-22.04
     strategy:


### PR DESCRIPTION
# Description

Preface -- sorry for the churn guys!

After the prior merge, the job still didn't run:

![debian-pkg-still-not-running](https://github.com/user-attachments/assets/75041f31-735f-4af2-b5f3-ee1d03e08513)

Turns out there was one remaining condition blocking it from running, which I've now snipped out. I don't see any other blocks, so hopefully this is it!

# Manual testing

(Not tested.. unfortunately main-only-CI tests only trigger after merging to `main`).

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

