### PR TITLE
Address additional feedback on Voodoo thread count PR #3935

### DIFF
--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -836,17 +836,15 @@ void DOSBOX_Init()
 
 	// Deprecate the boolean Voodoo multithreading setting
 	pbool = secprop->Add_bool("voodoo_multithreading", deprecated, false);
-	pbool->Set_help("Use 'voodoo_threads = auto / <value>'.");
+	pbool->Set_help("Renamed to 'voodoo_threads'");
 
 	pstring = secprop->Add_string("voodoo_threads", only_at_start, "auto");
 	pstring->Set_help(
-	        "Use threads to improved 3dfx Voodoo performance:\n"
-	        "  auto:     Use up to 7 threads based on available CPU cores (default).\n"
-	        "            This is in addition to the permanent main thread.\n"
-	        "  <value>:  Set a specific number of additional threads, for example: 12\n"
-	        "Note: Tests show that frame rates increase up to 7 threads after which\n"
-	        "      they level off or decrease, in general.\n"
-	        "      Threads are only created and active when 3dfx Voodoo is in use.");
+	        "Use threads to improve 3dfx Voodoo performance:\n"
+	        "  auto:     Use up to 8 threads based on available CPU cores (default).\n"
+	        "  <value>:  Set a specific number of threads between 1 and 16.\n"
+	        "Note: Tests show that frame rates increase up to 8 threads after which\n"
+	        "      they level off or decrease, in general.");
 
 	pbool = secprop->Add_bool("voodoo_bilinear_filtering", only_at_start, false);
 	pbool->Set_help(

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -453,13 +453,14 @@ bool Prop_int::IsValidValue(const Value& in)
 		return true;
 	}
 
-	LOG_WARNING("CONFIG: Invalid '%s' setting: '%s'. "
-	            "Value outside of the valid %s-%s range, using '%s'",
-	            propname.c_str(),
-	            in.ToString().c_str(),
-	            min_value.ToString().c_str(),
-	            max_value.ToString().c_str(),
-	            default_value.ToString().c_str());
+	LOG_WARNING(
+	        "CONFIG: Invalid '%s' setting: '%s'. "
+	        "Value outside of the valid range %s-%s, using '%s'",
+	        propname.c_str(),
+	        in.ToString().c_str(),
+	        min_value.ToString().c_str(),
+	        max_value.ToString().c_str(),
+	        default_value.ToString().c_str());
 
 	return false;
 }


### PR DESCRIPTION
# Description

(Per title)


# Manual testing

### Conf block:

```ini
#            voodoo_threads: Use threads to improve 3dfx Voodoo performance:
#                              auto:     Use up to 8 threads based on available CPU cores (default).
#                              <value>:  Set a specific number of threads between 1 and 16.
#                            Note: Tests show that frame rates increase up to 8 threads after which
#                                  they level off or decrease, in general.
```

### Results with valid values:

1. **`voodoo_threads = auto`** (on 4 CPU core rpi)

    `VOODOO: Initialized with 4 MB of RAM, 4 threads, and no bilinear filtering`

1. **`voodoo_threads = 1`**

    `VOODOO: Initialized with 4 MB of RAM, 1 threads, and no bilinear filtering`

1. **`voodoo_threads = 16`**

    `VOODOO: Initialized with 4 MB of RAM, 16 threads, and no bilinear filtering`

### Results with invalid values:

1. **`voodoo_threads = yes`** (on 4 CPU core rpi)

    `VOODOO: Invalid 'voodoo_threads' setting: 'yes', using 'auto'`
    `VOODOO: Initialized with 4 MB of RAM, 3 threads, and no bilinear filtering`

1. **`voodoo_threads = no`** (on 4 CPU core rpi)

    `VOODOO: Invalid 'voodoo_threads' setting: 'no', using 'auto'`
    `VOODOO: Initialized with 4 MB of RAM, 3 threads, and no bilinear filtering`

1. **`voodoo_threads = -1`**
    `CONFIG: Invalid 'voodoo_threads' setting: '17'. Value outside of the valid range 1-16, using '1'`
    `VOODOO: Initialized with 4 MB of RAM, 1 threads, and no bilinear filtering`

1. **`voodoo_threads = 128`**

    `CONFIG: Invalid 'voodoo_threads' setting: '128'. Value outside of the valid range 1-16, using '16'`
    `VOODOO: Initialized with 4 MB of RAM, 16 threads, and no bilinear filtering`

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

