### PR TITLE
Avoid a TSAN issue in SDL by using DOSBox's PIC timer to animate the `[● REC]` animation

### DIFF
--- a/include/sdlmain.h
+++ b/include/sdlmain.h
@@ -166,11 +166,6 @@ enum PRIORITY_LEVELS {
 	PRIORITY_LEVEL_HIGHEST
 };
 
-enum class SDL_DosBoxEvents : uint8_t {
-	RefreshAnimatedTitle,
-	NumEvents // dummy, keep last, do not use
-};
-
 struct SDL_Block {
 	bool initialized     = false;
 	bool active          = false; // If this isn't set don't draw

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3777,26 +3777,6 @@ static bool maybe_auto_switch_shader()
 	                                    reinit_render);
 }
 
-static bool is_user_event(const SDL_Event& event)
-{
-	const auto start_id = sdl.start_event_id;
-	const auto end_id   = start_id + enum_val(SDL_DosBoxEvents::NumEvents);
-
-	return (event.common.type >= start_id && event.common.type < end_id);
-}
-
-static void handle_user_event(const SDL_Event& event)
-{
-	const auto id = event.common.type - sdl.start_event_id;
-	switch (static_cast<SDL_DosBoxEvents>(id)) {
-	case SDL_DosBoxEvents::RefreshAnimatedTitle:
-		GFX_RefreshAnimatedTitle();
-		break;
-	default:
-		assert(false);
-	}
-}
-
 bool GFX_Events()
 {
 #if defined(MACOSX)
@@ -3829,10 +3809,6 @@ bool GFX_Events()
 			continue;
 		}
 #endif
-		if (is_user_event(event)) {
-			handle_user_event(event);
-			continue;
-		}
 		switch (event.type) {
 		case SDL_DISPLAYEVENT:
 			switch (event.display.event) {
@@ -4917,13 +4893,8 @@ int sdl_main(int argc, char* argv[])
 			return err;
 		}
 
-		// Timer is needed for title bar animations
-		if (SDL_Init(SDL_INIT_AUDIO | SDL_INIT_VIDEO | SDL_INIT_TIMER) < 0) {
+		if (SDL_Init(SDL_INIT_AUDIO | SDL_INIT_VIDEO) < 0) {
 			E_Exit("SDL: Can't init SDL %s", SDL_GetError());
-		}
-		sdl.start_event_id = SDL_RegisterEvents(enum_val(SDL_DosBoxEvents::NumEvents));
-		if (sdl.start_event_id == UINT32_MAX) {
-			E_Exit("SDL: Failed to alocate event IDs");
 		}
 
 		sdl.initialized = true;


### PR DESCRIPTION
# Description

When investigating TSAN issues relating to audio and video capture, @weirddan455 figured out that some of my issues were coming from SDL's threaded timer handling used by the titlebar animation.

The titlebar animation is fine, but it's SDL threaded timer that has some non-trivial internatls (and it's in there where the TSAN data races exist):

```
WARNING: ThreadSanitizer: data race (pid=21888)
  Read of size 4 at 0x000001963320 by main thread (mutexes: write M0):
    #0 SDL_AtomicTryLock_REAL ../../subprojects/SDL2-2.30.6/src/atomic/SDL_spinlock.c:75
    #1 SDL_AtomicLock_REAL ../../subprojects/SDL2-2.30.6/src/atomic/SDL_spinlock.c:176
    #2 SDL_AddTimer_REAL ../../subprojects/SDL2-2.30.6/src/timer/SDL_timer.c:283
    #3 SDL_AddTimer ../../subprojects/SDL2-2.30.6/src/dynapi/SDL_dynapi_procs.h:519
    #4 maybe_start_animation ../../src/gui/titlebar.cpp:154
    #5 GFX_RefreshTitle() ../../src/gui/titlebar.cpp:387
    #6 GFX_NotifyVideoCaptureStatus(bool) ../../src/gui/titlebar.cpp:418
    #7 CAPTURE_StartVideoCapture() ../../src/capture/capture.cpp:370
    #8 handle_capture_video_event ../../src/capture/capture.cpp:567
    #9 CHandlerEvent::Active(bool) ../../src/gui/sdl_mapper.cpp:1855
    #10 CTriggeredEvent::ActivateEvent(bool, bool) ../../src/gui/sdl_mapper.cpp:158
    #11 CBind::ActivateBind(long, bool, bool) ../../src/gui/sdl_mapper.cpp:274
    #12 CBindGroup::ActivateBindList(std::__debug::list<CBind*, std::allocator<CBind*> >*, long, bool) ../../src/gui/sdl_mapper.cpp:1432
    #13 CKeyBindGroup::CheckEvent(SDL_Event*) ../../src/gui/sdl_mapper.cpp:450
    #14 MAPPER_CheckEvent(SDL_Event*) ../../src/gui/sdl_mapper.cpp:2783
    #15 GFX_Events() ../../src/gui/sdlmain.cpp:4165
    #16 Normal_Loop ../../src/dosbox.cpp:188
    #17 DOSBOX_RunMachine() ../../src/dosbox.cpp:450
    #18 CALLBACK_RunRealInt(unsigned char) ../../src/cpu/callback.cpp:117
    #19 device_CON::Read(unsigned char*, unsigned short*) ../../src/dos/dev_con.h:89
    #20 DOS_Device::Read(unsigned char*, unsigned short*) ../../src/dos/dos_devices.cpp:329
    #21 DOS_ReadFile(unsigned short, unsigned char*, unsigned short*, bool) ../../src/dos/dos_files.cpp:665
    #22 DOS_Shell::ReadCommand[abi:cxx11]() ../../src/shell/shell_misc.cpp:140
    #23 DOS_Shell::InputCommand(char*) ../../src/shell/shell_misc.cpp:79
    #24 DOS_Shell::Run() ../../src/shell/shell.cpp:492
    #25 SHELL_Init() ../../src/shell/shell.cpp:1430
    #26 Config::StartUp() ../../src/misc/setup.cpp:1669
    #27 sdl_main(int, char**) ../../src/gui/sdlmain.cpp:5046
    #28 main ../../src/main.cpp:30

  Previous atomic write of size 4 at 0x000001963320 by thread T1:
    #0 SDL_AtomicUnlock_REAL ../../subprojects/SDL2-2.30.6/src/atomic/SDL_spinlock.c:190
    #1 SDL_TimerThread ../../subprojects/SDL2-2.30.6/src/timer/SDL_timer.c:130
    #2 SDL_RunThread ../../subprojects/SDL2-2.30.6/src/thread/SDL_thread.c:333
    #3 RunThread ../../subprojects/SDL2-2.30.6/src/thread/pthread/SDL_systhread.c:76

  Location is global 'SDL_timer_data' of size 208 at 0x000001963280

  Mutex M0 (0x720c00000c00) created at:
    #0 pthread_mutex_init ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1315 (libtsan.so.2+0x58bfd) (BuildId: 64c1e8de04b11a7d960abd7e45f94f3b277b7779)
    #1 SDL_CreateMutex_REAL ../../subprojects/SDL2-2.30.6/src/thread/pthread/SDL_sysmutex.c:58
    #2 SDL_AtomicTryLock_REAL ../../subprojects/SDL2-2.30.6/src/atomic/SDL_spinlock.c:72
    #3 SDL_AtomicLock_REAL ../../subprojects/SDL2-2.30.6/src/atomic/SDL_spinlock.c:176
    #4 SDL_GetErrBuf ../../subprojects/SDL2-2.30.6/src/thread/SDL_thread.c:275
    #5 SDL_ClearError_REAL ../../subprojects/SDL2-2.30.6/src/SDL_error.c:72
    #6 SDL_InitSubSystem_REAL ../../subprojects/SDL2-2.30.6/src/SDL.c:222
    #7 SDL_InitSubSystem_REAL ../../subprojects/SDL2-2.30.6/src/SDL.c:217
    #8 SDL_Init_REAL ../../subprojects/SDL2-2.30.6/src/SDL.c:394
    #9 SDL_Init ../../subprojects/SDL2-2.30.6/src/dynapi/SDL_dynapi_procs.h:88
    #10 sdl_main(int, char**) ../../src/gui/sdlmain.cpp:4921
    #11 main ../../src/main.cpp:30

  Thread T1 'SDLTimer' (tid=21890, running) created by main thread at:
    #0 pthread_create ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1022 (libtsan.so.2+0x5a267) (BuildId: 64c1e8de04b11a7d960abd7e45f94f3b277b7779)
    #1 SDL_SYS_CreateThread ../../subprojects/SDL2-2.30.6/src/thread/pthread/SDL_systhread.c:116
    #2 SDL_CreateThreadWithStackSize_REAL ../../subprojects/SDL2-2.30.6/src/thread/SDL_thread.c:401
    #3 SDL_CreateThreadInternal ../../subprojects/SDL2-2.30.6/src/thread/SDL_thread.c:452
    #4 SDL_TimerInit ../../subprojects/SDL2-2.30.6/src/timer/SDL_timer.c:227
    #5 SDL_InitSubSystem_REAL ../../subprojects/SDL2-2.30.6/src/SDL.c:256
    #6 SDL_InitSubSystem_REAL ../../subprojects/SDL2-2.30.6/src/SDL.c:217
    #7 SDL_Init_REAL ../../subprojects/SDL2-2.30.6/src/SDL.c:394
    #8 SDL_Init ../../subprojects/SDL2-2.30.6/src/dynapi/SDL_dynapi_procs.h:88
    #9 sdl_main(int, char**) ../../src/gui/sdlmain.cpp:4921
    #10 main ../../src/main.cpp:30

SUMMARY: ThreadSanitizer: data race ../../subprojects/SDL2-2.30.6/src/atomic/SDL_spinlock.c:75 in SDL_AtomicTryLock_REAL
==================
==================
WARNING: ThreadSanitizer: data race (pid=21888)
  Read of size 8 at 0x000001963330 by main thread:
    #0 SDL_AddTimer_REAL ../../subprojects/SDL2-2.30.6/src/timer/SDL_timer.c:329
    #1 SDL_AddTimer ../../subprojects/SDL2-2.30.6/src/dynapi/SDL_dynapi_procs.h:519
    #2 maybe_start_animation ../../src/gui/titlebar.cpp:154
    #3 GFX_RefreshTitle() ../../src/gui/titlebar.cpp:387
    #4 GFX_NotifyVideoCaptureStatus(bool) ../../src/gui/titlebar.cpp:418
    #5 CAPTURE_StartVideoCapture() ../../src/capture/capture.cpp:370
    #6 handle_capture_video_event ../../src/capture/capture.cpp:567
    #7 CHandlerEvent::Active(bool) ../../src/gui/sdl_mapper.cpp:1855
    #8 CTriggeredEvent::ActivateEvent(bool, bool) ../../src/gui/sdl_mapper.cpp:158
    #9 CBind::ActivateBind(long, bool, bool) ../../src/gui/sdl_mapper.cpp:274
    #10 CBindGroup::ActivateBindList(std::__debug::list<CBind*, std::allocator<CBind*> >*, long, bool) ../../src/gui/sdl_mapper.cpp:1432
    #11 CKeyBindGroup::CheckEvent(SDL_Event*) ../../src/gui/sdl_mapper.cpp:450
    #12 MAPPER_CheckEvent(SDL_Event*) ../../src/gui/sdl_mapper.cpp:2783
    #13 GFX_Events() ../../src/gui/sdlmain.cpp:4165
    #14 Normal_Loop ../../src/dosbox.cpp:188
    #15 DOSBOX_RunMachine() ../../src/dosbox.cpp:450
    #16 CALLBACK_RunRealInt(unsigned char) ../../src/cpu/callback.cpp:117
    #17 device_CON::Read(unsigned char*, unsigned short*) ../../src/dos/dev_con.h:89
    #18 DOS_Device::Read(unsigned char*, unsigned short*) ../../src/dos/dos_devices.cpp:329
    #19 DOS_ReadFile(unsigned short, unsigned char*, unsigned short*, bool) ../../src/dos/dos_files.cpp:665
    #20 DOS_Shell::ReadCommand[abi:cxx11]() ../../src/shell/shell_misc.cpp:140
    #21 DOS_Shell::InputCommand(char*) ../../src/shell/shell_misc.cpp:79
    #22 DOS_Shell::Run() ../../src/shell/shell.cpp:492
    #23 SHELL_Init() ../../src/shell/shell.cpp:1430
    #24 Config::StartUp() ../../src/misc/setup.cpp:1669
    #25 sdl_main(int, char**) ../../src/gui/sdlmain.cpp:5046
    #26 main ../../src/main.cpp:30

  Previous write of size 8 at 0x000001963330 by thread T1:
    #0 SDL_TimerThread ../../subprojects/SDL2-2.30.6/src/timer/SDL_timer.c:122
    #1 SDL_RunThread ../../subprojects/SDL2-2.30.6/src/thread/SDL_thread.c:333
    #2 RunThread ../../subprojects/SDL2-2.30.6/src/thread/pthread/SDL_systhread.c:76

  Location is global 'SDL_timer_data' of size 208 at 0x000001963280

  Thread T1 'SDLTimer' (tid=21890, running) created by main thread at:
    #0 pthread_create ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1022 (libtsan.so.2+0x5a267) (BuildId: 64c1e8de04b11a7d960abd7e45f94f3b277b7779)
    #1 SDL_SYS_CreateThread ../../subprojects/SDL2-2.30.6/src/thread/pthread/SDL_systhread.c:116
    #2 SDL_CreateThreadWithStackSize_REAL ../../subprojects/SDL2-2.30.6/src/thread/SDL_thread.c:401
    #3 SDL_CreateThreadInternal ../../subprojects/SDL2-2.30.6/src/thread/SDL_thread.c:452
    #4 SDL_TimerInit ../../subprojects/SDL2-2.30.6/src/timer/SDL_timer.c:227
    #5 SDL_InitSubSystem_REAL ../../subprojects/SDL2-2.30.6/src/SDL.c:256
    #6 SDL_InitSubSystem_REAL ../../subprojects/SDL2-2.30.6/src/SDL.c:217
    #7 SDL_Init_REAL ../../subprojects/SDL2-2.30.6/src/SDL.c:394
    #8 SDL_Init ../../subprojects/SDL2-2.30.6/src/dynapi/SDL_dynapi_procs.h:88
    #9 sdl_main(int, char**) ../../src/gui/sdlmain.cpp:4921
    #10 main ../../src/main.cpp:30

SUMMARY: ThreadSanitizer: data race ../../subprojects/SDL2-2.30.6/src/timer/SDL_timer.c:329 in SDL_AddTimer_REAL
```

This PR just side steps the problem by eliminating our use SDL's timers and uses the PIC timer to schedule the titlebar updates.

Combined with @weirddan455's PR https://github.com/dosbox-staging/dosbox-staging/pull/3931, I can now rapidly start and stop all of our media captures in quick succession without any TSAN issues:

```
2024-09-14 21:14:25.682 | CAPTURE: Capturing video output to '/home/pi/.config/dosbox/capture/video0192.avi'
2024-09-14 21:14:25.802 | CAPTURE: Capturing audio output to '/home/pi/.config/dosbox/capture/audio0075.wav'
2024-09-14 21:14:25.808 | CAPTURE: Stopped capturing audio output
2024-09-14 21:14:25.812 | CAPTURE: Stopped capturing video output
2024-09-14 21:14:25.845 | CAPTURE: Capturing upscaled image to '/home/pi/.config/dosbox/capture/image0009.png'
2024-09-14 21:14:25.917 | CAPTURE: Capturing upscaled image to '/home/pi/.config/dosbox/capture/image0010.png'
2024-09-14 21:14:26.055 | CAPTURE: Capturing audio output to '/home/pi/.config/dosbox/capture/audio0076.wav'
2024-09-14 21:14:26.137 | CAPTURE: Capturing video output to '/home/pi/.config/dosbox/capture/video0193.avi'
2024-09-14 21:14:26.138 | CAPTURE: Capturing upscaled image to '/home/pi/.config/dosbox/capture/image0011.png'
2024-09-14 21:14:26.495 | CAPTURE: Stopped capturing audio output
2024-09-14 21:14:26.503 | CAPTURE: Stopped capturing video output
2024-09-14 21:14:26.504 | CAPTURE: Cancelling pending video output capture
2024-09-14 21:14:26.504 | CAPTURE: Capturing audio output to '/home/pi/.config/dosbox/capture/audio0077.wav'
2024-09-14 21:14:26.621 | CAPTURE: Stopped capturing audio output
2024-09-14 21:14:26.738 | CAPTURE: Capturing audio output to '/home/pi/.config/dosbox/capture/audio0078.wav'
2024-09-14 21:14:26.770 | CAPTURE: Capturing video output to '/home/pi/.config/dosbox/capture/video0194.avi'
2024-09-14 21:14:27.250 | CAPTURE: Stopped capturing audio output
2024-09-14 21:14:27.277 | CAPTURE: Stopped capturing video output
2024-09-14 21:14:27.291 | CAPTURE: Cancelling pending video output capture
2024-09-14 21:14:27.291 | CAPTURE: Capturing audio output to '/home/pi/.config/dosbox/capture/audio0079.wav'
2024-09-14 21:14:27.368 | CAPTURE: Stopped capturing audio output
2024-09-14 21:14:27.508 | CAPTURE: Capturing video output to '/home/pi/.config/dosbox/capture/video0195.avi'
2024-09-14 21:14:27.889 | CAPTURE: Stopped capturing video output
2024-09-14 21:14:27.910 | CAPTURE: Cancelled pending audio output capture
2024-09-14 21:14:28.039 | CAPTURE: Capturing audio output to '/home/pi/.config/dosbox/capture/audio0080.wav'
2024-09-14 21:14:28.073 | CAPTURE: Capturing video output to '/home/pi/.config/dosbox/capture/video0196.avi'
2024-09-14 21:14:28.490 | CAPTURE: Stopped capturing video output
2024-09-14 21:14:28.492 | CAPTURE: Stopped capturing audio output
2024-09-14 21:14:28.495 | CAPTURE: Capturing audio output to '/home/pi/.config/dosbox/capture/audio0081.wav'
2024-09-14 21:14:28.603 | CAPTURE: Stopped capturing audio output
2024-09-14 21:14:28.700 | CAPTURE: Capturing video output to '/home/pi/.config/dosbox/capture/video0197.avi'
2024-09-14 21:14:29.233 | CAPTURE: Stopped capturing video output
2024-09-14 21:14:29.235 | CAPTURE: Cancelling pending video output capture
2024-09-14 21:14:29.248 | CAPTURE: Cancelled pending audio output capture
2024-09-14 21:14:29.337 | CAPTURE: Stopped capturing video output
2024-09-14 21:14:29.352 | CAPTURE: Capturing audio output to '/home/pi/.config/dosbox/capture/audio0082.wav'
2024-09-14 21:14:30.150 | PCSPEAKER: Shutting down impulse model
2024-09-14 21:14:30.154 | OPL: Shutting down OPL3
2024-09-14 21:14:30.154 | SB16: Shutting down
2024-09-14 21:14:30.154 | MPU-401: Shutting down
```

## Related issues

Related to #3927

# Manual testing

Extensively tested media capture using TSAN build of both DOSBox Staging and TSAN 
-built SDL2.

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

