### PR TITLE
website: Fix a couple typos in v0.82.0 release notes

### DIFF
--- a/website/docs/releases/release-notes/0.82.0.md
+++ b/website/docs/releases/release-notes/0.82.0.md
@@ -4,7 +4,7 @@
 
 ## Summary
 
-Just six short months after our monstre [0.81.0 release](0.81.0.md), we're back with
+Just six short months after our monster [0.81.0 release](0.81.0.md), we're back with
 another big one that adds
 
 <div class="compact" markdown>
@@ -682,7 +682,7 @@ For example:
   now also work.
 
 - The [JEMM memory manager](https://github.com/Baron-von-Riedesel/Jemm) now
-  works even with DOSBox Staging's VMware mouse emulated enabled (previuosly,
+  works even with DOSBox Staging's VMware mouse emulated enabled (previously,
   JEMM could only be started with `vmware_mouse = off`). This is useful for
   games like **1942: The Pacific Air War** which does not work correctly with
   Staging's emulated EMS memory.

--- a/website/docs/releases/release-notes/0.82.0.md
+++ b/website/docs/releases/release-notes/0.82.0.md
@@ -4,7 +4,7 @@
 
 ## Summary
 
-Just six short months after our monster [0.81.0 release](0.81.0.md), we're back with
+Just six short months after our *monstre* [0.81.0 release](0.81.0.md), we're back with
 another big one that adds
 
 <div class="compact" markdown>


### PR DESCRIPTION
# Description

Couple typos existed in the 0.82.0 release notes where a couple letters in the word were in the wrong order.


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [x] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

