### PR TITLE
Fix `INT10_ReloadFont()` regression on VGA

### DIFF
--- a/src/ints/int10.cpp
+++ b/src/ints/int10.cpp
@@ -230,50 +230,57 @@ static Bitu INT10_Handler(void) {
 		case 0x00: [[fallthrough]];
 		// Load and activate user font
 		case 0x10: {
-			const auto font_data = SegPhys(es) + reg_bp;
-			const auto reload    = (reg_al == 0x10);
-			const auto count     = reg_cx;
-			const auto offset    = reg_dx;
-			const auto map       = reg_bl & 0x7f;
-			const auto height    = reg_bh;
+			const auto font_data   = SegPhys(es) + reg_bp;
+			const auto reload      = (reg_al == 0x10);
+			const auto num_chars   = reg_cx;
+			const auto first_char  = reg_dx;
+			const auto font_block  = reg_bl & 0x7f;
+			const auto char_height = reg_bh;
 
-			INT10_LoadFont(font_data, reload, count, offset, map, height);
+			INT10_LoadFont(font_data,
+			               reload,
+			               num_chars,
+			               first_char,
+			               font_block,
+			               char_height);
 		} break;
 
 		// Load ROM 8x14 font
 		case 0x01: [[fallthrough]];
 		// Load and activate ROM 8x14 font
 		case 0x11: {
-			const auto reload     = (reg_al == 0x11);
-			constexpr auto Count  = 256;
-			constexpr auto Offset = 0;
-			const auto map        = reg_bl & 0x7f;
-			constexpr auto Height = 14;
+			const auto font_data = RealToPhysical(int10.rom.font_14);
+			const auto reload         = (reg_al == 0x11);
+			constexpr auto NumChars   = 256;
+			constexpr auto FirstChar  = 0;
+			const auto font_block     = reg_bl & 0x7f;
+			constexpr auto CharHeight = 14;
 
-			INT10_LoadFont(RealToPhysical(int10.rom.font_14),
+			INT10_LoadFont(font_data,
 			               reload,
-			               Count,
-			               Offset,
-			               map,
-			               Height);
+			               NumChars,
+			               FirstChar,
+			               font_block,
+			               CharHeight);
 		} break;
 
 		// Load ROM 8x8 font
 		case 0x02: [[fallthrough]];
 		// Load and activate ROM 8x8 font
 		case 0x12: {
-			const auto reload     = (reg_al == 0x12);
-			constexpr auto Count  = 256;
-			constexpr auto Offset = 0;
-			const auto map        = reg_bl & 0x7f;
-			constexpr auto Height = 8;
+			const auto font_data = RealToPhysical(int10.rom.font_8_first);
+			const auto reload         = (reg_al == 0x12);
+			constexpr auto NumChars   = 256;
+			constexpr auto FirstChar  = 0;
+			const auto font_block     = reg_bl & 0x7f;
+			constexpr auto CharHeight = 8;
 
-			INT10_LoadFont(RealToPhysical(int10.rom.font_8_first),
+			INT10_LoadFont(font_data,
 			               reload,
-			               Count,
-			               Offset,
-			               map,
-			               Height);
+			               NumChars,
+			               FirstChar,
+			               font_block,
+			               CharHeight);
 		} break;
 
 		// Set Block Specifier
@@ -290,18 +297,19 @@ static Bitu INT10_Handler(void) {
 				break;
 			}
 
-			const auto reload     = (reg_al == 0x14);
-			constexpr auto Count  = 256;
-			constexpr auto Offset = 0;
-			const auto map        = reg_bl & 0x7f;
-			constexpr auto Height = 16;
+			const auto font_data = RealToPhysical(int10.rom.font_16);
+			const auto reload         = (reg_al == 0x14);
+			constexpr auto NumChars   = 256;
+			constexpr auto FirstChar  = 0;
+			const auto font_block     = reg_bl & 0x7f;
+			constexpr auto CharHeight = 16;
 
-			INT10_LoadFont(RealToPhysical(int10.rom.font_16),
+			INT10_LoadFont(font_data,
 			               reload,
-			               Count,
-			               Offset,
-			               map,
-			               Height);
+			               NumChars,
+			               FirstChar,
+			               font_block,
+			               CharHeight);
 		} break;
 
 		// Graphics mode calls

--- a/src/ints/int10.cpp
+++ b/src/ints/int10.cpp
@@ -234,7 +234,7 @@ static Bitu INT10_Handler(void) {
 			const auto reload      = (reg_al == 0x10);
 			const auto num_chars   = reg_cx;
 			const auto first_char  = reg_dx;
-			const auto font_block  = reg_bl & 0x7f;
+			const auto font_block  = reg_bl;
 			const auto char_height = reg_bh;
 
 			INT10_LoadFont(font_data,
@@ -253,7 +253,7 @@ static Bitu INT10_Handler(void) {
 			const auto reload         = (reg_al == 0x11);
 			constexpr auto NumChars   = 256;
 			constexpr auto FirstChar  = 0;
-			const auto font_block     = reg_bl & 0x7f;
+			const auto font_block     = reg_bl;
 			constexpr auto CharHeight = 14;
 
 			INT10_LoadFont(font_data,
@@ -272,7 +272,7 @@ static Bitu INT10_Handler(void) {
 			const auto reload         = (reg_al == 0x12);
 			constexpr auto NumChars   = 256;
 			constexpr auto FirstChar  = 0;
-			const auto font_block     = reg_bl & 0x7f;
+			const auto font_block     = reg_bl;
 			constexpr auto CharHeight = 8;
 
 			INT10_LoadFont(font_data,
@@ -301,7 +301,7 @@ static Bitu INT10_Handler(void) {
 			const auto reload         = (reg_al == 0x14);
 			constexpr auto NumChars   = 256;
 			constexpr auto FirstChar  = 0;
-			const auto font_block     = reg_bl & 0x7f;
+			const auto font_block     = reg_bl;
 			constexpr auto CharHeight = 16;
 
 			INT10_LoadFont(font_data,

--- a/src/ints/int10.h
+++ b/src/ints/int10.h
@@ -375,9 +375,10 @@ void INT10_WriteString(uint8_t row, uint8_t col, uint8_t flag, uint8_t attr,
 void INT10_PutPixel(uint16_t x,uint16_t y,uint8_t page,uint8_t color);
 void INT10_GetPixel(uint16_t x,uint16_t y,uint8_t page,uint8_t * color);
 
-// Font funtions
-void INT10_LoadFont(const PhysPt _font, const bool reload, const int count,
-                    const int offset, const int map, const int height);
+// Font functions
+void INT10_LoadFont(const PhysPt font_data, const bool reload,
+                    const int num_chars, const int first_char,
+                    const int font_block, const int char_height);
 
 void INT10_ReloadFont();
 

--- a/src/ints/int10_memory.cpp
+++ b/src/ints/int10_memory.cpp
@@ -369,45 +369,58 @@ void INT10_SetupRomMemory(void) {
 	}
 }
 
-void INT10_ReloadRomFonts(void) {
+void INT10_ReloadRomFonts(void)
+{
 	// 16x8 font
-	PhysPt font16pt=RealToPhysical(int10.rom.font_16);
-	for (Bitu i=0;i<256*16;i++) {
-		phys_writeb(font16pt+i,int10_font_16[i]);
+	PhysPt font16pt = RealToPhysical(int10.rom.font_16);
+	for (Bitu i = 0; i < 256 * 16; i++) {
+		phys_writeb(font16pt + i, int10_font_16[i]);
 	}
-	phys_writeb(RealToPhysical(int10.rom.font_16_alternate),0x1d);
+	phys_writeb(RealToPhysical(int10.rom.font_16_alternate), 0x1d);
+
 	// 14x8 font
-	PhysPt font14pt=RealToPhysical(int10.rom.font_14);
-	for (Bitu i=0;i<256*14;i++) {
-		phys_writeb(font14pt+i,int10_font_14[i]);
+	PhysPt font14pt = RealToPhysical(int10.rom.font_14);
+	for (Bitu i = 0; i < 256 * 14; i++) {
+		phys_writeb(font14pt + i, int10_font_14[i]);
 	}
-	phys_writeb(RealToPhysical(int10.rom.font_14_alternate),0x1d);
+	phys_writeb(RealToPhysical(int10.rom.font_14_alternate), 0x1d);
+
 	// 8x8 fonts
-	PhysPt font8pt=RealToPhysical(int10.rom.font_8_first);
-	for (Bitu i=0;i<128*8;i++) {
-		phys_writeb(font8pt+i,int10_font_08[i]);
+	PhysPt font8pt = RealToPhysical(int10.rom.font_8_first);
+	for (Bitu i = 0; i < 128 * 8; i++) {
+		phys_writeb(font8pt + i, int10_font_08[i]);
 	}
-	font8pt=RealToPhysical(int10.rom.font_8_second);
-	for (Bitu i=0;i<128*8;i++) {
-		phys_writeb(font8pt+i,int10_font_08[i+128*8]);
+
+	font8pt = RealToPhysical(int10.rom.font_8_second);
+	for (Bitu i = 0; i < 128 * 8; i++) {
+		phys_writeb(font8pt + i, int10_font_08[i + 128 * 8]);
 	}
+
 	INT10_SetupRomMemoryChecksum();
 }
 
-void INT10_SetupRomMemoryChecksum(void) {
-	if (IS_EGAVGA_ARCH) { //EGA/VGA. Just to be safe
-		/* Sum of all bytes in rom module 256 should be 0 */
-		uint8_t sum = 0;
-		PhysPt rom_base = PhysicalMake(0xc000,0);
-		Bitu last_rombyte = 32*1024 - 1;		//32 KB romsize
-		for (Bitu i = 0;i < last_rombyte;i++)
-			sum += phys_readb(rom_base + i);	//OVERFLOW IS OKAY
-		sum = (uint8_t)((256 - (Bitu)sum)&0xff);
-		phys_writeb(rom_base + last_rombyte,sum);
+void INT10_SetupRomMemoryChecksum(void)
+{
+	// EGA/VGA. Just to be safe
+	if (IS_EGAVGA_ARCH) {
+		// Sum of all bytes in rom module 256 should be 0
+		uint8_t sum     = 0;
+		PhysPt rom_base = PhysicalMake(0xc000, 0);
+
+		// 32 KB romsize
+		Bitu last_rombyte = 32 * 1024 - 1;
+
+		for (Bitu i = 0; i < last_rombyte; i++) {
+			// Overflow is okay
+			sum += phys_readb(rom_base + i);
+		}
+		sum = (uint8_t)((256 - (Bitu)sum) & 0xff);
+
+		phys_writeb(rom_base + last_rombyte, sum);
 	}
 }
 
-
+// clang-format off
 uint8_t int10_font_08[256 * 8] = {
   0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
   0x7e, 0x81, 0xa5, 0x81, 0xbd, 0x99, 0x81, 0x7e,
@@ -1757,3 +1770,4 @@ uint8_t int10_font_16_alternate[19 * 17 + 1] = {
   0x66, 0xce, 0x96, 0x3e, 0x06, 0x06, 0x00, 0x00,
   0x00
 };
+// clang-format on

--- a/src/ints/int10_memory.cpp
+++ b/src/ints/int10_memory.cpp
@@ -187,53 +187,20 @@ void INT10_ReloadFont()
 	constexpr auto FirstChar = 0;
 	constexpr auto FontBlock = 0;
 
+	const auto char_height = CurMode->cheight;
+
+	const auto font_data = RealToPhysical(
+		char_height == 8  ? int10.rom.font_8_first :
+		char_height == 14 ? int10.rom.font_14 :
+		                    int10.rom.font_16
+	);
+
 	const auto is_vga_9dot_font = (IS_VGA_ARCH &&
 	                               !vga.seq.clocking_mode.is_eight_dot_mode);
 
-	switch (CurMode->cheight) {
-	case 8: {
-		const auto font_data = RealToPhysical(int10.rom.font_8_first);
-		constexpr auto CharHeight         = 8;
-		constexpr auto LoadAlternateChars = false;
+	const auto load_alternate_chars = (is_vga_9dot_font && char_height != 8);
 
-		load_font(font_data,
-		          Reload,
-		          NumChars,
-		          FirstChar,
-		          FontBlock,
-		          CharHeight,
-		          LoadAlternateChars);
-	} break;
-
-	case 14: {
-		const auto font_data      = RealToPhysical(int10.rom.font_14);
-		constexpr auto CharHeight = 14;
-		const auto load_alternate_chars = is_vga_9dot_font;
-
-		load_font(font_data,
-		          Reload,
-		          NumChars,
-		          FirstChar,
-		          FontBlock,
-		          CharHeight,
-		          load_alternate_chars);
-	} break;
-
-	case 16: {
-	default:
-		const auto font_data      = RealToPhysical(int10.rom.font_16);
-		constexpr auto CharHeight = 16;
-		const auto load_alternate_chars = is_vga_9dot_font;
-
-		load_font(font_data,
-		          Reload,
-		          NumChars,
-		          FirstChar,
-		          FontBlock,
-		          CharHeight,
-		          load_alternate_chars);
-	} break;
-	}
+	load_font(font_data, Reload, NumChars, FirstChar, FontBlock, char_height, load_alternate_chars);
 }
 
 void INT10_SetupRomMemory(void) {

--- a/src/ints/int10_memory.cpp
+++ b/src/ints/int10_memory.cpp
@@ -45,9 +45,9 @@ static const std::vector<uint16_t> map_offset = {
 };
 // clang-format on
 
-void INT10_LoadFont(const PhysPt _font_data, const bool reload,
-                    const int num_chars, const int first_char,
-                    const int _font_block, const int char_height)
+static void load_font(const PhysPt _font_data, const bool reload, const int num_chars,
+                      const int first_char, const int _font_block,
+                      const int char_height, const bool load_alternate_chars)
 {
 	constexpr auto BytesPerChar = 32;
 
@@ -93,13 +93,13 @@ void INT10_LoadFont(const PhysPt _font_data, const bool reload,
 		font_data += char_height;
 	}
 
-	// Load alternate 9x14 or 9x16 character patterns on VGA based on
-	// state of the clocking mode register
-	if (IS_VGA_ARCH && !vga.seq.clocking_mode.is_eight_dot_mode) {
+	// Load alternate 9x14 or 9x16 character patterns on VGA
+	if (load_alternate_chars) {
 		while (auto chr = mem_readb(font_data++)) {
 			MEM_BlockCopy(font_base_addr + chr * BytesPerChar,
 			              font_data,
 			              char_height);
+
 			font_data += char_height;
 		}
 	}
@@ -172,6 +172,14 @@ void INT10_LoadFont(const PhysPt _font_data, const bool reload,
 	}
 }
 
+void INT10_LoadFont(const PhysPt font_data, const bool reload,
+                    const int num_chars, const int first_char,
+                    const int font_block, const int char_height)
+{
+	constexpr auto LoadAlternateChars = false;
+	load_font(font_data, reload, num_chars, first_char, font_block, char_height, LoadAlternateChars);
+}
+
 void INT10_ReloadFont()
 {
 	constexpr auto Reload    = false;
@@ -179,27 +187,51 @@ void INT10_ReloadFont()
 	constexpr auto FirstChar = 0;
 	constexpr auto FontBlock = 0;
 
+	const auto is_vga_9dot_font = (IS_VGA_ARCH &&
+	                               !vga.seq.clocking_mode.is_eight_dot_mode);
+
 	switch (CurMode->cheight) {
 	case 8: {
 		const auto font_data = RealToPhysical(int10.rom.font_8_first);
-		constexpr auto CharHeight = 8;
+		constexpr auto CharHeight         = 8;
+		constexpr auto LoadAlternateChars = false;
 
-		INT10_LoadFont(font_data, Reload, NumChars, FirstChar, FontBlock, CharHeight);
+		load_font(font_data,
+		          Reload,
+		          NumChars,
+		          FirstChar,
+		          FontBlock,
+		          CharHeight,
+		          LoadAlternateChars);
 	} break;
 
 	case 14: {
 		const auto font_data      = RealToPhysical(int10.rom.font_14);
 		constexpr auto CharHeight = 14;
+		const auto load_alternate_chars = is_vga_9dot_font;
 
-		INT10_LoadFont(font_data, Reload, NumChars, FirstChar, FontBlock, CharHeight);
+		load_font(font_data,
+		          Reload,
+		          NumChars,
+		          FirstChar,
+		          FontBlock,
+		          CharHeight,
+		          load_alternate_chars);
 	} break;
 
 	case 16: {
 	default:
 		const auto font_data      = RealToPhysical(int10.rom.font_16);
 		constexpr auto CharHeight = 16;
+		const auto load_alternate_chars = is_vga_9dot_font;
 
-		INT10_LoadFont(font_data, Reload, NumChars, FirstChar, FontBlock, CharHeight);
+		load_font(font_data,
+		          Reload,
+		          NumChars,
+		          FirstChar,
+		          FontBlock,
+		          CharHeight,
+		          load_alternate_chars);
 	} break;
 	}
 }


### PR DESCRIPTION
# Description

This fixes a regression in the "Druid: Daemons of the Mind" installer where the whitespaces of the custom VGA font appear corrupted (introduced in https://github.com/dosbox-staging/dosbox-staging/commit/be3d059469a867623026e6f180a779c547493a64).

`INT10_ReloadFont()` should trigger the loading of alternate characters for 9-dot VGA fonts only, while `INT10_LoadFont()` should never do this. This has regressed during a recent cleanup & refactoring job.

This change also implements this conditional alternate charset loading mechanism more cleanly. Previously, the `font_block` argument was used as a "side channel" for signalling this criteria via a hack (by using a magic value of 0x80 which is not a valid value in the real BIOS call).

The last commit is the actual fix, the previous ones are  cleanup & refactoring jobs that don't change existing functionality (famous last words 🤞🏻 😆).

## Related issues

Fixes https://github.com/dosbox-staging/dosbox-staging/issues/3917

# Release notes

N/A

# Manual testing

- Confirmed the installer of ""Druid: Daemons of the Mind" appears correctly (also with `vga_8dot_font = on`):

<img width="1215" alt="image" src="https://github.com/user-attachments/assets/87585fbf-1f65-476c-b24f-685f422b1eae">

- Confirmed the following MODE commands yield 9-dot fonts with the default config (720 pixel wide modes), and 8-dot fonts with `vga_8dot_fonts = on` (640 pixel wide modes). (The remaining custom modes all use the 8x8 font, so the screen widths are always 640 for 80-column modes, and 1056 for 132-column modes.)
  - `MODE 80x25`
  - `MODE 80x28`
  - `MODE 80x30`
  - `MODE 40x25` (this is half-width, so 360/320 pixels)

- Executed a good portion of the [VGA text mode tests](https://github.com/dosbox-staging/dosbox-staging/wiki/Video-emulation-tests#text-modes).

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

