### PR TITLE
Complete support for code page 59829

### DIFF
--- a/contrib/resources/mapping/MAIN.TXT
+++ b/contrib/resources/mapping/MAIN.TXT
@@ -7,7 +7,7 @@
 # ID    - description                                            [ID usage originator]
 #
 #
-# Fully supported code pages (93 code pages):
+# Fully supported code pages (94 code pages):
 #
 # 113   - Yugoslavian, Latin                                     [AST Premium Exec DOS]
 # 437   - United States                                          [IBM, Microsoft]
@@ -98,6 +98,7 @@
 # 30040 - Russian, Cyrillic, with UAH                            [FreeDOS]
 # 58152 - Kazakh, Cyrillic, with EUR                             [FreeDOS]
 # 58210 - Azeri and Russian, Cyrillic                            [FreeDOS]
+# 59829 - Georgian                                               [FreeDOS]
 # 58335 - Kashubian and Polish, Mazovia based, with PLN (*)      [FreeDOS]
 # 59234 - Tatar, Cyrillic                                        [FreeDOS]
 # 62306 - Uzbek, Cyrillic                                        [FreeDOS]
@@ -168,12 +169,6 @@
 # 28604 - Celtic, ISO 8859-14 encoding                           [Microsoft]
 # 28605 - Western European, with EUR, ISO 8859-15 encoding       [Microsoft]
 # 28606 - South-Eastern European, with EUR, ISO 8859-16 encoding [Microsoft]
-#
-#
-# Code pages mostly supported (1 code page), but with unidentified characters still left (TODO):
-#
-# 59829 - Georgian                                               [FreeDOS]
-#       - 1 character still unidentified
 #
 #
 # Code pages with limited support (1 code page):
@@ -2592,6 +2587,7 @@ EXTENDS CODEPAGE 866
 CODEPAGE 59829 # Georgian
 # reference: https://en.wikipedia.org/wiki/Georgian_language
 #            https://en.wikipedia.org/wiki/Georgian_scripts
+#            https://en.m.wikibooks.org/wiki/Character_Encodings/Code_Tables/MS-DOS/Code_page_59829
 0x80 0x10d0        #GEORGIAN LETTER AN
 0x81 0x10d1        #GEORGIAN LETTER BAN
 0x82 0x10d2        #GEORGIAN LETTER GAN
@@ -2630,8 +2626,7 @@ CODEPAGE 59829 # Georgian
 0xa3 0x10f3        #GEORGIAN LETTER WE
 0xa4 0x10f4        #GEORGIAN LETTER HAR
 0xa5 0x10f5        #GEORGIAN LETTER HOE
-# TODO: next one is most likely SHIN with some accent
-# 0xa6
+0xa6 0x10e8 0x030c #GEORGIAN LETTER SHIN, COMBINING CARON
 EXTENDS CODEPAGE 437
 
 CODEPAGE 60258 # Russian Cyrillic and Latin Azeri


### PR DESCRIPTION
# Description

Added definition of previously unidentified character from code page 59829 (Georgian)


## Related issues

Fixes https://github.com/dosbox-staging/dosbox-staging/issues/1986


# Manual testing

Execute command `keyb ka 59829` - there should be no warnings printed out in logs, DOSBox should continue displaying it's messages like before.


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

