### PR TITLE
Close modem server socket before dialing

### DIFF
--- a/src/hardware/serialport/misc_util.cpp
+++ b/src/hardware/serialport/misc_util.cpp
@@ -102,11 +102,17 @@ bool NETClientSocket::SendByteBuffered(uint8_t val)
 	return SendArray(sendbuffer.data(), sendbuffer.size());
 }
 
-NETServerSocket::NETServerSocket()
-{}
+NETServerSocket::NETServerSocket() {}
 
-NETServerSocket::~NETServerSocket()
-{}
+NETServerSocket::~NETServerSocket() {}
+
+void NETServerSocket::Close()
+{
+	// Discard any queued incoming connections
+	while (auto accepted = Accept()) {
+		delete accepted;
+	}
+}
 
 NETServerSocket* NETServerSocket::NETServerFactory(const SocketType socketType,
                                                    const uint16_t port)

--- a/src/hardware/serialport/misc_util.h
+++ b/src/hardware/serialport/misc_util.h
@@ -116,6 +116,8 @@ public:
 	NETServerSocket(const NETServerSocket &) = delete; // prevent copying
 	NETServerSocket &operator=(const NETServerSocket &) = delete; // prevent assignment
 
+	virtual void Close();
+
 	static NETServerSocket* NETServerFactory(const SocketType socketType,
 	                                         const uint16_t port);
 

--- a/src/hardware/serialport/softmodem.cpp
+++ b/src/hardware/serialport/softmodem.cpp
@@ -310,7 +310,7 @@ bool CSerialModem::Dial(const char * host) {
 	clientsocket.reset(NETClientSocket::NETClientFactory(socketType,
 	                                                     destination, port));
 	if (!clientsocket->isopen) {
-		clientsocket.reset(nullptr);
+		clientsocket.reset();
 		LOG_MSG("SERIAL: Port %" PRIu8 " failed to connect.", GetPortNumber());
 		SendRes(ResNOCARRIER);
 		EnterIdleState();
@@ -378,7 +378,7 @@ void CSerialModem::Reset(){
 	plusinc = 0;
 	oldDTRstate = getDTR();
 	dtrmode = 2;
-	clientsocket.reset(nullptr);
+	clientsocket.reset();
 
 	memset(&reg,0,sizeof(reg));
 	reg[MREG_AUTOANSWER_COUNT] = 0;  // no autoanswer
@@ -401,8 +401,8 @@ void CSerialModem::EnterIdleState(){
 	ringing = false;
 	dtrofftimer = -1;
 	warmup_remain_ticks = 0;
-	clientsocket.reset(nullptr);
-	waitingclientsocket.reset(nullptr);
+	clientsocket.reset();
+	waitingclientsocket.reset();
 
 	// get rid of everything
 	if (serversocket) {
@@ -412,7 +412,7 @@ void CSerialModem::EnterIdleState(){
 		}
 	}
 	if (listenport) {
-		serversocket.reset(nullptr);
+		serversocket.reset();
 		serversocket.reset(NETServerSocket::NETServerFactory(socketType,
 		                                                     listenport));
 		if (!serversocket->isopen) {
@@ -420,13 +420,13 @@ void CSerialModem::EnterIdleState(){
 			        "%" PRIu16 ".",
 			        GetPortNumber(), listenport);
 
-			serversocket.reset(nullptr);
+			serversocket.reset();
 		} else
 			LOG_MSG("SERIAL: Port %" PRIu8 " modem listening on port "
 			        "%" PRIu16 " ...",
 			        GetPortNumber(), listenport);
 	}
-	waitingclientsocket.reset(nullptr);
+	waitingclientsocket.reset();
 
 	commandmode = true;
 	CSerial::setCD(false);
@@ -438,7 +438,7 @@ void CSerialModem::EnterIdleState(){
 
 void CSerialModem::EnterConnectedState() {
 	// we don't accept further calls
-	serversocket.reset(nullptr);
+	serversocket.reset();
 	SendRes(ResCONNECT);
 	commandmode = false;
 	telClient = {}; // reset values


### PR DESCRIPTION
# Description

This is a small fix where modem server socket listening for incoming calls is now closed before modem dials a number. Without this, you can dial yourself (something not physically possible with real phones) which results in really weird shit in games. If dialing fails then `EnterIdleState` will re-open the server socket.


# Release notes

Fixed a modem emulation oversight where the user could dial themselves.


# Manual testing

Tested with Telemate by trying to dial my own Dosbox instance. Connection properly fails since Dosbox is no longer listening for incoming connections.


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

