### PR TITLE
Keyboard layout autodetection fixes/improvements

### DIFF
--- a/src/dos/dos_locale.cpp
+++ b/src/dos/dos_locale.cpp
@@ -1346,7 +1346,7 @@ static void sort_detected_keyboard_layouts(
 
 static std::vector<KeyboardLayoutMaybeCodepage> get_detected_keyboard_layouts()
 {
-	const auto &host_locale = GetHostLocale();
+	const auto& host_locale = GetHostKeyboardLayouts();
 
 	auto keyboard_layouts = host_locale.keyboard_layout_list;
 
@@ -1402,10 +1402,11 @@ static void load_keyboard_layout()
 		}
 	}
 
-	const auto& host_locale = GetHostLocale();
-	if (using_detected && !host_locale.log_info.keyboard.empty()) {
+	if (using_detected) {
+		const auto& host_locale = GetHostKeyboardLayouts();
+		assert(!host_locale.log_info.empty());
 		LOG_MSG("LOCALE: Keyboard layout and code page detected from '%s'",
-		        host_locale.log_info.keyboard.c_str());
+		        host_locale.log_info.c_str());
 	}
 
 	// Apply the code page

--- a/src/dos/dos_locale.cpp
+++ b/src/dos/dos_locale.cpp
@@ -1357,16 +1357,16 @@ static void load_keyboard_layout()
 	bool using_detected     = false; // if layout list is autodetected
 	bool code_page_supplied = false; // if code page given in the parameter
 
-	if (config.keyboard_str.empty() || config.keyboard_str == "auto") {
+	if (config.keyboard_str == "auto") {
 		keyboard_layouts = get_detected_keyboard_layouts();
 		using_detected   = true;
 	} else {
 		const auto tokens = split(config.keyboard_str);
 		if (tokens.size() != 1 && tokens.size() != 2) {
-			keyboard_layouts = get_detected_keyboard_layouts();
-			using_detected   = true;
-			LOG_WARNING("LOCALE: Invalid 'keyboard_layout' setting '%s', using 'auto'",
+			LOG_WARNING("LOCALE: Invalid 'keyboard_layout' setting '%s', using 'us'",
 			            config.keyboard_str.c_str());
+			keyboard_layouts.push_back({"us"});
+			set_section_property_value("dos", "keyboard_layout", "us");
 		} else {
 			keyboard_layouts.push_back({tokens[0]});
 			if (tokens.size() >= 2) {

--- a/src/dos/dos_locale.cpp
+++ b/src/dos/dos_locale.cpp
@@ -1249,83 +1249,83 @@ static void sort_detected_keyboard_layouts(
 	        keyboard_layouts.begin(),
 	        keyboard_layouts.end(),
 	        [&](const auto& l, const auto& r) {
-		        // 'l' more preferable than 'r'    => return true
-		        // 'l' less preferable than 'r'    => return false
-		        // both layouts equally preferable => return false
-		        if (l == r) {
+			// 'l' more preferable than 'r'    => return true
+			// 'l' less preferable than 'r'    => return false
+			// both layouts equally preferable => return false
+			if (l == r) {
 			        return false;
-		        }
+			}
 
-		        // Prefer keyboard layouts containing a non-Latin script
-		        const bool l_has_non_latin = has_non_latin_script(l);
-		        const bool r_has_non_latin = has_non_latin_script(r);
-		        if (l_has_non_latin && !r_has_non_latin) {
-			        return true;
-		        } else if (!l_has_non_latin && r_has_non_latin) {
-			        return false;
-		        }
+			// Prefer keyboard layouts containing a non-Latin script
+			const bool l_has_non_latin = has_non_latin_script(l);
+			const bool r_has_non_latin = has_non_latin_script(r);
+			if (l_has_non_latin && !r_has_non_latin) {
+				return true;
+			} else if (!l_has_non_latin && r_has_non_latin) {
+				return false;
+			}
 
-		        // Prefer keyboard layouts containing a non-QWERTY-like
-		        // script
-		        const bool l_has_non_qwerty_like = has_non_qwerty_like_script(l);
-		        const bool r_has_non_qwerty_like = has_non_qwerty_like_script(r);
-		        if (l_has_non_qwerty_like && !r_has_non_qwerty_like) {
-			        return true;
-		        } else if (!l_has_non_qwerty_like && r_has_non_qwerty_like) {
-			        return false;
-		        }
+			// Prefer keyboard layouts containing a non-QWERTY-like
+			// script
+			const bool l_has_non_qwerty_like = has_non_qwerty_like_script(l);
+			const bool r_has_non_qwerty_like = has_non_qwerty_like_script(r);
+			if (l_has_non_qwerty_like && !r_has_non_qwerty_like) {
+				return true;
+			} else if (!l_has_non_qwerty_like && r_has_non_qwerty_like) {
+				return false;
+			}
 
-		        // Prefer keyboard layouts containing a non-QWERTY script
-		        const bool l_has_non_qwerty = has_non_qwerty_script(l);
-		        const bool r_has_non_qwerty = has_non_qwerty_script(r);
-		        if (l_has_non_qwerty && !r_has_non_qwerty) {
-			        return true;
-		        } else if (!l_has_non_qwerty && r_has_non_qwerty) {
-			        return false;
-		        }
+			// Prefer keyboard layouts containing a non-QWERTY script
+			const bool l_has_non_qwerty = has_non_qwerty_script(l);
+			const bool r_has_non_qwerty = has_non_qwerty_script(r);
+			if (l_has_non_qwerty && !r_has_non_qwerty) {
+				return true;
+			} else if (!l_has_non_qwerty && r_has_non_qwerty) {
+				return false;
+			}
 
-		        // Prefer keyboard layouts supporting more scripts
-		        const auto num_scripts_l = count_supported_scripts(l);
-		        const auto num_scripts_r = count_supported_scripts(r);
-		        if (num_scripts_l > num_scripts_r) {
-			        return true;
-		        } else if (num_scripts_l < num_scripts_r) {
-			        return false;
-		        }
+			// Prefer keyboard layouts supporting more scripts
+			const auto num_scripts_l = count_supported_scripts(l);
+			const auto num_scripts_r = count_supported_scripts(r);
+			if (num_scripts_l > num_scripts_r) {
+				return true;
+			} else if (num_scripts_l < num_scripts_r) {
+				return false;
+			}
 
-		        // Prefer layouts with non-default and non-standard code
-		        // page
-		        const bool l_has_code_page = l.code_page &&
-		                                     (*l.code_page != DefaultCodePage);
-		        const bool r_has_code_page = r.code_page &&
-		                                     (*r.code_page != DefaultCodePage);
-		        if (l_has_code_page && !r_has_code_page) {
-			        return true;
-		        } else if (!l_has_code_page && r_has_code_page) {
-			        return false;
-		        }
+			// Prefer layouts with non-default and non-standard code
+			// page
+			const bool l_has_code_page = l.code_page &&
+			                             (*l.code_page != DefaultCodePage);
+			const bool r_has_code_page = r.code_page &&
+			                             (*r.code_page != DefaultCodePage);
+			if (l_has_code_page && !r_has_code_page) {
+				return true;
+			} else if (!l_has_code_page && r_has_code_page) {
+				return false;
+			}
 
-		        // Prefer layouts which are not plain US ones
-		        const bool l_is_not_us = l.keyboard_layout != "us";
-		        const bool r_is_not_us = r.keyboard_layout != "us";
-		        if (l_is_not_us && !r_is_not_us) {
-			        return true;
-		        } else if (!l_is_not_us && r_is_not_us) {
-			        return false;
-		        }
+			// Prefer layouts which are not plain US ones
+			const bool l_is_not_us = l.keyboard_layout != "us";
+			const bool r_is_not_us = r.keyboard_layout != "us";
+			if (l_is_not_us && !r_is_not_us) {
+				return true;
+			} else if (!l_is_not_us && r_is_not_us) {
+				return false;
+			}
 
-		        // Prefer layouts which are not plain UK ones
-		        const bool l_is_not_uk = l.keyboard_layout != "uk";
-		        const bool r_is_not_uk = r.keyboard_layout != "uk";
-		        if (l_is_not_uk && !r_is_not_uk) {
-			        return true;
-		        } else if (!l_is_not_uk && r_is_not_uk) {
-			        return false;
-		        }
+			// Prefer layouts which are not plain UK ones
+			const bool l_is_not_uk = l.keyboard_layout != "uk";
+			const bool r_is_not_uk = r.keyboard_layout != "uk";
+			if (l_is_not_uk && !r_is_not_uk) {
+				return true;
+			} else if (!l_is_not_uk && r_is_not_uk) {
+				return false;
+			}
 
-		        // For now I have no sane idea for more criteria...
-		        return false;
-	        });
+			// For now I have no sane idea for more criteria...
+			return false;
+		});
 }
 
 static std::vector<KeyboardLayoutMaybeCodepage> get_detected_keyboard_layouts()

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -1218,13 +1218,14 @@ void DOSBOX_Init()
 	pstring = secprop->Add_string("keyboardlayout", deprecated, "");
 	pstring->Set_help("Renamed to 'keyboard_layout'.");
 
-	pstring = secprop->Add_string("keyboard_layout", only_at_start, "auto");
+	pstring = secprop->Add_string("keyboard_layout", only_at_start, "us");
 	pstring->Set_help(
-	        "Keyboard layout code ('auto' by default).\n"
+	        "Keyboard layout code ('us' by default).\n"
 	        "The list of supported keyboard layout codes can be displayed using the\n"
 	        "'--list-layouts' command-line argument, e.g., 'uk' is the British English\n"
 	        "layout. The layout can be followed by the code page number, e.g., 'uk 850'\n"
-	        "selects a Western-European screen font.\n"
+	        "selects a Western European screen font.\n"
+	        "Set to 'auto' to guess the values from the host OS settings.\n"
 	        "After startup, use the 'KEYB' command to manage keyboard layouts and code pages\n"
 	        "(run 'HELP KEYB' for details).");
 

--- a/src/misc/host_locale.h
+++ b/src/misc/host_locale.h
@@ -97,13 +97,6 @@ struct HostLocale {
 	// If the host OS support code cannot determine any of these values, it
 	// should leave them as default
 
-	// Keyboard layouts, optionally with code pages
-	std::vector<KeyboardLayoutMaybeCodepage> keyboard_layout_list = {};
-
-	// If the keyboard layouts list retrieved from the host OS is already
-	// sorted by user priority, set this to 'true'.
-	bool is_layout_list_sorted = false;
-
 	// DOS country code
 	std::optional<DosCountry> country = {};
 
@@ -115,14 +108,27 @@ struct HostLocale {
 
 	// If detection was successful, always provide info for the log output,
 	// telling which host OS property/value was used to determine the given
-	// locale. Feel free to provide it even if detection failed.
+	// locale.
 	struct {
-		std::string keyboard  = {};
 		std::string country   = {};
 		std::string numeric   = {};
 		std::string time_date = {};
 		std::string currency  = {};
 	} log_info = {};
+};
+
+struct HostKeyboardLayouts {
+	// Keyboard layouts, optionally with code pages
+	std::vector<KeyboardLayoutMaybeCodepage> keyboard_layout_list = {};
+
+	// If the keyboard layouts list retrieved from the host OS is already
+	// sorted by user priority, set this to 'true'.
+	bool is_layout_list_sorted = false;
+
+	// If detection was successful, always provide info for the log output,
+	// telling which host OS property/value was used to determine the
+	// language.
+	std::string log_info = {};
 };
 
 struct HostLanguage {
@@ -132,11 +138,12 @@ struct HostLanguage {
 
 	// If detection was successful, always provide info for the log output,
 	// telling which host OS property/value was used to determine the
-	// language. Feel free to provide it even if detection failed.
+	// language.
 	std::string log_info = {};
 };
 
-const HostLocale& GetHostLocale();
-const HostLanguage& GetHostLanguage();
+const HostLocale&          GetHostLocale();
+const HostKeyboardLayouts& GetHostKeyboardLayouts();
+const HostLanguage&        GetHostLanguage();
 
 #endif

--- a/src/misc/host_locale.h
+++ b/src/misc/host_locale.h
@@ -41,9 +41,17 @@ struct KeyboardLayoutMaybeCodepage {
 	// is a specific need to use a particular code page, set it here
 	std::optional<uint16_t> code_page = {};
 
+	// Set this if the host layout does not have a reasonable FreeDOS
+	// counterpart and the mapping is very poor/imprecise; this will lower
+	// the priority of this particular layout as much as possible
+	bool is_mapping_fuzzy = false;
+
 	bool operator==(const KeyboardLayoutMaybeCodepage& other) const
 	{
 		if (keyboard_layout != other.keyboard_layout) {
+			return false;
+		}
+		if (is_mapping_fuzzy != other.is_mapping_fuzzy) {
 			return false;
 		}
 		if (!code_page && !other.code_page) {
@@ -89,7 +97,12 @@ struct HostLocale {
 	// If the host OS support code cannot determine any of these values, it
 	// should leave them as default
 
+	// Keyboard layouts, optionally with code pages
 	std::vector<KeyboardLayoutMaybeCodepage> keyboard_layout_list = {};
+
+	// If the keyboard layouts list retrieved from the host OS is already
+	// sorted by user priority, set this to 'true'.
+	bool is_layout_list_sorted = false;
 
 	// DOS country code
 	std::optional<DosCountry> country = {};

--- a/src/misc/host_locale_macos.cpp
+++ b/src/misc/host_locale_macos.cpp
@@ -36,303 +36,306 @@ CHECK_NARROWING();
 // Detection data
 // ***************************************************************************
 
+// Constant to mark poor/imprecise keyboard layout mappings
+constexpr bool Fuzzy = true;
+
 // Mapping from Macintosh to DOS keyboard layout. Collected using:
 // 'System Settings' -> 'Keyboard' -> 'Text Input' -> 'Input Sources' settings
 // on macOS 'Sequoia' 15.1.1.
 // clang-format off
 static const std::unordered_map<int64_t, KeyboardLayoutMaybeCodepage> MacToDosKeyboard = {
 	// US (standard, QWERTY/national)
-	{  0,     { "us" }         }, // U. S.
-	{  15,    { "us" }         }, // Australian
-	{  29,    { "us" }         }, // Canadian
-	{  252,   { "us" }         }, // ABC
-	{ -1,     { "us" }         }, // Unicode Hex Input
-	{ -2,     { "us" }         }, // ABC - Extended
-	{ -3,     { "us" }         }, // ABC - India
-	{ -50,    { "us", 30021 }  }, // Hawaiian
-	{ -52,    { "us", 30021 }  }, // Samoan
-	{ -26112, { "us", 30034 }  }, // Cherokee - Nation
-	{ -26113, { "us", 30034 }  }, // Cherokee - QWERTY
+	{  0,     { "us" }             }, // U. S.
+	{  15,    { "us" }             }, // Australian
+	{  29,    { "us" }             }, // Canadian
+	{  252,   { "us" }             }, // ABC
+	{ -1,     { "us" }             }, // Unicode Hex Input
+	{ -2,     { "us" }             }, // ABC - Extended
+	{ -3,     { "us" }             }, // ABC - India
+	{ -50,    { "us", 30021 }      }, // Hawaiian
+	{ -52,    { "us", 30021 }      }, // Samoan
+	{ -26112, { "us", 30034 }      }, // Cherokee - Nation
+	{ -26113, { "us", 30034 }      }, // Cherokee - QWERTY
 	// US (international, QWERTY)
-	{  15000, { "ux" }         }, // U.S. International - PC
+	{  15000, { "ux" }             }, // U.S. International - PC
 	// US (Colemak)
-	{  12825, { "co" }         }, // Colemak
+	{  12825, { "co" }             }, // Colemak
 	// US (Dvorak)
-	{  16300, { "dv" }         }, // Dvorak
-	{  16301, { "dv" }         }, // Dvorak - QWERTY
+	{  16300, { "dv" }             }, // Dvorak
+	{  16301, { "dv" }             }, // Dvorak - QWERTY
 	// US (left-hand Dvorak)
-	{  16302, { "lh" }         }, // Dvorak Left-Handed
+	{  16302, { "lh" }             }, // Dvorak Left-Handed
 	// US (right-hand Dvorak)
-	{  16303, { "rh" }         }, // Dvorak Right-Handed
+	{  16303, { "rh" }             }, // Dvorak Right-Handed
 	// UK (standard, QWERTY)
-	{  2,     { "uk" }         }, // British
-	{  50,    { "uk" }         }, // Irish
-	{ -500,   { "uk" }         }, // Irish - Extended
-	{ -790,   { "uk", 30001 }  }, // Welsh
+	{  2,     { "uk" }             }, // British
+	{  50,    { "uk" }             }, // Irish
+	{ -500,   { "uk" }             }, // Irish - Extended
+	{ -790,   { "uk", 30001 }      }, // Welsh
 	// UK (alternate, QWERTY)
-	{  250,   { "uk168" }      }, // British - PC
+	{  250,   { "uk168" }          }, // British - PC
 	// Arabic (AZERTY/Arabic)
-	{ -17920, { "ar462" }      }, // Arabic
-	{ -17923, { "ar462" }      }, // Arabic - 123
-	{ -17940, { "ar462" }      }, // Arabic - AZERTY
-	{ -17921, { "ar462" }      }, // Arabic - PC
-	{ -2902,  { "ar462" }      }, // Afghan Dari
-	{ -2904,  { "ar462" }      }, // Afghan Pashto
-	{ -2903,  { "ar462" }      }, // Afghan Uzbek
-	{ -17960, { "ar462" }      }, // Persian - Legacy
-	{ -2901,  { "ar462" }      }, // Persian - Standard
-	{ -31486, { "ar462" }      }, // Syriac - Arabic
+	{ -17920, { "ar462" }          }, // Arabic
+	{ -17923, { "ar462" }          }, // Arabic - 123
+	{ -17940, { "ar462" }          }, // Arabic - AZERTY
+	{ -17921, { "ar462" }          }, // Arabic - PC
+	{ -2902,  { "ar462" }          }, // Afghan Dari
+	{ -2904,  { "ar462" }          }, // Afghan Pashto
+	{ -2903,  { "ar462" }          }, // Afghan Uzbek
+	{ -17960, { "ar462" }          }, // Persian - Legacy
+	{ -2901,  { "ar462" }          }, // Persian - Standard
+	{ -31486, { "ar462" }          }, // Syriac - Arabic
 	// Arabic (QWERTY/Arabic)
-	{ -18000, { "ar470" }      }, // Arabic - QWERTY
-	{ -19000, { "ar470" }      }, // Jawi
-	{ -1959,  { "ar470" }      }, // Persian - QWERTY
-	{ -22374, { "ar470" }      }, // Sindhi
-	{ -17926, { "ar470" }      }, // Sorani Kurdish
-	{ -30291, { "ar470" }      }, // Syriac - QWERTY
-	{ -27000, { "ar470" }      }, // Uyghur
+	{ -18000, { "ar470" }          }, // Arabic - QWERTY
+	{ -19000, { "ar470" }          }, // Jawi
+	{ -1959,  { "ar470" }          }, // Persian - QWERTY
+	{ -22374, { "ar470" }          }, // Sindhi
+	{ -17926, { "ar470" }          }, // Sorani Kurdish
+	{ -30291, { "ar470" }          }, // Syriac - QWERTY
+	{ -27000, { "ar470" }          }, // Uyghur
 	// Azeri (QWERTY/Cyrillic)"
-	{ -49,    { "az" }         }, // Azeri
+	{ -49,    { "az" }             }, // Azeri
 	// Belgian (AZERTY)
-	{  6,     { "be" }         }, // Belgian
+	{  6,     { "be" }             }, // Belgian
 	// Bulgarian (QWERTY/national)
-	{  19528, { "bg" }         }, // Bulgarian - Standard
+	{  19528, { "bg" }             }, // Bulgarian - Standard
 	// Bulgarian (QWERTY/phonetic)
-	{  19529, { "bg103" }      }, // Bulgarian - QWERTY
+	{  19529, { "bg103" }          }, // Bulgarian - QWERTY
 	// Brazilian (ABNT layout, QWERTY)
-	{  128,   { "br" }         }, // Brazilian - ABNT2
+	{  128,   { "br" }             }, // Brazilian - ABNT2
 	// Brazilian (US layout, QWERTY)
-	{  72,    { "br274" }      }, // Brazilian
-	{  71,    { "br274" }      }, // Brazilian - Legacy
+	{  72,    { "br274" }          }, // Brazilian
+	{  71,    { "br274" }          }, // Brazilian - Legacy
 	// Belarusian (QWERTY/national)
-	{  19517, { "by" }         }, // Belarusian
+	{  19517, { "by" }             }, // Belarusian
 	// Canadian (standard, QWERTY)
-	{ -19336, { "cf" }         }, // Canadian - PC
+	{ -19336, { "cf" }             }, // Canadian - PC
 	// Canadian (dual-layer, QWERTY)
-	{  80,    { "cf445" }      }, // Canadian - CSA
+	{  80,    { "cf445" }          }, // Canadian - CSA
 	// Czech (QWERTZ)
-	{ -14193, { "cz" }         }, // Czech
+	{ -14193, { "cz" }             }, // Czech
 	// Czech (programmers, QWERTY)
-	{  30778, { "cz489" }      }, // Czech - QWERTY
-	{  30779, { "cz489" }      }, // Slovak - QWERTY
+	{  30778, { "cz489" }          }, // Czech - QWERTY
+	{  30779, { "cz489" }          }, // Slovak - QWERTY
 	// German (standard, QWERTZ)
-	{  3,     { "de" }         }, // German
-	{ -18133, { "de" }         }, // German - Standard
-	{  92,    { "de" }         }, // Austrian
-	{  253,   { "de", 437 }    }, // ABC - QWERTZ
+	{  3,     { "de" }             }, // German
+	{ -18133, { "de" }             }, // German - Standard
+	{  92,    { "de" }             }, // Austrian
+	{  253,   { "de", 437 }        }, // ABC - QWERTZ
 	// Danish (QWERTY)
-	{  9,     { "dk" }         }, // Danish
+	{  9,     { "dk" }             }, // Danish
 	// Estonian (QWERTY)
-	{  30764, { "ee" }         }, // Estonian
+	{  30764, { "ee" }             }, // Estonian
 	// Spanish (QWERTY)
-	{  87,    { "es" }         }, // Spanish
-	{  8,     { "es" }         }, // Spanish - Legacy
+	{  87,    { "es" }             }, // Spanish
+	{  8,     { "es" }             }, // Spanish - Legacy
 	// Finnish (QWERTY/ASERTT)
-	{  17,    { "fi" }         }, // Finnish
-	{ -17,    { "fi" }         }, // Finnish - Extended
-	{ -18,    { "fi", 30000 }  }, // Finnish Sámi - PC
-	{ -1202,  { "fi", 30000 }  }, // Inari Sámi
-	{ -1206,  { "fi", 30000 }  }, // Skolt Sámi
+	{  17,    { "fi" }             }, // Finnish
+	{ -17,    { "fi" }             }, // Finnish - Extended
+	{ -18,    { "fi", 30000 }      }, // Finnish Sámi - PC
+	{ -1202,  { "fi", 30000 }      }, // Inari Sámi
+	{ -1206,  { "fi", 30000 }      }, // Skolt Sámi
 	// Faroese (QWERTY)
-	{ -47,    { "fo" }         }, // Faroese
+	{ -47,    { "fo" }             }, // Faroese
 	// French (standard, AZERTY)
-	{  1,     { "fr" }         }, // French
-	{  60,    { "fr" }         }, // French - PC
-	{  1111,  { "fr" }         }, // French - Numerical
-	{  251,   { "fr", 437 }    }, // ABC - AZERTY
+	{  1,     { "fr" }             }, // French
+	{  60,    { "fr" }             }, // French - PC
+	{  1111,  { "fr" }             }, // French - Numerical
+	{  251,   { "fr", 437 }        }, // ABC - AZERTY
 	// French (international, AZERTY)
 	// TODO: Is 30024 or 30025 a better one for the ADLaM/Wolof languages?
-	{ -29472, { "fx", 30025 }  }, // Adlam
+	{ -29472, { "fx", 30025 }      }, // Adlam
 	// Greek (459, non-standard/national)
-	{ -18944, { "gk459" }      }, // Greek
-	{ -18945, { "gk459" }      }, // Greek Polytonic
+	{ -18944, { "gk459" }          }, // Greek
+	{ -18945, { "gk459" }          }, // Greek Polytonic
 	// Croatian (QWERTZ/national)
-	{ -69,    { "hr" }         }, // Croatian - QWERTZ
+	{ -69,    { "hr" }             }, // Croatian - QWERTZ
 	// Hungarian (101-key, QWERTY)
-	{  30767, { "hu" }         }, // Hungarian - QWERTY
+	{  30767, { "hu" }             }, // Hungarian - QWERTY
 	// Hungarian (102-key, QWERTZ)
-	{  30763, { "hu208" }      }, // Hungarian
+	{  30763, { "hu208" }          }, // Hungarian
 	// Armenian (QWERTY/national)
-	{ -28161, { "hy" }         }, // Armenian - HM QWERTY
-	{ -28164, { "hy" }         }, // Armenian - Western QWERTY
+	{ -28161, { "hy" }             }, // Armenian - HM QWERTY
+	{ -28164, { "hy" }             }, // Armenian - Western QWERTY
 	// Hebrew (QWERTY/national)
-	{ -18432, { "il" }         }, // Hebrew
-	{ -18433, { "il" }         }, // Hebrew - PC
-	{ -18500, { "il" }         }, // Hebrew - QWERTY
-	{ -18501, { "il" }         }, // Yiddish - QWERTY
+	{ -18432, { "il" }             }, // Hebrew
+	{ -18433, { "il" }             }, // Hebrew - PC
+	{ -18500, { "il" }             }, // Hebrew - QWERTY
+	{ -18501, { "il" }             }, // Yiddish - QWERTY
 	// Icelandic (101-key, QWERTY)
-	{ -21,    { "is" }         }, // Icelandic
+	{ -21,    { "is" }             }, // Icelandic
 	// Italian (standard, QWERTY/national)
-	{  223,   { "it" }         }, // Italian
+	{  223,   { "it" }             }, // Italian
 	// Georgian (QWERTY/national)
-	{ -27650, { "ka" }         }, // Georgian - QWERTY
+	{ -27650, { "ka" }             }, // Georgian - QWERTY
 	// Kazakh (476, QWERTY/national)
-	{ -19501, { "kk476" }      }, // Kazakh
+	{ -19501, { "kk476" }          }, // Kazakh
 	// Kyrgyz (QWERTY/national)
-	{  19459, { "ky" }         }, // Kyrgyz
+	{  19459, { "ky" }             }, // Kyrgyz
 	// Latin American (QWERTY)
-	{  89,    { "la" }         }, // Latin American
+	{  89,    { "la" }             }, // Latin American
 	// Lithuanian (Baltic, QWERTY/phonetic)
-	{  30761, { "lt" }         }, // Lithuanian
+	{  30761, { "lt" }             }, // Lithuanian
 	// Latvian (standard, QWERTY/phonetic)
-	{  30765, { "lv" }         }, // Latvian
+	{  30765, { "lv" }             }, // Latvian
 	// Macedonian (QWERTZ/national)
-	{  19523, { "mk" }         }, // Macedonian
+	{  19523, { "mk" }             }, // Macedonian
 	// Mongolian (QWERTY/national)
-	{ -2276,  { "mn" }         }, // Mongolian
+	{ -2276,  { "mn" }             }, // Mongolian
 	// Maltese (UK layout, QWERTY)
-	{ -501,   { "mt" }         }, // Maltese
+	{ -501,   { "mt" }             }, // Maltese
 	// Nigerian (QWERTY)
-	{ -2461,  { "ng" }         }, // Hausa
-	{ -32355, { "ng" }         }, // Igbo
-	{ -32377, { "ng" }         }, // Yoruba
+	{ -2461,  { "ng" }             }, // Hausa
+	{ -32355, { "ng" }             }, // Igbo
+	{ -32377, { "ng" }             }, // Yoruba
 	// Dutch (QWERTY)
-	{  26,    { "nl" }         }, // Dutch
+	{  26,    { "nl" }             }, // Dutch
 	// Norwegian (QWERTY/ASERTT)
-	{  12,    { "no" }         }, // Norwegian
-	{ -12,    { "no" }         }, // Norwegian - Extended
-	{ -1209,  { "no", 30000 }  }, // Lule Sámi (Norway)
-	{ -1200,  { "no", 30000 }  }, // North Sámi
-	{ -1201,  { "no", 30000 }  }, // North Sámi - PC
-	{ -13,    { "no", 30000 }  }, // Norwegian Sámi - PC
-	{ -1207,  { "no", 30000 }  }, // South Sámi
+	{  12,    { "no" }             }, // Norwegian
+	{ -12,    { "no" }             }, // Norwegian - Extended
+	{ -1209,  { "no", 30000 }      }, // Lule Sámi (Norway)
+	{ -1200,  { "no", 30000 }      }, // North Sámi
+	{ -1201,  { "no", 30000 }      }, // North Sámi - PC
+	{ -13,    { "no", 30000 }      }, // Norwegian Sámi - PC
+	{ -1207,  { "no", 30000 }      }, // South Sámi
 	// Polish (programmers, QWERTY/phonetic)
-	{  30788, { "pl" }         }, // Polish
+	{  30788, { "pl" }             }, // Polish
 	// Polish (typewriter, QWERTZ/phonetic)
-	{  30762, { "pl214" }      }, // Polish - QWERTZ
+	{  30762, { "pl214" }          }, // Polish - QWERTZ
 	// Portuguese (QWERTY)
-	{  10,    { "po" }         }, // Portuguese
+	{  10,    { "po" }             }, // Portuguese
 	// Romanian (QWERTY/phonetic)
-	{ -39,    { "ro446" }      }, // Romanian
-	{ -38,    { "ro446" }      }, // Romanian - Standard
+	{ -39,    { "ro446" }          }, // Romanian
+	{ -38,    { "ro446" }          }, // Romanian - Standard
 	// Russian (standard, QWERTY/national)
-	{  19456, { "ru" }         }, // Russian
-	{  19458, { "ru" }         }, // Russian - PC
-	{  19457, { "ru" }         }, // Russian - QWERTY
+	{  19456, { "ru" }             }, // Russian
+	{  19458, { "ru" }             }, // Russian - PC
+	{  19457, { "ru" }             }, // Russian - QWERTY
 	// Russian (extended standard, QWERTY/national)
-	{ -14457, { "rx", 30013 }  }, // Chuvash
-	{  23978, { "rx", 30011 }  }, // Ingush
-	{  19690, { "rx", 30017 }  }, // Kildin Sámi
+	{ -14457, { "rx", 30013 }      }, // Chuvash
+	{  23978, { "rx", 30011 }      }, // Ingush
+	{  19690, { "rx", 30017 }      }, // Kildin Sámi
 	// Swiss (German, QWERTZ)
-	{  19,    { "sd" }         }, // Swiss German
+	{  19,    { "sd" }             }, // Swiss German
 	// Swiss (French, QWERTZ)
-	{  18,    { "sf" }         }, // Swiss French
+	{  18,    { "sf" }             }, // Swiss French
 	// Slovak (QWERTZ)
-	{ -11013, { "sk" }         }, // Slovak
+	{ -11013, { "sk" }             }, // Slovak
 	// Albanian (deadkeys, QWERTZ)
-	{ -31882, { "sq448" }      }, // Albanian
+	{ -31882, { "sq448" }          }, // Albanian
 	// Swedish (QWERTY/ASERTT)
-	{  7,     { "sv" }         }, // Swedish
-	{  224,   { "sv" }         }, // Swedish - Legacy
-	{ -15,    { "sv", 30000 }  }, // Swedish Sámi - PC
-	{ -1203,  { "sv", 30000 }  }, // Lule Sámi (Sweden)
-	{ -1205,  { "sv", 30000 }  }, // Pite Sámi
-	{ -1208,  { "sv", 30000 }  }, // Ume Sámi
+	{  7,     { "sv" }             }, // Swedish
+	{  224,   { "sv" }             }, // Swedish - Legacy
+	{ -15,    { "sv", 30000 }      }, // Swedish Sámi - PC
+	{ -1203,  { "sv", 30000 }      }, // Lule Sámi (Sweden)
+	{ -1205,  { "sv", 30000 }      }, // Pite Sámi
+	{ -1208,  { "sv", 30000 }      }, // Ume Sámi
 	// Tajik (QWERTY/national)
-	{  19460, { "tj" }         }, // Tajik (Cyrillic)
+	{  19460, { "tj" }             }, // Tajik (Cyrillic)
 	// Turkmen (QWERTY/phonetic)
-	{  15228, { "tm" }         }, // Turkmen
+	{  15228, { "tm" }             }, // Turkmen
 	// Turkish (QWERTY)
-	{ -36,    { "tr" }         }, // Turkish Q
-	{ -35,    { "tr" }         }, // Turkish Q - Legacy
+	{ -36,    { "tr" }             }, // Turkish Q
+	{ -35,    { "tr" }             }, // Turkish Q - Legacy
 	// Turkish (non-standard)
-	{ -5482,  { "tr440" }      }, // Turkish F
-	{ -24,    { "tr440" }      }, // Turkish F - Legacy
+	{ -5482,  { "tr440" }          }, // Turkish F
+	{ -24,    { "tr440" }          }, // Turkish F - Legacy
 	// Ukrainian (101-key, QWERTY/national)
-	{ -2354,  { "ua" }         }, // Ukrainian
-	{  19518, { "ua" }         }, // Ukrainian - Legacy  
-	{ -23205, { "ua" }         }, // Ukrainian - QWERTY
+	{ -2354,  { "ua" }             }, // Ukrainian
+	{  19518, { "ua" }             }, // Ukrainian - Legacy  
+	{ -23205, { "ua" }             }, // Ukrainian - QWERTY
 	// Uzbek (QWERTY/national)
-	{  19461, { "uz" }         }, // Uzbek (Cyrillic)
+	{  19461, { "uz" }             }, // Uzbek (Cyrillic)
 	// Vietnamese (QWERTY)
-	{ -31232, { "vi" }         }, // Vietnamese
+	{ -31232, { "vi" }             }, // Vietnamese
 
 	// For some keyboard families we don't have code pages, but in the
 	// corresponding states the QWERTY layout is typically used
-	{ -32044, { "us" }         }, // Akan
-	{ -18940, { "us" }         }, // Apache
-	{ -14789, { "us" }         }, // Assamese - InScript
-	{ -22528, { "us" }         }, // Bangla - InScript 
-	{ -22529, { "us" }         }, // Bangla - QWERTY
-	{ -11396, { "us" }         }, // Bodo
-	{ -18438, { "us" }         }, // Chickasaw
-	{ -17340, { "us" }         }, // Choctaw
-	{ -20481, { "us" }         }, // Devanagari - QWERTY
-	{ -17410, { "us" }         }, // Dhivehi - QWERTY
-	{ -25281, { "us" }         }, // Dogri
-	{ -2728,  { "us" }         }, // Dzongkha
-	{ -27432, { "us" }         }, // Ge'ez
-	{ -21504, { "us" }         }, // Gujarati - InScript
-	{ -21505, { "us" }         }, // Gujarati - QWERTY
-	{ -20992, { "us" }         }, // Gurmukhi - InScript
-	{ -20993, { "us" }         }, // Gurmukhi - QWERTY
-	{ -27472, { "us" }         }, // Hanifi Rohingya
-	{ -20480, { "us" }         }, // Hindi - InScript
-	{ -20564, { "us" }         }, // Hmong (Pahawh)
-	{ -30606, { "us" }         }, // Inuktitut - Nattilik
-	{ -30602, { "us" }         }, // Inuktitut - Nutaaq
-	{ -30603, { "us" }         }, // Inuttitut - Nunavik
-	{ -30604, { "us" }         }, // Inuktitut - Nunavut
-	{ -30600, { "us" }         }, // Inuktitut - QWERTY
-	{  11538, { "us" }         }, // Kabyle - QWERTY
-	{ -24064, { "us" }         }, // Kannada - InScript
-	{ -24065, { "us" }         }, // Kannada - QWERTY
-	{ -22530, { "us" }         }, // Kashmiri (Devanagari)
-	{ -26114, { "us" }         }, // Khmer
-	{ -25282, { "us" }         }, // Konkani
-	{ -361,   { "us" }         }, // Kurmanji Kurdish
-	{ -26115, { "us" }         }, // Lao
-	{ -23562, { "us" }         }, // Lushootseed
-	{ -25283, { "us" }         }, // Maithili - InScript
-	{ -24576, { "us" }         }, // Malayalam - InScript
-	{ -24577, { "us" }         }, // Malayalam - QWERTY
-	{ -3047,  { "us" }         }, // Mandaic - Arabic
-	{ -17993, { "us" }         }, // Mandaic - QWERTY
-	{ -22532, { "us" }         }, // Manipuri (Bengali)
-	{ -22534, { "us" }         }, // Manipuri (Meetei Mayek)
-	{ -51,    { "us" }         }, // Māori - InScript
-	{ -25284, { "us" }         }, // Marathi
-	{ -13161, { "us" }         }, // Mi'kmaq
-	{ -23561, { "us" }         }, // Mvskoke
-	{ -25602, { "us" }         }, // Myanmar
-	{ -25601, { "us" }         }, // Myanmar - QWERTY
-	{ -25709, { "us" }         }, // N'Ko - QWERTY
-	{ -18939, { "us" }         }, // Navajo
-	{ -25286, { "us" }         }, // Nepali - InScript
-	{ -31135, { "us" }         }, // Nepali - Remington
-	{ -22016, { "us" }         }, // Odiya - InScript
-	{ -22017, { "us" }         }, // Odiya - QWERTY
-	{  38342, { "us" }         }, // Osage - QWERTY
-	{ -20563, { "us" }         }, // Rejang - QWERTY
-	{ -23064, { "us" }         }, // Sanskrit
-	{ -22538, { "us" }         }, // Santali (Devanagari) - InScript
-	{ -22536, { "us" }         }, // Santali - (Ol Chiki)
-	{ -16901, { "us" }         }, // Sindhi (Devanagari) - InScript
-	{ -25088, { "us" }         }, // Sinhala
-	{ -25089, { "us" }         }, // Sinhala - QWERTY
-	{ -23552, { "us" }         }, // Telugu - InScript
-	{ -23553, { "us" }         }, // Telugu - QWERTY
-	{ -26624, { "us" }         }, // Thai
-	{ -24616, { "us" }         }, // Thai - Pattachote
-	{ -26628, { "us" }         }, // Tibetan - Otani
-	{ -26625, { "us" }         }, // Tibetan - QWERTY
-	{ -2398,  { "us" }         }, // Tibetan - Wylie
-	{  88,    { "us" }         }, // Tongan
-	{ -17925, { "us" }         }, // Urdu
-	{ -23498, { "us" }         }, // Wancho - QWERTY
-	{  4300,  { "us" }         }, // Wolastoqey
+	{ -32044, { "us", {},  Fuzzy } }, // Akan
+	{ -18940, { "us", {},  Fuzzy } }, // Apache
+	{ -14789, { "us", {},  Fuzzy } }, // Assamese - InScript
+	{ -22528, { "us", {},  Fuzzy } }, // Bangla - InScript 
+	{ -22529, { "us", {},  Fuzzy } }, // Bangla - QWERTY
+	{ -11396, { "us", {},  Fuzzy } }, // Bodo
+	{ -18438, { "us", {},  Fuzzy } }, // Chickasaw
+	{ -17340, { "us", {},  Fuzzy } }, // Choctaw
+	{ -20481, { "us", {},  Fuzzy } }, // Devanagari - QWERTY
+	{ -17410, { "us", {},  Fuzzy } }, // Dhivehi - QWERTY
+	{ -25281, { "us", {},  Fuzzy } }, // Dogri
+	{ -2728,  { "us", {},  Fuzzy } }, // Dzongkha
+	{ -27432, { "us", {},  Fuzzy } }, // Ge'ez
+	{ -21504, { "us", {},  Fuzzy } }, // Gujarati - InScript
+	{ -21505, { "us", {},  Fuzzy } }, // Gujarati - QWERTY
+	{ -20992, { "us", {},  Fuzzy } }, // Gurmukhi - InScript
+	{ -20993, { "us", {},  Fuzzy } }, // Gurmukhi - QWERTY
+	{ -27472, { "us", {},  Fuzzy } }, // Hanifi Rohingya
+	{ -20480, { "us", {},  Fuzzy } }, // Hindi - InScript
+	{ -20564, { "us", {},  Fuzzy } }, // Hmong (Pahawh)
+	{ -30606, { "us", {},  Fuzzy } }, // Inuktitut - Nattilik
+	{ -30602, { "us", {},  Fuzzy } }, // Inuktitut - Nutaaq
+	{ -30603, { "us", {},  Fuzzy } }, // Inuktitut - Nunavik
+	{ -30604, { "us", {},  Fuzzy } }, // Inuktitut - Nunavut
+	{ -30600, { "us", {},  Fuzzy } }, // Inuktitut - QWERTY
+	{  11538, { "us", {},  Fuzzy } }, // Kabyle - QWERTY
+	{ -24064, { "us", {},  Fuzzy } }, // Kannada - InScript
+	{ -24065, { "us", {},  Fuzzy } }, // Kannada - QWERTY
+	{ -22530, { "us", {},  Fuzzy } }, // Kashmiri (Devanagari)
+	{ -26114, { "us", {},  Fuzzy } }, // Khmer
+	{ -25282, { "us", {},  Fuzzy } }, // Konkani
+	{ -361,   { "us", {},  Fuzzy } }, // Kurmanji Kurdish
+	{ -26115, { "us", {},  Fuzzy } }, // Lao
+	{ -23562, { "us", {},  Fuzzy } }, // Lushootseed
+	{ -25283, { "us", {},  Fuzzy } }, // Maithili - InScript
+	{ -24576, { "us", {},  Fuzzy } }, // Malayalam - InScript
+	{ -24577, { "us", {},  Fuzzy } }, // Malayalam - QWERTY
+	{ -3047,  { "us", {},  Fuzzy } }, // Mandaic - Arabic
+	{ -17993, { "us", {},  Fuzzy } }, // Mandaic - QWERTY
+	{ -22532, { "us", {},  Fuzzy } }, // Manipuri (Bengali)
+	{ -22534, { "us", {},  Fuzzy } }, // Manipuri (Meetei Mayek)
+	{ -51,    { "us", {},  Fuzzy } }, // Māori - InScript
+	{ -25284, { "us", {},  Fuzzy } }, // Marathi
+	{ -13161, { "us", {},  Fuzzy } }, // Mi'kmaq
+	{ -23561, { "us", {},  Fuzzy } }, // Mvskoke
+	{ -25602, { "us", {},  Fuzzy } }, // Myanmar
+	{ -25601, { "us", {},  Fuzzy } }, // Myanmar - QWERTY
+	{ -25709, { "us", {},  Fuzzy } }, // N'Ko - QWERTY
+	{ -18939, { "us", {},  Fuzzy } }, // Navajo
+	{ -25286, { "us", {},  Fuzzy } }, // Nepali - InScript
+	{ -31135, { "us", {},  Fuzzy } }, // Nepali - Remington
+	{ -22016, { "us", {},  Fuzzy } }, // Odiya - InScript
+	{ -22017, { "us", {},  Fuzzy } }, // Odiya - QWERTY
+	{  38342, { "us", {},  Fuzzy } }, // Osage - QWERTY
+	{ -20563, { "us", {},  Fuzzy } }, // Rejang - QWERTY
+	{ -23064, { "us", {},  Fuzzy } }, // Sanskrit
+	{ -22538, { "us", {},  Fuzzy } }, // Santali (Devanagari) - InScript
+	{ -22536, { "us", {},  Fuzzy } }, // Santali - (Ol Chiki)
+	{ -16901, { "us", {},  Fuzzy } }, // Sindhi (Devanagari) - InScript
+	{ -25088, { "us", {},  Fuzzy } }, // Sinhala
+	{ -25089, { "us", {},  Fuzzy } }, // Sinhala - QWERTY
+	{ -23552, { "us", {},  Fuzzy } }, // Telugu - InScript
+	{ -23553, { "us", {},  Fuzzy } }, // Telugu - QWERTY
+	{ -26624, { "us", {},  Fuzzy } }, // Thai
+	{ -24616, { "us", {},  Fuzzy } }, // Thai - Pattachote
+	{ -26628, { "us", {},  Fuzzy } }, // Tibetan - Otani
+	{ -26625, { "us", {},  Fuzzy } }, // Tibetan - QWERTY
+	{ -2398,  { "us", {},  Fuzzy } }, // Tibetan - Wylie
+	{  88,    { "us", {},  Fuzzy } }, // Tongan
+	{ -17925, { "us", {},  Fuzzy } }, // Urdu
+	{ -23498, { "us", {},  Fuzzy } }, // Wancho - QWERTY
+	{  4300,  { "us", {},  Fuzzy } }, // Wolastoqey
 
 	// For some keyboard families we don't have code pages, but in the
 	// corresponding states the AZERTY layout is typically used
-	{  6983,  { "fr", 437 }    }, // Kabyle - AZERTY
-	{ -25708, { "fr", 437 }    }, // N'Ko
-	{ -12482, { "fr", 437 }    }, // Tifinagh - AZERTY
+	{  6983,  { "fr", 437, Fuzzy } }, // Kabyle - AZERTY
+	{ -25708, { "fr", 437, Fuzzy } }, // N'Ko
+	{ -12482, { "fr", 437, Fuzzy } }, // Tifinagh - AZERTY
 
 	// In some cases we do not have a matching QWERTY layout; if so, use
 	// the US/International keyboard with the best available code page
-	{ -68,    { "ux", 850 }    }, // Croatian - QWERTY
-	{  19521, { "us", 855 }    }, // Serbian
-	{ -19521, { "ux", 850 }    }, // Serbian (Latin)
-	{ -66,    { "ux", 850 }    }, // Slovenian
+	{ -68,    { "ux", 850, Fuzzy } }, // Croatian - QWERTY
+	{  19521, { "us", 855, Fuzzy } }, // Serbian
+	{ -19521, { "ux", 850, Fuzzy } }, // Serbian (Latin)
+	{ -66,    { "ux", 850, Fuzzy } }, // Slovenian
 };
 // clang-format on
 

--- a/src/misc/host_locale_macos.cpp
+++ b/src/misc/host_locale_macos.cpp
@@ -610,8 +610,19 @@ const HostLocale& GetHostLocale()
 		locale = HostLocale();
 
 		locale->country = get_dos_country(locale->log_info.country);
+	}
+
+	return *locale;
+}
+
+const HostKeyboardLayouts& GetHostKeyboardLayouts()
+{
+	static std::optional<HostKeyboardLayouts> locale = {};
+	if (!locale) {
+		locale = HostKeyboardLayouts();
+
 		locale->keyboard_layout_list = get_layouts_maybe_codepages(
-		        locale->log_info.keyboard);
+		        locale->log_info);
 	}
 
 	return *locale;

--- a/src/misc/host_locale_posix.cpp
+++ b/src/misc/host_locale_posix.cpp
@@ -1024,9 +1024,9 @@ static DesktopKeyboardLayouts get_keyboard_layouts_ini(
 			if (tokens[0] == model_key) {
 				keyboard_model = tokens[1];
 			} else if (tokens[0] == layouts_key) {
-				layouts = split(tokens[1], ",");
+				layouts = split_with_empties(tokens[1], ',');
 			} else if (tokens[0] == variants_key) {
-				variants = split(tokens[1], ",");
+				variants = split_with_empties(tokens[1], ',');
 			}
 		}
 	}

--- a/src/misc/host_locale_posix.cpp
+++ b/src/misc/host_locale_posix.cpp
@@ -1403,9 +1403,19 @@ const HostLocale& GetHostLocale()
 		locale->numeric   = get_dos_country(LcNumeric, log_info.numeric);
 		locale->time_date = get_dos_country(LcTime, log_info.time_date);
 		locale->currency  = get_dos_country(LcMonetary, log_info.currency);
+	}
+
+	return *locale;
+}
+
+const HostKeyboardLayouts& GetHostKeyboardLayouts()
+{
+	static std::optional<HostKeyboardLayouts> locale = {};
+	if (!locale) {
+		locale = HostKeyboardLayouts();
 
 		locale->keyboard_layout_list = get_layouts_maybe_codepages(
-		        log_info.keyboard);
+		        locale->log_info);
 
 		// Linux desktop environments keep the keyboard layouts sorted
 		// by user preference

--- a/src/misc/host_locale_posix.cpp
+++ b/src/misc/host_locale_posix.cpp
@@ -69,6 +69,9 @@ static const std::set<std::string> KeyboardModels102 = {"pc102",
                                                         "pc105",
                                                         "pc105+inet"};
 
+// Constant to mark poor/imprecise keyboard layout mappings
+constexpr bool Fuzzy = true;
+
 // Mapping from X11 to DOS keyboard layouts. Reference:
 // - /usr/share/X11/xkb/rules/evdev.lst
 // - 'localectl list-x11-keymap-variants <layout>' command
@@ -389,56 +392,57 @@ static const std::unordered_map<std::string, KeyboardLayoutMaybeCodepage> X11ToD
 	{ "rs",                         { "yc" }         },
 	// Serbian (no deadkey, QWERTZ/national)
 	{ "rs:combiningkeys",           { "yc450" }      },
+
 	// For some keyboard families we don't have code pages, but in the
 	// corresponding states the QWERTY layout is typically used
-	{ "brai",                       { "us" }         }, // Braille
-	{ "bd",                         { "us" }         }, // Bangladesh
-	{ "bt",                         { "us" }         }, // Buthan (Dzongkha)
-	{ "cn",                         { "us" }         }, // China
-	{ "et",                         { "us" }         }, // Ethiopia (Amharic)
-	{ "gh",                         { "us" }         }, // Ghana
-	{ "id",                         { "us" }         }, // Indonesia
-	{ "in",                         { "us" }         }, // India
-	{ "kh",                         { "us" }         }, // Khmer
-	{ "kr",                         { "us" }         }, // Korea
-	{ "jp",                         { "us" }         }, // Japan
-	{ "la",                         { "us" }         }, // Laos
-	{ "lk",                         { "us" }         }, // Sinhala
-	{ "md",                         { "us" }         }, // Moldavia
-	{ "mm",                         { "us" }         }, // Myanmar
-	{ "mv",                         { "us" }         }, // Maldives (Dhivehi)
-	{ "np",                         { "us" }         }, // Nepal
-	{ "th",                         { "us" }         }, // Thailand
-	{ "tw",                         { "us" }         }, // Taiwan
+	{ "brai",                   { "us", {},  Fuzzy } }, // Braille
+	{ "bd",                     { "us", {},  Fuzzy } }, // Bangladesh
+	{ "bt",                     { "us", {},  Fuzzy } }, // Buthan (Dzongkha)
+	{ "cn",                     { "us", {},  Fuzzy } }, // China
+	{ "et",                     { "us", {},  Fuzzy } }, // Ethiopia (Amharic)
+	{ "gh",                     { "us", {},  Fuzzy } }, // Ghana
+	{ "id",                     { "us", {},  Fuzzy } }, // Indonesia
+	{ "in",                     { "us", {},  Fuzzy } }, // India
+	{ "kh",                     { "us", {},  Fuzzy } }, // Khmer
+	{ "kr",                     { "us", {},  Fuzzy } }, // Korea
+	{ "jp",                     { "us", {},  Fuzzy } }, // Japan
+	{ "la",                     { "us", {},  Fuzzy } }, // Laos
+	{ "lk",                     { "us", {},  Fuzzy } }, // Sinhala
+	{ "md",                     { "us", {},  Fuzzy } }, // Moldavia
+	{ "mm",                     { "us", {},  Fuzzy } }, // Myanmar
+	{ "mv",                     { "us", {},  Fuzzy } }, // Maldives (Dhivehi)
+	{ "np",                     { "us", {},  Fuzzy } }, // Nepal
+	{ "th",                     { "us", {},  Fuzzy } }, // Thailand
+	{ "tw",                     { "us", {},  Fuzzy } }, // Taiwan
 
 	// In some cases we do not have a matching QWERTY layout; if so, use
 	// the US/International keyboard with the best available code page
-	{ "ba:us",                      { "ux", 850 }    }, // Bosnia
-	{ "de:us",                      { "ux", 850 }    }, // Germany
-	{ "de:qwerty",                  { "ux", 850 }    },
-	{ "de:dsb",                     { "ux", 850 }    }, // Sorbian
-	{ "fr:us",                      { "ux", 850 }    }, // France
-	{ "hr:us",                      { "ux", 850 }    }, // Croatia
-	{ "it:us",                      { "ux", 850 }    }, // Italy
-	{ "me:cyrillicyz",              { "us", 855 }    }, // Montenegro
-	{ "me:latinunicodeyz",          { "ux", 850 }    },
-	{ "me:latinyz",                 { "ux", 850 }    },
-	{ "si:us",                      { "ux", 850 }    }, // Slovenia
-	{ "tm:alt",                     { "ux", 437 }    }, // Turkmenistan
-	{ "us:hbs",                     { "ux", 850 }    }, // Serbo-Croatian
-	{ "vn:us",                      { "ux", 850 }    }, // Vietnam
+	{ "ba:us",                  { "ux", 850, Fuzzy } }, // Bosnia
+	{ "de:us",                  { "ux", 850, Fuzzy } }, // Germany
+	{ "de:qwerty",              { "ux", 850, Fuzzy } },
+	{ "de:dsb",                 { "ux", 850, Fuzzy } }, // Sorbian
+	{ "fr:us",                  { "ux", 850, Fuzzy } }, // France
+	{ "hr:us",                  { "ux", 850, Fuzzy } }, // Croatia
+	{ "it:us",                  { "ux", 850, Fuzzy } }, // Italy
+	{ "me:cyrillicyz",          { "us", 855, Fuzzy } }, // Montenegro
+	{ "me:latinunicodeyz",      { "ux", 850, Fuzzy } },
+	{ "me:latinyz",             { "ux", 850, Fuzzy } },
+	{ "si:us",                  { "ux", 850, Fuzzy } }, // Slovenia
+	{ "tm:alt",                 { "ux", 437, Fuzzy } }, // Turkmenistan
+	{ "us:hbs",                 { "ux", 850, Fuzzy } }, // Serbo-Croatian
+	{ "vn:us",                  { "ux", 850, Fuzzy } }, // Vietnam
 
 	// In some cases we do not have a matching QWERTZ layout; if so, use
 	// the German keyboard with the best available code page
-	{ "it:lldde",                   { "de", 850 }    }, // Ladin
+	{ "it:lldde",               { "de", 850, Fuzzy } }, // Ladin
 
 	// For some keyboard families we don't have code pages, but in the
 	// corresponding states the AZERTY layout is typically used
-	{ "gn",                         { "fr", 437 }    }, // Gwinea, N'Ko
+	{ "gn",                     { "fr", 437, Fuzzy } }, // Gwinea, N'Ko
 
 	// In some cases we do not have a matching AZERTY layout; if so, use
 	// the French keyboard with the best available code page
-	{ "vn:fr",                      { "fr", 850 }    }, // Vietnam
+	{ "vn:fr",                  { "fr", 850, Fuzzy } }, // Vietnam
 
 	// Certain DOS keyboard layouts are never detected by this mechanism,
 	// due to various reason:
@@ -760,9 +764,10 @@ static const std::unordered_map<std::string, KeyboardLayoutMaybeCodepage> TtyToD
 	{ "ua-ws",                               { "ua" }        },
 	// Serbian (deadkey, QWERTZ/national)
 	{ "sr-latin",                            { "yc" }        },
+
 	// In some cases we do not have a matching QWERTY layout; if so, use
 	// the US/International keyboard with the best available code page
-	{ "sr-cy",                               { "us", 855 }   }, // Serbia
+	{ "sr-cy",                          { "us", 855, Fuzzy } }, // Serbia
 };
 // clang-format on
 
@@ -1401,6 +1406,10 @@ const HostLocale& GetHostLocale()
 
 		locale->keyboard_layout_list = get_layouts_maybe_codepages(
 		        log_info.keyboard);
+
+		// Linux desktop environments keep the keyboard layouts sorted
+		// by user preference
+		locale->is_layout_list_sorted = true;
 	}
 
 	return *locale;

--- a/src/misc/host_locale_win32.cpp
+++ b/src/misc/host_locale_win32.cpp
@@ -32,6 +32,9 @@
 
 CHECK_NARROWING();
 
+// Constant to mark poor/imprecise keyboard layout mappings
+constexpr bool Fuzzy = true;
+
 // Mapping from modern Windows to DOS keyboard layouts. Developed using
 // https://kbdlayout.info web page for layout visualization
 // clang-format off
@@ -272,73 +275,73 @@ static const std::unordered_map<std::string, KeyboardLayoutMaybeCodepage> WinToD
 
 	// For some keyboard families we don't have code pages, but in the
 	// corresponding states the QWERTY layout is typically used
-	{ "0000044d", { "us" }         }, // Assamese - INSCRIPT
-	{ "00000445", { "us" }         }, // Bangla
-	{ "00020445", { "us" }         }, // Bangla - INSCRIPT
-	{ "00010445", { "us" }         }, // Bangla - INSCRIPT (Legacy)
-	{ "000b0c00", { "us" }         }, // Buginese
-	{ "00000804", { "us" }         }, // Chinese (Simplified) - US
-	{ "00001004", { "us" }         }, // Chinese (Simplified, Singapore) - US
-	{ "00000404", { "us" }         }, // Chinese (Traditional) - US
-	{ "00000c04", { "us" }         }, // Chinese (Traditional, Hong Kong S.A.R.) - US
-	{ "00001404", { "us" }         }, // Chinese (Traditional, Macao S.A.R.) - US
-	{ "00000439", { "us" }         }, // Devanagari - INSCRIPT
-	{ "00000465", { "us" }         }, // Divehi Phonetic
-	{ "00010465", { "us" }         }, // Divehi Typewriter
-	{ "00000c51", { "us" }         }, // Dzongkha
-	{ "00120c00", { "us" }         }, // Futhark
-	{ "00000447", { "us" }         }, // Gujarati
-	{ "00010439", { "us" }         }, // Hindi Traditional
-	{ "00000411", { "us" }         }, // Japanese
-	{ "00110c00", { "us" }         }, // Javanese
-	{ "0000044b", { "us" }         }, // Kannada
-	{ "00000453", { "us" }         }, // Khmer
-	{ "00010453", { "us" }         }, // Khmer (NIDA)
-	{ "00000412", { "us" }         }, // Korean
-	{ "00000454", { "us" }         }, // Lao
-	{ "00070c00", { "us" }         }, // Lisu (Basic)
-	{ "00080c00", { "us" }         }, // Lisu (Standard)
-	{ "0000044c", { "us" }         }, // Malayalam
-	{ "0000044e", { "us" }         }, // Marathi
-	{ "00010c00", { "us" }         }, // Myanmar (Phonetic order)
-	{ "00130c00", { "us" }         }, // Myanmar (Visual order)
-	{ "00000461", { "us" }         }, // Nepali
-	{ "00020c00", { "us" }         }, // New Tai Lue
-	{ "00000448", { "us" }         }, // Odia
-	{ "00040c00", { "uk" }         }, // Ogham
-	{ "000d0c00", { "us" }         }, // Ol Chiki
-	{ "000f0c00", { "it" }         }, // Old Italic
-	{ "00150c00", { "us" }         }, // Osage
-	{ "000e0c00", { "us" }         }, // Osmanya
-	{ "000a0c00", { "us" }         }, // Phags-pa
-	{ "00000446", { "us" }         }, // Punjabi
-	{ "0000045b", { "us" }         }, // Sinhala
-	{ "0001045b", { "us" }         }, // Sinhala - Wij 9
-	{ "00100c00", { "us" }         }, // Sora
-	{ "0000045a", { "us" }         }, // Syriac
-	{ "0001045a", { "us" }         }, // Syriac Phonetic
-	{ "00030c00", { "us" }         }, // Tai Le
-	{ "00000449", { "us" }         }, // Tamil
-	{ "00020449", { "us" }         }, // Tamil 99
-	{ "00030449", { "us" }         }, // Tamil Anjal
-	{ "0000044a", { "us" }         }, // Telugu
-	{ "0000041e", { "us" }         }, // Thai Kedmanee
-	{ "0002041e", { "us" }         }, // Thai Kedmanee (non-ShiftLock)
-	{ "0001041e", { "us" }         }, // Thai Pattachote
-	{ "0003041e", { "us" }         }, // Thai Pattachote (non-ShiftLock)
-	{ "00000451", { "us" }         }, // Tibetan (PRC)
-	{ "00010451", { "us" }         }, // Tibetan (PRC) - Updated
-	{ "0000105f", { "us" }         }, // Tifinagh (Basic)
-	{ "0001105f", { "us" }         }, // Tifinagh (Extended)
-	{ "00000420", { "us" }         }, // Urdu
+	{ "0000044d", { "us", {},  Fuzzy } }, // Assamese - INSCRIPT
+	{ "00000445", { "us", {},  Fuzzy } }, // Bangla
+	{ "00020445", { "us", {},  Fuzzy } }, // Bangla - INSCRIPT
+	{ "00010445", { "us", {},  Fuzzy } }, // Bangla - INSCRIPT (Legacy)
+	{ "000b0c00", { "us", {},  Fuzzy } }, // Buginese
+	{ "00000804", { "us", {},  Fuzzy } }, // Chinese (Simplified) - US
+	{ "00001004", { "us", {},  Fuzzy } }, // Chinese (Simplified, Singapore) - US
+	{ "00000404", { "us", {},  Fuzzy } }, // Chinese (Traditional) - US
+	{ "00000c04", { "us", {},  Fuzzy } }, // Chinese (Traditional, Hong Kong S.A.R.) - US
+	{ "00001404", { "us", {},  Fuzzy } }, // Chinese (Traditional, Macao S.A.R.) - US
+	{ "00000439", { "us", {},  Fuzzy } }, // Devanagari - INSCRIPT
+	{ "00000465", { "us", {},  Fuzzy } }, // Divehi Phonetic
+	{ "00010465", { "us", {},  Fuzzy } }, // Divehi Typewriter
+	{ "00000c51", { "us", {},  Fuzzy } }, // Dzongkha
+	{ "00120c00", { "us", {},  Fuzzy } }, // Futhark
+	{ "00000447", { "us", {},  Fuzzy } }, // Gujarati
+	{ "00010439", { "us", {},  Fuzzy } }, // Hindi Traditional
+	{ "00000411", { "us", {},  Fuzzy } }, // Japanese
+	{ "00110c00", { "us", {},  Fuzzy } }, // Javanese
+	{ "0000044b", { "us", {},  Fuzzy } }, // Kannada
+	{ "00000453", { "us", {},  Fuzzy } }, // Khmer
+	{ "00010453", { "us", {},  Fuzzy } }, // Khmer (NIDA)
+	{ "00000412", { "us", {},  Fuzzy } }, // Korean
+	{ "00000454", { "us", {},  Fuzzy } }, // Lao
+	{ "00070c00", { "us", {},  Fuzzy } }, // Lisu (Basic)
+	{ "00080c00", { "us", {},  Fuzzy } }, // Lisu (Standard)
+	{ "0000044c", { "us", {},  Fuzzy } }, // Malayalam
+	{ "0000044e", { "us", {},  Fuzzy } }, // Marathi
+	{ "00010c00", { "us", {},  Fuzzy } }, // Myanmar (Phonetic order)
+	{ "00130c00", { "us", {},  Fuzzy } }, // Myanmar (Visual order)
+	{ "00000461", { "us", {},  Fuzzy } }, // Nepali
+	{ "00020c00", { "us", {},  Fuzzy } }, // New Tai Lue
+	{ "00000448", { "us", {},  Fuzzy } }, // Odia
+	{ "00040c00", { "uk", {},  Fuzzy } }, // Ogham
+	{ "000d0c00", { "us", {},  Fuzzy } }, // Ol Chiki
+	{ "000f0c00", { "it", {},  Fuzzy } }, // Old Italic
+	{ "00150c00", { "us", {},  Fuzzy } }, // Osage
+	{ "000e0c00", { "us", {},  Fuzzy } }, // Osmanya
+	{ "000a0c00", { "us", {},  Fuzzy } }, // Phags-pa
+	{ "00000446", { "us", {},  Fuzzy } }, // Punjabi
+	{ "0000045b", { "us", {},  Fuzzy } }, // Sinhala
+	{ "0001045b", { "us", {},  Fuzzy } }, // Sinhala - Wij 9
+	{ "00100c00", { "us", {},  Fuzzy } }, // Sora
+	{ "0000045a", { "us", {},  Fuzzy } }, // Syriac
+	{ "0001045a", { "us", {},  Fuzzy } }, // Syriac Phonetic
+	{ "00030c00", { "us", {},  Fuzzy } }, // Tai Le
+	{ "00000449", { "us", {},  Fuzzy } }, // Tamil
+	{ "00020449", { "us", {},  Fuzzy } }, // Tamil 99
+	{ "00030449", { "us", {},  Fuzzy } }, // Tamil Anjal
+	{ "0000044a", { "us", {},  Fuzzy } }, // Telugu
+	{ "0000041e", { "us", {},  Fuzzy } }, // Thai Kedmanee
+	{ "0002041e", { "us", {},  Fuzzy } }, // Thai Kedmanee (non-ShiftLock)
+	{ "0001041e", { "us", {},  Fuzzy } }, // Thai Pattachote
+	{ "0003041e", { "us", {},  Fuzzy } }, // Thai Pattachote (non-ShiftLock)
+	{ "00000451", { "us", {},  Fuzzy } }, // Tibetan (PRC)
+	{ "00010451", { "us", {},  Fuzzy } }, // Tibetan (PRC) - Updated
+	{ "0000105f", { "us", {},  Fuzzy } }, // Tifinagh (Basic)
+	{ "0001105f", { "us", {},  Fuzzy } }, // Tifinagh (Extended)
+	{ "00000420", { "us", {},  Fuzzy } }, // Urdu
 
 	// For some keyboard families we don't have code pages, but in the
 	// corresponding states the QWERTZ layout is typically used
-	{ "000c0c00", { "de" }         }, // Gothic
+	{ "000c0c00", { "de", {},  Fuzzy } }, // Gothic
 
 	// For some keyboard families we don't have code pages, but in the
 	// corresponding states the AZERTY layout is typically used
-	{ "00090c00", { "fr", 437 }    }, // N’Ko
+	{ "00090c00", { "fr", 437, Fuzzy } }, // N’Ko
 };
 // clang-format on
 

--- a/src/misc/host_locale_win32.cpp
+++ b/src/misc/host_locale_win32.cpp
@@ -521,8 +521,19 @@ const HostLocale& GetHostLocale()
 		locale = HostLocale();
 
 		locale->country = get_dos_country(locale->log_info.country);
+	}
+
+	return *locale;
+}
+
+const HostKeyboardLayouts& GetHostKeyboardLayouts()
+{
+	static std::optional<HostKeyboardLayouts> locale = {};
+	if (!locale) {
+		locale = HostKeyboardLayouts();
+
 		locale->keyboard_layout_list = get_layouts_maybe_codepages(
-		        locale->log_info.keyboard);
+		        locale->log_info);
 	}
 
 	return *locale;


### PR DESCRIPTION
# Description

1. Default keyboard layout is now `us`, not `auto`
2. Keyboard layout is now only detected if user sets `keyboard_layout = auto`, otherwise the code is not executed
3. Fix for keyboard layout detection on KDE if some of the configured layouts has variants (like `us intl`) and some do not
4. Improve the keyboard layout selection algorithm
a) host->guest layout mappings which are not good matches are now marked as _fuzzy_ and they get the lowest priority during selection
b) if the OS can provide a keyboard layout list sorted by priority (according to the user), these priorities are generally respected (this applies to Linux only)

Remarks:
- I have decided to keep the sorting behavior of giving plain English layouts a very low priority; since the US English layout is now the default, if someone decides to change it to `auto`, he is probably interested in trying something else. Moreover, on modern Windows it's the OS who decides which keyboard layouts are listed in the GUI (probably based on the installed language packs, or something similar), so US English is probably always on the list even if the user prefers the national one.
- I really don't want to spend weeks tweaking the selection algorithm; there is probably no way to make it work for everyone. Please consider the autodetection as an option for all the folks who are not satisfied with US English, but do not want to read through the list of layouts, code pages, FreeDOS documentation, etc. For some of them it will work great, for others... not really. Such is life.


## Related issues

https://github.com/dosbox-staging/dosbox-staging/issues/4076


# Release notes

Keyboard layout now defaults to `us` as a safe option for almost everyone. If you want to experiment, the `auto` option is still there, but you have set it explicitly.

# Manual testing

- Set `keyboard_layout` to some improper value; it should load US keyboard (you can check this by executing `KEYB` command).
- On Linux with KDE set two keyboard layouts - _Polish_ and _US International with dead keys_. Set `keyboard_layout = auto`. DOSBox now sets whichever keyboard layout is first on the list in the _KDE System Settings_ and the log shows the _intl_ modifier near the _us_ host value:

```
LOCALE: Keyboard layout and code page detected from 'KDE: pl us:intl'
```

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [x] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

