### PR TITLE
Ensure physical host buttons only perform one bound event

### DIFF
--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -1892,6 +1892,8 @@ public:
 		        defmod & MMOD1 ? " mod1" : "",
 		        defmod & MMOD2 ? " mod2" : "",
 		        defmod & MMOD3 ? " mod3" : "");
+
+		drop_other_bound_events(this);
 	}
 
 protected:


### PR DESCRIPTION
# Description

This PR makes sure that physical host buttons only trigger one logical event. 

For example, if you map the 'F10' key to the screenshot action, then this PR will knock out the 'F10' key's prior logical event of passing the 'F10' keystroke to the DOS program. So now the F10 key would only perform the screenshot action and the DOS program won't get an F10 keypress.

An amber warning in the mapper UI now informs the user when a physical event's prior logical event is dropped (see screenshot below).

This "displacement" also happens when event handlers are programmatically bound to physical buttons, like how the CGA composite code binds the F10, F11, and F12 physical keys to composite actions:

```
MAPPER: Host button 'F10' now performs 'hand_select' instead of 'key_f10'
MAPPER: Host button 'F11' now performs 'hand_incval' instead of 'key_f11'
MAPPER: Host button 'F12' now performs 'hand_cgacomp' instead of 'key_f12'
```

This fixes the problem in Carmen San Diego when switching to composite mode using the F12 also locked the game when it was simultaneously processing the F12 keystroke in the same moment as the video mode switch. 

## Related issues

Fixes #4051.

# Release notes

When using the mapper, only one logical event can be bound to a given physical host button.  For example, if you map the 'F10' key to the screenshot action, then the F10 key will now perform the screenshot action and the DOS program won't get an F10 keypress.

An amber warning in the mapper UI will inform you when a prior logical event is dropped:

![remap-in-ui](https://github.com/user-attachments/assets/6a18676e-c945-4f65-8326-7a5f46a0093a)

When booting with `machine = cga`, this change prevents the 1986 edition of Where in the World is Carmen San Diego from locking up when switching to composite video using the F12 key.

# Manual testing

- Tested mapping multiple (unique) physical host buttons to a single logical events (works).
- Tested mapping the same physical host button to multiple logical events (no longer allowed; prior events are dropped).
- Tested and confirmed that with a default configuration and mapping, Carmen San Diego now can switch to composite mode using F12.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [x] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

