### PR TITLE
Fix platform specific parameters for ppc64le

### DIFF
--- a/.github/workflows/platforms.yml
+++ b/.github/workflows/platforms.yml
@@ -124,6 +124,8 @@ jobs:
 
             # Setup
             #  - use a minimal build because python fetching wraps segfaults under Docker
+            #  - zlib-ng fails to compile for ARM targets, work around by just disabling
+            #    it until a proper fix can be found
             meson setup \
                   -Duse_fluidsynth=false \
                   -Duse_sdl2_net=false \
@@ -131,6 +133,7 @@ jobs:
                   -Duse_mt32emu=false \
                   -Duse_slirp=false \
                   -Duse_alsa=false \
+                  -Duse_zlib_ng=false \
                   build
             # Build
             meson compile -C build

--- a/.github/workflows/platforms.yml
+++ b/.github/workflows/platforms.yml
@@ -89,7 +89,7 @@ jobs:
                 apt-get -qq install git curl findutils procps tar zstd screenfetch \
                                     < /dev/null > /dev/null
                 apt-get -qq install cmake g++ build-essential ccache libasound2-dev libgtest-dev \
-                                    libopusfile-dev libsdl2-dev zlib1g-dev libspeexdsp-dev \
+                                    libopusfile-dev libsdl2-dev zlib1g-dev libspeexdsp-dev libpng-dev \
                                     < /dev/null > /dev/null
                 # Meson from Debian repository is too old for DOSBox Staging
                 apt-get -qq install python3-setuptools python3-pip \

--- a/.github/workflows/platforms.yml
+++ b/.github/workflows/platforms.yml
@@ -39,9 +39,9 @@ jobs:
           - name: ARMv7 (Debian “bullseye”)
             arch: armv7
             distro: bullseye
-          - name: ARM64 (Ubuntu 20.04)
+          - name: ARM64 (Ubuntu 22.04)
             arch: aarch64
-            distro: ubuntu20.04
+            distro: ubuntu22.04
           - name: s390x (Debian "bookworm")
             arch: s390x
             distro: bookworm
@@ -83,7 +83,7 @@ jobs:
           # no secrets are present in the container state or logs.
           install: |
             case "${{ matrix.distro }}" in
-              ubuntu*|jessie|stretch|buster|bullseye)
+              ubuntu20.04|jessie|stretch|buster|bullseye)
                 # we only care about issues
                 apt-get -qq update  < /dev/null > /dev/null
                 apt-get -qq install git curl findutils procps tar zstd screenfetch \
@@ -96,7 +96,7 @@ jobs:
                                     < /dev/null > /dev/null
                 pip3 install meson ninja
                 ;;
-              bookworm)
+              ubuntu22.04|bookworm)
                 # we only care about issues
                 apt-get -qq update  < /dev/null > /dev/null
                 apt-get -qq install git curl findutils procps tar zstd screenfetch \

--- a/src/cpu/meson.build
+++ b/src/cpu/meson.build
@@ -14,32 +14,34 @@ conf_data.set10('C_PER_PAGE_W_OR_X', per_page_w_or_x_pref.auto() or per_page_w_o
 
 # Platform-specific
 core_selection = [
-    # cpu_family                  selected_core        dynrec_define    target     unaligned  per-page
-    #                                                                              mem        W^X
-    [ ['x86_64'],                 ['auto', 'dyn-x86'], 'C_DYNAMIC_X86', 'X86_64',  1,         1 ],
-    [ ['x86'],                    ['auto', 'dyn-x86'], 'C_DYNAMIC_X86', 'X86',     1,         1 ],
-    [ ['x86_64'],                 ['dynrec'],          'C_DYNREC',      'X86_64',  1,         1 ],
-    [ ['x86'],                    ['dynrec'],          'C_DYNREC',      'X86',     1,         1 ],
-    [ ['aarch64'],                ['auto', 'dynrec'],  'C_DYNREC',      'ARMV8LE', 1,         1 ], # ARMv8+ (64-bit)
-    [ ['arm'],                    ['auto', 'dynrec'],  'C_DYNREC',      'ARMV7LE', 1,         1 ], # ARMv7+
-    [ ['armv6'],                  ['auto', 'dynrec'],  'C_DYNREC',      'ARMV4LE', 0,         0 ], # ARMv6 or older
-    [ ['ppc64',   'powerpc64'],   ['auto', 'dynrec'],  'C_DYNREC',      'POWERPC', 1,         1 ], # 64 bit PPC processors (big-endian), running 32-bit big-endian code
-    [ ['ppc64le', 'powerpc64le'], ['auto', 'dynrec'],  'C_DYNREC',      'PPC64LE', 1,         1 ], # 64 bit PPC processors (little-endian)
-    [ ['ppc',     'powerpc'],     ['auto', 'dynrec'],  'C_DYNREC',      'POWERPC', 1,         0 ], # 32 bit PPC processors (big-endian)
-    [ ['mips'],                   ['auto', 'dynrec'],  'C_DYNREC',      'MIPSEL',  0,         0 ], # 32 bit MIPS processor
+    # cpu_family              endian      selected_core        dynrec_define    target     unaligned  per-page
+    #                                                                                      mem        W^X
+    [ ['x86_64'],             ['little'], ['auto', 'dyn-x86'], 'C_DYNAMIC_X86', 'X86_64',  1,         1 ],
+    [ ['x86'],                ['little'], ['auto', 'dyn-x86'], 'C_DYNAMIC_X86', 'X86',     1,         1 ],
+    [ ['x86_64'],             ['little'], ['dynrec'],          'C_DYNREC',      'X86_64',  1,         1 ],
+    [ ['x86'],                ['little'], ['dynrec'],          'C_DYNREC',      'X86',     1,         1 ],
+    [ ['aarch64'],            ['little'], ['auto', 'dynrec'],  'C_DYNREC',      'ARMV8LE', 1,         1 ], # ARMv8+ (64-bit)
+    [ ['arm'],                ['little'], ['auto', 'dynrec'],  'C_DYNREC',      'ARMV7LE', 1,         1 ], # ARMv7+
+    [ ['armv6'],              ['little'], ['auto', 'dynrec'],  'C_DYNREC',      'ARMV4LE', 0,         0 ], # ARMv6 or older
+    [ ['ppc64', 'powerpc64'], ['big'],    ['auto', 'dynrec'],  'C_DYNREC',      'POWERPC', 1,         1 ], # 64 bit PPC processors (big-endian), running 32-bit big-endian code
+    [ ['ppc64', 'powerpc64'], ['little'], ['auto', 'dynrec'],  'C_DYNREC',      'PPC64LE', 1,         1 ], # 64 bit PPC processors (little-endian)
+    [ ['ppc',   'powerpc'],   ['big'],    ['auto', 'dynrec'],  'C_DYNREC',      'POWERPC', 1,         0 ], # 32 bit PPC processors (big-endian)
+    [ ['mips'],               ['little'], ['auto', 'dynrec'],  'C_DYNREC',      'MIPSEL',  0,         0 ], # 32 bit MIPS processor
 ]
 
 selected_core = get_option('dynamic_core')
 
 foreach line : core_selection
     cpu_family = line[0]
-    opts_for_arch = line[1]
-    dynrec_define = line[2]
-    target_cpu = line[3]
-    unaligned_mem = line[4]
-    per_page_w_or_x = line[5]
+    endian = line[1]
+    opts_for_arch = line[2]
+    dynrec_define = line[3]
+    target_cpu = line[4]
+    unaligned_mem = line[5]
+    per_page_w_or_x = line[6]
     if (
         cpu_family.contains(host_machine.cpu_family())
+        and endian.contains(host_machine.endian())
         and opts_for_arch.contains(selected_core)
     )
         conf_data.set('C_TARGETCPU', target_cpu)


### PR DESCRIPTION
# Description

Previously, build script assumed that for little-endian PowerPC, Meson would report `ppc64le` as `cpu_family`. Actually, Meson returns just `ppc64` and endianness needs to be checked separately. Fix the Meson build script to do that.

Without this change, compiling on `ppc64le`  included 32-bit PowerPC code from `risc_ppc.h`, causing many errors about invalid casts from pointer to 32-bit integer types.

This issue was revealed by building DOSBox Staging 0.82.0 for Fedora in Fedora build environment. Builds for other architectures (x86_64, aarch64 and s390x) succeeded, but ppc64le failed due to this problem.

To help test the change, the issues in previously broken _Platform targets_ workflow are fixed.

## Related issues

#3991

# Manual testing

After applying this patch, Fedora build succeeded for all  architectures (x86_64, aarch64, ppc64le and s390x). The one for which I have hardware for, x86_64, also ran successfully.

I tested that _Platform builds_ workflow, with workflow fixes from this pull request otherwise succeeds, but ppc64le build fails. After including also the build fix from this pull request, aslo _Platform builds_ succeeds.

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

