### PR TITLE
Use LANG variable as a fallback for LC_* on POSIX systems

### DIFF
--- a/src/misc/host_locale_posix.cpp
+++ b/src/misc/host_locale_posix.cpp
@@ -919,7 +919,7 @@ static std::pair<std::string, std::string> split_posix_locale(const std::string&
 static std::optional<DosCountry> get_dos_country(const std::string& category,
                                                  std::string& log_info)
 {
-	const std::vector<std::string> Variables = {LcAll, category};
+	const std::vector<std::string> Variables = {LcAll, category, VariableLang};
 
 	const auto [variable, value] = get_env_variable_from_list(Variables);
 	if (value.empty()) {


### PR DESCRIPTION
# Description

On POSIX systems, use LANG environment variable if appropriate LC_* is not set by the given Linux distro.


## Related issues

Fixes https://github.com/dosbox-staging/dosbox-staging/issues/4071


# Manual testing

Execute DOSBox Staging (Linux build) with the command:

```bash
LC_ALL= LC_TELEPHONE= LANG=is_IS dosbox
```
 
It should detect country Iceland:
 
```
LOCALE: Country detected from 'LANG=is_IS'
LOCALE: Loading native locale for country 354 - 'Iceland'
```


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

