### PR TITLE
Use floating point inputs in the mouse emulation code (SDL 3 preparation)

### DIFF
--- a/include/mouse.h
+++ b/include/mouse.h
@@ -92,7 +92,7 @@ void MOUSE_EventButton(const MouseButtonId button_id, const bool pressed);
 void MOUSE_EventButton(const MouseButtonId button_id, const bool pressed,
                        const MouseInterfaceId device_id);
 
-void MOUSE_EventWheel(const int16_t w_rel);
+void MOUSE_EventWheel(const float w_rel);
 void MOUSE_EventWheel(const int16_t w_rel, const MouseInterfaceId device_id);
 
 // Notify that guest OS is being booted, so that certain

--- a/include/mouse.h
+++ b/include/mouse.h
@@ -1,4 +1,6 @@
 /*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
  *  Copyright (C) 2022-2024  The DOSBox Staging Team
  *  Copyright (C) 2002-2021  The DOSBox Team
  *

--- a/include/mouse.h
+++ b/include/mouse.h
@@ -84,7 +84,7 @@ enum class MouseButtonId : uint8_t {
 // ***************************************************************************
 
 void MOUSE_EventMoved(const float x_rel, const float y_rel,
-                      const int32_t x_abs, const int32_t y_abs);
+                      const float x_abs, const float y_abs);
 void MOUSE_EventMoved(const float x_rel, const float y_rel,
                       const MouseInterfaceId device_id);
 
@@ -121,8 +121,8 @@ struct MouseScreenParams {
 	DosBox::Rect draw_rect = {};
 
 	// New absolute mouse cursor position in logical units
-	int32_t x_abs = 0;
-	int32_t y_abs = 0;
+	float x_abs = 0;
+	float y_abs = 0;
 
 	// Whether the new mode is fullscreen or windowed
 	bool is_fullscreen = false;

--- a/src/hardware/input/mouse.cpp
+++ b/src/hardware/input/mouse.cpp
@@ -687,7 +687,7 @@ void MOUSE_EventButton(const MouseButtonId button_id, const bool pressed,
 	}
 }
 
-void MOUSE_EventWheel(const int16_t w_rel)
+void MOUSE_EventWheel(const float w_rel)
 {
 	// Event from GFX
 

--- a/src/hardware/input/mouse.cpp
+++ b/src/hardware/input/mouse.cpp
@@ -58,8 +58,8 @@ static struct {
 	DosBox::Rect draw_rect = {};
 
 	// Absolute position from start of drawing area in logical units
-	uint32_t cursor_x_abs  = 0;
-	uint32_t cursor_y_abs  = 0;
+	float cursor_x_abs = 0.0f;
+	float cursor_y_abs = 0.0f;
 
 	// If mouse cursor is outside of drawing area
 	bool cursor_is_outside = false;
@@ -91,28 +91,28 @@ static struct {
 
 } state;
 
-static void update_cursor_absolute_position(const int32_t x_abs, const int32_t y_abs)
+static void update_cursor_absolute_position(const float x_abs, const float y_abs)
 {
 	state.cursor_is_outside = false;
 
-	auto calc_pos = [&](const int pos,
+	auto calc_pos = [&](const float pos,
 	                    const int draw_start_pos,
-	                    const int draw_end_pos) -> uint32_t {
+	                    const int draw_end_pos) -> float {
 		assert(draw_end_pos - draw_start_pos > 1);
-		constexpr int min_pos = 0;
+		constexpr float MinPos = 0.0f;
 
-		if (pos < min_pos || pos < draw_start_pos) {
+		if (pos < MinPos || pos < static_cast<float>(draw_start_pos)) {
 			// Cursor is before the top or left of the draw area
 			state.cursor_is_outside = !state.is_captured;
-			return check_cast<uint32_t>(min_pos);
+			return MinPos;
 
-		} else if (pos >= draw_end_pos) {
+		} else if (pos >= static_cast<float>(draw_end_pos)) {
 			// Cursor is after the bottom or right of the draw area
 			state.cursor_is_outside = !state.is_captured;
-			return check_cast<uint32_t>(draw_end_pos - draw_start_pos - 1);
+			return static_cast<float>(draw_end_pos - draw_start_pos - 1);
 
 		} else {
-			return check_cast<uint32_t>(pos - draw_start_pos);
+			return pos - static_cast<float>(draw_start_pos);
 		}
 	};
 
@@ -121,8 +121,8 @@ static void update_cursor_absolute_position(const int32_t x_abs, const int32_t y
 	const auto x2 = x1 + check_cast<int>(mouse_shared.resolution_x);
 	const auto y2 = y1 + check_cast<int>(mouse_shared.resolution_y);
 
-	state.cursor_x_abs = calc_pos(check_cast<int>(x_abs), x1, x2);
-	state.cursor_y_abs = calc_pos(check_cast<int>(y_abs), y1, y2);
+	state.cursor_x_abs = calc_pos(x_abs, x1, x2);
+	state.cursor_y_abs = calc_pos(y_abs, y1, y2);
 }
 
 static void update_cursor_visibility()
@@ -564,7 +564,7 @@ void MOUSE_NotifyBooting()
 }
 
 void MOUSE_EventMoved(const float x_rel, const float y_rel,
-                      const int32_t x_abs, const int32_t y_abs)
+                      const float x_abs, const float y_abs)
 {
 	// Event from GFX
 

--- a/src/hardware/input/mouse.cpp
+++ b/src/hardware/input/mouse.cpp
@@ -1,4 +1,6 @@
 /*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
  *  Copyright (C) 2022-2024  The DOSBox Staging Team
  *  Copyright (C) 2002-2021  The DOSBox Team
  *

--- a/src/hardware/input/mouse_common.cpp
+++ b/src/hardware/input/mouse_common.cpp
@@ -1,5 +1,7 @@
 /*
- *  Copyright (C) 2022-2023  The DOSBox Staging Team
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2022-2024  The DOSBox Staging Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/hardware/input/mouse_common.cpp
+++ b/src/hardware/input/mouse_common.cpp
@@ -23,6 +23,7 @@
 #include <algorithm>
 
 #include "checks.h"
+#include "math_utils.h"
 #include "pic.h"
 
 CHECK_NARROWING();
@@ -90,16 +91,59 @@ uint8_t MOUSE_GetDelayFromRateHz(const uint16_t rate_hz)
 
 float MOUSE_ClampRelativeMovement(const float rel)
 {
+	constexpr float Max = 2048.0f;
 	// Enforce sane upper limit of relative mouse movement
-	return std::clamp(rel, -2048.0f, 2048.0f);
+	return std::clamp(rel, -Max, Max);
+}
+
+float MOUSE_ClampWheelMovement(const float rel)
+{
+	// Chosen so that the result always fits into int8_t
+	constexpr float Max = 127.0f;
+	// Enforce sane upper limit of relative mouse wheel
+	return std::clamp(rel, -Max, Max);
 }
 
 uint16_t MOUSE_ClampRateHz(const uint16_t rate_hz)
 {
-	constexpr uint16_t rate_min = 10;
-	constexpr uint16_t rate_max = 500;
+	constexpr uint16_t MinRate = 10;
+	constexpr uint16_t MaxRate = 500;
 
-	return std::clamp(rate_hz, rate_min, rate_max);
+	return std::clamp(rate_hz, MinRate, MaxRate);
+}
+
+bool MOUSE_HasAccumulatedInt(const float delta)
+{
+	// Value is above 0.5 for +1/-1 flip-flopping protection
+	constexpr float Threshold = 0.6f;
+
+	return std::fabs(delta) >= Threshold;
+}
+
+int8_t MOUSE_ConsumeInt8(float& delta, const bool skip_delta_update)
+{
+	if (!MOUSE_HasAccumulatedInt(delta)) {
+		return 0;
+	}
+
+	const auto consumed = std::round(delta);
+	if (!skip_delta_update) {
+		delta -= consumed;
+	}
+	return clamp_to_int8(consumed);
+}
+
+int16_t MOUSE_ConsumeInt16(float& delta, const bool skip_delta_update)
+{
+	if (!MOUSE_HasAccumulatedInt(delta)) {
+		return 0;
+	}
+
+	const auto consumed = std::round(delta);
+	if (!skip_delta_update) {
+		delta -= consumed;
+	}
+	return clamp_to_int16(consumed);
 }
 
 // ***************************************************************************

--- a/src/hardware/input/mouse_common.h
+++ b/src/hardware/input/mouse_common.h
@@ -1,5 +1,7 @@
 /*
- *  Copyright (C) 2022-2023  The DOSBox Staging Team
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2022-2024  The DOSBox Staging Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/hardware/input/mouse_common.h
+++ b/src/hardware/input/mouse_common.h
@@ -74,7 +74,12 @@ float MOUSE_GetBallisticsCoeff(const float speed);
 uint8_t MOUSE_GetDelayFromRateHz(const uint16_t rate_hz);
 
 float MOUSE_ClampRelativeMovement(const float rel);
+float MOUSE_ClampWheelMovement(const float rel);
 uint16_t MOUSE_ClampRateHz(const uint16_t rate_hz);
+
+bool MOUSE_HasAccumulatedInt(const float delta);
+int8_t MOUSE_ConsumeInt8(float& delta, const bool skip_delta_update = false);
+int16_t MOUSE_ConsumeInt16(float& delta, const bool skip_delta_update = false);
 
 // ***************************************************************************
 // Mouse speed calculation

--- a/src/hardware/input/mouse_config.cpp
+++ b/src/hardware/input/mouse_config.cpp
@@ -1,4 +1,6 @@
 /*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
  *  Copyright (C) 2022-2024  The DOSBox Staging Team
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/src/hardware/input/mouse_config.h
+++ b/src/hardware/input/mouse_config.h
@@ -1,5 +1,7 @@
 /*
- *  Copyright (C) 2022-2023  The DOSBox Staging Team
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2022-2024  The DOSBox Staging Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/hardware/input/mouse_interfaces.cpp
+++ b/src/hardware/input/mouse_interfaces.cpp
@@ -153,7 +153,7 @@ public:
 	~InterfaceDos() = default;
 
 	void NotifyMoved(const float x_rel, const float y_rel,
-	                 const uint32_t x_abs, const uint32_t y_abs) override;
+	                 const float x_abs, const float y_abs) override;
 	void NotifyButton(const MouseButtonId id, const bool pressed) override;
 	void NotifyWheel(const float w_rel) override;
 	void NotifyBooting() override;
@@ -178,7 +178,7 @@ public:
 	~InterfacePS2() = default;
 
 	void NotifyMoved(const float x_rel, const float y_rel,
-	                 const uint32_t x_abs, const uint32_t y_abs) override;
+	                 const float x_abs, const float y_abs) override;
 	void NotifyButton(const MouseButtonId id, const bool pressed) override;
 	void NotifyWheel(const float w_rel) override;
 	void NotifyBooting() override;
@@ -206,7 +206,7 @@ public:
 	~InterfaceCOM() = default;
 
 	void NotifyMoved(const float x_rel, const float y_rel,
-	                 const uint32_t x_abs, const uint32_t y_abs) override;
+	                 const float x_abs, const float y_abs) override;
 	void NotifyButton(const MouseButtonId id, const bool pressed) override;
 	void NotifyWheel(const float w_rel) override;
 
@@ -647,7 +647,7 @@ void InterfaceDos::Init()
 }
 
 void InterfaceDos::NotifyMoved(const float x_rel, const float y_rel,
-                               const uint32_t x_abs, const uint32_t y_abs)
+                               const float x_abs, const float y_abs)
 {
 	MOUSEDOS_NotifyMoved(x_rel * sensitivity_coeff_x,
 	                     y_rel * sensitivity_coeff_y,
@@ -714,7 +714,7 @@ void InterfacePS2::Init()
 }
 
 void InterfacePS2::NotifyMoved(const float x_rel, const float y_rel,
-                               const uint32_t x_abs, const uint32_t y_abs)
+                               const float x_abs, const float y_abs)
 {
 	// VMM always first, as it might demand event from PS/2 emulation!
 	MOUSEVMM_NotifyMoved(x_rel * sensitivity_coeff_vmm_x,
@@ -779,7 +779,7 @@ InterfaceCOM::InterfaceCOM(const uint8_t port_id)
 {}
 
 void InterfaceCOM::NotifyMoved(const float x_rel, const float y_rel,
-                               const uint32_t, const uint32_t)
+                               const float, const float)
 {
 	assert(listener);
 

--- a/src/hardware/input/mouse_interfaces.cpp
+++ b/src/hardware/input/mouse_interfaces.cpp
@@ -1,4 +1,6 @@
 /*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
  *  Copyright (C) 2022-2024  The DOSBox Staging Team
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/src/hardware/input/mouse_interfaces.cpp
+++ b/src/hardware/input/mouse_interfaces.cpp
@@ -155,7 +155,7 @@ public:
 	void NotifyMoved(const float x_rel, const float y_rel,
 	                 const uint32_t x_abs, const uint32_t y_abs) override;
 	void NotifyButton(const MouseButtonId id, const bool pressed) override;
-	void NotifyWheel(const int16_t w_rel) override;
+	void NotifyWheel(const float w_rel) override;
 	void NotifyBooting() override;
 
 	void UpdateInputType() override;
@@ -180,7 +180,7 @@ public:
 	void NotifyMoved(const float x_rel, const float y_rel,
 	                 const uint32_t x_abs, const uint32_t y_abs) override;
 	void NotifyButton(const MouseButtonId id, const bool pressed) override;
-	void NotifyWheel(const int16_t w_rel) override;
+	void NotifyWheel(const float w_rel) override;
 	void NotifyBooting() override;
 
 	void UpdateInputType() override;
@@ -208,7 +208,7 @@ public:
 	void NotifyMoved(const float x_rel, const float y_rel,
 	                 const uint32_t x_abs, const uint32_t y_abs) override;
 	void NotifyButton(const MouseButtonId id, const bool pressed) override;
-	void NotifyWheel(const int16_t w_rel) override;
+	void NotifyWheel(const float w_rel) override;
 
 	void UpdateRate() override;
 
@@ -665,7 +665,7 @@ void InterfaceDos::NotifyButton(const MouseButtonId button_id, const bool presse
 	MOUSEDOS_NotifyButton(GetButtonsSquished());
 }
 
-void InterfaceDos::NotifyWheel(const int16_t w_rel)
+void InterfaceDos::NotifyWheel(const float w_rel)
 {
 	MOUSEDOS_NotifyWheel(w_rel);
 }
@@ -736,7 +736,7 @@ void InterfacePS2::NotifyButton(const MouseButtonId button_id, const bool presse
 	MOUSEPS2_NotifyButton(GetButtonsSquished(), GetButtonsJoined());
 }
 
-void InterfacePS2::NotifyWheel(const int16_t w_rel)
+void InterfacePS2::NotifyWheel(const float w_rel)
 {
 	// VMM always first, as it might demand event from PS/2 emulation!
 	MOUSEVMM_NotifyWheel(w_rel);
@@ -799,7 +799,7 @@ void InterfaceCOM::NotifyButton(const MouseButtonId button_id, const bool presse
 	listener->NotifyButton(GetButtonsSquished()._data, button_id);
 }
 
-void InterfaceCOM::NotifyWheel(const int16_t w_rel)
+void InterfaceCOM::NotifyWheel(const float w_rel)
 {
 	assert(listener);
 

--- a/src/hardware/input/mouse_interfaces.h
+++ b/src/hardware/input/mouse_interfaces.h
@@ -1,5 +1,7 @@
 /*
- *  Copyright (C) 2022-2023  The DOSBox Staging Team
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2022-2024  The DOSBox Staging Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/hardware/input/mouse_interfaces.h
+++ b/src/hardware/input/mouse_interfaces.h
@@ -55,7 +55,7 @@ void MOUSEDOS_FinalizeInterrupt();
 // - understands up to 3 buttons
 
 void MOUSEDOS_NotifyMoved(const float x_rel, const float y_rel,
-                          const uint32_t x_abs, const uint32_t y_abs);
+                          const float x_abs, const float y_abs);
 void MOUSEDOS_NotifyButton(const MouseButtons12S buttons_12S);
 void MOUSEDOS_NotifyWheel(const float w_rel);
 
@@ -90,14 +90,14 @@ void MOUSEBIOS_FinalizeInterrupt();
 // ***************************************************************************
 
 void MOUSEVMM_NotifyInputType(const bool use_relative, const bool is_input_raw);
-void MOUSEVMM_NewScreenParams(const uint32_t x_abs, const uint32_t y_abs);
+void MOUSEVMM_NewScreenParams(const float x_abs, const float y_abs);
 void MOUSEVMM_Deactivate();
 
 // - needs absolute mouse position
 // - understands up to 3 buttons
 
 void MOUSEVMM_NotifyMoved(const float x_rel, const float y_rel,
-                          const uint32_t x_abs, const uint32_t y_abs);
+                          const float x_abs, const float y_abs);
 void MOUSEVMM_NotifyButton(const MouseButtons12S buttons_12S);
 void MOUSEVMM_NotifyWheel(const float w_rel);
 
@@ -129,7 +129,7 @@ public:
 	static MouseInterface* GetSerial(const uint8_t port_id);
 
 	virtual void NotifyMoved(const float x_rel, const float y_rel,
-	                         const uint32_t x_abs, const uint32_t y_abs) = 0;
+	                         const float x_abs, const float y_abs) = 0;
 	virtual void NotifyButton(const MouseButtonId id, const bool pressed) = 0;
 	virtual void NotifyWheel(const float w_rel) = 0;
 

--- a/src/hardware/input/mouse_interfaces.h
+++ b/src/hardware/input/mouse_interfaces.h
@@ -57,7 +57,7 @@ void MOUSEDOS_FinalizeInterrupt();
 void MOUSEDOS_NotifyMoved(const float x_rel, const float y_rel,
                           const uint32_t x_abs, const uint32_t y_abs);
 void MOUSEDOS_NotifyButton(const MouseButtons12S buttons_12S);
-void MOUSEDOS_NotifyWheel(const int16_t w_rel);
+void MOUSEDOS_NotifyWheel(const float w_rel);
 
 // ***************************************************************************
 // PS/2 mouse
@@ -75,7 +75,7 @@ void MOUSEPS2_NotifyMoved(const float x_rel, const float y_rel);
 void MOUSEPS2_NotifyMovedDummy(); // for virtual machine interfaces
 void MOUSEPS2_NotifyButton(const MouseButtons12S buttons_12S,
                            const MouseButtonsAll buttons_all);
-void MOUSEPS2_NotifyWheel(const int16_t w_rel);
+void MOUSEPS2_NotifyWheel(const float w_rel);
 
 // ***************************************************************************
 // BIOS mouse interface for PS/2 mouse
@@ -99,7 +99,7 @@ void MOUSEVMM_Deactivate();
 void MOUSEVMM_NotifyMoved(const float x_rel, const float y_rel,
                           const uint32_t x_abs, const uint32_t y_abs);
 void MOUSEVMM_NotifyButton(const MouseButtons12S buttons_12S);
-void MOUSEVMM_NotifyWheel(const int16_t w_rel);
+void MOUSEVMM_NotifyWheel(const float w_rel);
 
 // ***************************************************************************
 // Serial mouse
@@ -131,7 +131,7 @@ public:
 	virtual void NotifyMoved(const float x_rel, const float y_rel,
 	                         const uint32_t x_abs, const uint32_t y_abs) = 0;
 	virtual void NotifyButton(const MouseButtonId id, const bool pressed) = 0;
-	virtual void NotifyWheel(const int16_t w_rel) = 0;
+	virtual void NotifyWheel(const float w_rel) = 0;
 
 	void NotifyInterfaceRate(const uint16_t rate_hz);
 	virtual void NotifyBooting();

--- a/src/hardware/input/mouse_manymouse.cpp
+++ b/src/hardware/input/mouse_manymouse.cpp
@@ -1,4 +1,6 @@
 /*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
  *  Copyright (C) 2022-2024  The DOSBox Staging Team
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/src/hardware/input/mouse_manymouse.h
+++ b/src/hardware/input/mouse_manymouse.h
@@ -1,5 +1,7 @@
 /*
- *  Copyright (C) 2022-2023  The DOSBox Staging Team
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2022-2024  The DOSBox Staging Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/hardware/input/mouseif_dos_driver.cpp
+++ b/src/hardware/input/mouseif_dos_driver.cpp
@@ -1163,7 +1163,7 @@ static uint8_t move_cursor()
 		                     pending.x_abs,
 		                     pending.y_abs);
 
-	// Pending relative movement is now consummed
+	// Pending relative movement is now consumed
 	pending.x_rel = 0.0f;
 	pending.y_rel = 0.0f;
 
@@ -1244,7 +1244,7 @@ static uint8_t move_wheel()
 {
 	counter_w = clamp_to_int8(static_cast<int32_t>(counter_w + pending.w_rel));
 
-	// Pending wheel scroll is now consummed
+	// Pending wheel scroll is now consumed
 	pending.w_rel = 0;
 
 	state.last_wheel_moved_x = get_pos_x();
@@ -1273,7 +1273,7 @@ void MOUSEDOS_NotifyMoved(const float x_rel, const float y_rel,
 		// Uses relative mouse movements - processing is too complicated
 		// to easily predict whether the event can be safely omitted
 		event_needed = true;
-		// TODO: this can be done, but requyires refactoring
+		// TODO: this can be done, but requires refactoring
 	} else {
 		// Uses absolute mouse position (seamless mode), relative
 		// movements can wait to be reported - they are completely
@@ -1282,7 +1282,7 @@ void MOUSEDOS_NotifyMoved(const float x_rel, const float y_rel,
 			event_needed = true;
 	}
 
-	// Update values to be consummed when the event arrives
+	// Update values to be consumed when the event arrives
 	pending.x_rel = MOUSE_ClampRelativeMovement(pending.x_rel + x_rel);
 	pending.y_rel = MOUSE_ClampRelativeMovement(pending.y_rel + y_rel);
 	pending.x_abs = x_abs;

--- a/src/hardware/input/mouseif_dos_driver.cpp
+++ b/src/hardware/input/mouseif_dos_driver.cpp
@@ -1,4 +1,6 @@
 /*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
  *  Copyright (C) 2022-2024  The DOSBox Staging Team
  *  Copyright (C) 2002-2021  The DOSBox Team
  *

--- a/src/hardware/input/mouseif_ps2_bios.cpp
+++ b/src/hardware/input/mouseif_ps2_bios.cpp
@@ -1,4 +1,6 @@
 /*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
  *  Copyright (C) 2022-2024  The DOSBox Staging Team
  *  Copyright (C) 2002-2021  The DOSBox Team
  *

--- a/src/hardware/input/mouseif_virtual_machines.cpp
+++ b/src/hardware/input/mouseif_virtual_machines.cpp
@@ -1,4 +1,6 @@
 /*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
  *  Copyright (C) 2022-2024  The DOSBox Staging Team
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/src/hardware/input/mouseif_virtual_machines.cpp
+++ b/src/hardware/input/mouseif_virtual_machines.cpp
@@ -244,7 +244,7 @@ void MOUSEVMM_NotifyInputType(const bool new_use_relative, const bool new_is_inp
 }
 
 void MOUSEVMM_NotifyMoved(const float x_rel, const float y_rel,
-                          const uint32_t x_abs, const uint32_t y_abs)
+                          const float x_abs, const float y_abs)
 {
 	if (!mouse_shared.active_vmm) {
 		return;
@@ -257,7 +257,7 @@ void MOUSEVMM_NotifyMoved(const float x_rel, const float y_rel,
 
 	auto calculate = [](float& position,
 	                    const float relative,
-	                    const uint32_t absolute,
+	                    const float absolute,
 	                    const uint32_t resolution) {
 		assert(resolution > 1u);
 
@@ -276,7 +276,7 @@ void MOUSEVMM_NotifyMoved(const float x_rel, const float y_rel,
 			}
 		} else {
 			// Cursor position controlled by the host OS
-			position = static_cast<float>(absolute);
+			position = absolute;
 		}
 
 		position = std::clamp(position, 0.0f, static_cast<float>(resolution));
@@ -346,7 +346,7 @@ void MOUSEVMM_NotifyWheel(const float w_rel)
 	MOUSEPS2_NotifyMovedDummy();
 }
 
-void MOUSEVMM_NewScreenParams(const uint32_t x_abs, const uint32_t y_abs)
+void MOUSEVMM_NewScreenParams(const float x_abs, const float y_abs)
 {
 	MOUSEVMM_NotifyMoved(0.0f, 0.0f, x_abs, y_abs);
 }

--- a/src/hardware/serialport/serialmouse.cpp
+++ b/src/hardware/serialport/serialmouse.cpp
@@ -1,5 +1,7 @@
 /*
- *  Copyright (C) 2022-2023  The DOSBox Staging Team
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2022-2024  The DOSBox Staging Team
  *  Copyright (C) 2002-2021  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/src/hardware/serialport/serialmouse.h
+++ b/src/hardware/serialport/serialmouse.h
@@ -34,7 +34,7 @@ public:
 	void NotifyMoved(const float x_rel, const float y_rel);
 	void NotifyButton(const uint8_t new_buttons,
 	                  const MouseButtonId id); // changed button
-	void NotifyWheel(const int16_t w_rel);
+	void NotifyWheel(const float w_rel);
 
 	void BoostRate(const uint16_t rate_hz); // 0 = standard rate
 
@@ -88,12 +88,17 @@ private:
 	                                 // received mouse move event
 	bool got_another_button = false; // true = while transmitting a packet
 	                                 // we received mouse button event
-	uint8_t buttons  = 0;    // bit 0 = left, bit 1 = right, bit 2 = middle
-	float delta_x    = 0.0f; // accumulated movements not yet reported
-	float delta_y    = 0.0f;
-	int8_t counter_x = 0;    // position counters, as visible on guest size
-	int8_t counter_y = 0;
-	int8_t counter_w = 0;
+	uint8_t buttons = 0; // bit 0 = left, bit 1 = right, bit 2 = middle
+
+	// Accumulated mouse movement, waiting to be reported
+	float delta_x     = 0.0f;
+	float delta_y     = 0.0f;
+	float delta_wheel = 0.0f;
+
+	// Position counters, as visible on the guest size
+	int8_t counter_x     = 0;
+	int8_t counter_y     = 0;
+	int8_t counter_wheel = 0;
 };
 
 #endif // DOSBOX_SERIALMOUSE_H

--- a/src/hardware/serialport/serialmouse.h
+++ b/src/hardware/serialport/serialmouse.h
@@ -1,5 +1,7 @@
 /*
- *  Copyright (C) 2022-2023  The DOSBox Staging Team
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2022-2024  The DOSBox Staging Team
  *  Copyright (C) 2002-2021  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
# Description

- reworked internal mouse APIs (used for mouse wheel and seamless mouse) to accept floating point parameters, as provided by SDL 3 (SDL 2 only provides integer ones)
- some cleanups and code unification


## Related issues

None, but related to PR https://github.com/dosbox-staging/dosbox-staging/pull/4041


# Manual testing

- checked few games (_Civilization_, _Settlers II_, _Master of Orion II_) and applications (_Norton Commander_, _DOS Navigator_) still work with the emulated mouse driver (checked both seamless and captured mouse)
- checked serial (COM1), PS/2 (both register-level and BIOS-level access) with the software mentioned above, using _CtMouse_, as described on the Wiki https://github.com/dosbox-staging/dosbox-staging/wiki/Mouse-emulation-tests
- checked _VirtualBox_ and _VMware_ mouse interfaces with _Norton Commander_ and _DOS Navigator_ using the _VBADOS_ mouse driver (see the Wiki page above)
- for all the mouse interfaces/drivers providing wheel support, checked it using _Mpxplay_ 1.66
- checked that _Windows 3.11 for Workgroups_ still runs with the stock mouse driver


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

