### PR TITLE
Don't assert on empty log message

### DIFF
--- a/src/dos/dos_locale.cpp
+++ b/src/dos/dos_locale.cpp
@@ -1404,9 +1404,12 @@ static void load_keyboard_layout()
 
 	if (using_detected) {
 		const auto& host_locale = GetHostKeyboardLayouts();
-		assert(!host_locale.log_info.empty());
-		LOG_MSG("LOCALE: Keyboard layout and code page detected from '%s'",
-		        host_locale.log_info.c_str());
+		if (host_locale.log_info.empty()) {
+			LOG_MSG("LOCALE: Unable to detect keyboard layout. Falling back to default or some shit.");
+		} else {
+			LOG_MSG("LOCALE: Keyboard layout and code page detected from '%s'",
+					host_locale.log_info.c_str());
+		}
 	}
 
 	// Apply the code page


### PR DESCRIPTION
# Description

I'm getting this assert fail + crash in a debug build since the recent locale changes.  I don't think this should be an assert.  I'm using KDE but my `.config/kxkbrc` file does not contain a `[Layout]` section so it fails to detect.

Probably should change the log message but I don't know what it does exactly if this fails :laughing: 

# Manual testing

~~Tested on Linux.  This is Linux only code.~~

Scratch that.  I think this is actually cross-platform code but all I'm doing is removing an assert.  The `GetHostKeyboardLayouts()` function right above the assert calls into platform-specific code.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

