### PR TITLE
Improve the formatting of the written config file

### DIFF
--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -1363,7 +1363,7 @@ void DOSBOX_Init()
 	        "Important: The [autoexec] section must be the last section in the config!");
 
 	MSG_Add("CONFIGFILE_INTRO",
-	        "# This is the configuration file for " DOSBOX_PROJECT_NAME
+	        "# This is the configuration file for " DOSBOX_NAME
 	        " (%s).\n"
 	        "# Lines starting with a '#' character are comments.\n");
 

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -1200,9 +1200,12 @@ bool Config::WriteConfig(const std_fs::path& path) const
 					}
 					fprintf(outfile, ".");
 				};
+
 				print_values("CONFIG_VALID_VALUES", p->GetValues());
 				print_values("CONFIG_DEPRECATED_VALUES", p->GetDeprecatedValues());
+
 				fprintf(outfile, "\n");
+				fprintf(outfile, "#\n");
 			}
 		} else {
 			upcase(temp);


### PR DESCRIPTION
# Description

This is a nice & easy one 😎 

- Insert new lines after the setting descriptions in the written config. This massively improved the readability of the written config; it's especially apparent with big consecutive setting setting descriptions.

- Use the human-readable project name in the written config (`DOSBox Staging` instead of `dosbox-staging`)

# Manual testing

<img width="862" alt="image" src="https://github.com/user-attachments/assets/f5fdc694-d51f-4e98-bb75-9ff50c771dad">

<img width="911" alt="image" src="https://github.com/user-attachments/assets/defc694d-2f28-4a12-982b-a70c4db5c795">


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

