### PR TITLE
[post 0.82] Update and always use the vcpkg baseline in CI

### DIFF
--- a/.github/workflows/windows-msvc.yml
+++ b/.github/workflows/windows-msvc.yml
@@ -45,6 +45,16 @@ jobs:
         with:
           submodules: false
 
+      - name: Checkout vcpkg baseline
+        shell: pwsh
+        run: |
+          $baseline = (Get-Content vcpkg.json | ConvertFrom-Json).'builtin-baseline'
+          cd $env:VCPKG_INSTALLATION_ROOT
+          git fetch
+          rm vcpkg.exe
+          git -c advice.detachedHead=false checkout $baseline
+          bootstrap-vcpkg.bat -disableMetrics
+
       - name: Export GitHub Actions cache environment variables
         uses: actions/github-script@v7
         with:
@@ -111,6 +121,16 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: false
+
+      - name: Checkout vcpkg baseline
+        shell: pwsh
+        run: |
+          $baseline = (Get-Content vcpkg.json | ConvertFrom-Json).'builtin-baseline'
+          cd $env:VCPKG_INSTALLATION_ROOT
+          git fetch
+          rm vcpkg.exe
+          git -c advice.detachedHead=false checkout $baseline
+          bootstrap-vcpkg.bat -disableMetrics
 
       - name: Export GitHub Actions cache environment variables
         uses: actions/github-script@v7

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -24,5 +24,5 @@
       "host": true
     }
   ],
-  "builtin-baseline": "0f6d4051514549541e61b186c4543341fd6ca8dd"
+  "builtin-baseline": "6ebf8c123bc8077dc9216db6438eeabaa154c473"
 }


### PR DESCRIPTION
# Description

Vcpkg in CI has been failing to build with glib errors for a while now.

This PR bumps the vcpkg baseline just far enough such that we're still using the currently pinned glib 2.78.4, without going to 2.80.x.

The other more important long-term change is that the project baseline will be checked out on the CI host (the vcpkg installation itself is a git repo). 

This means that the we will "hold vcpkg back in time" to always match that of the baseline. For example, the baseline uses python 3.11 however if we went with the latest vcpkg baseline then it would use python 3.12.

Previous we weren't doing this checkout step, so the host vcpkg was using newer and newer tooling, which eventually clashed with our older desired packages.


## Related issues

Fixes #4010 


# Release notes

None.


# Manual testing

None; just a CI fix.


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

