### PR TITLE
Let unchangeable settings be queued and used on restart

### DIFF
--- a/README
+++ b/README
@@ -829,9 +829,10 @@ CONFIG -get "section property"
         config -get "cpu core"
     6. To view the list of possible cpu cores:
         config -help cpu core
-    7. To change the machine type and restart:
+    7. To change the machine type, memory size, and restart:
         config -set "machine cga"
-        config -wc -r
+        config -set "memsize 1"
+        config -r
     8. To configure the autoexec section to auto-mount a directory at start:
         config -axadd "mount c c:\dosgames" "c:"
         config -wc

--- a/include/control.h
+++ b/include/control.h
@@ -132,6 +132,8 @@ public:
 	const Section_line& GetOverwrittenAutoexecSection() const;
 	const std::string& GetOverwrittenAutoexecConf() const;
 
+	void ApplyQueuedValuesToCli(std::vector<std::string>& args) const;
+
 	void SetStartUp(void (*_function)(void));
 	void Init() const;
 	void ShutDown();

--- a/include/setup.h
+++ b/include/setup.h
@@ -430,6 +430,16 @@ public:
 	Property* Get_prop(int index);
 	Property* Get_prop(const std::string_view propname);
 
+	const_it begin() const
+	{
+		return properties.begin();
+	}
+
+	const_it end() const
+	{
+		return properties.end();
+	}
+
 	int Get_int(const std::string& _propname) const;
 
 	std::string Get_string(const std::string& _propname) const;

--- a/include/setup.h
+++ b/include/setup.h
@@ -173,6 +173,10 @@ public:
 		return default_value;
 	}
 
+	void SetQueueableValue(std::string&& value);
+
+	const std::optional<std::string>& GetQueuedValue() const;
+
 	bool IsRestrictedValue() const
 	{
 		return !valid_values.empty();
@@ -213,6 +217,7 @@ protected:
 	std::vector<Value> valid_values                        = {};
 	std::vector<std::string> enabled_options               = {};
 	std::map<Value, Value> deprecated_and_alternate_values = {};
+	std::optional<std::string> queueable_value             = {};
 	bool is_positive_bool_valid                            = false;
 	bool is_negative_bool_valid                            = false;
 

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -652,7 +652,7 @@ void DOSBOX_Init()
 	secprop->AddInitFunction(&PAGING_Init);
 	secprop->AddInitFunction(&MEM_Init);
 
-	pint = secprop->Add_int("memsize", when_idle, 16);
+	pint = secprop->Add_int("memsize", only_at_start, 16);
 	pint->SetMinMax(MEM_GetMinMegabytes(), MEM_GetMaxMegabytes());
 	pint->Set_help(
 	        "Amount of memory of the emulated machine has in MB (16 by default).\n"

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -4573,6 +4573,9 @@ extern void DEBUG_ShutDown(Section * /*sec*/);
 #endif
 
 void restart_dosbox(std::vector<std::string> &parameters) {
+
+	control->ApplyQueuedValuesToCli(parameters);
+
 #ifdef WIN32
 	std::string command_line = {};
 	bool first = true;

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -906,15 +906,10 @@ void CONFIG::Run(void)
 					return;
 				}
 
-				const auto* property = tsec->Get_prop(pvars[1]);
+				auto* property = tsec->Get_prop(pvars[1]);
 
 				if (!property) {
 					WriteOut(MSG_Get("PROGRAM_CONFIG_PROPERTY_ERROR"), pvars[1].c_str());
-					return;
-				}
-
-				if (property->GetChange() == Property::Changeable::OnlyAtStart) {
-					WriteOut(MSG_Get("PROGRAM_CONFIG_NOT_CHANGEABLE"), pvars[1].c_str());
 					return;
 				}
 
@@ -935,6 +930,13 @@ void CONFIG::Run(void)
 
 				if (value.empty()) {
 					WriteOut(MSG_Get("PROGRAM_CONFIG_SET_SYNTAX"));
+					return;
+				}
+
+				// If the value can't be set at runtime then queue it and let the user know
+				if (property->GetChange() == Property::Changeable::OnlyAtStart) {
+					WriteOut(MSG_Get("PROGRAM_CONFIG_NOT_CHANGEABLE"), pvars[1].c_str());
+					property->SetQueueableValue(std::move(value));
 					return;
 				}
 

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -215,7 +215,7 @@ void Program::ChangeToLongCmd()
 	}
 
 	// Clear so it gets even more save
-	full_arguments.assign(""); 
+	full_arguments.assign("");
 }
 
 bool Program::SuppressWriteOut(const char* format)
@@ -1147,7 +1147,8 @@ void PROGRAMS_Init(Section* sec)
 	MSG_Add("CONJUNCTION_AND", "and");
 
 	MSG_Add("PROGRAM_CONFIG_NOT_CHANGEABLE",
-	        "Setting '%s' is not changeable at runtime.\n");
+	        "[color=yellow]The '%s' setting can't be changed at runtime.[reset]\n"
+	        "However, it will be applied on restart by running 'CONFIG -r' or via the restart hotkey.\n");
 
 	MSG_Add("PROGRAM_CONFIG_DEPRECATED",
 	        "[color=light-red]This is a deprecated setting only kept for compatibility with old configs.\n"

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -747,6 +747,17 @@ std::vector<Value> Property::GetDeprecatedValues() const
 	return values;
 }
 
+void Property::SetQueueableValue(std::string&& value)
+{
+	assert(!value.empty());
+	queueable_value = std::move(value);
+}
+
+const std::optional<std::string>& Property::GetQueuedValue() const
+{
+	return queueable_value;
+}
+
 const Value& Property::GetAlternateForDeprecatedValue(const Value& val) const
 {
 	const auto it = deprecated_and_alternate_values.find(val);


### PR DESCRIPTION
# Description

This PR lets unchangeable values hold a (new) queued value that's used on restart (`CONFIG -r` or via hotkey), without having to write a temporary config file.

## Related issues

Fixes #2565 (thanks for the tip @FeralChild64 )

# Release notes

DOSBox Staging will now queue changes for unchangeable settings such as `machine` and `memsize`, and use them when restarting with `CONFIG -r` or via hotkey. 

For example, to change the machine type to CGA and use 1 MB of RAM:

```shell
Z:\> machine cga
Z:\> memsize 1
z:\> config -r
```

# Manual testing

Confirmed queued changes are properly written to conf files:
- `CONFIG -wcd`
- `CONFIG -wc`
- `CONFIG -wc custom.conf`

Confirmed queued changes are used on restart.

Confirmed that multiple restarts and changes work:
- Changing the same properly doesn't conflict (ie: machine cga, then ega, then pcjr)
- Changes made during a prior restart are correctly held in subsequent restart. For example, setting `memsize 1` persists across multiple machine type restarts.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [x] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

