### PR TITLE
Use std::atomic for CaptureState enum

### DIFF
--- a/src/capture/capture.cpp
+++ b/src/capture/capture.cpp
@@ -47,9 +47,9 @@ static struct {
 	bool path_initialised = false;
 
 	struct {
-		CaptureState audio = {};
-		CaptureState midi  = {};
-		CaptureState video = {};
+		std::atomic<CaptureState> audio = {};
+		std::atomic<CaptureState> midi  = {};
+		std::atomic<CaptureState> video = {};
 	} state = {};
 
 	struct {
@@ -61,6 +61,16 @@ static struct {
 		int32_t image              = 1;
 		int32_t serial_log         = 1;
 	} next_index = {};
+
+	void reset()
+	{
+		path.clear();
+		path_initialised = false;
+		state.audio = CaptureState::Off;
+		state.midi = CaptureState::Off;
+		state.video = CaptureState::Off;
+		next_index = {};
+	}
 } capture = {};
 
 static std::unique_ptr<ImageCapturer> image_capturer = {};
@@ -577,7 +587,7 @@ static void capture_destroy(Section* /*sec*/)
 		capture.state.video = CaptureState::Off;
 	}
 
-	capture = {};
+	capture.reset();
 }
 
 static void capture_init(Section* sec)


### PR DESCRIPTION
# Description

More TSAN warning fixes.  I had to write a `reset()` function since `= {}` would not compile as `std::atomic` has the assignment operator deleted.

## Related issues

Fixes #3927

# Release notes

Nothing user facing.  Just more TSAN fixes.

# Manual testing

Ran a TSAN build and captured audio and video in Doom.  No more warning are shown.  I actually never got a warning on my system for audio but I did for video.  The video warning had a different callstack but it was these same enum variables that were the problem.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

