### PR TITLE
Use an optimal number of threads in Voodoo 

### DIFF
--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -834,8 +834,19 @@ void DOSBOX_Init()
 	        "   4: 2 MB for the FBI and one TMU with 2 MB (default).\n"
 	        "  12: 4 MB for the FBI and two TMUs, each with 4 MB.");
 
-	pbool = secprop->Add_bool("voodoo_multithreading", only_at_start, true);
-	pbool->Set_help("Use threads to improve 3dfx Voodoo performance (enabled by default).");
+	// Deprecate the boolean Voodoo multithreading setting
+	pbool = secprop->Add_bool("voodoo_multithreading", deprecated, false);
+	pbool->Set_help("Use 'voodoo_threads = auto / <value>'.");
+
+	pstring = secprop->Add_string("voodoo_threads", only_at_start, "auto");
+	pstring->Set_help(
+	        "Use threads to improved 3dfx Voodoo performance:\n"
+	        "  auto:     Use up to 7 threads based on available CPU cores (default).\n"
+	        "            This is in addition to the permanent main thread.\n"
+	        "  <value>:  Set a specific number of additional threads, for example: 12\n"
+	        "Note: Tests show that frame rates increase up to 7 threads after which\n"
+	        "      they level off or decrease, in general.\n"
+	        "      Threads are only created and active when 3dfx Voodoo is in use.");
 
 	pbool = secprop->Add_bool("voodoo_bilinear_filtering", only_at_start, false);
 	pbool->Set_help(


### PR DESCRIPTION
# Description

This PR replaces the `"voodoo_multithreading"` conf setting with `"voodoo_threads"`, which will use up to seven threads based on available CPU cores. This is enabled by default, however the user can either disable it or set a custom number of threads.

The sweet spot of seven threads was based on @PoloniumRain's benchmarks and recommendation:  https://github.com/schellingb/dosbox-pure/issues/300#issuecomment-2144050898.

## Related issues

None.

# Release notes

The `"voodoo_multithreading"` conf setting has been replaced with `"voodoo_threads"`, which uses up to seven threads based on available CPU cores. This is enabled by default, however the user can either disable it or set a custom number of threads.

Thanks to @PoloniumRain's from the DOSBox Pure project for [his benchmark results](https://github.com/schellingb/dosbox-pure/issues/300#issuecomment-2144050898).   

# Manual testing

I'm seeing the same performance on the Pi (4 core), which is expected.
On my Ryzen (8 cores) in win11, I'm seeing modest speed up in Descent 2 and Quake 2 for DOS.

Testing valid and invalid values in the new `"voodoo_threads"` conf setting.

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [ ] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [x] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

