### PR TITLE
Revert CRLF keyboard change

### DIFF
--- a/src/dos/dev_con.h
+++ b/src/dos/dev_con.h
@@ -96,16 +96,9 @@ bool device_CON::Read(uint8_t* data, uint16_t* size)
 		case Ascii::CarriageReturn:
 			data[count++] = Ascii::CarriageReturn;
 
-			// DOS's console device expands CR's to CRLF's when
-			// reading from the STDIN handle (other operating
-			// systems don't). CRLF is sent regardless if the
-			// program reads multiple bytes at once or one byte at a
-			// time.
+			// It's only expanded if there's room for it
 			if (*size > count) {
 				data[count++] = Ascii::LineFeed;
-			} else {
-				assert(!readcache);
-				readcache = Ascii::LineFeed;
 			}
 			*size  = count;
 			reg_ax = oldax;


### PR DESCRIPTION
# Description

Turns out the fix to make LF always follow CR for keyboard input wasn't correct. 

@weirddan455, thanks for catching this!

## Related issues

Fixes #4066 

Re-opens #4007


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [ ] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

