### PR TITLE
Let GUS use its documented IRQ, DMA, and base addresses

### DIFF
--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -1861,7 +1861,7 @@ void init_gus_dosbox_settings(Section_prop& secprop)
 
 	auto* hex_prop = secprop.Add_hex("gusbase", when_idle, 0x240);
 	assert(hex_prop);
-	hex_prop->Set_values({"240", "220", "260", "280", "2a0", "2c0", "2e0", "300"});
+	hex_prop->Set_values({"210", "220", "230", "240", "250", "260"});
 	hex_prop->Set_help(
 	        "The IO base address of the Gravis UltraSound (240 by default).");
 


### PR DESCRIPTION
# Description

Previously some IRQ's weren't available, like IRQ 2 and 15, and they weren't defined in the order that was expected via the IO port 2xB address selector.

(more detail in the commit message and comments in the code).

## Related issues

Fixes #3957

# Release notes

The Gravis Ultrasound's configuration options have been changed to reflect the actual options available on the GUS card:
 - Base addresses now range from 210 through 260,
 - IRQs 2 and 15 have been added, and
 - DMA 0 has been dropped.

This also fixes a crash in Fast Tracker II when GUS is configured to use IRQ 7.

# Manual testing

Tested mod players (capamod, FT 208, FT 213, impulse tracker), 15+ games, and some that ultramid.

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [x] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

