### PR TITLE
Ensure the line feed follows carriage return when reading from the DOS console

### DIFF
--- a/include/ascii.h
+++ b/include/ascii.h
@@ -1,0 +1,43 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2024-2024  The DOSBox Staging Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#ifndef DOSBOX_ASCII_H
+#define DOSBOX_ASCII_H
+
+#include <cstdint>
+
+namespace Ascii {
+
+enum ControlCode : uint8_t {
+	// Control characters
+	Null           = 0x00,
+	CtrlC          = 0x03,
+	Backspace      = 0x08,
+	LineFeed       = 0x0a,
+	FormFeed       = 0x0c,
+	CarriageReturn = 0x0d,
+	Escape         = 0x1b,
+	Delete         = 0x7f,
+	Extended       = 0xe0,
+};
+
+}
+
+#endif

--- a/src/dos/dev_con.h
+++ b/src/dos/dev_con.h
@@ -35,14 +35,16 @@ public:
 	bool Write(uint8_t* data, uint16_t* size) override;
 	bool Seek(uint32_t* pos, uint32_t type) override;
 	void Close() override;
-	uint16_t GetInformation(void) override;
-	bool ReadFromControlChannel(PhysPt /*bufptr*/, uint16_t /*size*/,
-	                            uint16_t* /*retcode*/) override
+	uint16_t GetInformation() override;
+	bool ReadFromControlChannel([[maybe_unused]] PhysPt bufptr,
+	                            [[maybe_unused]] uint16_t size,
+	                            [[maybe_unused]] uint16_t* retcode) override
 	{
 		return false;
 	}
-	bool WriteToControlChannel(PhysPt /*bufptr*/, uint16_t /*size*/,
-	                           uint16_t* /*retcode*/) override
+	bool WriteToControlChannel([[maybe_unused]] PhysPt bufptr,
+	                           [[maybe_unused]] uint16_t size,
+	                           [[maybe_unused]] uint16_t* retcode) override
 	{
 		return false;
 	}
@@ -53,115 +55,135 @@ private:
 
 	uint8_t readcache = 0;
 	struct ansi {
-		bool esc = false;
-		bool sci = false;
-		bool enabled = false;
-		uint8_t attr = 0x7;
+		bool esc                       = false;
+		bool sci                       = false;
+		bool enabled                   = false;
+		uint8_t attr                   = 0x7;
 		uint8_t data[NUMBER_ANSI_DATA] = {};
-		uint8_t numberofarg = 0;
-		int8_t savecol = 0;
-		int8_t saverow = 0;
-		bool warned = false;
+		uint8_t numberofarg            = 0;
+		int8_t savecol                 = 0;
+		int8_t saverow                 = 0;
+		bool warned                    = false;
 	} ansi = {};
 };
 
 void device_CON::ClearAnsi()
 {
 	memset(ansi.data, 0, NUMBER_ANSI_DATA);
-	ansi.esc = false;
-	ansi.sci = false;
+	ansi.esc         = false;
+	ansi.sci         = false;
 	ansi.numberofarg = 0;
 }
 
-bool device_CON::Read(uint8_t * data,uint16_t * size) {
-	uint16_t oldax=reg_ax;
-	uint16_t count=0;
+bool device_CON::Read(uint8_t* data, uint16_t* size)
+{
+	uint16_t oldax = reg_ax;
+	uint16_t count = 0;
 	INT10_SetCurMode();
 	if ((readcache) && (*size)) {
-		data[count++]=readcache;
+		data[count++] = readcache;
 		if (dos.echo) {
 			INT10_TeletypeOutputViaInterrupt(readcache, 7);
 		}
-		readcache=0;
+		readcache = 0;
 	}
-	while (*size>count) {
-		reg_ah=(IS_EGAVGA_ARCH)?0x10:0x0;
+	while (*size > count) {
+		reg_ah = (IS_EGAVGA_ARCH) ? 0x10 : 0x0;
 		CALLBACK_RunRealInt(0x16);
-		switch(reg_al) {
+		switch (reg_al) {
 		case 13:
-			data[count++]=0x0D;
-			if (*size>count) data[count++]=0x0A;    // it's only expanded if there is room for it. (NO cache)
-			*size=count;
-			reg_ax=oldax;
-			if(dos.echo) {
-				// maybe don't do this ( no need for it actually
-				// ) (but it's compatible)
+			data[count++] = 0x0D;
+
+			// It's only expanded if there's room for it
+			if (*size > count) {
+				data[count++] = 0x0A;
+			}
+			*size  = count;
+			reg_ax = oldax;
+			if (dos.echo) {
+				// Maybe don't do this (no need for it actually)
+				// (but it's compatible)
 				INT10_TeletypeOutputViaInterrupt(13, 7);
 				INT10_TeletypeOutputViaInterrupt(10, 7);
 			}
 			return true;
 			break;
 		case 8:
-			if(*size==1) data[count++]=reg_al;  //one char at the time so give back that BS
-			else if(count) {                    //Remove data if it exists (extended keys don't go right)
-				data[count--]=0;
+			// One char at the time so give back that BS
+			if (*size == 1) {
+				data[count++] = reg_al;
+			}
+
+			// Remove data if it exists (extended keys don't go right)
+			else if (count) {
+				data[count--] = 0;
 				INT10_TeletypeOutputViaInterrupt(8, 7);
 				INT10_TeletypeOutputViaInterrupt(' ', 7);
 			} else {
-				continue;                       //no data read yet so restart whileloop.
+				// No data read yet so restart while loop
+				continue;
 			}
 			break;
-		case 0xe0: /* Extended keys in the  int 16 0x10 case */
-			if(!reg_ah) { /*extended key if reg_ah isn't 0 */
+		case 0xe0:
+			// Extended keys in the  int 16 0x10 case
+			if (!reg_ah) {
+				// Extended key if reg_ah isn't 0
 				data[count++] = reg_al;
 			} else {
 				data[count++] = 0;
-				if (*size>count) data[count++] = reg_ah;
-				else readcache = reg_ah;
+				if (*size > count) {
+					data[count++] = reg_ah;
+				} else {
+					readcache = reg_ah;
+				}
 			}
 			break;
-		case 0: /* Extended keys in the int 16 0x0 case */
-			data[count++]=reg_al;
-			if (*size>count) data[count++]=reg_ah;
-			else readcache=reg_ah;
+		case 0:
+			// Extended keys in the int 16 0x0 case
+			data[count++] = reg_al;
+			if (*size > count) {
+				data[count++] = reg_ah;
+			} else {
+				readcache = reg_ah;
+			}
 			break;
-		default:
-			data[count++]=reg_al;
-			break;
+		default: data[count++] = reg_al; break;
 		}
-		if(dos.echo) { //what to do if *size==1 and character is BS ?????
+		if (dos.echo) {
+			// What to do if *size==1 and character is BS ?????
 			INT10_TeletypeOutputViaInterrupt(reg_al, 7);
 		}
 	}
-	*size=count;
-	reg_ax=oldax;
+	*size  = count;
+	reg_ax = oldax;
 	return true;
 }
 
-bool device_CON::Write(uint8_t * data,uint16_t * size) {
+bool device_CON::Write(uint8_t* data, uint16_t* size)
+{
 	constexpr uint8_t code_escape = 0x1b;
-	uint16_t count=0;
+	uint16_t count                = 0;
 	Bitu i;
-	uint8_t col,row,page;
-	uint16_t ncols,nrows;
+	uint8_t col, row, page;
+	uint16_t ncols, nrows;
 	uint8_t tempdata;
 	INT10_SetCurMode();
-	while (*size>count) {
-		if (!ansi.esc){
+	while (*size > count) {
+		if (!ansi.esc) {
 			if (data[count] == code_escape) {
-				/*clear the datastructure */
+				// Clear the datastructure
 				ClearAnsi();
-				/* start the sequence */
-				ansi.esc=true;
+				// Start the sequence
+				ansi.esc = true;
 				count++;
 				continue;
 			} else if (data[count] == '\t' && !dos.direct_output) {
-				/* expand tab if not direct output */
-				page = real_readb(BIOSMEM_SEG,BIOSMEM_CURRENT_PAGE);
+				// Expand tab if not direct output
+				page = real_readb(BIOSMEM_SEG, BIOSMEM_CURRENT_PAGE);
 				do {
 					Output(' ');
-					col=CURSOR_POS_COL(page);
-				} while(col%8);
+					col = CURSOR_POS_COL(page);
+				} while (col % 8);
 				count++;
 				continue;
 			} else {
@@ -169,30 +191,32 @@ bool device_CON::Write(uint8_t * data,uint16_t * size) {
 				count++;
 				continue;
 			}
-	}
-
-	if(!ansi.sci){
-            
-		switch(data[count]){
-		case '[': 
-			ansi.sci=true;
-			break;
-		case '7': /* save cursor pos + attr */
-		case '8': /* restore this  (Wonder if this is actually used) */
-		case 'D':/* scrolling DOWN*/
-		case 'M':/* scrolling UP*/ 
-		default:
-			LOG(LOG_IOCTL,LOG_NORMAL)("ANSI: unknown char %c after a esc",data[count]); /*prob () */
-			ClearAnsi();
-			break;
 		}
-		count++;
-		continue;
-	}
-	/*ansi.esc and ansi.sci are true */
-	if (!dos.internal_output) ansi.enabled=true;
-	page = real_readb(BIOSMEM_SEG,BIOSMEM_CURRENT_PAGE);
-	switch(data[count]){
+
+		if (!ansi.sci) {
+
+			switch (data[count]) {
+			case '[': ansi.sci = true; break;
+			case '7': // Save cursor pos + attr
+			case '8': // Restore this (wonder if this is actually used)
+			case 'D': // Scrolling down
+			case 'M': // Scrolling up
+			default:
+				// prob ()
+				LOG(LOG_IOCTL, LOG_NORMAL)
+				("ANSI: unknown char %c after a esc", data[count]);
+				ClearAnsi();
+				break;
+			}
+			count++;
+			continue;
+		}
+		// ansi.esc and ansi.sci are true
+		if (!dos.internal_output) {
+			ansi.enabled = true;
+		}
+		page = real_readb(BIOSMEM_SEG, BIOSMEM_CURRENT_PAGE);
+		switch (data[count]) {
 		case '0':
 		case '1':
 		case '2':
@@ -203,112 +227,128 @@ bool device_CON::Write(uint8_t * data,uint16_t * size) {
 		case '7':
 		case '8':
 		case '9':
-			ansi.data[ansi.numberofarg]=10*ansi.data[ansi.numberofarg]+(data[count]-'0');
+			ansi.data[ansi.numberofarg] = 10 * ansi.data[ansi.numberofarg] +
+			                              (data[count] - '0');
 			break;
-		case ';': /* till a max of NUMBER_ANSI_DATA */
+		case ';': // Till a max of NUMBER_ANSI_DATA
 			ansi.numberofarg++;
 			break;
-		case 'm':               /* SGR */
-			for(i=0;i<=ansi.numberofarg;i++){ 
-				switch(ansi.data[i]){
-				case 0: /* normal */
-					ansi.attr=0x07;//Real ansi does this as well. (should do current defaults)
+		case 'm': // SGR
+			for (i = 0; i <= ansi.numberofarg; i++) {
+				switch (ansi.data[i]) {
+				case 0: // Normal
+					// Real ansi does this as well. (should
+					// do current defaults)
+					ansi.attr = 0x07;
 					break;
-				case 1: /* bold mode on*/
-					ansi.attr|=0x08;
+				case 1: // Bold mode on
+					ansi.attr |= 0x08;
 					break;
-				case 4: /* underline */
-					LOG(LOG_IOCTL,LOG_NORMAL)("ANSI:no support for underline yet");
+				case 4: // Underline
+					LOG(LOG_IOCTL, LOG_NORMAL)
+					("ANSI:no support for underline yet");
 					break;
-				case 5: /* blinking */
-					ansi.attr|=0x80;
+				case 5: // Blinking
+					ansi.attr |= 0x80;
 					break;
-				case 7: /* reverse */
-					ansi.attr=0x70;//Just like real ansi. (should do use current colors reversed)
+				case 7: // Reverse
+					// Just like real ansi. (should do use
+					// current colors reversed)
+					ansi.attr = 0x70;
 					break;
-				case 30: /* fg color black */
-					ansi.attr&=0xf8;
-					ansi.attr|=0x0;
+				case 30: // Foreground color black
+					ansi.attr &= 0xf8;
+					ansi.attr |= 0x0;
 					break;
-				case 31:  /* fg color red */
-					ansi.attr&=0xf8;
-					ansi.attr|=0x4;
+				case 31: // Foreground color red
+					ansi.attr &= 0xf8;
+					ansi.attr |= 0x4;
 					break;
-				case 32:  /* fg color green */
-					ansi.attr&=0xf8;
-					ansi.attr|=0x2;
+				case 32: // Foreground color green
+					ansi.attr &= 0xf8;
+					ansi.attr |= 0x2;
 					break;
-				case 33: /* fg color yellow */
-					ansi.attr&=0xf8;
-					ansi.attr|=0x6;
+				case 33: // Foreground color yellow
+					ansi.attr &= 0xf8;
+					ansi.attr |= 0x6;
 					break;
-				case 34: /* fg color blue */
-					ansi.attr&=0xf8;
-					ansi.attr|=0x1;
+				case 34: // Foreground color blue
+					ansi.attr &= 0xf8;
+					ansi.attr |= 0x1;
 					break;
-				case 35: /* fg color magenta */
-					ansi.attr&=0xf8;
-					ansi.attr|=0x5;
+				case 35: // Foreground color magenta
+					ansi.attr &= 0xf8;
+					ansi.attr |= 0x5;
 					break;
-				case 36: /* fg color cyan */
-					ansi.attr&=0xf8;
-					ansi.attr|=0x3;
+				case 36: // Foreground color cyan
+					ansi.attr &= 0xf8;
+					ansi.attr |= 0x3;
 					break;
-				case 37: /* fg color white */
-					ansi.attr&=0xf8;
-					ansi.attr|=0x7;
+				case 37: // Foreground color white
+					ansi.attr &= 0xf8;
+					ansi.attr |= 0x7;
 					break;
 				case 40:
-					ansi.attr&=0x8f;
-					ansi.attr|=0x0;
+					ansi.attr &= 0x8f;
+					ansi.attr |= 0x0;
 					break;
 				case 41:
-					ansi.attr&=0x8f;
-					ansi.attr|=0x40;
+					ansi.attr &= 0x8f;
+					ansi.attr |= 0x40;
 					break;
 				case 42:
-					ansi.attr&=0x8f;
-					ansi.attr|=0x20;
+					ansi.attr &= 0x8f;
+					ansi.attr |= 0x20;
 					break;
 				case 43:
-					ansi.attr&=0x8f;
-					ansi.attr|=0x60;
+					ansi.attr &= 0x8f;
+					ansi.attr |= 0x60;
 					break;
 				case 44:
-					ansi.attr&=0x8f;
-					ansi.attr|=0x10;
+					ansi.attr &= 0x8f;
+					ansi.attr |= 0x10;
 					break;
 				case 45:
-					ansi.attr&=0x8f;
-					ansi.attr|=0x50;
+					ansi.attr &= 0x8f;
+					ansi.attr |= 0x50;
 					break;
 				case 46:
-					ansi.attr&=0x8f;
-					ansi.attr|=0x30;
-					break;	
+					ansi.attr &= 0x8f;
+					ansi.attr |= 0x30;
+					break;
 				case 47:
-					ansi.attr&=0x8f;
-					ansi.attr|=0x70;
+					ansi.attr &= 0x8f;
+					ansi.attr |= 0x70;
 					break;
-				default:
-					break;
+				default: break;
 				}
 			}
 			ClearAnsi();
 			break;
 		case 'f':
-		case 'H':/* Cursor Pos*/
-			if(!ansi.warned) { //Inform the debugger that ansi is used.
+		case 'H': // Cursor Position
+			if (!ansi.warned) {
+				// Inform the debugger that ansi is used
 				ansi.warned = true;
-				LOG(LOG_IOCTL,LOG_WARN)("ANSI SEQUENCES USED");
+				LOG(LOG_IOCTL, LOG_WARN)("ANSI SEQUENCES USED");
 			}
-			ncols = real_readw(BIOSMEM_SEG,BIOSMEM_NB_COLS);
-			nrows = IS_EGAVGA_ARCH ? (real_readb(BIOSMEM_SEG,BIOSMEM_NB_ROWS) + 1) : 25;
-			/* Turn them into positions that are on the screen */
-			if(ansi.data[0] == 0) ansi.data[0] = 1;
-			if(ansi.data[1] == 0) ansi.data[1] = 1;
-			if(ansi.data[0] > nrows) ansi.data[0] = (uint8_t)nrows;
-			if(ansi.data[1] > ncols) ansi.data[1] = (uint8_t)ncols;
+			ncols = real_readw(BIOSMEM_SEG, BIOSMEM_NB_COLS);
+			nrows = IS_EGAVGA_ARCH
+			              ? (real_readb(BIOSMEM_SEG, BIOSMEM_NB_ROWS) + 1)
+			              : 25;
+			// Turn them into positions that are on the screen
+			if (ansi.data[0] == 0) {
+				ansi.data[0] = 1;
+			}
+			if (ansi.data[1] == 0) {
+				ansi.data[1] = 1;
+			}
+			if (ansi.data[0] > nrows) {
+				ansi.data[0] = (uint8_t)nrows;
+			}
+			if (ansi.data[1] > ncols) {
+				ansi.data[1] = (uint8_t)ncols;
+			}
 
 			// ansi=1 based,  int10 is 0 based
 			INT10_SetCursorPosViaInterrupt(--(ansi.data[0]),
@@ -316,134 +356,191 @@ bool device_CON::Write(uint8_t * data,uint16_t * size) {
 			                               page);
 			ClearAnsi();
 			break;
-			/* cursor up down and forward and backward only change the row or the col not both */
-		case 'A': /* cursor up*/
-			col=CURSOR_POS_COL(page) ;
-			row=CURSOR_POS_ROW(page) ;
-			tempdata = (ansi.data[0]? ansi.data[0] : 1);
-			if(tempdata > row) { row=0; } 
-			else { row-=tempdata;}
-			INT10_SetCursorPosViaInterrupt(row, col, page);
-			ClearAnsi();
-			break;
-		case 'B': /*cursor Down */
-			col=CURSOR_POS_COL(page) ;
-			row=CURSOR_POS_ROW(page) ;
-			nrows = IS_EGAVGA_ARCH ? (real_readb(BIOSMEM_SEG,BIOSMEM_NB_ROWS) + 1) : 25;
-			tempdata = (ansi.data[0]? ansi.data[0] : 1);
-			if(tempdata + static_cast<Bitu>(row) >= nrows)
-				{ row = nrows - 1;}
-			else	{ row += tempdata; }
-			INT10_SetCursorPosViaInterrupt(row, col, page);
-			ClearAnsi();
-			break;
-		case 'C': /*cursor forward */
-			col=CURSOR_POS_COL(page);
-			row=CURSOR_POS_ROW(page);
-			ncols = real_readw(BIOSMEM_SEG,BIOSMEM_NB_COLS);
-			tempdata=(ansi.data[0]? ansi.data[0] : 1);
-			if(tempdata + static_cast<Bitu>(col) >= ncols) 
-				{ col = ncols - 1;} 
-			else	{ col += tempdata;}
-			INT10_SetCursorPosViaInterrupt(row, col, page);
-			ClearAnsi();
-			break;
-		case 'D': /*Cursor Backward  */
-			col=CURSOR_POS_COL(page);
-			row=CURSOR_POS_ROW(page);
-			tempdata=(ansi.data[0]? ansi.data[0] : 1);
-			if(tempdata > col) {col = 0;}
-			else { col -= tempdata;}
-			INT10_SetCursorPosViaInterrupt(row, col, page);
-			ClearAnsi();
-			break;
-		case 'J': /*erase screen and move cursor home*/
-			if(ansi.data[0]==0) ansi.data[0]=2;
-			if(ansi.data[0]!=2) {/* every version behaves like type 2 */
-				LOG(LOG_IOCTL,LOG_NORMAL)("ANSI: esc[%dJ called : not supported handling as 2",ansi.data[0]);
+			// Cursor up down and forward and backward only change
+			// the row or the col not both
+		case 'A': // Cursor up
+			col      = CURSOR_POS_COL(page);
+			row      = CURSOR_POS_ROW(page);
+			tempdata = (ansi.data[0] ? ansi.data[0] : 1);
+			if (tempdata > row) {
+				row = 0;
+			} else {
+				row -= tempdata;
 			}
-			INT10_ScrollWindow(0,0,255,255,0,ansi.attr,page);
+			INT10_SetCursorPosViaInterrupt(row, col, page);
+			ClearAnsi();
+			break;
+		case 'B': // Cursor Down
+			col      = CURSOR_POS_COL(page);
+			row      = CURSOR_POS_ROW(page);
+			nrows    = IS_EGAVGA_ARCH
+			                 ? (real_readb(BIOSMEM_SEG, BIOSMEM_NB_ROWS) + 1)
+			                 : 25;
+			tempdata = (ansi.data[0] ? ansi.data[0] : 1);
+			if (tempdata + static_cast<Bitu>(row) >= nrows) {
+				row = nrows - 1;
+			} else {
+				row += tempdata;
+			}
+			INT10_SetCursorPosViaInterrupt(row, col, page);
+			ClearAnsi();
+			break;
+		case 'C': // Cursor forward
+			col      = CURSOR_POS_COL(page);
+			row      = CURSOR_POS_ROW(page);
+			ncols    = real_readw(BIOSMEM_SEG, BIOSMEM_NB_COLS);
+			tempdata = (ansi.data[0] ? ansi.data[0] : 1);
+			if (tempdata + static_cast<Bitu>(col) >= ncols) {
+				col = ncols - 1;
+			} else {
+				col += tempdata;
+			}
+			INT10_SetCursorPosViaInterrupt(row, col, page);
+			ClearAnsi();
+			break;
+		case 'D': // Cursor backward
+			col      = CURSOR_POS_COL(page);
+			row      = CURSOR_POS_ROW(page);
+			tempdata = (ansi.data[0] ? ansi.data[0] : 1);
+			if (tempdata > col) {
+				col = 0;
+			} else {
+				col -= tempdata;
+			}
+			INT10_SetCursorPosViaInterrupt(row, col, page);
+			ClearAnsi();
+			break;
+		case 'J': // Erase screen and move cursor home
+			if (ansi.data[0] == 0) {
+				ansi.data[0] = 2;
+			}
+			if (ansi.data[0] != 2) {
+				// Every version behaves like type 2
+				LOG(LOG_IOCTL, LOG_NORMAL)
+				("ANSI: esc[%dJ called : not supported handling as 2",
+				 ansi.data[0]);
+			}
+			INT10_ScrollWindow(0, 0, 255, 255, 0, ansi.attr, page);
 			ClearAnsi();
 			INT10_SetCursorPosViaInterrupt(0, 0, page);
 			break;
-		case 'h': /* SET   MODE (if code =7 enable linewrap) */
-		case 'I': /* RESET MODE */
-			LOG(LOG_IOCTL,LOG_NORMAL)("ANSI: set/reset mode called(not supported)");
+		case 'h': // Set mode (if code =7 enable linewrap)
+		case 'I': // Reset mode
+			LOG(LOG_IOCTL, LOG_NORMAL)
+			("ANSI: set/reset mode called(not supported)");
 			ClearAnsi();
 			break;
-		case 'u': /* Restore Cursor Pos */
+		case 'u': // Restore Cursor Pos
 			INT10_SetCursorPosViaInterrupt(ansi.saverow, ansi.savecol, page);
 			ClearAnsi();
 			break;
-		case 's': /* SAVE CURSOR POS */
-			ansi.savecol=CURSOR_POS_COL(page);
-			ansi.saverow=CURSOR_POS_ROW(page);
+		case 's': // Save cursor position
+			ansi.savecol = CURSOR_POS_COL(page);
+			ansi.saverow = CURSOR_POS_ROW(page);
 			ClearAnsi();
 			break;
-		case 'K': /* erase till end of line (don't touch cursor) */
-			col = CURSOR_POS_COL(page);
-			row = CURSOR_POS_ROW(page);
-			ncols = real_readw(BIOSMEM_SEG,BIOSMEM_NB_COLS);
-			INT10_WriteChar(' ',ansi.attr,page,ncols-col,true); //Use this one to prevent scrolling when end of screen is reached
-			//for(i = col;i<(Bitu) ncols; i++) INT10_TeletypeOutputAttr(' ',ansi.attr,true);
+		case 'K': // Erase till end of line (don't touch cursor)
+			col   = CURSOR_POS_COL(page);
+			row   = CURSOR_POS_ROW(page);
+			ncols = real_readw(BIOSMEM_SEG, BIOSMEM_NB_COLS);
+
+			// Use this one to prevent scrolling when end of screen
+			// is reached
+			INT10_WriteChar(' ', ansi.attr, page, ncols - col, true);
+
+			// for(i = col;i<(Bitu) ncols; i++)
+			// INT10_TeletypeOutputAttr(' ',ansi.attr,true);
 			INT10_SetCursorPosViaInterrupt(row, col, page);
 			ClearAnsi();
 			break;
-		case 'M': /* delete line (NANSI) */
-			row = CURSOR_POS_ROW(page);
-			ncols = real_readw(BIOSMEM_SEG,BIOSMEM_NB_COLS);
-			nrows = IS_EGAVGA_ARCH ? (real_readb(BIOSMEM_SEG,BIOSMEM_NB_ROWS) + 1) : 25;
-			INT10_ScrollWindow(row,0,nrows-1,ncols-1,ansi.data[0]? -ansi.data[0] : -1,ansi.attr,0xFF);
+		case 'M': // Delete line (NANSI)
+			row   = CURSOR_POS_ROW(page);
+			ncols = real_readw(BIOSMEM_SEG, BIOSMEM_NB_COLS);
+			nrows = IS_EGAVGA_ARCH
+			              ? (real_readb(BIOSMEM_SEG, BIOSMEM_NB_ROWS) + 1)
+			              : 25;
+			INT10_ScrollWindow(row,
+			                   0,
+			                   nrows - 1,
+			                   ncols - 1,
+			                   ansi.data[0] ? -ansi.data[0] : -1,
+			                   ansi.attr,
+			                   0xFF);
 			ClearAnsi();
 			break;
-		case 'l':/* (if code =7) disable linewrap */
-		case 'p':/* reassign keys (needs strings) */
-		case 'i':/* printer stuff */
+		case 'l': // (if code =7) disable linewrap
+		case 'p': // Reassign keys (needs strings)
+		case 'i': // Printer stuff
 		default:
-			LOG(LOG_IOCTL,LOG_NORMAL)("ANSI: unhandled char %c in esc[",data[count]);
+			LOG(LOG_IOCTL, LOG_NORMAL)
+			("ANSI: unhandled char %c in esc[", data[count]);
 			ClearAnsi();
 			break;
 		}
 		count++;
 	}
-	*size=count;
+	*size = count;
 	return true;
 }
 
-bool device_CON::Seek(uint32_t * pos,uint32_t /*type*/) {
-	// seek is valid
+bool device_CON::Seek(uint32_t* pos, [[maybe_unused]] uint32_t type)
+{
+	// Seek is valid
 	*pos = 0;
 	return true;
 }
 
-void device_CON::Close() {
+void device_CON::Close() {}
+
+uint16_t device_CON::GetInformation()
+{
+	uint16_t head = mem_readw(BIOS_KEYBOARD_BUFFER_HEAD);
+	uint16_t tail = mem_readw(BIOS_KEYBOARD_BUFFER_TAIL);
+
+	// No Key Available
+	if ((head == tail) && !readcache) {
+		return 0x80D3;
+	}
+
+	// Key Available
+	if (readcache || real_readw(0x40, head)) {
+		return 0x8093;
+	}
+
+	// Remove the zero from keyboard buffer
+	uint16_t start = mem_readw(BIOS_KEYBOARD_BUFFER_START);
+	uint16_t end   = mem_readw(BIOS_KEYBOARD_BUFFER_END);
+	head += 2;
+	if (head >= end) {
+		head = start;
+	}
+	mem_writew(BIOS_KEYBOARD_BUFFER_HEAD, head);
+
+	// No Key Available
+	return 0x80D3;
 }
 
-uint16_t device_CON::GetInformation(void) {
-	uint16_t head=mem_readw(BIOS_KEYBOARD_BUFFER_HEAD);
-	uint16_t tail=mem_readw(BIOS_KEYBOARD_BUFFER_TAIL);
-
-	if ((head==tail) && !readcache) return 0x80D3;	/* No Key Available */
-	if (readcache || real_readw(0x40,head)) return 0x8093;		/* Key Available */
-
-	/* remove the zero from keyboard buffer */
-	uint16_t start=mem_readw(BIOS_KEYBOARD_BUFFER_START);
-	uint16_t end	=mem_readw(BIOS_KEYBOARD_BUFFER_END);
-	head+=2;
-	if (head>=end) head=start;
-	mem_writew(BIOS_KEYBOARD_BUFFER_HEAD,head);
-	return 0x80D3; /* No Key Available */
-}
-
-void device_CON::Output(uint8_t chr) {
+void device_CON::Output(uint8_t chr)
+{
 	if (dos.internal_output || ansi.enabled) {
-		if (CurMode->type==M_TEXT) {
-			uint8_t page=real_readb(BIOSMEM_SEG,BIOSMEM_CURRENT_PAGE);
-			uint8_t col=CURSOR_POS_COL(page);
-			uint8_t row=CURSOR_POS_ROW(page);
-			BIOS_NCOLS;BIOS_NROWS;
-			if (nrows==row+1 && (chr=='\n' || (ncols==col+1 && chr!='\r' && chr!=8 && chr!=7))) {
-				INT10_ScrollWindow(0,0,(uint8_t)(nrows-1),(uint8_t)(ncols-1),-1,ansi.attr,page);
+		if (CurMode->type == M_TEXT) {
+			uint8_t page = real_readb(BIOSMEM_SEG, BIOSMEM_CURRENT_PAGE);
+			uint8_t col = CURSOR_POS_COL(page);
+			uint8_t row = CURSOR_POS_ROW(page);
+			BIOS_NCOLS;
+			BIOS_NROWS;
+			if (nrows == row + 1 &&
+			    (chr == '\n' || (ncols == col + 1 && chr != '\r' &&
+			                     chr != 8 && chr != 7))) {
+
+				INT10_ScrollWindow(0,
+				                   0,
+				                   (uint8_t)(nrows - 1),
+				                   (uint8_t)(ncols - 1),
+				                   -1,
+				                   ansi.attr,
+				                   page);
+
 				INT10_SetCursorPosViaInterrupt(row - 1, col, page);
 			}
 		}

--- a/src/dos/dev_con.h
+++ b/src/dos/dev_con.h
@@ -116,7 +116,6 @@ bool device_CON::Read(uint8_t* data, uint16_t* size)
 				INT10_TeletypeOutputViaInterrupt(Ascii::LineFeed, 7);
 			}
 			return true;
-			break;
 		case Ascii::Backspace:
 			// One char at the time so give back that BS
 			if (*size == 1) {

--- a/src/dos/dev_con.h
+++ b/src/dos/dev_con.h
@@ -96,9 +96,16 @@ bool device_CON::Read(uint8_t* data, uint16_t* size)
 		case Ascii::CarriageReturn:
 			data[count++] = Ascii::CarriageReturn;
 
-			// It's only expanded if there's room for it
+			// DOS's console device expands CR's to CRLF's when
+			// reading from the STDIN handle (other operating
+			// systems don't). CRLF is sent regardless if the
+			// program reads multiple bytes at once or one byte at a
+			// time.
 			if (*size > count) {
 				data[count++] = Ascii::LineFeed;
+			} else {
+				assert(!readcache);
+				readcache = Ascii::LineFeed;
 			}
 			*size  = count;
 			reg_ax = oldax;

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -25,6 +25,7 @@
 #include <ctime>
 #include <array>
 
+#include "ascii.h"
 #include "bios.h"
 #include "callback.h"
 #include "dos_locale.h"
@@ -1404,9 +1405,6 @@ static Bitu DOS_26Handler(void) {
     return CBRET_NONE;
 }
 
-constexpr uint8_t code_ctrl_c = 0x03;
-constexpr uint8_t code_esc    = 0x1b;
-
 bool DOS_IsCancelRequest()
 {
 	if (shutdown_requested)
@@ -1420,10 +1418,10 @@ bool DOS_IsCancelRequest()
 		DOS_ReadFile(STDIN, &code, &count);
 
 		// Check if user requested to cancel
-		if (shutdown_requested || count == 0 ||
-			code == 'q' || code == 'Q' ||
-		    code == code_ctrl_c || code == code_esc)
+		if (shutdown_requested || count == 0 || code == 'q' ||
+		    code == 'Q' || code == Ascii::CtrlC || code == Ascii::Escape) {
 			return true;
+		}
 	}
 
 	// Return control if no key pressed


### PR DESCRIPTION
# Description

When reading the MS-DOS console device, the line feed character always follows a carriage return (the infamous Microsoft 'CRLF' sequence :grin: ).

DOSBox gets this right when reading enough bytes at a time that both the CRLF can fit into a single read operation. However, if the read size is split or done byte-by-byte, the trailing LF isn't sent.

Thanks to @darkstar's issue report and their acquaintance's description of the cause.

This must not have been a big deal given it hasn't posed a problem in decades, but a German adware game by Ford Motor Company is sensitive to this and always expects CRLF after pressing enter.

Reviewers - I had to apply clang-format to cleanup `dev_con.h` first, so that's the first commit. Suggest skipping it and just reading the second and third commits.

## Related issues

Fixes #4007

# Release notes

CRLF is now always sent when reading from the console device. This fixes the name entry part of the 'Ford Fiesta Werbespiel' game.

# Manual testing

TODO: Need to test more apps, games, etc. Will update as I test more.

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [x] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

