### PR TITLE
Platforms builds workflow - add RISC-V, update to Debian 12

### DIFF
--- a/.github/workflows/platforms.yml
+++ b/.github/workflows/platforms.yml
@@ -35,10 +35,10 @@ jobs:
         include:
           - name: ARMv6 (Raspbian)
             arch: armv6
-            distro: bullseye
-          - name: ARMv7 (Debian “bullseye”)
+            distro: bookworm
+          - name: ARMv7 (Debian “bookworm”)
             arch: armv7
-            distro: bullseye
+            distro: bookworm
           - name: ARM64 (Ubuntu 22.04)
             arch: aarch64
             distro: ubuntu22.04

--- a/.github/workflows/platforms.yml
+++ b/.github/workflows/platforms.yml
@@ -42,12 +42,16 @@ jobs:
           - name: ARM64 (Ubuntu 22.04)
             arch: aarch64
             distro: ubuntu22.04
+          - name: riscv64 (Ubuntu 22.04)
+            arch: riscv64
+            distro: ubuntu22.04   
           - name: s390x (Debian "bookworm")
             arch: s390x
             distro: bookworm
           - name: ppc64le (Debian "bookworm")
             arch: ppc64le
             distro: bookworm
+            
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
# Description

Added RISC-V 64 to platforms.yml per https://github.com/dosbox-staging/dosbox-staging/pull/4000#issuecomment-2440156144 leading to [Supported platforms](https://github.com/uraimo/run-on-arch-action?tab=readme-ov-file#supported-platforms).

Updated platforms.yml to Debian 12 to match #3950

Related:
- #1095

# Manual testing

https://github.com/Torinde/dosbox-staging/actions/runs/11572261319
![image](https://github.com/user-attachments/assets/44eaa35a-d01c-419f-a8d9-361337986653)
(the riscv64 job is the fastest among the six)

# Checklist

I have:

- [ ] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [ ] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [ ] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

