### PR TITLE
Enable SDL atomic subsystem in Meson wrap

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -709,7 +709,7 @@ sdl2_dep = dependency(
 
         'use_dummies=false',
         'system_iconv=disabled',
-        'use_atomic=disabled',
+        'use_atomic=enabled',
         'use_file=disabled',
         'use_filesystem=disabled',
         'use_hidapi=disabled',


### PR DESCRIPTION
# Description

Fixes a thread sanitizer warning and known data race (by SDL code comment) inside SDL Timer
This is used in DOSBox Staging for animating the title bar

The SDL atomic subsystem is enabled by default upstream
We had this disabled for some reason in our SDL Meson wrap
When this is disabled, SDL falls back to a sketchy mutex implementation for their custom spinlock

## Related issues

Alternate fix for @interloper98 's PR #3932

# Release notes

No known user-facing bugs

# Manual testing

I was able to reproduce the TSAN warnings by forcing the SDL meson wrap to build.  I used the following command.  Forcing `sdl2_net` is important as otherwise it still used by system SDL.

```
meson setup -Dbuildtype=debug -Dunit_tests=disabled -Db_sanitize=thread --force-fallback-for=sdl2,sdl2_net build/tsan
```

After applying this fix, I no longer get TSAN warnings when rapidly pressing the video record hotkey.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

