### PR TITLE
Fix debugger keypresses not being registered on Windows

### DIFF
--- a/include/support.h
+++ b/include/support.h
@@ -65,6 +65,26 @@ constexpr uint16_t dos_pagesize = 4096;
 // is in-range of a char and returns it as such.
 char int_to_char(int val);
 
+// A change in one of these 2 commits changed the behavior of toupper() on Windows with MSVC
+// d225c9a619fc69de19a68da473dcfa244862582d - Probably this giant commit
+// 0b1f510683b36d46440a781f8e151b7f942a9f23 - This one won't compile so I can't rule it out
+
+// I found some documentation that states toupper() can change behavior based on locale
+// However, the debugger depends on this specific behavior
+// It passes in values larger than an 8 bit char can hold and needs those to stay intact
+
+// Not even sure if this is defined behavior (might be one of those janky C functions that casts int to char)
+// There are several other instances of toupper() throughout the code that should be looked at
+// This is a workaround for the specific case of the debugger for now
+// We may choose to remove this code later or use it elsewhere where only ascii letters should be considered
+constexpr int ascii_to_upper(int c)
+{
+	if (c >= 'a' && c <= 'z') {
+		return c - 'a' + 'A';
+	}
+	return c;
+}
+
 constexpr bool char_is_negative([[maybe_unused]] char c)
 {
 #if (CHAR_MIN < 0) // char is signed

--- a/src/debug/debug.cpp
+++ b/src/debug/debug.cpp
@@ -1079,7 +1079,7 @@ bool ChangeRegister(char* str)
 bool ParseCommand(char* str) {
 	char* found = str;
 	for(char* idx = found;*idx != 0; idx++)
-		*idx = toupper(*idx);
+		*idx = ascii_to_upper(*idx);
 
 	found = trim(found);
 	std::string s_found(found);
@@ -1743,7 +1743,7 @@ uint32_t DEBUG_CheckKeys(void) {
 			break;
 		}
 #endif
-		switch (toupper(key)) {
+		switch (ascii_to_upper(key)) {
 		case 27:	// escape (a bit slow): Clears line. and processes alt commands.
 			key=getch();
 			if(key < 0) { //Purely escape Clear line
@@ -1751,7 +1751,7 @@ uint32_t DEBUG_CheckKeys(void) {
 				break;
 			}
 
-			switch(toupper(key)) {
+			switch(ascii_to_upper(key)) {
 			case 'D' : // ALT - D: DS:SI
 				dataSeg = SegValue(ds);
 				if (cpu.pmode && !(reg_flags & FLAG_VM)) dataOfs = reg_esi;


### PR DESCRIPTION
# Description

Regression from either d225c9a619fc69de19a68da473dcfa244862582d or 0b1f510683b36d46440a781f8e151b7f942a9f23 Latter commit would not build so I can't confirm

One of those locale changes changed the behavior of the toupper() function Wrote my own ascii_to_upper() function to match expectations in the debugger code

## Related issues

Fixes #4089

# Release notes

Don't think this was ever in a release

# Manual testing

_Please describe the tests that you ran to verify your changes._

_Provide clear instructions so the reviewers can reproduce and verify your results._

_Include relevant details for your test configuration, operating system, etc._

_Ideally, you would also test your changes with a [sanitizer build](https://github.com/dosbox-staging/dosbox-staging/blob/main/BUILD.md#make-a-sanitizer-build) and confirm no issues were found._

_Non-trivial changes **must be** tested on all three OSes we support. If you can't test on a particular OS, ask the team or contributors for help._

The change has been manually tested on:

- [x] Windows
- [ ] macOS
- [x] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

