### PR TITLE
Fix ManyMouse support in Windows builds

### DIFF
--- a/include/mouse.h
+++ b/include/mouse.h
@@ -253,9 +253,16 @@ public:
 
 	static bool IsNoMouseMode();
 	static bool IsMappingBlockedByDriver();
-	
-	static bool CheckInterfaces(const ListIDs &list_ids);
-	static bool PatternToRegex(const std::string &pattern, std::regex &regex);
+
+	using MappingSupport = enum {
+		Supported,            // fully supported
+		NotCompiledIn,        // ManyMouse not included in the build
+		NotAvailableRawInput, // user has to disable 'mouse_raw_input'
+	};
+	static MappingSupport IsMappingSupported();
+
+	static bool CheckInterfaces(const ListIDs& list_ids);
+	static bool PatternToRegex(const std::string& pattern, std::regex& regex);
 
 	// This one is ONLY for interactive mapping in MOUSECTL.COM!
 	bool MapInteractively(const MouseInterfaceId interface_id,

--- a/src/dos/program_mousectl.h
+++ b/src/dos/program_mousectl.h
@@ -43,6 +43,7 @@ private:
 	bool ParseSensitivity(const std::string &param, int16_t &value);
 	static bool ParseIntParam(const std::string &param, int &value);
 	bool CheckInterfaces();
+	bool CheckMappingSupported();
 	bool CheckMappingPossible();
 	void FinalizeMapping();
 

--- a/src/hardware/input/mouse_interfaces.cpp
+++ b/src/hardware/input/mouse_interfaces.cpp
@@ -682,7 +682,7 @@ void InterfaceDos::NotifyBooting()
 void InterfaceDos::UpdateInputType()
 {
 	const bool use_relative = IsMapped() || MOUSE_IsCaptured();
-	const bool is_input_raw = IsMapped() || mouse_config.raw_input;
+	const bool is_input_raw = IsMapped() || MOUSE_IsRawInput();
 
 	MOUSEDOS_NotifyInputType(use_relative, is_input_raw);
 }
@@ -749,7 +749,7 @@ void InterfacePS2::NotifyBooting()
 void InterfacePS2::UpdateInputType()
 {
 	const bool use_relative = IsMapped() || MOUSE_IsCaptured();
-	const bool is_input_raw = IsMapped() || mouse_config.raw_input;
+	const bool is_input_raw = IsMapped() || MOUSE_IsRawInput();
 
 	MOUSEVMM_NotifyInputType(use_relative, is_input_raw);
 }

--- a/src/hardware/input/mouse_interfaces.h
+++ b/src/hardware/input/mouse_interfaces.h
@@ -33,6 +33,7 @@ void MOUSE_NotifyDisconnect(const MouseInterfaceId interface_id);
 
 void MOUSE_UpdateGFX();
 bool MOUSE_IsCaptured();
+bool MOUSE_IsRawInput();
 bool MOUSE_IsProbeForMappingAllowed();
 
 // ***************************************************************************

--- a/src/hardware/input/mouse_manymouse.cpp
+++ b/src/hardware/input/mouse_manymouse.cpp
@@ -225,8 +225,15 @@ void ManyMouseGlue::Rescan()
 
 void ManyMouseGlue::RescanIfSafe()
 {
-	if (rescan_blocked_config)
+	if (rescan_blocked_config) {
 		return;
+	}
+
+#if defined(WIN32)
+	if (mouse_config.raw_input) {
+		return;
+	}
+#endif
 
 	ShutdownIfSafe();
 	InitIfNeeded();

--- a/src/platform/visualc/config.h
+++ b/src/platform/visualc/config.h
@@ -21,6 +21,9 @@
 /* Define to 1 to enable slirp networking support, requires libslirp */
 #define C_SLIRP 1
 
+/* Define to 1 to enable dual-mouse gaming support using ManyMouse library */
+#define C_MANYMOUSE 1
+
 /* Define to 1 when zlib-ng support is provided by the system */
 #define C_SYSTEM_ZLIB_NG 1
 


### PR DESCRIPTION
# Description

- modified Windows-specific `config.h` file to restore _ManyMouse_ compilation on Windows (regression)
- on Windows prevent _ManyMouse_ usage together with raw mouse input; these are not compatible

This definitely has to be a part of 0.82.1 release.

## Related issues

Fixes https://github.com/dosbox-staging/dosbox-staging/issues/4026


# Release notes

Fixed dual-mouse gaming support not working on Windows.


# Manual testing

- try using `mousectl -all` and `mousectl DOS -map` commands under Windows - they should be blocked if `mouse_raw_input` is set to `true`
- `config -set mouse_raw_input true` command should not disrupt mouse mapping (check on Windows, in windowed mode)

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [x] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

