### PR TITLE
Rework translated messages handling

### DIFF
--- a/contrib/resources/translations/br.lng
+++ b/contrib/resources/translations/br.lng
@@ -1,3 +1,7 @@
+// Writing script used in this translation, can be one of:
+// Latin, Arabic, Armenian, Cherokee, Cyrillic, Georgian, Greek, Hebrew
+#SCRIPT Latin
+
 :DOSBOX_HELP
 Uso: %s [OPÇÃO]... [CAMINHO]
 

--- a/contrib/resources/translations/de.lng
+++ b/contrib/resources/translations/de.lng
@@ -1,3 +1,7 @@
+// Writing script used in this translation, can be one of:
+// Latin, Arabic, Armenian, Cherokee, Cyrillic, Georgian, Greek, Hebrew
+#SCRIPT Latin
+
 :DOSBOX_HELP
 Verwendung: %s [OPTION]... [PFAD]
 

--- a/contrib/resources/translations/en.lng
+++ b/contrib/resources/translations/en.lng
@@ -1,3 +1,7 @@
+// Writing script used in this translation, can be one of:
+// Latin, Arabic, Armenian, Cherokee, Cyrillic, Georgian, Greek, Hebrew
+#SCRIPT Latin
+
 :DOSBOX_HELP
 Usage: %s [OPTION]... [PATH]
 

--- a/contrib/resources/translations/es.lng
+++ b/contrib/resources/translations/es.lng
@@ -1,3 +1,7 @@
+// Writing script used in this translation, can be one of:
+// Latin, Arabic, Armenian, Cherokee, Cyrillic, Georgian, Greek, Hebrew
+#SCRIPT Latin
+
 :DOSBOX_HELP
 Uso: %s [OPCIÓN]... [RUTA]
 

--- a/contrib/resources/translations/fr.lng
+++ b/contrib/resources/translations/fr.lng
@@ -1,3 +1,7 @@
+// Writing script used in this translation, can be one of:
+// Latin, Arabic, Armenian, Cherokee, Cyrillic, Georgian, Greek, Hebrew
+#SCRIPT Latin
+
 :CONFIG_FULLSCREEN
 Démarrer DOSBox directement en mode plein écran.
 .

--- a/contrib/resources/translations/it.lng
+++ b/contrib/resources/translations/it.lng
@@ -1,3 +1,7 @@
+// Writing script used in this translation, can be one of:
+// Latin, Arabic, Armenian, Cherokee, Cyrillic, Georgian, Greek, Hebrew
+#SCRIPT Latin
+
 :DOSBOX_HELP
 Utilizzo: %s [OPZIONE]... [PERCORSO]
 

--- a/contrib/resources/translations/nl.lng
+++ b/contrib/resources/translations/nl.lng
@@ -1,3 +1,7 @@
+// Writing script used in this translation, can be one of:
+// Latin, Arabic, Armenian, Cherokee, Cyrillic, Georgian, Greek, Hebrew
+#SCRIPT Latin
+
 :DOSBOX_HELP
 Gebruik: %s [OPTIE]... [PAD]
 

--- a/contrib/resources/translations/pl.lng
+++ b/contrib/resources/translations/pl.lng
@@ -1,3 +1,7 @@
+// Writing script used in this translation, can be one of:
+// Latin, Arabic, Armenian, Cherokee, Cyrillic, Georgian, Greek, Hebrew
+#SCRIPT Latin
+
 :DOSBOX_HELP
 Składnia: %s [OPCJE]... [ŚCIEŻKA]
 

--- a/contrib/resources/translations/ru.lng
+++ b/contrib/resources/translations/ru.lng
@@ -1,3 +1,7 @@
+// Writing script used in this translation, can be one of:
+// Latin, Arabic, Armenian, Cherokee, Cyrillic, Georgian, Greek, Hebrew
+#SCRIPT Cyrillic
+
 :TITLEBAR_CYCLES_MS
 циклов/мс
 .

--- a/docs/dosbox.1
+++ b/docs/dosbox.1
@@ -1,5 +1,5 @@
 .\"                                      Hey, EMACS: -*- nroff -*-
-.TH DOSBOX 1 "Nov 23, 2024"
+.TH DOSBOX 1 "Nov 24, 2024"
 .\" Please adjust this date whenever revising the manpage.
 
 .SH NAME
@@ -42,6 +42,8 @@ dosbox \- DOSBox Staging, x86/DOS emulator, a modern continuation of DOSBox
 .B dosbox \-\-list\-countries
 .LP
 .B dosbox \-\-list\-layouts
+.LP
+.B dosbox \-\-list\-code\-pages
 .LP
 .B dosbox \-\-list\-glshaders
 .LP
@@ -98,6 +100,8 @@ Legacy single dash abbrevations still work for backwards compatibility.
 
 --list-layouts           List all supported keyboard layouts with their codes.
                          Codes are to be used in the 'keyboard_layout' config setting.
+
+--list-code-pages        List all bundled code pages.
 
 --list-glshaders         List all available OpenGL shaders and their paths.
                          Shaders are to be used in the 'glshader' config setting.

--- a/include/ansi_code_markup.h
+++ b/include/ansi_code_markup.h
@@ -1,7 +1,7 @@
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *
- *  Copyright (C) 2022-2023  The DOSBox Staging Team
+ *  Copyright (C) 2022-2024  The DOSBox Staging Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -23,20 +23,39 @@
 
 #include <string>
 
-/*!
- * \brief Convert marked up strings to strings with ANSI codes
- * 
- * \param str 
- * \return std::string 
- */
+// Convert marked up strings to strings with ANSI codes
 std::string convert_ansi_markup(const char* str);
-
-/*!
- * \brief Convert marked up strings to strings with ANSI codes
- * 
- * \param str 
- * \return std::string 
- */
 std::string convert_ansi_markup(const std::string &str);
+
+// Pre-defined markups to help creating strings
+namespace Ansi {
+	extern const std::string Reset;
+
+	// Low intensity text colours
+	extern const std::string ColorBlack;
+	extern const std::string ColorBlue;
+	extern const std::string ColorGreen;
+	extern const std::string ColorCyan;
+	extern const std::string ColorRed;
+	extern const std::string ColorMagenta;
+	extern const std::string ColorBrown;
+	extern const std::string ColorLightGray;
+
+	// High intensity text colours
+	extern const std::string ColorDarkGray;
+	extern const std::string ColorLightBlue;
+	extern const std::string ColorLightGreen;
+	extern const std::string ColorLightCyan;
+	extern const std::string ColorLightRed;
+	extern const std::string ColorLightMagenta;
+	extern const std::string ColorYellow;
+	extern const std::string ColorWhite;
+
+	// Definitions to help keeping the command output style consistent
+	extern const std::string& HighlightHeader;
+	extern const std::string& HighlightSelection;
+
+	// TODO: Rework the whole code to use definitions from this header
+}
 
 #endif // DOSBOX_ANSI_CODE_MARKUP_H

--- a/include/control.h
+++ b/include/control.h
@@ -46,6 +46,7 @@ struct CommandLineArguments {
 	bool fullscreen;
 	bool list_countries;
 	bool list_layouts;
+	bool list_code_pages;
 	bool list_glshaders;
 	bool version;
 	bool help;

--- a/include/dosbox.h
+++ b/include/dosbox.h
@@ -1,4 +1,7 @@
 /*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2019-2024  The DOSBox Staging Team
  *  Copyright (C) 2002-2021  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -19,8 +22,9 @@
 #ifndef DOSBOX_DOSBOX_H
 #define DOSBOX_DOSBOX_H
 
-#include "config.h"
 #include "compiler.h"
+#include "config.h"
+#include "messages.h"
 #include "types.h"
 
 #include <memory>
@@ -53,13 +57,6 @@ extern bool shutdown_requested;
 // circumstances.
 [[noreturn]] void E_Exit(const char *message, ...)
         GCC_ATTRIBUTE(__format__(__printf__, 1, 2));
-
-void MSG_Add(const char*,const char*); // add messages (in UTF-8) to the language file
-const char* MSG_Get(const char*); // get messages (adapted to current code page)
-                                  // from the language file
-const char* MSG_GetRaw(const char*); // get messages (in UTF-8, without ANSI
-                                     // preprocessing) from the language file
-bool MSG_Exists(const char*);
 
 class Section;
 class Section_prop;

--- a/include/messages.h
+++ b/include/messages.h
@@ -1,0 +1,49 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2024-2024  The DOSBox Staging Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#ifndef DOSBOX_MESSAGES_H
+#define DOSBOX_MESSAGES_H
+
+#include <cstdint>
+#include <string>
+
+// Add message (in UTF-8 encoding) to the translation system
+void MSG_Add(const std::string& name, const std::string& message);
+void MSG_AddNoFormatString(const std::string& name, const std::string& message);
+
+// Get message text, adapted to the current code page,
+// with markup tags converted to ANSI escape codes
+const char* MSG_Get(const std::string& name);
+
+// Get message text in UTF-8, without ANSI markup tags conversions
+const char* MSG_GetRaw(const std::string& name);
+
+// Like 'MSG_GetRaw', but does not check if code page is compatible with current
+// translation.
+// Use this one if the string is going to be logged or sent to the host OS.
+const char* MSG_GetForHost(const std::string& name);
+
+bool MSG_Exists(const std::string& name);
+
+bool MSG_WriteToFile(const std::string& file_name);
+
+void MSG_NotifyNewCodePage();
+
+#endif // DOSBOX_MESSAGES_H

--- a/include/setup.h
+++ b/include/setup.h
@@ -160,7 +160,7 @@ public:
 	// If the setting's help text contains a '%s' marker, the `GetHelp`
 	// functions will substitute it with the setting's default value.
 	std::string GetHelp() const;
-	std::string GetHelpUtf8() const;
+	std::string GetHelpForHost() const;
 
 	virtual bool SetValue(const std::string& str) = 0;
 

--- a/include/unicode.h
+++ b/include/unicode.h
@@ -92,6 +92,9 @@ std::string lowercase_dos(const std::string& str, const uint16_t code_page);
 std::string uppercase_dos(const std::string& str);
 std::string uppercase_dos(const std::string& str, const uint16_t code_page);
 
+// Calculate length of a UTF-8 encoded string
+size_t length_utf8(const std::string& str);
+
 // Check if two code pages are the same
 bool is_code_page_equal(const uint16_t code_page1, const uint16_t code_page2);
 

--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -2616,7 +2616,7 @@ std::string CPU_GetCyclesConfigAsString()
 		}
 
 		s += " ";
-		return s += MSG_GetRaw("TITLEBAR_CYCLES_MS");
+		return s += MSG_GetForHost("TITLEBAR_CYCLES_MS");
 
 	} else {
 		// Modern mode
@@ -2648,11 +2648,11 @@ std::string CPU_GetCyclesConfigAsString()
 		}
 
 		s += " ";
-		s += MSG_GetRaw("TITLEBAR_CYCLES_MS");
+		s += MSG_GetForHost("TITLEBAR_CYCLES_MS");
 
 		if (modern_cycles_config.throttle && !max_mode) {
 			s += " (";
-			s += MSG_GetRaw("TITLEBAR_CYCLES_THROTTLED");
+			s += MSG_GetForHost("TITLEBAR_CYCLES_THROTTLED");
 			s += ")";
 		}
 		return s;

--- a/src/dos/dos_keyboard_layout.cpp
+++ b/src/dos/dos_keyboard_layout.cpp
@@ -45,6 +45,7 @@ static const std::string ResourceDirCodePage = "freedos-cpi";
 static void notify_code_page_changed()
 {
 	// Re-create various information to match new code page
+	MSG_NotifyNewCodePage();
 	DOS_UpdateCurrentProgramName();
 	DOS_RepopulateCountryInfo();
 	AUTOEXEC_NotifyNewCodePage();
@@ -1234,8 +1235,7 @@ KeyboardLayoutResult DOS_LoadKeyboardLayout(const std::string& keyboard_layout,
 	}
 
 	// Log loaded code page
-	if (old_code_page != dos.loaded_codepage ||
-	    old_font_origin != loaded_layout->GetCodePageFontOrigin()) {
+	if (old_code_page != dos.loaded_codepage) {
 		switch (loaded_layout->GetCodePageFontOrigin()) {
 		case CodePageFontOrigin::Rom:
 			LOG_MSG("LOCALE: Loaded code page %d (ROM font)",
@@ -1267,7 +1267,8 @@ KeyboardLayoutResult DOS_LoadKeyboardLayout(const std::string& keyboard_layout,
 		        DOS_GetKeyboardLayoutName(new_keyboard_layout).c_str());
 	}
 
-	if (old_code_page != dos.loaded_codepage) {
+	if (old_code_page != dos.loaded_codepage ||
+	    old_font_origin != loaded_layout->GetCodePageFontOrigin()) {
 		notify_code_page_changed();
 	}
 

--- a/src/dos/dos_locale.cpp
+++ b/src/dos/dos_locale.cpp
@@ -556,12 +556,12 @@ static const std::string AnsiHighlight = "[color=light-green]";
 static std::string get_output_header(const char* header_msg_id,
                                      const bool for_keyb_command = false)
 {
-	const std::string raw_header = MSG_GetRaw(header_msg_id);
 	if (for_keyb_command) {
-		return AnsiWhite + raw_header + ":" + AnsiReset + "\n\n";
+		return AnsiWhite + MSG_Get(header_msg_id) + ":" + AnsiReset + "\n\n";
 	} else {
-		return std::string("\n") + raw_header + "\n" +
-		       std::string(raw_header.size(), '-') + "\n\n";
+		std::string header_str = MSG_GetForHost(header_msg_id);
+		return std::string("\n") + header_str.c_str() + "\n" +
+		       std::string(header_str.size(), '-') + "\n\n";
 	}
 }
 
@@ -574,11 +574,11 @@ std::string DOS_GenerateListCountriesMessage()
 	     ++it) {
 		message += format_str("  %-5d - %s\n",
 		                      enum_val(it->first),
-		                      MSG_GetRaw(it->second.GetMsgName().c_str()));
+		                      MSG_GetForHost(it->second.GetMsgName()));
 	}
 
 	message += "\n";
-	message += MSG_GetRaw("DOSBOX_HELP_LIST_COUNTRIES_2");
+	message += MSG_GetForHost("DOSBOX_HELP_LIST_COUNTRIES_2");
 	message += "\n";
 
 	return message;
@@ -627,7 +627,13 @@ std::string DOS_GenerateListKeyboardLayoutsMessage(const bool for_keyb_command)
 		column_1_width = std::max(column_1_width, column_1_raw.length());
 
 		// Column 2 - localized keyboard name/description
-		const auto column_2 = MSG_GetRaw(entry.GetMsgName().c_str());
+		std::string column_2;
+		if (for_keyb_command) {
+			column_2 = MSG_Get(entry.GetMsgName());
+		} else {
+			column_2 = MSG_GetForHost(entry.GetMsgName());
+		}
+
 		table.push_back({column_1_ansi, column_2, highlight});
 	}
 
@@ -655,7 +661,7 @@ std::string DOS_GenerateListKeyboardLayoutsMessage(const bool for_keyb_command)
 		return convert_ansi_markup(message);
 	} else {
 		message += "\n";
-		message += MSG_GetRaw("DOSBOX_HELP_LIST_KEYBOARD_LAYOUTS_2");
+		message += MSG_GetForHost("DOSBOX_HELP_LIST_KEYBOARD_LAYOUTS_2");
 		message += "\n";
 
 		return message;
@@ -684,8 +690,8 @@ std::string DOS_GenerateListCodePagesMessage()
 		Row row = {};
 
 		row.column1 = format_str("% 7d - ", entry.first);
-		row.column2 = MSG_GetRaw(page_msg_name.c_str());
-		row.column3 = MSG_GetRaw(script_msg_name.c_str());
+		row.column2 = MSG_GetForHost(page_msg_name);
+		row.column3 = MSG_GetForHost(script_msg_name);
 
 		max_column2_length = std::max(max_column2_length,
 		                              length_utf8(row.column2));
@@ -708,7 +714,7 @@ std::string DOS_GenerateListCodePagesMessage()
 	}
 
 	message += "\n";
-	message += MSG_GetRaw("DOSBOX_HELP_LIST_CODE_PAGES_2");
+	message += MSG_GetForHost("DOSBOX_HELP_LIST_CODE_PAGES_2");
 	message += "\n";
 
 	return message;

--- a/src/dos/dos_locale.cpp
+++ b/src/dos/dos_locale.cpp
@@ -548,16 +548,12 @@ uint16_t DOS_GetCountry()
 // Helper functions for 'dosbox --list-*' commands
 // ***************************************************************************
 
-// ANSI codes for colors
-static const std::string AnsiReset     = "[reset]";
-static const std::string AnsiWhite     = "[color=white]";
-static const std::string AnsiHighlight = "[color=light-green]";
-
 static std::string get_output_header(const char* header_msg_id,
                                      const bool for_keyb_command = false)
 {
 	if (for_keyb_command) {
-		return AnsiWhite + MSG_Get(header_msg_id) + ":" + AnsiReset + "\n\n";
+		return Ansi::HighlightHeader + MSG_Get(header_msg_id) + ":" +
+		       Ansi::Reset + "\n\n";
 	} else {
 		std::string header_str = MSG_GetForHost(header_msg_id);
 		return std::string("\n") + header_str.c_str() + "\n" +
@@ -616,9 +612,9 @@ std::string DOS_GenerateListKeyboardLayoutsMessage(const bool for_keyb_command)
 			}
 			column_1_raw += layout_code;
 			if (highlight_code == layout_code) {
-				column_1_ansi += AnsiHighlight;
+				column_1_ansi += Ansi::HighlightSelection;
 				column_1_ansi += layout_code;
-				column_1_ansi += AnsiReset;
+				column_1_ansi += Ansi::Reset;
 				highlight = true;
 			} else {
 				column_1_ansi += layout_code;
@@ -637,18 +633,18 @@ std::string DOS_GenerateListKeyboardLayoutsMessage(const bool for_keyb_command)
 		table.push_back({column_1_ansi, column_2, highlight});
 	}
 
-	const size_t column_1_highlighted_width = AnsiHighlight.size() +
-	                                          AnsiReset.size() + column_1_width;
+	const size_t column_1_highlighted_width = Ansi::HighlightSelection.size() +
+	                                          Ansi::Reset.size() + column_1_width;
 	for (auto& table_row : table) {
 		if (table_row.highlight) {
 			table_row.column1.resize(column_1_highlighted_width, ' ');
 			message += format_str("%s*%s %s %s- %s%s\n",
-			                      AnsiHighlight.c_str(),
-                                              AnsiReset.c_str(),
+			                      Ansi::HighlightSelection.c_str(),
+                                              Ansi::Reset.c_str(),
                                               table_row.column1.c_str(),
-			                      AnsiHighlight.c_str(),
+			                      Ansi::HighlightSelection.c_str(),
 			                      table_row.column2.c_str(),
-			                      AnsiReset.c_str());
+			                      Ansi::Reset.c_str());
 		} else {
 			table_row.column1.resize(column_1_width, ' ');
 			message += format_str("  %s - %s\n",

--- a/src/dos/dos_locale.cpp
+++ b/src/dos/dos_locale.cpp
@@ -775,7 +775,7 @@ std::string DOS_GetKeyboardScriptName(const KeyboardScript keyboard_script)
 	assert(LocaleData::ScriptInfo.contains(script));
 	const auto msg_id = LocaleData::ScriptInfo.at(script).GetMsgName();
 
-	std::string result = MSG_Get(msg_id.c_str());
+	std::string result = MSG_Get(msg_id);
 
 	switch (keyboard_script) {
 	case KeyboardScript::LatinQwerty:
@@ -897,7 +897,7 @@ std::string DOS_GetCodePageDescription(const uint16_t code_page)
 		return {};
 	}
 
-	return MSG_Get(CodePageInfoEntry::GetMsgName(code_page).c_str());
+	return MSG_Get(CodePageInfoEntry::GetMsgName(code_page));
 }
 
 std::optional<CodePageWarning> DOS_GetCodePageWarning(const uint16_t code_page)

--- a/src/dos/dos_locale.h
+++ b/src/dos/dos_locale.h
@@ -415,6 +415,34 @@ struct CountryInfoEntry {
 	std::string GetMsgName() const;
 };
 
+// List of all the supported alphabets
+enum class Script : uint8_t {
+	Latin,
+	Arabic,
+	Armenian,
+	Cherokee,
+	Cyrillic,
+	Georgian,
+	Greek,
+	Hebrew,
+};
+
+struct ScriptInfoEntry {
+	// Script code according to ISO 15924, but uppercase
+	std::string script_code;
+
+	std::string script_name;
+
+	std::string GetMsgName() const;
+};
+
+struct CodePageInfoEntry {
+	std::string description = {};
+	Script script           = {};
+
+	static std::string GetMsgName(const uint16_t code_page);
+};
+
 enum class KeyboardScript {
 	// Latin scripts
 	LatinQwerty, /// always keep it the 1st one!
@@ -435,7 +463,6 @@ enum class KeyboardScript {
 	Georgian,
 	Greek,
 	Hebrew,
-	Thai,
 	// Markers for comparing
 	LastQwertyLikeScript = LatinAsertt,
 	LastLatinScript      = LatinNonStandard,
@@ -465,6 +492,8 @@ namespace LocaleData {
 
 extern const std::map<std::string, std::vector<uint16_t>> BundledCpiContent;
 extern const std::map<uint16_t, CodePageWarning>          CodePageWarnings;
+extern const std::map<Script, ScriptInfoEntry>            ScriptInfo;
+extern const std::map<uint16_t, CodePageInfoEntry>        CodePageInfo;
 extern const std::vector<KeyboardLayoutInfoEntry>         KeyboardLayoutInfo;
 extern const std::map<uint16_t, DosCountry>               CodeToCountryCorrectionMap;
 extern const std::map<DosCountry, CountryInfoEntry>       CountryInfo;
@@ -475,11 +504,12 @@ extern const std::map<DosCountry, CountryInfoEntry>       CountryInfo;
 
 std::string DOS_GenerateListCountriesMessage();
 std::string DOS_GenerateListKeyboardLayoutsMessage(const bool for_keyb_command = false);
+std::string DOS_GenerateListCodePagesMessage();
 
 // Functions for the KEYB command - help output
 
 std::string DOS_GetKeyboardLayoutName(const std::string& layout);
-std::string DOS_GetKeyboardScriptName(const KeyboardScript script);
+std::string DOS_GetKeyboardScriptName(const KeyboardScript keyboard_script);
 std::string DOS_GetShortcutKeyboardScript1();
 std::string DOS_GetShortcutKeyboardScript2();
 std::string DOS_GetShortcutKeyboardScript3();
@@ -488,6 +518,8 @@ std::optional<KeyboardScript> DOS_GetKeyboardLayoutScript2(const std::string& la
                                                            const uint16_t code_page);
 std::optional<KeyboardScript> DOS_GetKeyboardLayoutScript3(const std::string& layout,
                                                            const uint16_t code_page);
+
+std::string DOS_GetCodePageDescription(const uint16_t code_page);
 
 std::optional<CodePageWarning> DOS_GetCodePageWarning(const uint16_t code_page);
 

--- a/src/dos/dos_locale_data.cpp
+++ b/src/dos/dos_locale_data.cpp
@@ -43,6 +43,18 @@ std::string CountryInfoEntry::GetMsgName() const
 	return base_str + country_code;
 }
 
+std::string ScriptInfoEntry::GetMsgName() const
+{
+	const std::string base_str = "SCRIPT_NAME_";
+	return base_str + script_code;
+}
+
+std::string CodePageInfoEntry::GetMsgName(const uint16_t code_page)
+{
+	const std::string base_str = "CODE_PAGE_DESCRIPTION_";
+	return base_str + std::to_string(code_page);
+}
+
 std::string KeyboardLayoutInfoEntry::GetMsgName() const
 {
 	assert(!layout_codes.empty());
@@ -85,6 +97,117 @@ const std::map<std::string, std::vector<uint16_t>> LocaleData::BundledCpiContent
 // clang-format off
 const std::map<uint16_t, CodePageWarning> LocaleData::CodePageWarnings = {
         { 60258, CodePageWarning::DottedI },
+};
+// clang-format on
+
+// clang-format off
+const std::map<Script, ScriptInfoEntry> LocaleData::ScriptInfo = {
+        { Script::Latin,    { "LATN", "Latin"    } },
+        { Script::Arabic,   { "ARAB", "Arabic"   } },
+        { Script::Armenian, { "ARMN", "Armenian" } },
+        { Script::Cherokee, { "CHER", "Cherokee" } },
+        { Script::Cyrillic, { "CYRL", "Cyrillic" } },
+        { Script::Georgian, { "GEOR", "Georgian" } },
+        { Script::Greek,    { "GREK", "Greek"    } },
+        { Script::Hebrew,   { "HEBR", "Hebrew"   } },
+};
+// clang-format on
+
+// clang-format off
+const std::map<uint16_t, CodePageInfoEntry> LocaleData::CodePageInfo = {
+	// Standard ROM code page
+	{ 437,   { "United States",                                   Script::Latin    } },
+	// FreeDOS standard package code pages
+	{ 113,   { "Yugoslavian",                                     Script::Latin    } },
+	{ 667,   { "Polish, Mazovia encoding",                        Script::Latin    } },
+	{ 668,   { "Polish, 852-compatible",                          Script::Latin    } },
+	{ 737,   { "Greek-2",                                         Script::Greek    } },
+	{ 770,   { "Baltic",                                          Script::Latin    } },
+	{ 771,   { "Lithuanian and Russian, KBL encoding",            Script::Cyrillic } },
+	{ 773,   { "Latin-7 (Baltic, old encoding)",                  Script::Latin    } },
+	{ 775,   { "Latin-7 (Baltic)",                                Script::Latin    } },
+	{ 777,   { "Lithuanian, accented, old encoding",              Script::Latin    } },
+	{ 778,   { "Lithuanian, accented, LST 1590-2 encoding",       Script::Latin    } },
+	{ 808,   { "Russian, with EUR symbol",                        Script::Cyrillic } },
+	{ 848,   { "Ukrainian, with EUR symbol",                      Script::Cyrillic } },
+	{ 849,   { "Belarusian, with EUR symbol",                     Script::Cyrillic } },
+	{ 850,   { "Latin-1 (Western European)",                      Script::Latin    } },
+	{ 851,   { "Greek, old encoding",                             Script::Greek    } },
+	{ 852,   { "Latin-2 (Central European), with EUR symbol",     Script::Latin    } },
+	{ 853,   { "Latin-3 (Turkish, Maltese, and Esperanto)",       Script::Latin    } },
+	{ 855,   { "South Slavic",                                    Script::Cyrillic } },
+	{ 856,   { "Hebrew-2, with EUR symbol",                       Script::Hebrew   } },
+	{ 857,   { "Latin-5 (Turkish), with EUR symbol",              Script::Latin    } },
+	{ 858,   { "Latin-1 (Western European), with EUR symbol",     Script::Latin    } },
+	{ 859,   { "Latin-9 (Western European), with EUR symbol",     Script::Latin    } },
+	{ 860,   { "Portuguese",                                      Script::Latin    } },
+	{ 861,   { "Icelandic",                                       Script::Latin    } },
+	{ 862,   { "Hebrew-2",                                        Script::Hebrew   } },
+	{ 863,   { "Canadian French",                                 Script::Latin    } },
+	{ 864,   { "Arabic",                                          Script::Arabic   } },
+	{ 865,   { "Nordic",                                          Script::Latin    } },
+	{ 866,   { "Russian",                                         Script::Cyrillic } },
+	{ 867,   { "Czech and Slovak, Kamenický encoding",            Script::Latin    } },
+	{ 869,   { "Greek, with EUR symbol",                          Script::Greek    } },
+	{ 872,   { "South Slavic, with EUR symbol",                   Script::Cyrillic } },
+	{ 899,   { "Armenian, ArmSCII-8A encoding",                   Script::Armenian } },
+	{ 991,   { "Polish, Mazovia encoding, with PLN symbol",       Script::Latin    } },
+	{ 1116,  { "Estonian",                                        Script::Latin    } },
+	{ 1117,  { "Latvian",                                         Script::Latin    } },
+	{ 1118,  { "Lithuanian, LST 1283 encoding",                   Script::Latin    } },
+	{ 1119,  { "Lithuanian and Russian, LST 1284 encoding",       Script::Cyrillic } },
+	{ 1125,  { "Ukrainian",                                       Script::Cyrillic } },
+	{ 1131,  { "Belarusian",                                      Script::Cyrillic } },
+	{ 3012,  { "Latvian and Russian, RusLat encoding",            Script::Cyrillic } },
+	{ 3021,  { "Bulgarian, MIK encoding",                         Script::Cyrillic } },
+	{ 3845,  { "Hungarian, CWI-2 encoding",                       Script::Latin    } },
+	{ 3846,  { "Turkish",                                         Script::Latin    } },
+	{ 3848,  { "Brazilian, ABICOMP encoding",                     Script::Latin    } },
+	{ 30000, { "Saami, Kalo and Finnic",                          Script::Latin    } },
+	{ 30001, { "Celtic and Scots, with EUR symbol",               Script::Latin    } },
+	{ 30002, { "Tajik, with EUR symbol",                          Script::Cyrillic } },
+	{ 30003, { "Latin American, with EUR symbol",                 Script::Latin    } },
+	{ 30004, { "Greenlandic and North Germanic, with EUR symbol", Script::Latin    } },
+	{ 30005, { "Nigerian, with EUR symbol",                       Script::Latin    } },
+	{ 30006, { "Vietnamese, VISCII encoding",                     Script::Latin    } },
+	{ 30007, { "Latin and Romance, with EUR symbol",              Script::Latin    } },
+	{ 30008, { "Abkhaz and Ossetian, with EUR symbol",            Script::Cyrillic } },
+	{ 30009, { "Romani and Turkic, with EUR symbol",              Script::Latin    } },
+	{ 30010, { "Gagauz and Moldovan, with EUR symbol",            Script::Cyrillic } },
+	{ 30011, { "Russian Southern, with EUR symbol",               Script::Cyrillic } },
+	{ 30012, { "Siberian, with EUR symbol",                       Script::Cyrillic } },
+	{ 30013, { "Turkic, with EUR symbol",                         Script::Cyrillic } },
+	{ 30014, { "Finno-ugric (Mari, Udmurt), with EUR symbol",     Script::Cyrillic } },
+	{ 30015, { "Khanty, with EUR symbol",                         Script::Cyrillic } },
+	{ 30016, { "Mansi, with EUR symbol",                          Script::Cyrillic } },
+	{ 30017, { "Russian Northwestern, with EUR symbol",           Script::Cyrillic } },
+	{ 30018, { "Tatar Latin and Russian, with EUR symbol",        Script::Cyrillic } },
+	{ 30019, { "Chechen Latin and Russian, with EUR symbol",      Script::Cyrillic } },
+	{ 30020, { "Low Saxon and Frisian, with EUR symbol",          Script::Latin    } },
+	{ 30021, { "Oceania, with EUR symbol",                        Script::Latin    } },
+	{ 30022, { "Canadian First Nations, with EUR symbol",         Script::Latin    } },
+	{ 30023, { "Southern African, with EUR symbol",               Script::Latin    } },
+	{ 30024, { "Northern and Eastern African, with EUR symbol",   Script::Latin    } },
+	{ 30025, { "Western African, with EUR symbol",                Script::Latin    } },
+	{ 30026, { "Central African, with EUR symbol",                Script::Latin    } },
+	{ 30027, { "Beninese, with EUR symbol",                       Script::Latin    } },
+	{ 30028, { "Nigerien, with EUR symbol",                       Script::Latin    } },
+	{ 30029, { "Mexican, with EUR symbol",                        Script::Latin    } },
+	{ 30030, { "Mexican-2, with EUR symbol",                      Script::Latin    } },
+	{ 30031, { "Latin-4 (Northern European), with EUR symbol",    Script::Latin    } },
+	{ 30032, { "Latin-6, with EUR symbol",                        Script::Latin    } },
+	{ 30033, { "Crimean Tatar, with UAH symbol",                  Script::Latin    } },
+	{ 30034, { "Cherokee",                                        Script::Cherokee } },
+	{ 30039, { "Ukrainian, with UAH symbol",                      Script::Cyrillic } },
+	{ 30040, { "Russian, with UAH symbol",                        Script::Cyrillic } },
+	{ 58152, { "Kazakh, with EUR symbol",                         Script::Cyrillic } },
+	{ 58210, { "Azeri Cyrillic and Russian",                      Script::Cyrillic } },
+	{ 59234, { "Tatar",                                           Script::Cyrillic } },
+	{ 58335, { "Kashubian, Mazovia-based, with PLN symbol",       Script::Latin    } },
+	{ 59829, { "Georgian",                                        Script::Georgian } },
+	{ 60258, { "Azeri Latin and Russian",                         Script::Cyrillic } },
+	{ 60853, { "Georgian with capital letters",                   Script::Georgian } },
+	{ 62306, { "Uzbek",                                           Script::Cyrillic } },
 };
 // clang-format on
 

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -4886,7 +4886,7 @@ int sdl_main(int argc, char* argv[])
 		if (arguments->help) {
 			assert(argv && argv[0]);
 			const auto program_name = argv[0];
-			const auto help = format_str(MSG_GetRaw("DOSBOX_HELP"),
+			const auto help = format_str(MSG_GetForHost("DOSBOX_HELP"),
 			                             program_name);
 			printf("%s", help.c_str());
 			return 0;

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -4274,7 +4274,9 @@ static void messages_add_command_line()
 	        "                           Codes are to be used in the 'country' config setting.\n"
 	        "\n"
 	        "  --list-layouts           List all supported keyboard layouts with their codes.\n"
-	        "                           Codes are to be used in the 'keyboardlayout' config setting.\n"
+	        "                           Codes are to be used in the 'keyboard_layout' config setting.\n"
+	        "\n"
+	        "  --list-code-pages        List all bundled code pages.\n"
 	        "\n"
 	        "  --list-glshaders         List all available OpenGL shaders and their paths.\n"
 	        "                           Shaders are to be used in the 'glshader' config setting.\n"
@@ -4688,6 +4690,12 @@ static void list_keyboard_layouts()
 	printf("%s\n", message_utf8.c_str());
 }
 
+static void list_code_pages()
+{
+	const auto message_utf8 = DOS_GenerateListCodePagesMessage();
+	printf("%s\n", message_utf8.c_str());
+}
+
 static int print_primary_config_location()
 {
 	const auto path = GetPrimaryConfigPath();
@@ -4787,8 +4795,8 @@ int sdl_main(int argc, char* argv[])
 	loguru::g_preamble_pipe    = true;
 
 	if (arguments->version || arguments->help || arguments->printconf ||
-	    arguments->editconf || arguments->eraseconf ||
-	    arguments->list_countries || arguments->list_layouts ||
+	    arguments->editconf || arguments->eraseconf || arguments->list_countries ||
+	    arguments->list_layouts || arguments->list_code_pages ||
 	    arguments->list_glshaders || arguments->erasemapper) {
 		loguru::g_stderr_verbosity = loguru::Verbosity_WARNING;
 	}
@@ -4901,6 +4909,10 @@ int sdl_main(int argc, char* argv[])
 		}
 		if (arguments->list_layouts) {
 			list_keyboard_layouts();
+			return 0;
+		}
+		if (arguments->list_code_pages) {
+			list_code_pages();
 			return 0;
 		}
 		if (arguments->list_glshaders) {

--- a/src/gui/shader_manager.cpp
+++ b/src/gui/shader_manager.cpp
@@ -197,7 +197,7 @@ std::deque<std::string> ShaderManager::GenerateShaderInventoryMessage() const
 {
 	std::deque<std::string> inventory;
 	inventory.emplace_back("");
-	inventory.emplace_back(MSG_GetRaw("DOSBOX_HELP_LIST_GLSHADERS_1"));
+	inventory.emplace_back(MSG_GetForHost("DOSBOX_HELP_LIST_GLSHADERS_1"));
 	inventory.emplace_back("");
 
 	const std::string file_prefix = "        ";
@@ -214,11 +214,11 @@ std::deque<std::string> ShaderManager::GenerateShaderInventoryMessage() const
 
 		const char* pattern = nullptr;
 		if (!dir_exists) {
-			pattern = MSG_GetRaw("DOSBOX_HELP_LIST_GLSHADERS_NOT_EXISTS");
+			pattern = MSG_GetForHost("DOSBOX_HELP_LIST_GLSHADERS_NOT_EXISTS");
 		} else if (!dir_has_shaders) {
-			pattern = MSG_GetRaw("DOSBOX_HELP_LIST_GLSHADERS_NO_SHADERS");
+			pattern = MSG_GetForHost("DOSBOX_HELP_LIST_GLSHADERS_NO_SHADERS");
 		} else {
-			pattern = MSG_GetRaw("DOSBOX_HELP_LIST_GLSHADERS_LIST");
+			pattern = MSG_GetForHost("DOSBOX_HELP_LIST_GLSHADERS_LIST");
 		}
 		inventory.emplace_back(format_str(pattern, dir.u8string().c_str()));
 
@@ -232,7 +232,7 @@ std::deque<std::string> ShaderManager::GenerateShaderInventoryMessage() const
 		}
 		inventory.emplace_back("");
 	}
-	inventory.emplace_back(MSG_GetRaw("DOSBOX_HELP_LIST_GLSHADERS_2"));
+	inventory.emplace_back(MSG_GetForHost("DOSBOX_HELP_LIST_GLSHADERS_2"));
 
 	return inventory;
 }

--- a/src/gui/titlebar.cpp
+++ b/src/gui/titlebar.cpp
@@ -230,12 +230,9 @@ static std::string get_dosbox_version()
 
 static std::string get_mouse_hint_simple()
 {
-	// We are using 'MSG_GetRaw' here as we want messages to stay as UTF-8
-
 	if (state.mouse_hint_id == MouseHint::CapturedHotkey ||
 	    state.mouse_hint_id == MouseHint::CapturedHotkeyMiddle) {
-		// 'MSG_GetRaw' because we want messages to stay as UTF-8
-		return MSG_GetRaw("TITLEBAR_HINT_CAPTURED");
+		return MSG_GetForHost("TITLEBAR_HINT_CAPTURED");
 	} else {
 		return {};
 	}
@@ -246,8 +243,9 @@ static std::string get_mouse_hint_full()
 	char hint_buffer[200] = {0};
 
 	auto create_hint_str = [&](const char* requested_name) {
-		// 'MSG_GetRaw' because we want messages to stay as UTF-8
-		safe_sprintf(hint_buffer, MSG_GetRaw(requested_name), PRIMARY_MOD_NAME);
+		safe_sprintf(hint_buffer,
+		             MSG_GetForHost(requested_name),
+		             PRIMARY_MOD_NAME);
 		return hint_buffer;
 	};
 
@@ -291,16 +289,16 @@ static void maybe_add_muted_mark(std::string& title_str)
 {
 	// Do not add 'mute' tag if emulator is paused
 	if (state.is_audio_muted && !sdl.is_paused) {
-		title_str = BeginTag + MSG_GetRaw("TITLEBAR_MUTED") + EndTag +
-		            title_str;
+		title_str = BeginTag + MSG_GetForHost("TITLEBAR_MUTED") +
+		            EndTag + title_str;
 	}
 }
 
 static void maybe_add_recording_pause_mark(std::string& title_str)
 {
 	if (sdl.is_paused) {
-		title_str = BeginTag + MSG_GetRaw("TITLEBAR_PAUSED") + EndTag +
-		            title_str;
+		title_str = BeginTag + MSG_GetForHost("TITLEBAR_PAUSED") +
+		            EndTag + title_str;
 		return;
 	}
 

--- a/src/misc/ansi_code_markup.cpp
+++ b/src/misc/ansi_code_markup.cpp
@@ -25,6 +25,34 @@
 #include "support.h"
 #include "ansi_code_markup.h"
 
+// Pre-defined markups to help creating strings
+
+const std::string Ansi::Reset               = "[reset]";
+
+// Low intensity text colours
+const std::string Ansi::ColorBlack          = "[color=black]";
+const std::string Ansi::ColorBlue           = "[color=blue]";
+const std::string Ansi::ColorGreen          = "[color=green]";
+const std::string Ansi::ColorCyan           = "[color=cyan]";
+const std::string Ansi::ColorRed            = "[color=red]";
+const std::string Ansi::ColorMagenta        = "[color=magenta]";
+const std::string Ansi::ColorBrown          = "[color=brown]";
+const std::string Ansi::ColorLightGray      = "[color=light-grey]";
+
+// High intensity text colours
+const std::string Ansi::ColorDarkGray       = "[color=dark-grey]";
+const std::string Ansi::ColorLightBlue      = "[color=light-blue]";
+const std::string Ansi::ColorLightGreen     = "[color=light-green]";
+const std::string Ansi::ColorLightCyan      = "[color=light-cyan]";
+const std::string Ansi::ColorLightRed       = "[color=light-red]";
+const std::string Ansi::ColorLightMagenta   = "[color=light-magenta]";
+const std::string Ansi::ColorYellow         = "[color=yellow]";
+const std::string Ansi::ColorWhite          = "[color=white]";
+
+// Definitions to help keeping the command output style consistent
+const std::string& Ansi::HighlightHeader    = Ansi::ColorWhite;
+const std::string& Ansi::HighlightSelection = Ansi::ColorLightGreen;
+
 /*!
  * \brief Represents a markup tag.
  *

--- a/src/misc/help_util.cpp
+++ b/src/misc/help_util.cpp
@@ -1,3 +1,23 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2022-2024  The DOSBox Staging Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
 #include "dosbox.h"
 
 #include <map>
@@ -26,26 +46,26 @@ std::string HELP_GetShortHelp(const std::string &cmd_name)
 {
 	// Try to find short help first
 	const std::string short_key_command = "SHELL_CMD_" + cmd_name + "_HELP";
-	if (MSG_Exists(short_key_command.c_str())) {
-		return MSG_Get(short_key_command.c_str());
+	if (MSG_Exists(short_key_command)) {
+		return MSG_Get(short_key_command);
 	}
 	const std::string short_key_program = "PROGRAM_" + cmd_name + "_HELP";
-	if (MSG_Exists(short_key_program.c_str())) {
-		return MSG_Get(short_key_program.c_str());
+	if (MSG_Exists(short_key_program)) {
+		return MSG_Get(short_key_program);
 	}
 
 	// If it does not exist, extract first line of long help
 	auto extract = [](const std::string &long_key) {
-		const std::string str(MSG_Get(long_key.c_str()));
+		const std::string str(MSG_Get(long_key));
 		const auto pos = str.find('\n');
 		return str.substr(0, pos != std::string::npos ? pos + 1 : pos);
 	};
 	const std::string long_key_command = "SHELL_CMD_" + cmd_name + "_HELP_LONG";
-	if (MSG_Exists(long_key_command.c_str())) {
+	if (MSG_Exists(long_key_command)) {
 		return extract(long_key_command);
 	}
 	const std::string long_key_program = "PROGRAM_" + cmd_name + "_HELP_LONG";
-	if (MSG_Exists(long_key_program.c_str())) {
+	if (MSG_Exists(long_key_program)) {
 		return extract(long_key_program);
 	}
 

--- a/src/misc/messages.cpp
+++ b/src/misc/messages.cpp
@@ -21,17 +21,7 @@
 
 #include "dosbox.h"
 
-#include <clocale>
-#include <cstdio>
-#include <cstdlib>
-#include <cstring>
-#include <map>
-#include <vector>
-
-#include "std_filesystem.h"
-#include <string>
-#include <unordered_map>
-
+#include "../dos/dos_locale.h"
 #include "ansi_code_markup.h"
 #include "checks.h"
 #include "control.h"
@@ -39,209 +29,766 @@
 #include "fs_utils.h"
 #include "host_locale.h"
 #include "setup.h"
+#include "std_filesystem.h"
 #include "string_utils.h"
 #include "support.h"
 #include "unicode.h"
 
-#define LINE_IN_MAXLEN 2048
+#include <cctype>
+#include <fstream>
+#include <map>
+#include <set>
+#include <string>
 
 CHECK_NARROWING();
 
-static const char *msg_not_found = "Message not Found!\n";
+static const std::string MsgNotFound = " MESSAGE NOT FOUND! ";
+static const std::string MsgNotValid = " MESSAGE NOT VALID! ";
+
+// ***************************************************************************
+// Single message storage class
+// ***************************************************************************
 
 class Message {
-private:
-	std::string markup_msg = {};
-	std::string rendered_msg = {};
-
-	std::map<uint16_t, std::string> rendered_msg_by_codepage = {};
-
-	static std::string to_dos(const std::string& in_str, const uint16_t code_page)
-	{
-		return utf8_to_dos(in_str,
-		                   DosStringConvertMode::WithControlCodes,
-		                   UnicodeFallback::Box,
-		                   code_page);
-	}
-
-	const char* CachedRenderString(const std::string& msg,
-	                               std::map<uint16_t, std::string>& output_msg_by_codepage)
-	{
-		assert(msg.length());
-		const uint16_t cp = get_utf8_code_page();
-		if (output_msg_by_codepage[cp].empty()) {
-			output_msg_by_codepage[cp] = to_dos(msg, cp);
-			assert(output_msg_by_codepage[cp].length());
-		}
-
-		return output_msg_by_codepage[cp].c_str();
-	}
-
 public:
+	// Note: any message needs to be verified before it can be safely used!
+
+	// Constructor for original, English strings
+	Message(const std::string& message, const bool can_contain_format_string);
+	// Constructor for translated strings from external file
+	Message(const std::string& message);
+
+	const std::string& Get();
+	const std::string& GetRaw();
+
+	bool IsValid() const
+	{
+		return is_verified && is_ok;
+	}
+	void MarkInvalid()
+	{
+		is_ok = false;
+	}
+
+	// Use this one for English messages only
+	void VerifyEnglish(const std::string& name);
+	// Use this one for translated messages
+	void VerifyTranslated(const std::string& name, const Message& english);
+
+private:
 	Message() = delete;
-	Message(const char *markup)
-	{
-		Set(markup);
-	}
 
-	const char *GetRaw()
-	{
-		assert(markup_msg.length());
-		return markup_msg.c_str();
-	}
+	std::string GetLogStart(const std::string& name) const;
 
-	const char *GetRendered()
-	{
-		assert(markup_msg.length());
-		if (rendered_msg.empty())
-			rendered_msg = convert_ansi_markup(markup_msg.c_str());
+	void VerifyMessage(const std::string& name);
+	void VerifyFormatString(const std::string& name);
+	void VerifyFormatStringAgainst(const std::string& name,
+	                               const Message& english);
 
-		assert(rendered_msg.length());
-		const uint16_t cp = get_utf8_code_page();
-		if (rendered_msg_by_codepage[cp].empty()) {
-			rendered_msg_by_codepage[cp] = to_dos(rendered_msg, cp);
-			assert(rendered_msg_by_codepage[cp].length());
-		}
+	const bool is_english;
+	const bool can_contain_format_string;
 
-		return rendered_msg_by_codepage[cp].c_str();
-	}
+	bool is_verified = false;
+	bool is_ok       = true;
 
-	void Set(const char *markup)
-	{
-		assert(markup);
-		markup_msg = markup;
+	// Original message, UTF-8, can contain DOSBox ANSI markups
+	std::string message_raw = {};
+	// Message in DOS encoding, markups converted to ANSI control codes
+	std::string message_dos_ansi = {};
 
-		rendered_msg.clear();
-		rendered_msg_by_codepage.clear();
-	}
+	uint16_t code_page = 0;
+
+	struct FormatSpecifier {
+		std::string flags     = {};
+		std::string width     = {};
+		std::string precision = {};
+		std::string length    = {};
+
+		char format = '\0';
+
+		std::string AsString() const;
+	};
+
+	std::vector<FormatSpecifier> format_specifiers = {};
 };
 
-static std::unordered_map<std::string, Message> messages = {};
-static std::vector<std::string> messages_order           = {};
+Message::Message(const std::string& message, const bool can_contain_format_string)
+        : is_english(true),
+          can_contain_format_string(can_contain_format_string),
+          message_raw(message)
+{}
 
-static bool message_file_loaded = false;
+Message::Message(const std::string& message)
+	: is_english(false),
+	  can_contain_format_string(false),
+	  message_raw(message)
+{}
 
-// Add the message if it doesn't exist yet
-void MSG_Add(const char* name, const char* markup_msg)
+std::string Message::GetLogStart(const std::string& name) const
 {
-	const auto pair = messages.try_emplace(name, markup_msg);
-	if (pair.second) { // if the insertion was successful
-		messages_order.emplace_back(name);
-	} else if (!message_file_loaded &&
-	           strcmp(pair.first->second.GetRaw(), markup_msg) != 0) {
-		// Detect duplicates in the English language
-		LOG_WARNING("LOCALE: Duplicate text added for message '%s'. "
-		            "Second instance is ignored.",
-		            name);
-	} else {
-		// Duplicate ID definitions most likely occured by adding the help in the code
-		// after it was added by a help-file.
+	std::string result = is_english ? "LOCALE: English message '"
+	                                : "LOCALE: Translated message '";
+	return result + name + "'";
+}
+
+const std::string& Message::Get()
+{
+	if (message_raw.empty()) {
+		return message_raw;
+	}
+
+	const auto current_code_page = get_utf8_code_page();
+	if (message_dos_ansi.empty() || code_page != current_code_page) {
+		code_page = current_code_page;
+		message_dos_ansi = utf8_to_dos(convert_ansi_markup(message_raw),
+                                               DosStringConvertMode::WithControlCodes,
+                                               UnicodeFallback::Box,
+                                               code_page);
+	}
+
+	return message_dos_ansi;
+}
+
+const std::string& Message::GetRaw()
+{
+	return message_raw;
+}
+
+void Message::VerifyMessage(const std::string& name)
+{
+	if (!is_ok || is_verified) {
+		return;
+	}
+
+	for (const auto item : message_raw) {
+		if (item == '\n' || is_extended_printable_ascii(item)) {
+			continue;
+		}
+
+		// No special characters allowed, except a newline character;
+		// please use DOSBox tags instead of ANSI escape sequences
+		LOG_WARNING("%s contains invalid character 0x%02x",
+		            GetLogStart(name).c_str(),
+		            item);
+		is_ok = false;
+		break;
 	}
 }
 
-// Replace existing or add if it doesn't exist
-static void msg_replace(const char *name, const char *markup_msg)
+void Message::VerifyFormatString(const std::string& name)
 {
-	auto it = messages.find(name);
-	if (it == messages.end()) {
-		MSG_Add(name, markup_msg);
-	} else {
-		it->second.Set(markup_msg);
-	}
-}
-
-static bool load_message_file(const std_fs::path &filename)
-{
-	if (filename.empty())
-		return false;
-
-	if (!path_exists(filename) || !is_readable(filename)) {
-		return false;
+	if (!is_ok || is_verified) {
+		return;
 	}
 
-	FILE *mfile = fopen(filename.string().c_str(), "rt");
-	if (!mfile) {
-		return false;
-	}
+	// clang-format off
+	const std::set<char> Flags   = {
+		'-', '+', ' ', '#', '0'
+	};
+	const std::set<char> Lengths = {
+		'h', 'l', 'j', 'z', 't', 'L'
+	};
+	const std::set<char> Formats = {
+		'd', 'i', 'u', 'o', 'x', 'X', 'f', 'F', 'e', 'E', 'g', 'G',
+		'a', 'A', 'c', 'C', 's', 'p', 'n'
+	};
+	// clang-format on
 
-	char linein[LINE_IN_MAXLEN];
-	char name[LINE_IN_MAXLEN];
-	char message[LINE_IN_MAXLEN * 10];
-	/* Start out with empty strings */
-	name[0] = 0;
-	message[0] = 0;
-	while (fgets(linein, LINE_IN_MAXLEN, mfile) != nullptr) {
-		/* Parse the read line */
-		/* First remove characters 10 and 13 from the line */
-		char * parser=linein;
-		char * writer=linein;
-		while (*parser) {
-			if (*parser!=10 && *parser!=13) {
-				*writer++=*parser;
+	auto log_problem = [&](const std::string& error) {
+		if (!is_ok) {
+			// At least one error already reported
+			return;
+		}
+
+		// NOTE: If you want to skip format string checks for the given
+		//       message, put a 'MsgFlagNoFormatString' flag into
+		//       the relevant 'MSG_Add' call
+		LOG_WARNING("%s contains an incorrect format specifier: %s",
+		            GetLogStart(name).c_str(),
+		            error.c_str());
+		is_ok = false;
+	};
+
+	// Look for format specifier
+	for (auto it = message_raw.begin(); it < message_raw.end(); ++it) {
+		if (*it != '%') {
+			// Not a format specifier
+			continue;
+		} else if (*(++it) == '%') {
+			// Percent sign, not a format specifier
+			continue;
+		}
+
+		// Found a new specifier - parse it according to:
+		// - https://cplusplus.com/reference/cstdio/printf/
+		format_specifiers.push_back({});
+		auto& specifier = format_specifiers.back();
+
+		// First check for POSIX format string extensions
+		auto it_tmp = it;
+		if (*it_tmp == '*') {
+			++it_tmp;
+		}
+		if (*it_tmp != '0' && std::isdigit(*it_tmp)) {
+			// Skip all the digits
+			while (std::isdigit(*it_tmp)) {
+				++it_tmp;
 			}
-			parser++;
+			if (*it_tmp == '$') {
+				log_problem(
+				        "POSIX extension used, "
+				        "this won't work on Windows");
+				// We do not support parsing this
+				format_specifiers.clear();
+				return;
+			}
 		}
-		*writer=0;
-		/* New message name */
-		if (linein[0]==':') {
-			message[0] = 0;
-			safe_strcpy(name, linein + 1);
-			/* End of message marker */
-		} else if (linein[0]=='.') {
-			/* Replace/Add the message to the internal languagefile */
-			/* Remove last newline (marker is \n.\n) */
-			size_t ll = safe_strlen(message);
-			// This second if should not be needed, but better be safe.
-			if (ll && message[ll - 1] == '\n')
-				message[ll - 1] = 0;
-			msg_replace(name, message);
+
+		// Extract the 'flags'
+		std::set<char> flags = {};
+		bool already_warned  = false;
+		while (Flags.contains(*it)) {
+			if (flags.contains(*it) && !already_warned) {
+				log_problem("duplicated flag");
+				already_warned = true;
+			} else {
+				flags.insert(*it);
+			}
+			specifier.flags.push_back(*(it++));
+		}
+
+		// Extract the 'width'
+		if (*it == '*') {
+			specifier.width = "*";
 		} else {
-			/* Normal message to be added */
-			safe_strcat(message, linein);
-			safe_strcat(message, "\n");
+			while (std::isdigit(*it)) {
+				specifier.width.push_back(*(it++));
+			}
+		}
+
+		// Extract the 'precision'
+		if (*it == '.') {
+			if (*(++it) == '*') {
+				specifier.precision = "*";
+			}
+			while (std::isdigit(*it)) {
+				specifier.precision.push_back(*(it++));
+			}
+			if (specifier.precision.empty()) {
+				log_problem("precision not specified");
+			}
+		}
+
+		// Extract the 'length'
+		if ((*it == 'h' && *(it + 1) == 'h') ||
+		    (*it == 'l' && *(it + 1) == 'l')) {
+			specifier.length.push_back(*(it++));
+			specifier.length.push_back(*(it++));
+		} else if (Lengths.contains(*it)) {
+			specifier.length.push_back(*(it++));
+		}
+
+		// Extract the 'format'
+		if (Formats.contains(*it)) {
+			specifier.format = *it;
+		} else {
+			log_problem("data format not specified");
 		}
 	}
-	fclose(mfile);
-	message_file_loaded = true;
-	return true;
 }
 
-const char* MSG_Get(const char* requested_name)
+void Message::VerifyFormatStringAgainst(const std::string& name, const Message& english)
 {
-	const auto it = messages.find(requested_name);
-	if (it != messages.end()) {
-		return it->second.GetRendered();
+	if (!is_ok || is_verified) {
+		return;
 	}
-	LOG_WARNING("LOCALE: Message '%s' not found", requested_name);
-	return msg_not_found;
-}
 
-const char* MSG_GetRaw(const char* requested_name)
-{
-	const auto it = messages.find(requested_name);
-	if (it != messages.end()) {
-		return it->second.GetRaw();
+	// Check if the number of format specifiers match
+	if (format_specifiers.size() != english.format_specifiers.size()) {
+		LOG_WARNING(
+		        "%s has %d format specifier(s) "
+		        "while English has %d specifier(s)",
+		        GetLogStart(name).c_str(),
+		        static_cast<int>(format_specifiers.size()),
+		        static_cast<int>(english.format_specifiers.size()));
+		if (format_specifiers.size() < english.format_specifiers.size()) {
+			is_ok = false;
+			return;
+		}
 	}
-	LOG_WARNING("LOCALE: Message '%s' not found", requested_name);
-	return msg_not_found;
+
+	// Check if format specifiers are compatible to each other
+	auto are_compatible = [&](const char format_1, const char format_2) {
+		if (format_1 == format_2) {
+			return true;
+		}
+
+		const std::set<std::pair<char, char>> CompatiblePairs = {
+		        // Fully interchangeable formats
+		        {'d', 'i'}, // signed decimal integer
+		        // Different case pairs
+		        {'x', 'X'}, // octal
+		        {'f', 'F'}, // decimal floating point
+		        {'e', 'E'}, // scientific notation
+		        {'g', 'G'}, // floating or scientific - shorter one
+		        {'a', 'A'}, // decimal floating point
+		        {'c', 'C'}, // character
+		};
+
+		return CompatiblePairs.contains({format_1, format_2}) ||
+		       CompatiblePairs.contains({format_2, format_1});
+	};
+
+	const auto index_limit = std::min(format_specifiers.size(),
+	                                  english.format_specifiers.size());
+
+	for (size_t i = 0; i < index_limit; ++i) {
+		const auto& specifier         = format_specifiers[i];
+		const auto& specifier_english = english.format_specifiers[i];
+
+		if (!are_compatible(specifier.format, specifier_english.format) ||
+		    (specifier.width == "*" && specifier_english.width != "*") ||
+		    (specifier.width != "*" && specifier_english.width == "*") ||
+		    (specifier.precision == "*" && specifier_english.precision != "*") ||
+		    (specifier.precision != "*" && specifier_english.precision == "*")) {
+			LOG_WARNING(
+			        "%s has format specifier '%s' "
+			        "incompatible with English counterpart '%s'",
+			        GetLogStart(name).c_str(),
+			        specifier.AsString().c_str(),
+			        specifier_english.AsString().c_str());
+			is_ok = false;
+			break;
+		}
+	}
 }
 
-bool MSG_Exists(const char *requested_name)
+void Message::VerifyEnglish(const std::string& name)
 {
-	return contains(messages, requested_name);
+	assert(is_english);
+	if (is_verified) {
+		return;
+	}
+
+	if (can_contain_format_string) {
+		VerifyFormatString(name);
+	}
+
+	VerifyMessage(name);
+	is_verified = true;
 }
 
-// Write the names and messages (in the order they were added) to the given location
-bool MSG_Write(const char * location) {
-	FILE *out = fopen(location, "w+t");
-	if (!out)
+void Message::VerifyTranslated(const std::string& name, const Message& english)
+{
+	assert(!is_english);
+	if (is_verified) {
+		return;
+	}
+
+	const auto is_english_valid = english.IsValid();
+
+	if (english.can_contain_format_string) {
+		VerifyFormatString(name);
+		if (is_english_valid) {
+			VerifyFormatStringAgainst(name, english);
+		}
+	}
+
+	VerifyMessage(name);
+	is_verified = is_english_valid;
+}
+
+std::string Message::FormatSpecifier::AsString() const
+{
+	std::string result = "%";
+
+	result += flags + width;
+	if (!precision.empty()) {
+		result += ".";
+		result += precision;
+	}
+	result += length;
+	if (format != '\0') {
+		result += format;
+	}
+
+	return result;
+}
+
+// ***************************************************************************
+// Internal implementation
+// ***************************************************************************
+
+static std::vector<std::string> message_order = {};
+
+static std::map<std::string, Message> dictionary_english    = {};
+static std::map<std::string, Message> dictionary_translated = {};
+static std::optional<Script> translation_script             = {};
+
+// Whether the translation is compatible with the current code page
+static bool is_code_page_compatible = true;
+
+static std::set<std::string> already_warned_not_found = {};
+
+// Metadata keys - for now only one is available, writing script type
+static const std::string KeyScript = "#SCRIPT ";
+
+// Check if currently set code page is compatible with the translation
+static void check_code_page()
+{
+	// Every DOS code page is suitable for displaying Latin script
+	if (!translation_script || *translation_script == Script::Latin) {
+		is_code_page_compatible = true;
+		return;
+	}
+
+	// Check if code page is known
+	const bool is_code_page_known = LocaleData::CodePageInfo.contains(
+	        dos.loaded_codepage);
+
+	// For known code pages check their compatibility
+	if (is_code_page_known) {
+		const auto code_page_script =
+		        LocaleData::CodePageInfo.at(dos.loaded_codepage).script;
+		if (*translation_script == code_page_script) {
+			is_code_page_compatible = true;
+			return;
+		}
+	}
+
+	// Code page is unknown or not compatible
+	is_code_page_compatible = false;
+
+	// Log a warning before exit
+	const auto& script_name = LocaleData::ScriptInfo.at(*translation_script).script_name;
+	LOG_WARNING(
+	        "LOCALE: Code page %d %s the '%s' script; "
+	        "using internal English language messages as a fallback",
+	        dos.loaded_codepage,
+	        is_code_page_known ? "does not support"
+	                           : "is unknown and can't be used with",
+	        script_name.c_str());
+	return;
+}
+
+static void add_message(const std::string& name, const std::string& message,
+                        const bool can_contain_format_string)
+{
+	if (dictionary_english.contains(name)) {
+		if (dictionary_english.at(name).GetRaw() != message) {
+			dictionary_english.at(name).MarkInvalid();
+			LOG_ERR("LOCALE: Duplicate text for '%s'", name.c_str());
+		}
+		return;
+	}
+
+	message_order.push_back(name);
+	dictionary_english.emplace(name, Message(message, can_contain_format_string));
+
+	auto& english = dictionary_english.at(name);
+	english.VerifyEnglish(name);
+	if (dictionary_translated.contains(name)) {
+		dictionary_translated.at(name).VerifyTranslated(name, english);
+	}
+}
+
+static const char* get_message(const std::string& name,
+                               const bool raw_requested        = false,
+                               const bool skip_code_page_check = false)
+{
+	// Check if message exists in English dictionary
+	if (!dictionary_english.contains(name)) {
+		if (!already_warned_not_found.contains(name)) {
+			LOG_WARNING("LOCALE: Message '%s' not found", name.c_str());
+			already_warned_not_found.insert(name);
+		}
+		return MsgNotFound.c_str();
+	}
+
+	// Try to return translated string, if possible
+	if ((is_code_page_compatible || skip_code_page_check) &&
+	    dictionary_translated.contains(name) &&
+	    dictionary_translated.at(name).IsValid()) {
+		if (raw_requested) {
+			return dictionary_translated.at(name).GetRaw().c_str();
+		} else {
+			return dictionary_translated.at(name).Get().c_str();
+		}
+	}
+
+	// Try to return the original, English string
+	if (!dictionary_english.at(name).IsValid()) {
+		return MsgNotValid.c_str();
+	}
+
+	if (raw_requested) {
+		return dictionary_english.at(name).GetRaw().c_str();
+	} else {
+		return dictionary_english.at(name).Get().c_str();
+	}
+}
+
+static void clear_translated_messages()
+{
+	dictionary_translated.clear();
+	translation_script = {};
+}
+
+static bool load_messages(const std_fs::path& file_name)
+{
+	if (file_name.empty()) {
 		return false;
+	}
 
-	for (const auto &name : messages_order)
-		fprintf(out, ":%s\n%s\n.\n", name.c_str(), messages.at(name).GetRaw());
+	if (!path_exists(file_name) || !is_readable(file_name)) {
+		return false;
+	}
 
-	fclose(out);
+	clear_translated_messages();
+
+	std::ifstream in_file(file_name);
+
+	std::string line = {};
+	int line_number  = -1;
+
+	auto problem_generic = [&](const std::string& error) {
+		LOG_ERR("LOCALE: Translation file error in line %d: %s",
+		        static_cast<int>(line_number),
+		        error.c_str());
+		clear_translated_messages();
+	};
+
+	auto problem_with_message = [&](const std::string& name,
+	                                const std::string& error) {
+		LOG_ERR("LOCALE: Translation file error in line %d, message '%s': %s",
+		        static_cast<int>(line_number),
+		        name.c_str(),
+		        error.c_str());
+		clear_translated_messages();
+	};
+
+	bool reading_metadata = true;
+	while (std::getline(in_file, line)) {
+		++line_number;
+		if (line.empty() || line.starts_with("//")) {
+			continue;
+		}
+
+		auto trimmed_line = line;
+		trim(trimmed_line);
+		if (trimmed_line.starts_with(KeyScript)) {
+			if (!reading_metadata) {
+				problem_generic("metadata not at the start of file");
+				return false;
+			}
+			if (translation_script) {
+				problem_generic("script already specified");
+				return false;
+			}
+			std::string value = trimmed_line.substr(KeyScript.length());
+			trim(value);
+			for (const auto& entry : LocaleData::ScriptInfo) {
+				if (iequals(value, entry.second.script_name)) {
+					translation_script = entry.first;
+					break;
+				}
+			}
+			if (!translation_script) {
+				problem_generic("unknown script");
+				return false;
+			}
+			continue;
+		}
+
+		reading_metadata = false;
+		if (!line.starts_with(':')) {
+			problem_generic("wrong syntax");
+			return false;
+		}
+
+		const std::string name = line.substr(1);
+
+		if (name.empty()) {
+			problem_generic("message name is empty");
+			return false;
+		}
+
+		std::string text = {};
+
+		bool is_text_terminated = false;
+		bool is_first_text_line = true;
+		while (std::getline(in_file, line)) {
+			++line_number;
+			if (line == ".") {
+				is_text_terminated = true;
+				break;
+			}
+
+			if (is_first_text_line) {
+				is_first_text_line = false;
+			} else {
+				text += "\n";
+			}
+
+			text += line;
+		}
+
+		if (!is_text_terminated) {
+			problem_with_message(name, "message text not terminated");
+			return false;
+		}
+
+		if (text.empty()) {
+			problem_with_message(name, "message text is empty");
+			return false;
+		}
+
+		if (dictionary_translated.contains(name)) {
+			problem_with_message(name, "duplicated message name");
+			return false;
+		}
+
+		dictionary_translated.emplace(name, Message(text));
+
+		auto& translated = dictionary_translated.at(name);
+		if (dictionary_english.contains(name)) {
+			translated.VerifyTranslated(name, dictionary_english.at(name));
+		}
+	}
+
+	++line_number;
+	if (in_file.bad()) {
+		problem_generic("I/O error");
+		return false;
+	} else if (dictionary_translated.empty()) {
+		problem_generic("file has no content");
+		return false;
+	}
+
+	if (!translation_script) {
+		LOG_WARNING("LOCALE: Translation file did not specify the language script");
+	}
+
+	if (dos.loaded_codepage) {
+		check_code_page();
+	}
+
 	return true;
+}
+
+static bool save_messages(const std_fs::path& file_name)
+{
+	if (file_name.empty()) {
+		return false;
+	}
+
+	std::ofstream out_file(file_name);
+
+	// Output help line
+	out_file << "// Writing script used in this translation, can be one of:\n";
+	out_file << "// ";
+	bool is_first_script = true;
+	for (const auto& entry : LocaleData::ScriptInfo) {
+		if (is_first_script) {
+			is_first_script = false;
+		} else {
+			out_file << ", ";
+		}
+		out_file << entry.second.script_name;
+	}
+	out_file << "\n";
+
+	// Output script definition
+	std::string script_name = {};
+	if (translation_script) {
+		// Saving translated messages, script is specified
+		assert(LocaleData::ScriptInfo.contains(*translation_script));
+		script_name = LocaleData::ScriptInfo.at(*translation_script).script_name;
+	} else {
+		// Saving English messages, script is always Latin
+		assert(LocaleData::ScriptInfo.contains(Script::Latin));
+		script_name = LocaleData::ScriptInfo.at(Script::Latin).script_name;
+	}
+	if (translation_script || dictionary_translated.empty()) {
+		out_file << KeyScript << script_name;
+	} else {
+		// Script was not specified in the input file
+		out_file << "// " << KeyScript << script_name;
+	}
+	out_file << "\n\n";
+
+	// Save all the messages, in the original order
+	for (const auto& name : message_order) {
+		if (out_file.fail()) {
+			break;
+		}
+
+		std::string text = {};
+		if (dictionary_translated.contains(name)) {
+			text = dictionary_translated.at(name).GetRaw();
+		} else {
+			assert(dictionary_english.contains(name));
+			text = dictionary_english.at(name).GetRaw();
+		}
+
+		out_file << ":" << name << "\n" << text << "\n.\n";
+	}
+
+	if (out_file.fail()) {
+		LOG_ERR("LOCALE: I/O error writing translation file");
+		return false;
+	}
+
+	return true;
+}
+
+// ***************************************************************************
+// External interface
+// ***************************************************************************
+
+void MSG_Add(const std::string& name, const std::string& message)
+{
+	constexpr bool CanContainFormatString = true;
+	add_message(name, message, CanContainFormatString);
+}
+
+void MSG_AddNoFormatString(const std::string& name, const std::string& message)
+{
+	constexpr bool CanContainFormatString = false;
+	add_message(name, message, CanContainFormatString);
+}
+
+const char* MSG_Get(const std::string& name)
+{
+	return get_message(name);
+}
+
+const char* MSG_GetRaw(const std::string& name)
+{
+	constexpr bool RawRequested = true;
+	return get_message(name, RawRequested);
+}
+
+const char* MSG_GetForHost(const std::string& name)
+{
+	constexpr bool RawRequested      = true;
+	constexpr bool SkipCodePageCheck = true;
+	return get_message(name, RawRequested, SkipCodePageCheck);
+}
+
+bool MSG_Exists(const std::string& name)
+{
+	return dictionary_english.contains(name);
+}
+
+bool MSG_WriteToFile(const std::string& file_name)
+{
+	return save_messages(file_name);
+}
+
+void MSG_NotifyNewCodePage()
+{
+	check_code_page();
 }
 
 // MSG_Init loads the requested language provided on the command line or
@@ -292,7 +839,7 @@ void MSG_Init([[maybe_unused]] Section_prop *section)
 			                              language_file + extension);
 		}
 
-		const auto result = load_message_file(file_path);
+		const auto result = load_messages(file_path);
 		if (!result) {
 			LOG_MSG("LOCALE: Could not load language file '%s', "
 			        "using internal English language messages",
@@ -333,7 +880,7 @@ void MSG_Init([[maybe_unused]] Section_prop *section)
 	// Try to load autodetected language
 	const auto file_extension = host_language.language_file + extension;
 	file_path = get_resource_path(subdirectory, file_extension);
-	const auto result = load_message_file(file_path);
+	const auto result = load_messages(file_path);
 
 	if (result) {
 		LOG_MSG("LOCALE: Loaded language file '%s' "

--- a/src/misc/messages_stubs.cpp
+++ b/src/misc/messages_stubs.cpp
@@ -1,7 +1,7 @@
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *
- *  Copyright (C) 2022-2022  The DOSBox Staging Team
+ *  Copyright (C) 2022-2024  The DOSBox Staging Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -21,24 +21,31 @@
 // Empty functions to suppress output in unit tests as well as a to eliminate
 // dependency-sprawl
 
-void MSG_Add(const char *, const char *) {}
+#include "messages.h"
 
-const char *MSG_Get(char const *)
+void MSG_Add(const std::string&, const std::string&) {}
+
+const char* MSG_Get(const std::string&)
 {
 	return "";
 }
 
-const char *MSG_GetRaw(char const *)
+const char* MSG_GetRaw(const std::string&)
 {
 	return "";
 }
 
-bool MSG_Exists(const char *)
+const char* MSG_GetForHost(const std::string&)
+{
+	return "";
+}
+
+bool MSG_Exists(const std::string&)
 {
 	return true;
 }
 
-bool MSG_Write(const char *)
+bool MSG_WriteToFile(const std::string&)
 {
 	return true;
 }

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -314,8 +314,6 @@ void Program::AddToHelpList()
 	}
 }
 
-bool MSG_Write(const char*);
-
 class CONFIG final : public Program {
 public:
 	CONFIG()
@@ -975,7 +973,7 @@ void CONFIG::Run(void)
 				return;
 			}
 
-			if (!MSG_Write(pvars[0].c_str())) {
+			if (!MSG_WriteToFile(pvars[0])) {
 				WriteOut(MSG_Get("PROGRAM_CONFIG_FILE_ERROR"),
 				         pvars[0].c_str());
 				return;

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -343,11 +343,11 @@ std::string Property::GetHelp() const
 	return result;
 }
 
-std::string Property::GetHelpUtf8() const
+std::string Property::GetHelpForHost() const
 {
 	std::string result = {};
 	if (MSG_Exists(create_config_name(propname).c_str())) {
-		std::string help_text = MSG_GetRaw(create_config_name(propname).c_str());
+		std::string help_text = MSG_GetForHost(create_config_name(propname));
 		// Fill in the default value if the help text contains '%s'.
 		if (help_text.find("%s") != std::string::npos) {
 			help_text = format_str(help_text,
@@ -357,9 +357,9 @@ std::string Property::GetHelpUtf8() const
 	}
 
 	const auto configitem_has_message = [this](const auto& val) {
-		return MSG_Exists(create_config_item_name(propname, val).c_str()) ||
+		return MSG_Exists(create_config_item_name(propname, val)) ||
 		       (iequals(val, propname) &&
-		        MSG_Exists(create_config_item_name(propname, {}).c_str()));
+		        MSG_Exists(create_config_item_name(propname, {})));
 	};
 	if (std::any_of(enabled_options.begin(),
 	                enabled_options.end(),
@@ -369,12 +369,12 @@ std::string Property::GetHelpUtf8() const
 				result.append("\n");
 			}
 			if (iequals(val, propname) &&
-			    MSG_Exists(create_config_item_name(propname, {}).c_str())) {
-				result.append(MSG_GetRaw(
-				        create_config_item_name(propname, {}).c_str()));
+			    MSG_Exists(create_config_item_name(propname, {}))) {
+				result.append(MSG_GetForHost(
+				        create_config_item_name(propname, {})));
 			} else {
-				result.append(MSG_GetRaw(
-				        create_config_item_name(propname, val).c_str()));
+				result.append(MSG_GetForHost(
+				        create_config_item_name(propname, val)));
 			}
 		}
 	}
@@ -1049,7 +1049,7 @@ bool Section_prop::HandleInputline(const std::string& line)
 		if (p->IsDeprecated()) {
 			LOG_WARNING("CONFIG: Deprecated option '%s'\n\n%s\n",
 			            name.c_str(),
-			            p->GetHelpUtf8().c_str());
+			            p->GetHelpForHost().c_str());
 
 			if (!p->IsDeprecatedButAllowed()) {
 				return false;
@@ -1128,7 +1128,7 @@ bool Config::WriteConfig(const std_fs::path& path) const
 	}
 
 	// Print start of config file and add a return to improve readibility
-	fprintf(outfile, MSG_GetRaw("CONFIGFILE_INTRO"), DOSBOX_VERSION);
+	fprintf(outfile, MSG_GetForHost("CONFIGFILE_INTRO"), DOSBOX_VERSION);
 	fprintf(outfile, "\n");
 
 	for (auto tel = sectionlist.cbegin(); tel != sectionlist.cend(); ++tel) {
@@ -1158,7 +1158,7 @@ bool Config::WriteConfig(const std_fs::path& path) const
 					continue;
 				}
 
-				auto help = p->GetHelpUtf8();
+				auto help = p->GetHelpForHost();
 
 				std::string::size_type pos = std::string::npos;
 
@@ -1188,7 +1188,7 @@ bool Config::WriteConfig(const std_fs::path& path) const
 					fprintf(outfile,
 					        "%s%s:",
 					        prefix,
-					        MSG_GetRaw(values_msg_key));
+					        MSG_GetForHost(values_msg_key));
 
 					std::vector<Value>::const_iterator it =
 					        values.begin();
@@ -1222,7 +1222,7 @@ bool Config::WriteConfig(const std_fs::path& path) const
 			upcase(temp);
 			strcat(temp, "_CONFIGFILE_HELP");
 
-			const char* helpstr   = MSG_GetRaw(temp);
+			const char* helpstr   = MSG_GetForHost(temp);
 			const char* linestart = helpstr;
 			char* helpwrite       = helpline;
 

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -277,7 +277,7 @@ static std::string create_config_name(const std::string& propname)
 
 void Property::Set_help(const std::string& in)
 {
-	MSG_Add(create_config_name(propname).c_str(), in.c_str());
+	MSG_Add(create_config_name(propname), in);
 }
 
 static std::string create_config_item_name(const std::string& propname,
@@ -293,19 +293,19 @@ static std::string create_config_item_name(const std::string& propname,
 
 void Property::SetOptionHelp(const std::string& option, const std::string& in)
 {
-	MSG_Add(create_config_item_name(propname, option).c_str(), in.c_str());
+	MSG_Add(create_config_item_name(propname, option), in);
 }
 
 void Property::SetOptionHelp(const std::string& in)
 {
-	MSG_Add(create_config_item_name(propname, {}).c_str(), in.c_str());
+	MSG_Add(create_config_item_name(propname, {}), in);
 }
 
 std::string Property::GetHelp() const
 {
 	std::string result = {};
-	if (MSG_Exists(create_config_name(propname).c_str())) {
-		std::string help_text = MSG_Get(create_config_name(propname).c_str());
+	if (MSG_Exists(create_config_name(propname))) {
+		std::string help_text = MSG_Get(create_config_name(propname));
 		// Fill in the default value if the help text contains '%s'.
 		if (help_text.find("%s") != std::string::npos) {
 			help_text = format_str(help_text,
@@ -315,9 +315,9 @@ std::string Property::GetHelp() const
 	}
 
 	const auto configitem_has_message = [this](const auto& val) {
-		return MSG_Exists(create_config_item_name(propname, val).c_str()) ||
+		return MSG_Exists(create_config_item_name(propname, val)) ||
 		       (iequals(val, propname) &&
-		        MSG_Exists(create_config_item_name(propname, {}).c_str()));
+		        MSG_Exists(create_config_item_name(propname, {})));
 	};
 	if (std::any_of(enabled_options.begin(),
 	                enabled_options.end(),
@@ -327,12 +327,12 @@ std::string Property::GetHelp() const
 				result.append("\n");
 			}
 			if (iequals(val, propname) &&
-			    MSG_Exists(create_config_item_name(propname, {}).c_str())) {
+			    MSG_Exists(create_config_item_name(propname, {}))) {
 				result.append(MSG_Get(
-				        create_config_item_name(propname, {}).c_str()));
+				        create_config_item_name(propname, {})));
 			} else {
 				result.append(MSG_Get(
-				        create_config_item_name(propname, val).c_str()));
+				        create_config_item_name(propname, val)));
 			}
 		}
 	}
@@ -346,7 +346,7 @@ std::string Property::GetHelp() const
 std::string Property::GetHelpForHost() const
 {
 	std::string result = {};
-	if (MSG_Exists(create_config_name(propname).c_str())) {
+	if (MSG_Exists(create_config_name(propname))) {
 		std::string help_text = MSG_GetForHost(create_config_name(propname));
 		// Fill in the default value if the help text contains '%s'.
 		if (help_text.find("%s") != std::string::npos) {

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -1927,6 +1927,7 @@ void Config::ParseArguments()
 	arguments.fullscreen  = cmdline->FindRemoveBoolArgument("fullscreen");
 	arguments.list_countries = cmdline->FindRemoveBoolArgument("list-countries");
 	arguments.list_layouts = cmdline->FindRemoveBoolArgument("list-layouts");
+	arguments.list_code_pages = cmdline->FindRemoveBoolArgument("list-code-pages");
 	arguments.list_glshaders = cmdline->FindRemoveBoolArgument("list-glshaders");
 	arguments.noconsole   = cmdline->FindRemoveBoolArgument("noconsole");
 	arguments.startmapper = cmdline->FindRemoveBoolArgument("startmapper");

--- a/src/misc/unicode.cpp
+++ b/src/misc/unicode.cpp
@@ -2241,6 +2241,20 @@ std::string uppercase_dos(const std::string& str, const uint16_t code_page)
 	return uppercase_dos_common(str, get_custom_code_page(code_page));
 }
 
+size_t length_utf8(const std::string& str)
+{
+	// TODO: Provide more efficient implementation;
+	// this will require UTF-8 decoder refactoring
+
+	constexpr uint16_t BasicCodePage = 437;
+
+	return utf8_to_dos(str,
+	                   DosStringConvertMode::NoSpecialCharacters,
+	                   UnicodeFallback::Simple,
+	                   BasicCodePage)
+	        .length();
+}
+
 bool is_code_page_equal(const uint16_t code_page1, const uint16_t code_page2)
 {
 	load_config_if_needed();

--- a/src/shell/autoexec.cpp
+++ b/src/shell/autoexec.cpp
@@ -96,7 +96,11 @@ static std::map<Placement, std::list<std::string>> autoexec_lines;
 // AUTOEXEC.BAT generation code
 // ***************************************************************************
 
-std::string create_autoexec_bat_utf8()
+// Warning: only execute this once, when the initial AUTOEXEC.BAT is being
+// created. Language might change at runtime, affecting the length of strings;
+// if this happens when executing the AUTOEXEC.BAT, changed offsets in the file
+// might confuse our COMMAND.COM, leading to errors in BAT file execution.
+static std::string create_autoexec_bat_utf8()
 {
 	std::string out;
 
@@ -138,10 +142,10 @@ std::string create_autoexec_bat_utf8()
 	// We want unprocessed UTF8 form of messages here (thus 'MSG_GetRaw'
 	// calls, not 'MSG_Get'), they will be converted to DOS code page later,
 	// together with the '[autoexec]' section content
-	static const std::string comment_start    = ":: ";
-	static const std::string header_generated = comment_start +
+	static const std::string comment_start = ":: ";
+	const std::string header_generated = comment_start +
 		MSG_GetRaw("AUTOEXEC_BAT_GENERATED");
-	static const std::string header_autoexec_section = comment_start +
+	const std::string header_autoexec_section = comment_start +
 		MSG_GetRaw("AUTOEXEC_BAT_CONFIG_SECTION");
 
 	// Put 'ECHO OFF' and 'SET variable=value' if needed

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -1305,28 +1305,27 @@ void SHELL_Init() {
 	        "Cannot move multiple files to a single file.\n");
 	MSG_Add("SHELL_CMD_FOR_HELP",
 	        "Run a specified command for each string in a set.\n");
-	MSG_Add("SHELL_CMD_FOR_HELP_LONG",
-		"Usage:\n"
-		"  [color=light-green]for[reset] [color=white]%VAR[reset] [color=light-cyan]in[reset] [color=white](SET)[reset] [color=light-cyan]do[reset] [color=white]COMMAND[reset]\n"
-		"\n"
-		"Parameters:\n"
-		"  [color=white]%VAR[reset]     single character representing a variable, prefixed by a '%'\n"
-		"  [color=light-cyan]in[reset]       case-insensitive keyword\n"
-		"  [color=white](SET)[reset]    set of strings to replace [color=white]%VAR[reset] instances in [color=white]COMMAND[reset]\n"
-		"  [color=light-cyan]do[reset]       case-insensitive keyword\n"
-		"  [color=white]COMMAND[reset]  command to repeat for each string in [color=white](SET)[reset]\n"
-		"\n"
-		"Notes:\n"
-		"  - In batch files, [color=white]%VAR[reset] must be written as [color=white]%%VAR[reset] (two percent signs) instead.\n"
-		"  - Strings in [color=white](SET)[reset] may be separated by any valid DOS separator.\n"
-		"  - Any string in [color=white](SET)[reset] containing wildcards (* or ?) will expand to\n" 
-		"    the set of matching files in the current directory.\n"
-		"  - Using another [color=light-green]for[reset] command as [color=white]COMMAND[reset] is not permitted.\n"
-		"\n"
-		"Examples:\n"
-		"  [color=light-green]for[reset] [color=white]%C[reset] [color=light-cyan]in[reset] [color=white](ONE TWO)[reset] [color=light-cyan]do[reset] [color=white]MKDIR[reset] [color=white]%C[reset]\n"
-		"  [color=light-green]for[reset] [color=white]%D[reset] [color=light-cyan]in[reset] [color=white](*.TXT)[reset] [color=light-cyan]do[reset] [color=white]ECHO[reset] [color=white]%D[reset]\n"
-	);
+	MSG_AddNoFormatString("SHELL_CMD_FOR_HELP_LONG",
+	        "Usage:\n"
+	        "  [color=light-green]for[reset] [color=white]%VAR[reset] [color=light-cyan]in[reset] [color=white](SET)[reset] [color=light-cyan]do[reset] [color=white]COMMAND[reset]\n"
+	        "\n"
+	        "Parameters:\n"
+	        "  [color=white]%VAR[reset]     single character representing a variable, prefixed by a '%'\n"
+	        "  [color=light-cyan]in[reset]       case-insensitive keyword\n"
+	        "  [color=white](SET)[reset]    set of strings to replace [color=white]%VAR[reset] instances in [color=white]COMMAND[reset]\n"
+	        "  [color=light-cyan]do[reset]       case-insensitive keyword\n"
+	        "  [color=white]COMMAND[reset]  command to repeat for each string in [color=white](SET)[reset]\n"
+	        "\n"
+	        "Notes:\n"
+	        "  - In batch files, [color=white]%VAR[reset] must be written as [color=white]%%VAR[reset] (two percent signs) instead.\n"
+	        "  - Strings in [color=white](SET)[reset] may be separated by any valid DOS separator.\n"
+	        "  - Any string in [color=white](SET)[reset] containing wildcards (* or ?) will expand to\n"
+	        "    the set of matching files in the current directory.\n"
+	        "  - Using another [color=light-green]for[reset] command as [color=white]COMMAND[reset] is not permitted.\n"
+	        "\n"
+	        "Examples:\n"
+	        "  [color=light-green]for[reset] [color=white]%C[reset] [color=light-cyan]in[reset] [color=white](ONE TWO)[reset] [color=light-cyan]do[reset] [color=white]MKDIR[reset] [color=white]%C[reset]\n"
+	        "  [color=light-green]for[reset] [color=white]%D[reset] [color=light-cyan]in[reset] [color=white](*.TXT)[reset] [color=light-cyan]do[reset] [color=white]ECHO[reset] [color=white]%D[reset]\n");
 
 	/* Ensure help categories are loaded into the message vector */
 	HELP_AddMessages();

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -227,10 +227,10 @@ bool DOS_Shell::WriteHelp(const std::string &command, char *args) {
 
 	MoreOutputStrings output(*this);
 	std::string short_key("SHELL_CMD_" + command + "_HELP");
-	output.AddString("%s\n", MSG_Get(short_key.c_str()));
+	output.AddString("%s\n", MSG_Get(short_key));
 	std::string long_key("SHELL_CMD_" + command + "_HELP_LONG");
-	if (MSG_Exists(long_key.c_str()))
-		output.AddString("%s", MSG_Get(long_key.c_str()));
+	if (MSG_Exists(long_key))
+		output.AddString("%s", MSG_Get(long_key));
 	else
 		output.AddString("%s\n", command.c_str());
 	output.Display();

--- a/vs/dosbox.vcxproj
+++ b/vs/dosbox.vcxproj
@@ -938,6 +938,7 @@ IF %ERRORLEVEL% LSS 8 SET ERRORLEVEL = 0</Command>
     <ClInclude Include="..\include\mem.h" />
     <ClInclude Include="..\include\mem_host.h" />
     <ClInclude Include="..\include\mem_unaligned.h" />
+    <ClInclude Include="..\include\messages.h" />
     <ClInclude Include="..\include\midi.h" />
     <ClInclude Include="..\include\mixer.h" />
     <ClInclude Include="..\include\mmx.h" />

--- a/vs/dosbox.vcxproj.filters
+++ b/vs/dosbox.vcxproj.filters
@@ -1023,6 +1023,9 @@
     <ClInclude Include="..\include\mem_unaligned.h">
       <Filter>include</Filter>
     </ClInclude>
+    <ClInclude Include="..\include\messages.h">
+      <Filter>include</Filter>
+    </ClInclude>
     <ClInclude Include="..\include\midi.h">
       <Filter>include</Filter>
     </ClInclude>


### PR DESCRIPTION
# Description

Rewritten translated messages handling; now has a format string sanitizer (already used by me to create PR https://github.com/dosbox-staging/dosbox-staging/pull/3964) to prevent crashes due to outdated translations, `MSG_*` functions now take `std::string` arguments, plus there are several user-visible improvements listed in the proposed _Release notes_.

Limitation: the translation fallback to English (when the code page does not provide needed Cyrillic / Greek / etc. script) does not work in the generated `Z:\AUTOEXEC.BAT` - we can't risk string length changes when it s being executed. Maybe I'll work it around at some point, but I don't want to do this now.

BTW. The rework in `messages.cpp`  is a precondition for switching translations at runtime.


## Related issues

Fixes https://github.com/dosbox-staging/dosbox-staging/issues/3498 (together with previous localisation PRs)


# Release notes

- Added `--list-code-pages` command line option, to list all the available code pages with a brief description.
- The `KEYB` command output is now event more informative, it now prints code page description.
- Non-Latin translations are only used for DOS messages if the selected code page supports the given script; otherwise DOSBox reverts to English messages,


# Manual testing

- start DOSBox with `language = fr` setting - it will display some warnings about several translated messages not matching the English strings regarding the format strings (`fr` and `ru` translations weren't updated since a long time...) - 'time /?' command will now print a partially translated help string, as the non-matching translated string will be rejected by the format string sanitizer
- start DOSBox with `--list-code-pages` command line argument - it should display information about all the bundled code pages
- withing DOSBox try commands `keyb pl`, `keyb us 113`, etc. - command should now display code page descriptions

For testing modified language handling, I suggest to use this dummy Greek translation - rename it to `gr-dummy.lng`, put into the build directory where other `*.lng` files are stored, and set `language = gr-dummy` in the config file:

[gr-dummy.txt](https://github.com/user-attachments/files/17951748/gr-dummy.txt)

When you use this dummy language:
- strings in the titlebar (`cycles/ms`, etc.) should be replaced with some dummy Greek letters, all the time
- `dosbox --list-code-pages`, `dosbox --list-layouts` and `dosbox --list-countries` commands will display Greek letters from the dummy translation file no matter what you put into `keyboard_layout` config option (BTW, Greek keyboard layout is `gk`, `gk220`, or `gk459`)
- inside DOSBox, you can select a Greek code page (`keyb us 869` will do so without setting the non-standard keyboard layout, `keyb us` restores a Latin-only code page) - an illegal command error (just type something dummy in the command prompt) prints out some Greek letters if and only if a Greek code page is set
- similarly, `keyb /list` prints out some Greek letters at the start of the message if and only if a Greek code page is set
- each time you select a non-Greek code page, a warning should be logged


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [x] provided the release notes draft (for significant user-facing changes).
- [x] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [x] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

