### PR TITLE
Fix VGA draw address calculation

### DIFF
--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -1304,7 +1304,9 @@ static void VGA_VerticalTimer(uint32_t /*val*/)
 	double draw_skip = 0.0;
 	if (vga.draw.vblank_skip) {
 		draw_skip = vga.draw.delay.htotal * static_cast<double>(vga.draw.vblank_skip);
-		vga.draw.address += vga.draw.address_add * vga.draw.vblank_skip / vga.draw.address_line_total;
+		vga.draw.address += vga.draw.address_add *
+		                    (vga.draw.vblank_skip /
+		                     vga.draw.address_line_total);
 	}
 
 	// add the draw event


### PR DESCRIPTION
# Description

In some demos by the Majic 12 group (Show and Face), the rotor zoom effect was offset by roughly half the screen.

This bisected to 5a5d8f and then further bisecting at the line-level isolated it to this order-of-operation change.

## Related issues

Fixes #3449.

# Release notes

The offset rotor zoom effect in the Show and Face demos by Majic 12  is fixed.

# Manual testing

Tested a handful of demos and games. Will try to work through these test programs here too - https://github.com/dosbox-staging/dosbox-staging/wiki/Video-emulation-tests#minimum-recommended-set-of-tests

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [x] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

