### PR TITLE
Fix Windows 98 S3 driver regression

### DIFF
--- a/src/hardware/vga_s3.cpp
+++ b/src/hardware/vga_s3.cpp
@@ -389,12 +389,8 @@ uint8_t SVGA_S3_ReadCRTC(io_port_t reg, io_width_t)
 	case 0x2e:	/* New Chip ID  (low byte of PCI device ID) */
 		return 0x11;	// Trio64
 	case 0x2f:	/* Revision */
-		// The documention leaves this unspecified and says "This will
-		// change with each stepping". Therefore we max this out under
-		// the assumption that newer steppings fix(ed) issues in prior
-		// steppings, and we want to avoid drivers witholding features
-		// based on stepping bugs.
-		return 0xff;
+		return 0x00;	// Trio64 (exact value?)
+//		return 0x44;	// Trio64 V+
 	case 0x30:	/* CR30 Chip ID/REV register */
 		return 0xe1;	// Trio+ dual byte
 	case 0x31:	/* CR31 Memory Configuration */


### PR DESCRIPTION
# Description

This reverts commit b673d0b057c5d12c71c0a7cd79649997984a4ec4.

This commit bumped the chip's stepping level to allow the Windows 3.1 S3 1.70.04 driver to use all available XGA calls, such as those needed to draw the grid of squadron ships in the game 'Alpha Squadron', reported in #2767.

Unfortunately this caused a regression under Windows 98 reported in #3945. Thanks to @emxd for catching this!

## Related issues

Fixes #3945

Reopens #2767

# Release notes

None; regression occurred and was fixed within the 0.82 release phase.

# Manual testing

Tested Windows 3.1 and Windows 98 per instructions in both releated tickets.

# Checklist


I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

