### PR TITLE
Update Polish (pl) translation, minor English string fix

### DIFF
--- a/contrib/resources/translations/pl.lng
+++ b/contrib/resources/translations/pl.lng
@@ -1903,6 +1903,13 @@ Plik z tabelą programów i przypisanych do nich wersji systemu DOS, w formacie
 wartości rozdzielonych tabulatorami, używany przez polecenie SETVER.EXE do
 trwałego zapamiętania ustawień (domyślnie wartość pusta).
 .
+:CONFIG_FILE_LOCKING
+Włącza blokowanie plików (emulacja SHARE.EXE; domyślnie włączona).
+Wymagane do poprawnego działania niektórych aplikacji Windows 3.1x.
+Zazwyczaj nie powoduje problemów z grami dla systemu DOS, z rzadkimi wyjątkami
+(np. demo Astral Blur). Jeśli zobaczysz błędy związane z dostępem do plików,
+spróbuj wyłączyć to ustawienie.
+.
 :CONFIGITEM_IPX
 Włącza emulację protokołu IPX po UDP/IP (domyślnie wyłączone).
 .
@@ -1962,7 +1969,7 @@ Linie z tej sekcji zostaną wykonane podczas startu.
 Ważne: sekcja [autoexec] musi znajdować się na końcu pliku konfiguracyjnego!
 .
 :CONFIGFILE_INTRO
-# DOSBox Staging %s - plik konfiguracyjny.
+# DOSBox Staging (%s) - plik konfiguracyjny.
 # Linie zaczynające się od # są komentarzami.
 
 .
@@ -2136,8 +2143,9 @@ Nie znaleziono pliku wykonywalnego: '%s'
 i
 .
 :PROGRAM_CONFIG_NOT_CHANGEABLE
-Parametr '%s' nie może być zmieniony w trakcie pracy.
-
+[color=yellow]Ustawienie '%s' nie może być zmieniony w trakcie pracy.[reset]
+Zmiana zostanie uwzględniona dopiero po restarcie poleceniem 'CONFIG -r'
+lub odpowiednim skrótem klawiszowym.
 .
 :PROGRAM_CONFIG_DEPRECATED
 [color=light-red]To ustawienie jest przestarzałe, obsługiwane wyłącznie dla kompatybilności
@@ -3070,6 +3078,15 @@ Mapowanie niedostępne w trybie pracy bez użycia myszy ('nomouse').
 .
 :PROGRAM_MOUSECTL_MAPPING_BLOCKED_BY_DRIVER
 Mapowanie niedostępne przy obecnym sterowniku myszy w systemie gościa.
+
+.
+:PROGRAM_MOUSECTL_MANYMOUSE_NOT_BUILT
+Ta kompilacja nie obsługuje mapowania fizycznych myszy.
+
+.
+:PROGRAM_MOUSECTL_MANYMOUSE_RAW_INPUT
+Mapowanie fizycznych myszy jest niedostępne z powodu włączonego ustawienia
+'mouse_raw_input'.
 
 .
 :PROGRAM_MOUSECTL_NO_INTERFACES

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -1148,7 +1148,8 @@ void PROGRAMS_Init(Section* sec)
 
 	MSG_Add("PROGRAM_CONFIG_NOT_CHANGEABLE",
 	        "[color=yellow]The '%s' setting can't be changed at runtime.[reset]\n"
-	        "However, it will be applied on restart by running 'CONFIG -r' or via the restart hotkey.\n");
+	        "However, it will be applied on restart by running 'CONFIG -r' or via the\n"
+	        "restart hotkey.\n");
 
 	MSG_Add("PROGRAM_CONFIG_DEPRECATED",
 	        "[color=light-red]This is a deprecated setting only kept for compatibility with old configs.\n"


### PR DESCRIPTION
# Description

- Fix for line breaking in `PROGRAM_CONFIG_NOT_CHANGEABLE` English string
- Updated Polish translation

This change is meant to be merged both to main branch and to 0.82.1 - it only translated strings added/changed there.

# Manual testing

Type `config -set language=sindarin` - error message should be now correctly displayed, without line breaks in strange places.


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

