### PR TITLE
Sort SoundFonts in `MIXER /LISTMIDI` output & fix current SF2 matching

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -106,7 +106,7 @@ AlignOperands:  AlignAfterOperator
 #   #endif
 #   #endif
 #
-IndentPPDirectives: BeforeHash
+IndentPPDirectives: None
 
 # Always place function bodies on their own lines because
 # it makes a mess when some are on the same line and others are

--- a/src/midi/midi_fluidsynth.cpp
+++ b/src/midi/midi_fluidsynth.cpp
@@ -241,7 +241,7 @@ bool MidiHandlerFluidsynth::Open([[maybe_unused]] const char* conf)
 	Close();
 
 	FluidSynthSettingsPtr fluid_settings(new_fluid_settings(),
-	                                    delete_fluid_settings);
+	                                     delete_fluid_settings);
 	if (!fluid_settings) {
 		LOG_WARNING("FSYNTH: new_fluid_settings failed");
 		return false;
@@ -259,12 +259,10 @@ bool MidiHandlerFluidsynth::Open([[maybe_unused]] const char* conf)
 	const auto sample_rate_hz = MIXER_GetSampleRate();
 	ms_per_audio_frame        = MillisInSecond / sample_rate_hz;
 
-	fluid_settings_setnum(fluid_settings.get(),
-	                      "synth.sample-rate",
-	                      sample_rate_hz);
+	fluid_settings_setnum(fluid_settings.get(), "synth.sample-rate", sample_rate_hz);
 
 	FluidSynthPtr fluid_synth(new_fluid_synth(fluid_settings.get()),
-	                         delete_fluid_synth);
+	                          delete_fluid_synth);
 	if (!fluid_synth) {
 		LOG_WARNING("FSYNTH: Failed to create the FluidSynth synthesizer.");
 		return false;
@@ -287,9 +285,10 @@ bool MidiHandlerFluidsynth::Open([[maybe_unused]] const char* conf)
 	}
 
 	if (scale_by_percent < 1 || scale_by_percent > 800) {
-		LOG_WARNING("FSYNTH: Invalid volume scaling percentage: %d; "
-		            "must be between 1 and 800, defaulting to 100%%",
-		            scale_by_percent);
+		LOG_WARNING(
+		        "FSYNTH: Invalid volume scaling percentage: %d; "
+		        "must be between 1 and 800, defaulting to 100%%",
+		        scale_by_percent);
 		scale_by_percent = 100;
 	}
 	fluid_synth_set_gain(fluid_synth.get(),
@@ -321,13 +320,14 @@ bool MidiHandlerFluidsynth::Open([[maybe_unused]] const char* conf)
 		// convert the string to a double
 		const auto val = atof(str_val.c_str());
 		if (val < min_val || val > max_val) {
-			LOG_WARNING("FSYNTH: Invalid %s setting (%s), needs to be between "
-			            "%.2f and %.2f: using default (%.2f)",
-			            name,
-			            str_val.c_str(),
-			            min_val,
-			            max_val,
-			            def_val);
+			LOG_WARNING(
+			        "FSYNTH: Invalid %s setting (%s), needs to be between "
+			        "%.2f and %.2f: using default (%.2f)",
+			        name,
+			        str_val.c_str(),
+			        min_val,
+			        max_val,
+			        def_val);
 			return def_val;
 		}
 		return val;
@@ -378,15 +378,17 @@ bool MidiHandlerFluidsynth::Open([[maybe_unused]] const char* conf)
 			if (chorus[4] == "triangle") {
 				chorus_mod_wave = fluid_chorus_mod::FLUID_CHORUS_MOD_TRIANGLE;
 			} else if (chorus[4] != "sine") { // default is sine
-				LOG_WARNING("FSYNTH: Invalid chorus modulation wave type ('%s'), "
-				            "needs to be 'sine' or 'triangle'",
-				            chorus[4].c_str());
+				LOG_WARNING(
+				        "FSYNTH: Invalid chorus modulation wave type ('%s'), "
+				        "needs to be 'sine' or 'triangle'",
+				        chorus[4].c_str());
 			}
 
 		} else {
-			LOG_WARNING("FSYNTH: Invalid number of custom chorus settings (%d), "
-			            "should be five",
-			            static_cast<int>(chorus.size()));
+			LOG_WARNING(
+			        "FSYNTH: Invalid number of custom chorus settings (%d), "
+			        "should be five",
+			        static_cast<int>(chorus.size()));
 		}
 	}
 	// API accept an integer voice-count
@@ -426,9 +428,10 @@ bool MidiHandlerFluidsynth::Open([[maybe_unused]] const char* conf)
 			reverb_level = validate_setting(
 			        "reverb level", reverb[3], reverb_level, 0.0, 1.0);
 		} else {
-			LOG_WARNING("FSYNTH: Invalid number of custom reverb settings (%d), "
-			            "should be four",
-			            static_cast<int>(reverb.size()));
+			LOG_WARNING(
+			        "FSYNTH: Invalid number of custom reverb settings (%d), "
+			        "should be four",
+			        static_cast<int>(reverb.size()));
 		}
 	}
 
@@ -586,8 +589,9 @@ void MidiHandlerFluidsynth::Close()
 	MIXER_LockMixerThread();
 
 	if (had_underruns) {
-		LOG_WARNING("FSYNTH: Fix underruns by lowering CPU load, increasing "
-		            "your conf's prebuffer, or using a simpler SoundFont");
+		LOG_WARNING(
+		        "FSYNTH: Fix underruns by lowering CPU load, increasing "
+		        "your conf's prebuffer, or using a simpler SoundFont");
 		had_underruns = false;
 	}
 
@@ -884,9 +888,9 @@ MIDI_RC MidiHandlerFluidsynth::ListAll(Program* caller)
 
 		if (do_highlight) {
 			const auto output = format_str("%s* %s%s\n",
-			                                  green,
-			                                  line.c_str(),
-			                                  reset);
+			                               green,
+			                               line.c_str(),
+			                               reset);
 
 			caller->WriteOut(convert_ansi_markup(output).c_str());
 		} else {

--- a/src/midi/midi_fluidsynth.h
+++ b/src/midi/midi_fluidsynth.h
@@ -26,10 +26,10 @@
 #if C_FLUIDSYNTH
 
 #include <atomic>
-#include <memory>
-#include <vector>
 #include <fluidsynth.h>
+#include <memory>
 #include <thread>
+#include <vector>
 
 #include "mixer.h"
 #include "rwqueue.h"
@@ -50,11 +50,11 @@ public:
 		return MidiDeviceType::BuiltIn;
 	}
 
-	bool Open(const char *conf) override;
+	bool Open(const char* conf) override;
 	void Close() override;
 	void PlayMsg(const MidiMessage& msg) override;
-	void PlaySysex(uint8_t *sysex, size_t len) override;
-	MIDI_RC ListAll(Program *caller) override;
+	void PlaySysex(uint8_t* sysex, size_t len) override;
+	MIDI_RC ListAll(Program* caller) override;
 
 private:
 	void ApplyChannelMessage(const std::vector<uint8_t>& msg);
@@ -82,7 +82,7 @@ private:
 
 	// Used to track the balance of time between the last mixer callback
 	// versus the current MIDI Sysex or Msg event.
-	double last_rendered_ms = 0.0;
+	double last_rendered_ms   = 0.0;
 	double ms_per_audio_frame = 0.0;
 
 	bool had_underruns = false;

--- a/src/midi/midi_fluidsynth.h
+++ b/src/midi/midi_fluidsynth.h
@@ -28,11 +28,13 @@
 #include <atomic>
 #include <fluidsynth.h>
 #include <memory>
+#include <optional>
 #include <thread>
 #include <vector>
 
 #include "mixer.h"
 #include "rwqueue.h"
+#include "std_filesystem.h"
 
 class MidiHandlerFluidsynth final : public MidiHandler {
 public:
@@ -78,7 +80,7 @@ private:
 	RWQueue<MidiWork> work_fifo{1};
 	std::thread renderer = {};
 
-	std::string selected_font = "";
+	std::optional<std_fs::path> current_sf2_path = {};
 
 	// Used to track the balance of time between the last mixer callback
 	// versus the current MIDI Sysex or Msg event.


### PR DESCRIPTION
# Description

This PR changes the following in the `MIXER /LISTMIDI` command's output _only_ (the resolution of the SoundFont file hasn't been changed at all):

- The list of SoundFonts is now sorted
- The current SoundFont is not moved to the top of the list anymore
- The highlighting of the current SoundFont file is performed in a case-insensitive manner on Windows and macOS (as they have case-preserving filesystems, in contrast to the strictly case-sensitive Linux filesystems that everybody seems to be still using)
 
# Release notes

The list of available SoundFont files in the `MIXER /LISTMIDI` command's output is now sorted. The highlighting of the current SoundFont file is done in a case-insensitive manner on Windows and macOS.


# Manual testing

Tested on macOS; should be applicable to Windows, too. Haven't tested on Linux but there should be no change in behaviour there.

## Current `main` behaviour

Problems:

- The SoundFont names are in a random unsorted order
- The highlighted item always appears at the top of the list (for no good reason)
- `creative_1mgm.sf2` (what `soundfont` is set to) and `Creative_1mgm.sf2`(the actual name on the filesystem) both appear in the list

<img width="1097" alt="image" src="https://github.com/user-attachments/assets/29c35f77-a5c7-43c1-9062-b8651a2f4870">


## PR behaviour

- The SoundFonts are not alphabetically sorted by name
- The current SoundFont is highlighted in the A-Z sorted list (its position is not altered)
- `Creative_1mgm.sf2` is highlighted (despite we set `soundfont` to `creative_1mgm.sf2`, all lowercase)

<img width="1101" alt="image" src="https://github.com/user-attachments/assets/cbcd04f9-574c-495a-86d9-02bc4e9341a6">


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [x] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

