### PR TITLE
Eliminate the internal `InstantLaunch` verbosity level

### DIFF
--- a/include/control.h
+++ b/include/control.h
@@ -34,10 +34,9 @@
 
 enum class Verbosity : int8_t {
 	//                Welcome | Early Stdout |
-	Quiet,         //   no    |    no        |
-	InstantLaunch, //   no    |    yes       |
-	Low,           //   no    |    yes       |
-	High,          //   yes   |    yes       |
+	Quiet, //   no    |    no        |
+	Low,   //   no    |    yes       |
+	High,  //   yes   |    yes       |
 };
 
 struct CommandLineArguments {

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -1691,7 +1691,7 @@ Verbosity Config::GetStartupVerbosity() const
 	}
 	if (user_choice == "auto") {
 		return (cmdline->HasDirectory() || cmdline->HasExecutableName())
-		             ? Verbosity::InstantLaunch
+		             ? Verbosity::Low
 		             : Verbosity::High;
 	}
 

--- a/src/shell/autoexec.cpp
+++ b/src/shell/autoexec.cpp
@@ -326,9 +326,7 @@ AutoExecModule::AutoExecModule(Section* configuration)
 	const bool exit_arg_exists = arguments->exit;
 
 	// Check if instant-launch is active
-	const bool using_instant_launch_with_executable =
-	        control->GetStartupVerbosity() == Verbosity::InstantLaunch &&
-	        cmdline->HasExecutableName();
+	const bool using_instant_launch_with_executable = cmdline->HasExecutableName();
 
 	// Should we add an 'exit' call to the end of autoexec.bat?
 	const bool should_add_exit = exit_call_exists || exit_arg_exists ||

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -460,9 +460,11 @@ void DOS_Shell::CMD_EXIT(char *args)
 {
 	HELP("EXIT");
 
+	assert(control);
 	const bool wants_force_exit = control->arguments.exit;
-	const bool is_normal_launch = control->GetStartupVerbosity() !=
-	                              Verbosity::InstantLaunch;
+
+	assert(control->cmdline);
+	const auto is_instant_launch = control->cmdline->HasExecutableName();
 
 	// Check if this is an early-exit situation, in which case we avoid
 	// exiting because the user might have a configuration problem and we
@@ -472,7 +474,7 @@ void DOS_Shell::CMD_EXIT(char *args)
 
 	const auto not_early_exit = exiting_after_seconds > early_exit_seconds;
 
-	if (wants_force_exit || is_normal_launch || not_early_exit) {
+	if (wants_force_exit || is_instant_launch || not_early_exit) {
 		exit_cmd_called = true;
 		return;
 	}


### PR DESCRIPTION
# Description

This PR fixes a problem where the `quiet` verbosity level was incorrectly used when it should be `low` per the `startup_verbosity` conf documentation. This caused a problem where a user was seeing a black screen when launching with some batch files.

## Related issues

Unfortunately I can't find this ticket.

# Release notes

Fixed a bug where the startup verbosity level could lead to a blank console.

# Manual testing

Tested all verbosity levels.

Tested launching with an executable from the DOSBox Staging CLI and confirmed the `low` verbosity is used.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

