### PR TITLE
Fix SoundBlaster DMA regression

### DIFF
--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -771,7 +771,7 @@ static void dsp_dma_callback(const DmaChannel* chan, const DmaEvent event)
 	case DmaEvent::ReachedTerminalCount: break;
 
 	case DmaEvent::IsMasked:
-		if (sb.mode != DspMode::Dma) {
+		if (sb.mode == DspMode::Dma) {
 			// Catch up to current time, but don't generate an IRQ!
 			// Fixes problems with later sci games.
 			const auto t = PIC_FullIndex() - last_dma_callback;


### PR DESCRIPTION
# Description

Regression from 4f4bfa296467eec85ca423f962a2e13d6836e927

Conditional was accidently inverted during a refactor
This caused a clicking noise in Worms


## Related issues

Fixes #4083


# Release notes

Bug was never in a point release

# Manual testing

- Confirmed this fixes the Worms issue
- Doom and Tyrian still work correctly

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

