### PR TITLE
Fix 'launchable' in the Flathub metainfo.xml file

### DIFF
--- a/contrib/linux/org.dosbox-staging.dosbox-staging.metainfo.xml
+++ b/contrib/linux/org.dosbox-staging.dosbox-staging.metainfo.xml
@@ -66,7 +66,7 @@
     <control>console</control>
     <control>gamepad</control>
   </recommends>
-  <launchable type="desktop-id">org.dosbox-staging.DOSBoxStaging.desktop</launchable>
+  <launchable type="desktop-id">org.dosbox-staging.dosbox-staging.desktop</launchable>
   <developer_name>The DOSBox Staging Team</developer_name>
   <update_contact>dreamer.tan@gmail.com</update_contact>
   <url type="homepage">https://www.dosbox-staging.org/</url>


### PR DESCRIPTION
# Description

According to metainfo file specification:
- https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines/#id
- https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines/#launchable

the `launchable` tag must be exactly the same as the `Application-ID` followed by `.desktop` suffix. This rule was broken in the https://github.com/dosbox-staging/dosbox-staging/pull/3854 PR.


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

