### PR TITLE
Auto switch shader when starting a Voodoo game

### DIFF
--- a/src/hardware/voodoo.cpp
+++ b/src/hardware/voodoo.cpp
@@ -7496,6 +7496,9 @@ static void Voodoo_UpdateScreen()
 			const auto frames_per_second = static_cast<float>(
 			        1000.0 / v->draw.frame_period_ms);
 
+			constexpr auto reinit_render = false;
+			RENDER_MaybeAutoSwitchShader(GFX_GetCanvasSizeInPixels(), video_mode, reinit_render);
+
 			RENDER_SetSize(image_info, frames_per_second);
 		}
 


### PR DESCRIPTION
# Description

I noticed when starting a Voodoo game, the display was not filling the window.  Resizing the window fixed the issue.  You can see it at about the 1:00 mark on this video @interloper98 posted:  https://github.com/dosbox-staging/dosbox-staging/pull/3935#issuecomment-2357425531

It turns out the problem was the shader was not switching when initially starting a Voodoo game (but it does on window resize).  Added a function call to `RENDER_MaybeAutoSwitchShader` to resolve this.  This code matches what `VGA_SetupDrawing` does for non-Voodoo games.

# Release notes

Fixed a bug where the wrong shader could be loaded in Voodoo games.

# Manual testing

Start a Voodoo game and observe that the shader now correctly auto switches.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

