### PR TITLE
Fix deadlock on exit in GUS

### DIFF
--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -1491,8 +1491,10 @@ static void gus_destroy([[maybe_unused]] Section* sec)
 	//       ULTRASND and ULTRADIR environment variables.
 
 	if (gus) {
+		MIXER_LockMixerThread();
 		gus->PrintStats();
 		gus.reset();
+		MIXER_UnlockMixerThread();
 	}
 }
 


### PR DESCRIPTION
# Description

Very subtle race condition here
I was taking a lock inside the destructor but that gets called after the unique_ptr gets replaced by nullptr
This results in the mixer seeing that there is no gus object and not stopping the GUS RWQueue
To fix, place a lock around the gus.reset() call

# Manual testing

I was not able to reproduce this.  It's somewhat rare.  @kklobe reported it only happened twice in 150 runs.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

