### PR TITLE
Add non-blocking disk access delays for IO operations

### DIFF
--- a/include/dos_inc.h
+++ b/include/dos_inc.h
@@ -254,6 +254,7 @@ uint8_t DOS_FindDevice(const char* name);
 void DOS_SetupDevices();
 void DOS_ClearDrivesAndFiles();
 void DOS_ShutDownDevices();
+void DOS_SetDiskAccessDelay(const bool use_disk_access_delay);
 
 /* Execute and new process creation */
 bool DOS_NewPSP(uint16_t pspseg,uint16_t size);

--- a/src/dos/cdrom.h
+++ b/src/dos/cdrom.h
@@ -120,9 +120,6 @@ public:
 	virtual void InitNewMedia       () {}
 	virtual bool HasDataTrack       () const = 0;
 	virtual bool HasFullMscdexSupport() = 0;
-
-protected:
-	void LagDriveResponse() const;
 };
 
 namespace CDROM {

--- a/src/dos/dos_devices.cpp
+++ b/src/dos/dos_devices.cpp
@@ -129,6 +129,8 @@ bool DOS_ExtDevice::WriteToControlChannel(PhysPt bufptr, uint16_t size, uint16_t
 
 bool DOS_ExtDevice::Read(uint8_t *data, uint16_t *size)
 {
+	DiskAccessDelayGuard disk_access_delay = {};
+
 	PhysPt bufptr = (dos.dcp << 4) | 32;
 	for (uint16_t no = 0; no < *size; no++) {
 		// INPUT
@@ -140,12 +142,16 @@ bool DOS_ExtDevice::Read(uint8_t *data, uint16_t *size)
 			}
 			*data++ = mem_readb(bufptr);
 		}
+
+		disk_access_delay.AddBytesRead();
 	}
 	return true;
 }
 
 bool DOS_ExtDevice::Write(uint8_t *data, uint16_t *size)
 {
+	DiskAccessDelayGuard disk_access_delay = {};
+
 	PhysPt bufptr = (dos.dcp << 4) | 32;
 	for (uint16_t no = 0; no < *size; no++) {
 		mem_writeb(bufptr, *data);
@@ -158,6 +164,8 @@ bool DOS_ExtDevice::Write(uint8_t *data, uint16_t *size)
 			}
 		}
 		data++;
+
+		disk_access_delay.AddBytesWritten();
 	}
 	return true;
 }

--- a/src/dos/program_imgmount.cpp
+++ b/src/dos/program_imgmount.cpp
@@ -547,6 +547,9 @@ void IMGMOUNT::Run(void)
 				IDE_CDROM_Attach(ide_index,
 				                 is_second_cable_slot,
 				                 drive_index(drive));
+
+				LOG_MSG("IDE: Using IDE controller IO timing instead of disk access delays");
+				DOS_SetDiskAccessDelay(false);
 			} else {
 				WriteOut(MSG_Get(
 				        "PROGRAM_IMGMOUNT_IDE_CONTROLLERS_UNAVAILABLE"));

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -561,6 +561,8 @@ static void DOSBOX_RealInit(Section* sec)
 	}
 
 	VGA_SetRatePreference(section->Get_string("dos_rate"));
+
+	DOS_SetDiskAccessDelay(section->Get_bool("disk_access_delay"));
 }
 
 // Returns decimal seconds of elapsed uptime.
@@ -704,6 +706,17 @@ void DOSBOX_Init()
 	        "            500 to 5000 ns is the most useful range.\n"
 	        "Note: Only set this on a per-game basis when necessary as it slows down\n"
 	        "      the whole emulator.");
+
+	pbool = secprop->Add_bool("disk_access_delay", when_idle, false);
+	pbool->Set_help(
+	        "Emulate disk access delays ('off' by default).\n"
+	        "on:   Emulate disk access delays for floppy drives, hard drives, and CD-ROM\n"
+	        "      drives (default). This is preferable in cases were games crash or\n"
+	        "      misbehave if the disk access times are unrealistically fast (e.g.,\n"
+	        "      Deus, Ishar 3, Robinson's Requiem, Time Warriors, Chasm - The Rift,\n"
+	        "      Start Trek - A Final Unity, Emergency Room, etc.)\n"
+	        "off:  Disable disk access delay emulation. The only benefit to this is\n"
+	        "      this slightly faster install and load time.");
 
 	pstring = secprop->Add_string("dos_rate", when_idle, "default");
 	pstring->Set_help(

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -707,9 +707,9 @@ void DOSBOX_Init()
 	        "Note: Only set this on a per-game basis when necessary as it slows down\n"
 	        "      the whole emulator.");
 
-	pbool = secprop->Add_bool("disk_access_delay", when_idle, false);
+	pbool = secprop->Add_bool("disk_access_delay", when_idle, true);
 	pbool->Set_help(
-	        "Emulate disk access delays ('off' by default).\n"
+	        "Emulate disk access delays ('on' by default).\n"
 	        "on:   Emulate disk access delays for floppy drives, hard drives, and CD-ROM\n"
 	        "      drives (default). This is preferable in cases were games crash or\n"
 	        "      misbehave if the disk access times are unrealistically fast (e.g.,\n"


### PR DESCRIPTION
# Description

This adds realistic delays to `DOS_File` derived drive classes (virtual, local, ISO, FAT, device, and CDROM) read, write, seek, and close file operations.

It fixes DOS games that either directly measure IO call timing (and then get divide by zero errors using the results), or have logic that's sensitive to nearly instant IO call timing.

It uses a disk access delay guard object to keep delay functionality in one place. The guard aspect means the work is performed when it goes out of scope. This makes it easy to accumulate 'work' in large functions that have many exit points, without having to add code at each exit point.

Game benchmarks (FPS rates) are unaffected, however drive benchmarks are now much more realistic:

Hercules, early 80s:

![hercules-machine-IO-speeds](https://github.com/user-attachments/assets/5a5c612a-a80a-4b00-a7e5-503d34383421)

CGA/Tandy/PCjr, mid 80s:

![pcjr-cga-tandy-machine-IO-speeds](https://github.com/user-attachments/assets/43588ead-f7ec-4674-b6b8-e3576df4c678)

EGA, mid to late 80s:

![ega-machine-IO-speeds](https://github.com/user-attachments/assets/22b90aa5-0910-416e-9c7b-a57349d79124)

VGA, very late 80s and on:

![vga-machine-IO-speeds](https://github.com/user-attachments/assets/1db7f579-1d00-452a-a78e-7f48b4a8d5bb)

There's a conf option:

```ini
[dosbox]
disk_access_delay = bool (default false)
```

When disabled:

![media-delay-off-IO-speeds](https://github.com/user-attachments/assets/09154310-71e3-468d-90e2-a058b603e686)


## Related issues

Fixes #3512 **Silmarils games newer than 1994**, Deus (1996), Ishar 3 (1994), Robinson's Requiem (1994), and Time Warriors (1997)

Fixes **Chasm The Rift** audio track looping (replaces feature from #2622)

Fixes **Star Trek - A Final Unity (1995)** CDROM speed check [1](https://www.vogons.org/viewtopic.php?t=43375), [2](https://www.vogons.org/viewtopic.php?t=3763), [3](https://www.vogons.org/viewtopic.php?t=71955), [4](https://www.vogons.org/viewtopic.php?t=27182), [5](https://adventuregamers.com/archive/forums/hint-requests-technical-problems/16492-pissed-off-about-final-unity.html)

Fixes **Emergency Room (1995)** CDROM speed check [1](https://www.vogons.org/viewtopic.php?t=17726)

# Release notes

Mount drives can now have their access times realistically delayed. This fixes division by zero crashes in Deus (1996), Ishar 3 (1994), Robinson's Requiem (1994), and Time Warriors (1997) and fixes the CDROM speed checks in the Star Trek - A Final Unity (1995) and Emergency Room (1995) installers.

This can be enabled using the `disk_access_delay` setting either at runtime or in the conf file under the `[dosbox]` section.

# Manual testing

Tested many games from various eras (CGA, EGA, VGA),  tested drives mounted from local directoriy (`mount d cdrom/ -t iso`) and images (`imgmount ... `), also tested CDDA mounts from image and files. Tested benchmarks (FPS is unaffected and load times are still very fast), also tested Windows 3.1.

# Checklist


I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [x] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

