### PR TITLE
Fix country detection on Windows

### DIFF
--- a/src/misc/host_locale.cpp
+++ b/src/misc/host_locale.cpp
@@ -28,6 +28,7 @@
 #include <iostream>
 #include <sstream>
 #include <string>
+#include <unordered_map>
 
 CHECK_NARROWING();
 
@@ -39,7 +40,7 @@ CHECK_NARROWING();
 // several historic countries and territories. Reference:
 // - https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
 // clang-format off
-static const std::map<std::string, DosCountry> IsoToDosCountryMap = {
+static const std::unordered_map<std::string, DosCountry> IsoToDosCountryMap = {
 	// List ordered by DOS country code, primary ISO country code first
 	{ "AQ",    DosCountry::International  }, // Antarctica
 	{ "EU",    DosCountry::International  }, // European Union

--- a/src/misc/host_locale_win32.cpp
+++ b/src/misc/host_locale_win32.cpp
@@ -358,10 +358,12 @@ static std::string to_string(const wchar_t* input, const size_t input_length)
 		return {};
 	}
 
-	std::vector<char> buffer(buffer_size);
+	std::vector<char> buffer(buffer_size + 1);
 	WideCharToMultiByte(DefaultCodePage,  0, input, check_cast<int>(input_length),
 	                    buffer.data(), buffer_size, nullptr, nullptr);
-	return std::string(buffer.begin(), buffer.end());
+	buffer[buffer_size] = '\0';
+
+	return std::string(buffer.begin(), std::find(buffer.begin(), buffer.end(), '\0'));
 }
 
 static std::map<std::string, std::string> read_layouts_registry(const std::string& subkey)


### PR DESCRIPTION
# Description

- Fix for problem with detecting country on _Windows_ (visible in the log posted by the _Discord_ user _llm_). Reason: improper conversion from _Windows_ multi-byte string to `std::string`, some garbage could be left after trailing `\0`.
- Changed one forgotten `std::map` to `std::unordered_map` (general suggestion by @interloper98 from one of the previous reviews).


# Release notes

Not needed, the botched code wasn't released yet.


# Manual testing

On _Windows_ start the emulator with `country = auto` setting - log should contain something like:

```
LOCALE: Country detected from 'pl-PL'
LOCALE: Loading modern locale for country 48 - 'Poland'
```

Country `International English` should not be set except some rare cases (see `IsoToDosCountryMap` in https://github.com/dosbox-staging/dosbox-staging/blob/main/src/misc/host_locale.cpp).


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

