### PR TITLE
Fix missing XML tag in Visual Studio solution file

### DIFF
--- a/vs/dosbox.vcxproj.filters
+++ b/vs/dosbox.vcxproj.filters
@@ -105,6 +105,7 @@
     </ClCompile>
     <ClCompile Include="..\src\dos\dos_locale_data.cpp">
       <Filter>src\dos</Filter>
+    </ClCompile>
     <ClCompile Include="..\src\dos\dos_memory.cpp">
       <Filter>src\dos</Filter>
     </ClCompile>


### PR DESCRIPTION
# Description

Bisected to commit d225c9a619fc69de19a68da473dcfa244862582d

Suspected a problem in Visual Studio's metadata, so fed the XML files through `xmllint --noout`, which caught it:

```
dosbox.vcxproj.filters:897: parser error : Opening and ending tag mismatch: ClCompile line 106 and ItemGroup
  </ItemGroup>
              ^
dosbox.vcxproj.filters:1715: parser error : Opening and ending tag mismatch: ItemGroup line 3 and Project
</Project>
          ^
dosbox.vcxproj.filters:1716: parser error : Premature end of data in tag Project line 2
```

## Related issues

Fixes #4091 

Confirmed fixed in visual studio 2022.

# Checklist


I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

