### PR TITLE
Fix deadlock on exit while LPT DAC is running

### DIFF
--- a/include/hardware.h
+++ b/include/hardware.h
@@ -86,4 +86,7 @@ void SBLASTER_NotifyUnlockMixer();
 void REELMAGIC_NotifyLockMixer();
 void REELMAGIC_NotifyUnlockMixer();
 
+void LPTDAC_NotifyLockMixer();
+void LPTDAC_NotifyUnlockMixer();
+
 #endif

--- a/src/hardware/lpt_dac.cpp
+++ b/src/hardware/lpt_dac.cpp
@@ -138,7 +138,7 @@ LptDac::~LptDac()
 	MIXER_DeregisterChannel(channel);
 }
 
-std::unique_ptr<LptDac> lpt_dac = {};
+static std::unique_ptr<LptDac> lpt_dac = {};
 
 static void LPT_DAC_PicCallback()
 {
@@ -221,4 +221,18 @@ void LPT_DAC_Init(Section* section)
 	TIMER_AddTickHandler(LPT_DAC_PicCallback);
 
 	MIXER_UnlockMixerThread();
+}
+
+void LPTDAC_NotifyLockMixer()
+{
+	if (lpt_dac) {
+		lpt_dac->output_queue.Stop();
+	}
+}
+
+void LPTDAC_NotifyUnlockMixer()
+{
+	if (lpt_dac) {
+		lpt_dac->output_queue.Start();
+	}
 }

--- a/src/hardware/lpt_dac.h
+++ b/src/hardware/lpt_dac.h
@@ -87,6 +87,5 @@ private:
 	int frames_rendered_this_tick = 0;
 };
 
-extern std::unique_ptr<LptDac> lpt_dac;
 
 #endif

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -292,6 +292,8 @@ void MIXER_LockMixerThread()
 
 	PS1DAC_NotifyLockMixer();
 
+	LPTDAC_NotifyLockMixer();
+
 	GUS_NotifyLockMixer();
 
 	REELMAGIC_NotifyLockMixer();
@@ -308,6 +310,8 @@ void MIXER_UnlockMixerThread()
 	TANDYDAC_NotifyUnlockMixer();
 
 	PS1DAC_NotifyUnlockMixer();
+
+	LPTDAC_NotifyUnlockMixer();
 
 	GUS_NotifyUnlockMixer();
 


### PR DESCRIPTION
# Description
Regression from 9579fb213d571fbd16f7af778f2373635e5fa8a8

LPT DAC was left out of a refactor that modified the mixer lock
Added back the check to stop the LPT DAC queue

## Related issues

Fixes #4061


# Release notes

Never in a release.  Bug was only present in main for a few hours :smile: 


# Manual testing

Ran the takeover demo.  Closed it and confirmed it cleanly exits now.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

