### PR TITLE
Fix failing assertion when keyboard layout autodetection fails, prefer ROM font for autodetected code pages

### DIFF
--- a/src/dos/dos_locale.cpp
+++ b/src/dos/dos_locale.cpp
@@ -1349,6 +1349,14 @@ static std::vector<KeyboardLayoutMaybeCodepage> get_detected_keyboard_layouts()
 	const auto& host_locale = GetHostKeyboardLayouts();
 
 	auto keyboard_layouts = host_locale.keyboard_layout_list;
+	if (keyboard_layouts.empty()) {
+		LOG_MSG("LOCALE: Could not detect host keyboard layouts");
+		return {};
+	}
+
+	assert(!host_locale.log_info.empty());
+	LOG_MSG("LOCALE: Keyboard layout and code page detected from '%s'",
+	        host_locale.log_info.c_str());
 
 	// Keyboard layouts in modern OSes support just one script (like only
 	// Latin, only Greek, only Cyrillic, etc.) and in countries using
@@ -1400,13 +1408,6 @@ static void load_keyboard_layout()
 				}
 			}
 		}
-	}
-
-	if (using_detected) {
-		const auto& host_locale = GetHostKeyboardLayouts();
-		assert(!host_locale.log_info.empty());
-		LOG_MSG("LOCALE: Keyboard layout and code page detected from '%s'",
-		        host_locale.log_info.c_str());
 	}
 
 	// Apply the code page

--- a/src/dos/dos_locale.cpp
+++ b/src/dos/dos_locale.cpp
@@ -1412,7 +1412,7 @@ static void load_keyboard_layout()
 
 	// Apply the code page
 	KeyboardLayoutResult result = KeyboardLayoutResult::LayoutNotKnown;
-	const bool prefer_rom_font  = !using_detected && !code_page_supplied;
+	const bool prefer_rom_font  = using_detected || !code_page_supplied;
 	for (const auto& keyboard_layout : keyboard_layouts) {
 		uint16_t tried_code_page = 0;
 		if (keyboard_layout.code_page) {
@@ -1458,8 +1458,9 @@ static void load_keyboard_layout()
 
 	// Make sure some keyboard layout is actually set
 	if (DOS_GetLoadedLayout().empty()) {
+		constexpr bool PreferRomFont = true;
 		uint16_t tried_code_page = 0;
-		DOS_LoadKeyboardLayout("us", tried_code_page);
+		DOS_LoadKeyboardLayout("us", tried_code_page, {}, PreferRomFont);
 	}
 }
 


### PR DESCRIPTION
# Description

_Describe a summary of your changes clearly and concisely, including motivation and context._
_Breaking changes need extra explanation on backward compatibility considerations._

_Feel free to include additional details, but please respect the reviewer's time and keep it brief._


## Related issues

_Related issues can be listed here (remove the section if not applicable.)_


# Release notes

_If this is a user-facing change that should be mentioned in the release notes, please provide a draft of the notes here._

_It doesn't have to be perfect; the person writing the release notes will expand this if needed._

_(Remove the section if no notes are needed.)_


# Manual testing

_Please describe the tests that you ran to verify your changes._

_Provide clear instructions so the reviewers can reproduce and verify your results._

_Include relevant details for your test configuration, operating system, etc._

_Ideally, you would also test your changes with a [sanitizer build](https://github.com/dosbox-staging/dosbox-staging/blob/main/BUILD.md#make-a-sanitizer-build) and confirm no issues were found._

_Non-trivial changes **must be** tested on all three OSes we support. If you can't test on a particular OS, ask the team or contributors for help._

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [ ] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [ ] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [ ] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [ ] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

