### PR TITLE
Lower PVS Studio (and compilation) warning limits

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -112,7 +112,7 @@ jobs:
               -Duse_sdl2_net=false
               -Duse_slirp=false
             needs_min_deps: true
-            max_warnings: -1
+            max_warnings: 2
 
           - name: GCC 12, Debian 12, ARMv7
             os: ubuntu-22.04
@@ -137,7 +137,7 @@ jobs:
           - name: GCC 12, Debian 12, ppc64le
             os: ubuntu-22.04
             build_flags: -Dbuildtype=debug --cross-file dosbox-cross
-            max_warnings: 21
+            max_warnings: 0
             run_tests: true
             cross: true
             arch: ppc64el

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -112,7 +112,7 @@ jobs:
               -Duse_sdl2_net=false
               -Duse_slirp=false
             needs_min_deps: true
-            max_warnings: 2
+            max_warnings: 0
 
           - name: GCC 12, Debian 12, ARMv7
             os: ubuntu-22.04

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -48,7 +48,7 @@ jobs:
             run_tests: false # the shell_cmds_tests hang on arm64
             build_flags: -Dbuildtype=debug
             brew_path: /opt/homebrew
-            max_warnings: 42
+            max_warnings: 0
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/pvs-studio.yml
+++ b/.github/workflows/pvs-studio.yml
@@ -120,7 +120,7 @@ jobs:
 
       - name: Summarize report
         env:
-          MAX_BUGS: 90
+          MAX_BUGS: 88
         run: |
           echo "Full report is included in build Artifacts"
           echo

--- a/src/midi/midi.cpp
+++ b/src/midi/midi.cpp
@@ -88,8 +88,8 @@ uint8_t MIDI_message_len_by_status[256] = {
 #include "midi_alsa.h"
 #endif
 
-static std::unique_ptr<MidiDevice> create_device(const std::string& name,
-                                                 const std::string& config)
+static std::unique_ptr<MidiDevice> create_device([[maybe_unused]] const std::string& name,
+                                                 [[maybe_unused]] const std::string& config)
 {
 	using namespace MidiDeviceName;
 


### PR DESCRIPTION
# Description

Two PVS Studio warnings were fixed since the last time the limit was set - let's adjust the limit.

After the review, also got rid of two compiler warnings in MIDI code (by adding `[[maybe_unused]]`) and limited compilation warning allowance.

# Manual testing

Checked with _Mortal Kombat II_ and _DOOM_ games that MIDI audio still works.

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

