### PR TITLE
Fix typos Nix0S to NixOS 

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ a significant length of time.
 [vcpkg]: https://github.com/microsoft/vcpkg
 
 
-### Windows (MSYS2), macOS (MacPorts), Haiku, Nix0S, others
+### Windows (MSYS2), macOS (MacPorts), Haiku, NixOS, others
 
 Instructions for other build systems and operating systems are documented
 in [BUILD.md].

--- a/docs/build-nix.md
+++ b/docs/build-nix.md
@@ -1,4 +1,4 @@
-# Building on Nix0S
+# Building on NixOS
 
 Compiling code on Nix requires slightly different inputs from other linux distros,
 since the appropriate environment variables for pkg-config are only avaliable


### PR DESCRIPTION
# Description

Fix two typos Nix0S to NixOS 

# Manual testing

Only two characters changed, no testing.

# Checklist

I have:

- [ ] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [ ] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [ ] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

