### PR TITLE
Simplify the GUS reset register logic and fix DMA IRQ handling

### DIFF
--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -998,13 +998,16 @@ bool Gus::PerformDmaTransfer()
 			ram_pos += skip;
 		}
 	}
-	// Raise the TC irq if needed
-	if ((dma_ctrl & 0x20) != 0) {
+
+	if (dma_channel->has_reached_terminal_count) {
 		// We've hit the terminal count, so enable that bit
 		dma_ctrl |= DMA_TC_STATUS_BITMASK;
-		irq_status |= 0x80;
-		CheckIrq();
-		assert(dma_channel->has_reached_terminal_count);
+
+		// Raise the TC irq if needed
+		if ((dma_ctrl & 0x20) != 0) {
+			irq_status |= 0x80;
+			CheckIrq();
+		}
 		return false;
 	}
 	return true;

--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -1231,6 +1231,8 @@ void Gus::PrintStats()
 uint16_t Gus::ReadFromPort(const io_port_t port, io_width_t width)
 {
 	std::lock_guard lock(mutex);
+	RenderUpToNow();
+
 	//	LOG_MSG("GUS: Read from port %x", port);
 	switch (port - port_base) {
 	case 0x206: return irq_status;

--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -1036,6 +1036,7 @@ static void GUS_DMA_Event(uint32_t)
 
 void Gus::StartDmaTransfers()
 {
+	PIC_RemoveEvents(GUS_DMA_Event);
 	PIC_AddEvent(GUS_DMA_Event, MS_PER_DMA_XFER);
 }
 

--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -197,11 +197,8 @@ private:
 static void GUS_TimerEvent(uint32_t t);
 static void GUS_DMA_Event(uint32_t val);
 
-// Reset Register (4Ch)
-//
-// Described in section 2.6.1.9, page 16, of the UltraSound Software Development
-// Kit (SDK) Version 2.22
-
+// Reset Register (4Ch), section 2.6.1.9, page 16, of the UltraSound Software
+// Development Kit (SDK) Version 2.22
 union ResetRegister {
 	uint8_t data = 0;
 


### PR DESCRIPTION
# Description

This is just a general bug fix that closes #3645, #3649, #3963.

Changes are split up as small as possible to help catch any future regressions.

# Release notes

Fixed a regression that prevented the GUS from playing audio in _HELL: A Cyberpunk Thriller_ and in the 1997 demo _'Atlantis, Deep Like A Sea'_.

# Manual testing

I've tested plenty of demos, mod player, GUS-MIDI games, and GUS tracker games, and haven't hit any regressions or issues. I searched the issue tracker for closed GUS tickets and tested those too (Star Control II, Star Trek Next Generation, Solty's, Warcraft 2, and they're working, too).

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [x] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

