### PR TITLE
Bump macOS runner to macOS-13

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -33,7 +33,7 @@ jobs:
       matrix:
         conf:
           - name: Clang
-            host: macos-12
+            host: macos-13
             arch: x86_64
             needs_deps: true
             run_tests: true
@@ -114,7 +114,7 @@ jobs:
     strategy:
       matrix:
         runner:
-          - host: macos-12
+          - host: macos-13
             arch: x86_64
             build_flags: -Db_lto=true
             brew_path: /usr/local/homebrew


### PR DESCRIPTION
# Description

A quick fix to bump the macOS runner to `macos-13` and avoid issues from the impending retirement of `macos-12`.

## Related issues

#4037 

# Manual testing

Downloaded the artifact on macOS Sequoia and ran both ARM and X86_64 binaries.

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

