### PR TITLE
Improve platform builds workflow

### DIFF
--- a/.github/workflows/platforms.yml
+++ b/.github/workflows/platforms.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           submodules: false
 
-      - uses: uraimo/run-on-arch-action@master
+      - uses: uraimo/run-on-arch-action@v2.8.1
         name: Build artifact
         id: build
         with:

--- a/.github/workflows/platforms.yml
+++ b/.github/workflows/platforms.yml
@@ -2,6 +2,7 @@ name: Platform builds
 
 on:
   schedule: [cron: '0 14 * * *']
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/platforms.yml
+++ b/.github/workflows/platforms.yml
@@ -42,12 +42,12 @@ jobs:
           - name: ARM64 (Ubuntu 20.04)
             arch: aarch64
             distro: ubuntu20.04
-          - name: s390x (Fedora)
+          - name: s390x (Debian "bookworm")
             arch: s390x
-            distro: fedora_latest
-          - name: ppc64le (Fedora)
+            distro: bookworm
+          - name: ppc64le (Debian "bookworm")
             arch: ppc64le
-            distro: fedora_latest
+            distro: bookworm
 
     steps:
       - uses: actions/checkout@v4
@@ -89,10 +89,21 @@ jobs:
                 apt-get -qq install git curl findutils procps tar zstd screenfetch \
                                     < /dev/null > /dev/null
                 apt-get -qq install cmake g++ build-essential ccache libasound2-dev libgtest-dev \
-                                    libopusfile-dev libsdl2-dev python3-setuptools python3-pip zlib1g-dev \
-                                    libspeexdsp-dev \
+                                    libopusfile-dev libsdl2-dev zlib1g-dev libspeexdsp-dev \
+                                    < /dev/null > /dev/null
+                # Meson from Debian repository is too old for DOSBox Staging
+                apt-get -qq install python3-setuptools python3-pip \
                                     < /dev/null > /dev/null
                 pip3 install meson ninja
+                ;;
+              bookworm)
+                # we only care about issues
+                apt-get -qq update  < /dev/null > /dev/null
+                apt-get -qq install git curl findutils procps tar zstd screenfetch \
+                                    < /dev/null > /dev/null
+                apt-get -qq install cmake g++ build-essential ccache meson libasound2-dev libgtest-dev \
+                                    libopusfile-dev libsdl2-dev zlib1g-dev libspeexdsp-dev libpng-dev \
+                                    < /dev/null > /dev/null
                 ;;
               fedora*)
                 dnf -q -y update


### PR DESCRIPTION
# Description

_Platform builds_ workflow was broken for ppc64le and s390x architectures. This was because run-on-arch-action used by that workflow had reduced the set of available (os, arch) pairs. Migrate to supported pairs, and do two general improvements:

* Allow workflow dispatch for this workflow, so it can be run manually in addition to running periodically
* Fix version on run-on-arch-action, so that in the future, breaking changes there do not automatically break the workflow

## Related issues

Problems testing #3991 motivated this effort.

# Manual testing

Ran the workflow in my fork. Got s390x to pass and ppc64le to fail in the way that #3991 fixes. All ARM builds are failing for some reason related to zlib-ng Meson wrap. It looks like a genuine build problem when using that Meson wrap, so out of scope for this pull request where the focus is in the workflow itself.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [ ] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.