### PR TITLE
Add a file_locking config option

### DIFF
--- a/include/dos_inc.h
+++ b/include/dos_inc.h
@@ -228,6 +228,8 @@ bool DOS_CreateTempFile(char* const name, uint16_t* entry);
 bool DOS_FileExists(const char* const name);
 bool DOS_LockFile(const uint16_t entry, const uint32_t pos, const uint32_t len);
 bool DOS_UnlockFile(const uint16_t entry, const uint32_t pos, const uint32_t len);
+void DOS_InitFileLocking(Section* sec);
+bool DOS_IsFileLocking();
 
 /* Helper Functions */
 bool DOS_MakeName(const char* const name, char* const fullname, uint8_t* drive);

--- a/src/dos/dos_misc.cpp
+++ b/src/dos/dos_misc.cpp
@@ -66,6 +66,9 @@ static Bitu INT2A_Handler(void) {
 static bool DOS_MultiplexFunctions(void) {
 	switch (reg_ax) {
 	case 0x1000:
+		if (!DOS_IsFileLocking()) {
+			return false;
+		}
 		// Report that SHARE.EXE is installed
 		reg_al = 0xff;
 		return true;

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -1239,6 +1239,15 @@ void DOSBOX_Init()
 	        "tab-separated format, used by SETVER.EXE as a persistent storage\n"
 	        "(empty by default).");
 
+	secprop->AddInitFunction(&DOS_InitFileLocking, changeable_at_runtime);
+	pbool = secprop->Add_bool("file_locking", when_idle, true);
+	pbool->Set_help(
+	        "Enable file locking (SHARE.EXE emulation; enabled by default).\n"
+	        "This is required for some Windows 3.1x applications to work properly.\n"
+	        "It generally does not cause problems for DOS games except in rare cases\n"
+	        "(e.g., Astral Blur demo). If you experience crashes related to file\n"
+	        "permissions, you can try disabling this.");
+
 	// Mscdex
 	secprop->AddInitFunction(&MSCDEX_Init);
 	secprop->AddInitFunction(&DRIVES_Init);


### PR DESCRIPTION
# Description

This was originally implemented by commit 7d806a86d6f346418e57805608e2fcd885dcbbe8
It was hard-coded to enabled and does not cause problems for the vast majority of DOS software
It did cause a regression for the Astral Blur demo so this config option is added to disable file locking if needed

## Related issues

Fixes #4015

# Release notes

Add a config option to disable file locking (previously this was always enabled)

# Manual testing

Astral Blur demo now works when `file_locking = false`

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [x] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

