### PR TITLE
Lower default master volume

### DIFF
--- a/include/mixer.h
+++ b/include/mixer.h
@@ -233,12 +233,17 @@ public:
 	void SetResampleMethod(const ResampleMethod method);
 	void SetZeroOrderHoldUpsamplerTargetRate(const int target_rate_hz);
 
+	// The crossfeed strength is a perceptually linear scale from 0.0
+	// to 1.0. A value of 0.0 means no crossfeed, and 1.0 means the stereo
+	// signal is collapsed into mono.
 	void SetCrossfeedStrength(const float strength);
 	float GetCrossfeedStrength() const;
 
+	// The reverb level is a perceptually linear scale from 0.0 to 1.0.
 	void SetReverbLevel(const float level);
 	float GetReverbLevel() const;
 
+	// The chorus level is a perceptually linear scale from 0.0 to 1.0
 	void SetChorusLevel(const float level);
 	float GetChorusLevel() const;
 

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -261,7 +261,7 @@ public:
 	bool WakeUp();
 
 	std::vector<AudioFrame> audio_frames = {};
-	std::recursive_mutex mutex = {};
+	std::recursive_mutex mutex           = {};
 
 	std::atomic<bool> is_enabled = false;
 
@@ -270,7 +270,6 @@ public:
 		float send_gain = 0.0f;
 	} reverb            = {};
 	bool do_reverb_send = false;
-
 
 	struct {
 		float level     = 0.0f;
@@ -427,7 +426,7 @@ private:
 			int order          = 0;
 			int cutoff_freq_hz = 0;
 		} lowpass = {};
-	} filters               = {};
+	} filters = {};
 
 	struct {
 		float strength  = 0.0f;
@@ -480,14 +479,15 @@ void MIXER_SetReverbPreset(const ReverbPreset new_preset);
 ChorusPreset MIXER_GetChorusPreset();
 void MIXER_SetChorusPreset(const ChorusPreset new_preset);
 
-// Generic callback used for audio devices which generate audio on the main thread
-// These devices produce audio on the main thread and consume on the mixer thread
-// This callback is the consumer part
+// Generic callback used for audio devices which generate audio on the main
+// thread These devices produce audio on the main thread and consume on the
+// mixer thread This callback is the consumer part
 template <class DeviceType, class AudioType, bool stereo, bool signeddata, bool nativeorder>
 inline void MIXER_PullFromQueueCallback(const int frames_requested, DeviceType* device)
 {
-	// Currently only handles mono sound (output_queue is a primitive type and frames == samples)
-	// Special case for AudioType == AudioFrame (stereo floating-point sound)
+	// Currently only handles mono sound (output_queue is a primitive type
+	// and frames == samples) Special case for AudioType == AudioFrame
+	// (stereo floating-point sound)
 	static_assert((!stereo) || std::is_same_v<AudioType, AudioFrame>);
 
 	// AudioFrame type is always stereo
@@ -496,22 +496,29 @@ inline void MIXER_PullFromQueueCallback(const int frames_requested, DeviceType* 
 	assert(device && device->channel);
 
 	if (MIXER_FastForwardModeEnabled()) {
-		// Special case, normally only hit when using the fast-forward hotkey (Alt + F12)
-		// We need a very large buffer to compensate or it results in static
+		// Special case, normally only hit when using the fast-forward
+		// hotkey (Alt + F12) We need a very large buffer to compensate
+		// or it results in static
 
 		// Mostly arbitrary but it works well in testing.
-		// The queue just needs to be large enough to hold the large frame requests we get in fast-forward mode.
-		// This value can be tweaked without much consequence if it ever becomes problematic.
+		// The queue just needs to be large enough to hold the large
+		// frame requests we get in fast-forward mode. This value can be
+		// tweaked without much consequence if it ever becomes
+		// problematic.
 		constexpr float MaxExpectedFastForwardFactor = 100.0f;
-		device->output_queue.Resize(iceil(device->channel->GetFramesPerBlock() * MaxExpectedFastForwardFactor));
+		device->output_queue.Resize(iceil(device->channel->GetFramesPerBlock() *
+		                                  MaxExpectedFastForwardFactor));
 	} else {
-		// Normal case, resize the queue to ensure we don't have high latency
-		// Resize is a fast operation, only setting a variable for max capacity
-		// It does not drop frames or append zeros to the end of the underlying data structure
+		// Normal case, resize the queue to ensure we don't have high
+		// latency Resize is a fast operation, only setting a variable
+		// for max capacity It does not drop frames or append zeros to
+		// the end of the underlying data structure
 
-		// Size to 2x blocksize. The mixer callback will request 1x blocksize.
-		// This provides a good size to avoid over-runs and stalls.
-		device->output_queue.Resize(iceil(device->channel->GetFramesPerBlock() * 2.0f));
+		// Size to 2x blocksize. The mixer callback will request 1x
+		// blocksize. This provides a good size to avoid over-runs and
+		// stalls.
+		device->output_queue.Resize(
+		        iceil(device->channel->GetFramesPerBlock() * 2.0f));
 	}
 	static std::vector<AudioType> to_mix = {};
 

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -126,12 +126,12 @@ enum class ChannelFeature {
 enum class FilterState { Off, On };
 
 struct MixerChannelSettings {
-	bool is_enabled          = {};
-	AudioFrame user_volume   = {};
-	StereoLine lineout_map   = {};
-	float crossfeed_strength = {};
-	float reverb_level       = {};
-	float chorus_level       = {};
+	bool is_enabled             = {};
+	AudioFrame user_volume_gain = {};
+	StereoLine lineout_map      = {};
+	float crossfeed_strength    = {};
+	float reverb_level          = {};
+	float chorus_level          = {};
 };
 
 enum class ResampleMethod {
@@ -190,19 +190,19 @@ public:
 	// The "user volume" is the volume level of the built-in DOSBox mixer
 	// (MIXER command)
 	const AudioFrame GetUserVolume() const;
-	void SetUserVolume(const AudioFrame volume);
+	void SetUserVolume(const AudioFrame gain);
 
 	// The "app volume" is the volume level set programmatically by DOS
 	// programs (on audio devices that support that, e.g., the Sound
 	// Blaster mixer, or the CD Audio volume level).
 	//
-	// For example, if you set the volume level of the CDAUDIO channel to 50%
-	// in the mixer via `MIXER CDAUDIO 50`, then you also set the CD audio
-	// music level in a game to "half volume", the final volume will be around
-	// 25%.
+	// For example, if you set the volume level of the CDAUDIO channel to
+	// 50% in the mixer via `MIXER CDAUDIO 50`, then you also set the CD
+	// audio music level in a game to "half volume", the final volume will
+	// be around 25%.
 	//
 	const AudioFrame GetAppVolume() const;
-	void SetAppVolume(const AudioFrame volume);
+	void SetAppVolume(const AudioFrame gain);
 
 	void SetChannelMap(const StereoLine map);
 
@@ -345,14 +345,14 @@ private:
 	std::atomic<int> sample_rate_hz = 0;
 
 	// Volume gains
-	// ~~~~~!~~~~~~
-	// The user sets this via MIXER.COM, which lets them magnify or diminish
-	// the channel's volume relative to other adjustments, such as any
-	// adjustments done by the application at runtime.
+	// ~~~~~~~~~~~~
+	// The user sets this via the MIXER command, which lets them magnify or
+	// diminish the channel's volume relative to other adjustments, such as
+	// any adjustments done by the application at runtime.
 	AudioFrame user_volume_gain = {1.0f, 1.0f};
 
 	// The application (might) adjust a channel's volume programmatically at
-	// runtime via the Sound Blaster or ReelMagic control interfaces.
+	// runtime (e.g., via the Sound Blaster or ReelMagic control interfaces).
 	AudioFrame app_volume_gain = {1.0f, 1.0f};
 
 	// The 0 dB volume gain is used to bring a channel to 0 dB in the
@@ -368,9 +368,9 @@ private:
 	//
 	float db0_volume_gain = 1.0f;
 
-	// All three of these are multiplied together to form the combined
-	// volume gain. This means we can apply one float-multiply per sample
-	// and perform all three adjustments at once.
+	// All three of these volume gains are multiplied together to form the
+	// combined volume gain. This means we can apply one float-multiply per
+	// sample and perform all three adjustments at once.
 	//
 	AudioFrame combined_volume_gain = {1.0f, 1.0f};
 
@@ -458,7 +458,7 @@ void MIXER_DisableFastForwardMode();
 bool MIXER_FastForwardModeEnabled();
 
 const AudioFrame MIXER_GetMasterVolume();
-void MIXER_SetMasterVolume(const AudioFrame volume);
+void MIXER_SetMasterVolume(const AudioFrame gain);
 
 void MIXER_Mute();
 void MIXER_Unmute();

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -472,7 +472,7 @@ void MIXER_UnlockMixerThread();
 void MIXER_CloseAudioDevice();
 
 // Return true if the mixer was explicitly muted by the user (as opposed to
-// auto-muted when `mute_when_inactive` is enabled)
+// auto-muted when `mute_when_inactive` is enabled).
 bool MIXER_IsManuallyMuted();
 
 CrossfeedPreset MIXER_GetCrossfeedPreset();
@@ -485,14 +485,14 @@ ChorusPreset MIXER_GetChorusPreset();
 void MIXER_SetChorusPreset(const ChorusPreset new_preset);
 
 // Generic callback used for audio devices which generate audio on the main
-// thread These devices produce audio on the main thread and consume on the
-// mixer thread This callback is the consumer part
+// thread. These devices produce audio on the main thread and consume on the
+// mixer thread. This callback is the consumer part.
 template <class DeviceType, class AudioType, bool stereo, bool signeddata, bool nativeorder>
 inline void MIXER_PullFromQueueCallback(const int frames_requested, DeviceType* device)
 {
 	// Currently only handles mono sound (output_queue is a primitive type
-	// and frames == samples) Special case for AudioType == AudioFrame
-	// (stereo floating-point sound)
+	// and frames == samples). Special case for AudioType == AudioFrame
+	// (stereo floating-point sound).
 	static_assert((!stereo) || std::is_same_v<AudioType, AudioFrame>);
 
 	// AudioFrame type is always stereo
@@ -502,8 +502,8 @@ inline void MIXER_PullFromQueueCallback(const int frames_requested, DeviceType* 
 
 	if (MIXER_FastForwardModeEnabled()) {
 		// Special case, normally only hit when using the fast-forward
-		// hotkey (Alt + F12) We need a very large buffer to compensate
-		// or it results in static
+		// hotkey (Alt + F12). We need a very large buffer to compensate
+		// or it results in static.
 
 		// Mostly arbitrary but it works well in testing.
 		// The queue just needs to be large enough to hold the large
@@ -515,9 +515,9 @@ inline void MIXER_PullFromQueueCallback(const int frames_requested, DeviceType* 
 		                                  MaxExpectedFastForwardFactor));
 	} else {
 		// Normal case, resize the queue to ensure we don't have high
-		// latency Resize is a fast operation, only setting a variable
+		// latency. Resize is a fast operation, only setting a variable
 		// for max capacity It does not drop frames or append zeros to
-		// the end of the underlying data structure
+		// the end of the underlying data structure.
 
 		// Size to 2x blocksize. The mixer callback will request 1x
 		// blocksize. This provides a good size to avoid over-runs and

--- a/src/dos/program_mixer.cpp
+++ b/src/dos/program_mixer.cpp
@@ -206,9 +206,8 @@ static std::variant<Error, Command> parse_volume_command(const std::string& s,
                                                          const std::string& channel_name)
 {
 	if (is_global_channel(channel_name)) {
-		const auto message = format_str(
-		        MSG_Get("SHELL_CMD_MIXER_INVALID_GLOBAL_COMMAND"),
-		        s.c_str());
+		const auto message = format_str(MSG_Get("SHELL_CMD_MIXER_INVALID_GLOBAL_COMMAND"),
+		                                s.c_str());
 
 		return error(ErrorType::InvalidGlobalCommand, message);
 	}
@@ -278,8 +277,8 @@ static std::variant<Error, Command> parse_volume_command(const std::string& s,
 		} else {
 			const Error error = {ErrorType::InvalidVolumeCommand,
 			                     format_str(MSG_Get("SHELL_CMD_MIXER_INVALID_VOLUME_COMMAND"),
-			                                   channel_name.c_str(),
-			                                   s.c_str())};
+			                                channel_name.c_str(),
+			                                s.c_str())};
 			return error;
 		}
 
@@ -293,15 +292,15 @@ static std::variant<Error, Command> parse_volume_command(const std::string& s,
 		} else {
 			const Error error = {ErrorType::InvalidVolumeCommand,
 			                     format_str(MSG_Get("SHELL_CMD_MIXER_INVALID_VOLUME_COMMAND"),
-			                                   channel_name.c_str(),
-			                                   s.c_str())};
+			                                channel_name.c_str(),
+			                                s.c_str())};
 			return error;
 		}
 	} else { // more than 2 parts
 		const Error error = {ErrorType::InvalidVolumeCommand,
 		                     format_str(MSG_Get("SHELL_CMD_MIXER_INVALID_VOLUME_COMMAND"),
-		                                   channel_name.c_str(),
-		                                   s.c_str())};
+		                                channel_name.c_str(),
+		                                s.c_str())};
 		return error;
 	}
 }
@@ -333,8 +332,8 @@ static bool is_command_with_prefix(const std::string& s, const char prefix)
 static Error make_invalid_master_channel_command_error(const std::string& command)
 {
 	const auto message = format_str(MSG_Get("SHELL_CMD_MIXER_INVALID_CHANNEL_COMMAND"),
-	                                   ChannelName::Master,
-	                                   command.c_str());
+	                                ChannelName::Master,
+	                                command.c_str());
 
 	return error(ErrorType::InvalidMasterChannelCommand, message);
 }
@@ -367,7 +366,7 @@ static std::variant<Error, Command> parse_crossfeed_command(
 		                 : "SHELL_CMD_MIXER_MISSING_CROSSFEED_STRENGTH");
 
 		const auto message = format_str(MSG_Get(msg_id),
-		                                   channel_name.c_str());
+		                                channel_name.c_str());
 
 		return error(ErrorType::MissingCrossfeedStrength, message);
 	}
@@ -417,7 +416,7 @@ static std::variant<Error, Command> parse_reverb_command(const std::string& s,
 		                             : "SHELL_CMD_MIXER_MISSING_REVERB_LEVEL");
 
 		const auto message = format_str(MSG_Get(msg_id),
-		                                   channel_name.c_str());
+		                                channel_name.c_str());
 
 		return error(ErrorType::MissingReverbLevel, message);
 	}
@@ -468,7 +467,7 @@ static std::variant<Error, Command> parse_chorus_command(const std::string& s,
 		                             : "SHELL_CMD_MIXER_MISSING_CHORUS_LEVEL");
 
 		const auto message = format_str(MSG_Get(msg_id),
-		                                   channel_name.c_str());
+		                                channel_name.c_str());
 
 		return error(ErrorType::MissingChorusLevel, message);
 	}
@@ -783,8 +782,9 @@ void MIXER::Run()
 
 		// To give people a hint if their [autoexec] contains invalid
 		// MIXER commands.
-		LOG_WARNING("MIXER: Incorrect MIXER command invocation; "
-		            "run MIXER /? for help");
+		LOG_WARNING(
+		        "MIXER: Incorrect MIXER command invocation; "
+		        "run MIXER /? for help");
 	}
 }
 

--- a/src/dos/program_mixer.cpp
+++ b/src/dos/program_mixer.cpp
@@ -43,7 +43,7 @@ bool SelectChannel::operator==(const SelectChannel that) const
 
 bool SetVolume::operator==(const SetVolume that) const
 {
-	return volume == that.volume;
+	return volume_as_gain == that.volume_as_gain;
 }
 
 bool SetStereoMode::operator==(const SetStereoMode that) const
@@ -85,10 +85,10 @@ void Executor::operator()(const SelectChannel cmd)
 void Executor::operator()(const SetVolume cmd)
 {
 	if (master_channel) {
-		MIXER_SetMasterVolume(cmd.volume);
+		MIXER_SetMasterVolume(cmd.volume_as_gain);
 	} else {
 		assert(channel);
-		channel->SetUserVolume({cmd.volume.left, cmd.volume.right});
+		channel->SetUserVolume(cmd.volume_as_gain);
 	}
 }
 
@@ -903,17 +903,17 @@ void MIXER::ShowMixerStatus()
 	column_layout.append({'\n'});
 
 	auto show_channel = [&](const std::string& name,
-	                        const AudioFrame& volume,
+	                        const AudioFrame& volume_as_gain,
 	                        const std::string& mode,
 	                        const std::string& xfeed,
 	                        const std::string& reverb,
 	                        const std::string& chorus) {
 		WriteOut(column_layout.c_str(),
 		         name.c_str(),
-		         static_cast<double>(gain_to_percentage(volume.left)),
-		         static_cast<double>(gain_to_percentage(volume.right)),
-		         static_cast<double>(gain_to_decibel(volume.left)),
-		         static_cast<double>(gain_to_decibel(volume.right)),
+		         static_cast<double>(gain_to_percentage(volume_as_gain.left)),
+		         static_cast<double>(gain_to_percentage(volume_as_gain.right)),
+		         static_cast<double>(gain_to_decibel(volume_as_gain.left)),
+		         static_cast<double>(gain_to_decibel(volume_as_gain.right)),
 		         mode.c_str(),
 		         xfeed.c_str(),
 		         reverb.c_str(),

--- a/src/dos/program_mixer.h
+++ b/src/dos/program_mixer.h
@@ -59,7 +59,7 @@ struct SelectChannel {
 };
 
 struct SetVolume {
-	AudioFrame volume = {};
+	AudioFrame volume_as_gain = {};
 	bool operator==(const SetVolume that) const;
 };
 
@@ -69,16 +69,19 @@ struct SetStereoMode {
 };
 
 struct SetCrossfeedStrength {
+	// 0.0 to 1.0
 	float strength = {};
 	bool operator==(const SetCrossfeedStrength that) const;
 };
 
 struct SetReverbLevel {
+	// 0.0 to 1.0
 	float level = {};
 	bool operator==(const SetReverbLevel that) const;
 };
 
 struct SetChorusLevel {
+	// 0.0 to 1.0
 	float level = {};
 	bool operator==(const SetChorusLevel that) const;
 };

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -280,24 +280,19 @@ bool MIXER_FastForwardModeEnabled()
 }
 
 // The queues listed here are for audio devices that run on the main thread
-// The mixer thread can be waiting on the main thread to produce audio in these queues
-// We need to stop them before aquiring a mutex lock to avoid a deadlock
-// These are called infrequently when global mixer state is changed (mostly on device init/destroy and in the MIXER command line program)
-// Individual channels also have a mutex which can be safely aquired without stopping these queues
+// The mixer thread can be waiting on the main thread to produce audio in these
+// queues We need to stop them before aquiring a mutex lock to avoid a deadlock
+// These are called infrequently when global mixer state is changed (mostly on
+// device init/destroy and in the MIXER command line program) Individual channels
+// also have a mutex which can be safely aquired without stopping these queues
 void MIXER_LockMixerThread()
 {
 	PCSPEAKER_NotifyLockMixer();
-
 	TANDYDAC_NotifyLockMixer();
-
 	PS1DAC_NotifyLockMixer();
-
 	LPTDAC_NotifyLockMixer();
-
 	GUS_NotifyLockMixer();
-
 	REELMAGIC_NotifyLockMixer();
-
 	SBLASTER_NotifyLockMixer();
 
 	mixer.mutex.lock();
@@ -306,17 +301,11 @@ void MIXER_LockMixerThread()
 void MIXER_UnlockMixerThread()
 {
 	PCSPEAKER_NotifyUnlockMixer();
-
 	TANDYDAC_NotifyUnlockMixer();
-
 	PS1DAC_NotifyUnlockMixer();
-
 	LPTDAC_NotifyUnlockMixer();
-
 	GUS_NotifyUnlockMixer();
-
 	REELMAGIC_NotifyUnlockMixer();
-
 	SBLASTER_NotifyLockMixer();
 
 	mixer.mutex.unlock();
@@ -839,8 +828,7 @@ void MixerChannel::SetAppVolume(const AudioFrame gain)
 		constexpr auto MaxUnityVolume = 1.0f;
 		return clamp(vol, MinUnityVolume, MaxUnityVolume);
 	};
-	app_volume_gain = {clamp_to_unity(gain.left),
-	                   clamp_to_unity(gain.right)};
+	app_volume_gain = {clamp_to_unity(gain.left), clamp_to_unity(gain.right)};
 	UpdateCombinedVolume();
 
 #ifdef DEBUG
@@ -849,7 +837,7 @@ void MixerChannel::SetAppVolume(const AudioFrame gain)
 	        name,
 	        static_cast<double>(left),
 	        static_cast<double>(right),
-	        static_cast<double>(app_volume_gain.left  * 100.0f),
+	        static_cast<double>(app_volume_gain.left * 100.0f),
 	        static_cast<double>(app_volume_gain.right * 100.0f));
 #endif
 }
@@ -1115,13 +1103,17 @@ static float get_mixer_frames_per_tick()
 
 float MixerChannel::GetFramesPerTick() const
 {
-	const float stretch_factor = static_cast<float>(sample_rate_hz) / static_cast<float>(mixer.sample_rate_hz);
+	const float stretch_factor = static_cast<float>(sample_rate_hz) /
+	                             static_cast<float>(mixer.sample_rate_hz);
+
 	return get_mixer_frames_per_tick() * stretch_factor;
 }
 
 float MixerChannel::GetFramesPerBlock() const
 {
-	const float stretch_factor = static_cast<float>(sample_rate_hz) / static_cast<float>(mixer.sample_rate_hz);
+	const float stretch_factor = static_cast<float>(sample_rate_hz) /
+	                             static_cast<float>(mixer.sample_rate_hz);
+
 	return static_cast<float>(mixer.blocksize) * stretch_factor;
 }
 
@@ -1156,7 +1148,7 @@ void MixerChannel::Mix(const int frames_requested)
 		std::unique_lock lock(mutex);
 
 		auto stretch_factor = static_cast<float>(sample_rate_hz) /
-						static_cast<float>(mixer.sample_rate_hz);
+		                      static_cast<float>(mixer.sample_rate_hz);
 
 		auto frames_remaining = iceil(
 		        static_cast<float>(frames_needed - audio_frames.size()) *
@@ -1214,7 +1206,7 @@ void MixerChannel::AddSilence()
 				        combined_volume_gain;
 
 				AudioFrame out_frame = {};
-				out_frame[mapped_output_left]  = frame_with_gain.left;
+				out_frame[mapped_output_left] = frame_with_gain.left;
 				out_frame[mapped_output_right] = frame_with_gain.right;
 
 				audio_frames.push_back(out_frame);
@@ -1478,7 +1470,7 @@ void MixerChannel::InitZohUpsamplerState()
 	                     static_cast<float>(zoh_upsampler.target_rate_hz);
 	assert(zoh_upsampler.step < 1.0f);
 
-	zoh_upsampler.pos  = 0.0f;
+	zoh_upsampler.pos = 0.0f;
 }
 
 void MixerChannel::InitLerpUpsamplerState()
@@ -1548,8 +1540,8 @@ void MixerChannel::SetReverbLevel(const float level)
 {
 	std::lock_guard lock(mutex);
 
-	constexpr auto LevelMin    = 0.0f;
-	constexpr auto LevelMax    = 1.0f;
+	constexpr auto LevelMin   = 0.0f;
+	constexpr auto LevelMax   = 1.0f;
 	constexpr auto LevelMinDb = -40.0f;
 	constexpr auto LevelMaxDb = 0.0f;
 
@@ -1589,8 +1581,8 @@ float MixerChannel::GetReverbLevel() const
 
 void MixerChannel::SetChorusLevel(const float level)
 {
-	constexpr auto LevelMin    = 0.0f;
-	constexpr auto LevelMax    = 1.0f;
+	constexpr auto LevelMin   = 0.0f;
+	constexpr auto LevelMax   = 1.0f;
 	constexpr auto LevelMinDb = -24.0f;
 	constexpr auto LevelMaxDb = 0.0f;
 
@@ -1651,6 +1643,7 @@ static constexpr void fill_8to16_lut()
 	}
 }
 
+// clang-format off
 template <class Type, bool stereo, bool signeddata, bool nativeorder>
 AudioFrame MixerChannel::ConvertNextFrame(const Type* data, const int pos)
 {
@@ -1669,7 +1662,7 @@ AudioFrame MixerChannel::ConvertNextFrame(const Type* data, const int pos)
 				frame.left  = lut_u8to16[static_cast<uint8_t>(data[left_pos])];
 				frame.right = lut_u8to16[static_cast<uint8_t>(data[right_pos])];
 			} else {
-				frame.left = lut_u8to16[static_cast<uint8_t>(data[pos])];
+				frame.left  = lut_u8to16[static_cast<uint8_t>(data[pos])];
 			}
 		}
 		// signed 8-bit
@@ -1678,7 +1671,7 @@ AudioFrame MixerChannel::ConvertNextFrame(const Type* data, const int pos)
 				frame.left  = lut_s8to16[static_cast<int8_t>(data[left_pos])];
 				frame.right = lut_s8to16[static_cast<int8_t>(data[right_pos])];
 			} else {
-				frame.left = lut_s8to16[static_cast<int8_t>(data[pos])];
+				frame.left  = lut_s8to16[static_cast<int8_t>(data[pos])];
 			}
 		}
 	} else {
@@ -1689,33 +1682,27 @@ AudioFrame MixerChannel::ConvertNextFrame(const Type* data, const int pos)
 					frame.left  = static_cast<float>(data[left_pos]);
 					frame.right = static_cast<float>(data[right_pos]);
 				} else {
-					auto host_pt0 = reinterpret_cast<const uint8_t* const>(
-					        data + left_pos);
-					auto host_pt1 = reinterpret_cast<const uint8_t* const>(
-					        data + right_pos);
+					auto host_pt0 = reinterpret_cast<const uint8_t* const>(data + left_pos);
+					auto host_pt1 = reinterpret_cast<const uint8_t* const>(data + right_pos);
 
 					if (sizeof(Type) == 2) {
 						frame.left  = (int16_t)host_readw(host_pt0);
 						frame.right = (int16_t)host_readw(host_pt1);
 					} else {
-						frame.left = static_cast<float>(
-						        (int32_t)host_readd(host_pt0));
-						frame.right = static_cast<float>(
-						        (int32_t)host_readd(host_pt1));
+						frame.left  = static_cast<float>((int32_t)host_readd(host_pt0));
+						frame.right = static_cast<float>((int32_t)host_readd(host_pt1));
 					}
 				}
 			} else { // mono
 				if (nativeorder) {
 					frame.left = static_cast<float>(data[pos]);
 				} else {
-					auto host_pt = reinterpret_cast<const uint8_t* const>(
-					        data + pos);
+					auto host_pt = reinterpret_cast<const uint8_t* const>(data + pos);
 
 					if (sizeof(Type) == 2) {
 						frame.left = (int16_t)host_readw(host_pt);
 					} else {
-						frame.left = static_cast<float>(
-						        (int32_t)host_readd(host_pt));
+						frame.left = static_cast<float>((int32_t)host_readd(host_pt));
 					}
 				}
 			}
@@ -1723,56 +1710,31 @@ AudioFrame MixerChannel::ConvertNextFrame(const Type* data, const int pos)
 			const auto offs = 32768;
 			if (stereo) {
 				if (nativeorder) {
-					frame.left = static_cast<float>(
-					        static_cast<int>(data[left_pos]) -
-					        offs);
-					frame.right = static_cast<float>(
-					        static_cast<int>(data[right_pos]) -
-					        offs);
+					frame.left = static_cast<float>(static_cast<int>(data[left_pos]) - offs);
+
+					frame.right = static_cast<float>(static_cast<int>(data[right_pos]) - offs);
 				} else {
-					auto host_pt0 = reinterpret_cast<const uint8_t* const>(
-					        data + left_pos);
-					auto host_pt1 = reinterpret_cast<const uint8_t* const>(
-					        data + right_pos);
+					auto host_pt0 = reinterpret_cast<const uint8_t* const>(data + left_pos);
+					auto host_pt1 = reinterpret_cast<const uint8_t* const>(data + right_pos);
 
 					if (sizeof(Type) == 2) {
-						frame.left = static_cast<float>(
-						        static_cast<int>(host_readw(
-						                host_pt0)) -
-						        offs);
-						frame.right = static_cast<float>(
-						        static_cast<int>(host_readw(
-						                host_pt1)) -
-						        offs);
+						frame.left  = static_cast<float>(static_cast<int>(host_readw(host_pt0)) - offs);
+						frame.right = static_cast<float>(static_cast<int>(host_readw(host_pt1)) - offs);
 					} else {
-						frame.left = static_cast<float>(
-						        static_cast<int>(host_readd(
-						                host_pt0)) -
-						        offs);
-						frame.right = static_cast<float>(
-						        static_cast<int>(host_readd(
-						                host_pt1)) -
-						        offs);
+						frame.left  = static_cast<float>(static_cast<int>(host_readd(host_pt0)) - offs);
+						frame.right = static_cast<float>(static_cast<int>(host_readd(host_pt1)) - offs);
 					}
 				}
 			} else { // mono
 				if (nativeorder) {
-					frame.left = static_cast<float>(
-					        static_cast<int>(data[pos]) - offs);
+					frame.left = static_cast<float>(static_cast<int>(data[pos]) - offs);
 				} else {
-					auto host_pt = reinterpret_cast<const uint8_t* const>(
-					        data + pos);
+					auto host_pt = reinterpret_cast<const uint8_t* const>(data + pos);
 
 					if (sizeof(Type) == 2) {
-						frame.left = static_cast<float>(
-						        static_cast<int>(host_readw(
-						                host_pt)) -
-						        offs);
+						frame.left = static_cast<float>(static_cast<int>(host_readw(host_pt)) - offs);
 					} else {
-						frame.left = static_cast<float>(
-						        static_cast<int>(host_readd(
-						                host_pt)) -
-						        offs);
+						frame.left = static_cast<float>(static_cast<int>(host_readd(host_pt)) - offs);
 					}
 				}
 			}
@@ -1780,6 +1742,7 @@ AudioFrame MixerChannel::ConvertNextFrame(const Type* data, const int pos)
 	}
 	return frame;
 }
+// clang-format on
 
 // Converts sample stream to floats, performs output channel mappings, removes
 // clicks, and optionally performs zero-order-hold-upsampling.
@@ -1796,7 +1759,7 @@ void MixerChannel::ConvertSamplesAndMaybeZohUpsample(const Type* data,
 	const auto mapped_channel_left  = channel_map.left;
 	const auto mapped_channel_right = channel_map.right;
 
-	auto pos             = 0;
+	auto pos = 0;
 
 	while (pos < num_frames) {
 		prev_frame = next_frame;
@@ -1805,6 +1768,7 @@ void MixerChannel::ConvertSamplesAndMaybeZohUpsample(const Type* data,
 			if (stereo) {
 				next_frame.left = static_cast<float>(
 				        data[pos * 2 + 0]);
+
 				next_frame.right = static_cast<float>(
 				        data[pos * 2 + 1]);
 			} else {
@@ -1829,7 +1793,7 @@ void MixerChannel::ConvertSamplesAndMaybeZohUpsample(const Type* data,
 		envelope.Process(stereo, frame_with_gain);
 
 		AudioFrame out_frame = {};
-		out_frame[mapped_output_left]  += frame_with_gain.left;
+		out_frame[mapped_output_left] += frame_with_gain.left;
 		out_frame[mapped_output_right] += frame_with_gain.right;
 
 		convert_buffer.push_back(out_frame);
@@ -1867,7 +1831,7 @@ AudioFrame MixerChannel::ApplyCrossfeed(const AudioFrame frame) const
 	auto pan = [](const float sample, const float pan) -> AudioFrame {
 		return {(1.0f - pan) * sample, pan * sample};
 	};
-	const auto a = pan(frame.left,  crossfeed.pan_left);
+	const auto a = pan(frame.left, crossfeed.pan_left);
 	const auto b = pan(frame.right, crossfeed.pan_right);
 	return {a.left + b.left, a.right + b.right};
 }
@@ -1989,8 +1953,8 @@ AudioFrame MixerChannel::Sleeper::MaybeFadeOrListen(const AudioFrame& frame)
 
 void MixerChannel::Sleeper::MaybeSleep()
 {
-	// A signed integer can a durration of ~24 days in milliseconds, which is
-	// surely more than enough.
+	// A signed integer can a durration of ~24 days in milliseconds, which
+	// is surely more than enough.
 	const auto awake_for_ms = check_cast<int>(GetTicksSince(woken_at_ms));
 
 	// Not enough time has passed.. .. try to sleep later
@@ -2068,9 +2032,12 @@ void MixerChannel::AddSamples(const int num_frames, const Type* data)
 
 	// Assert that we're not attempting to do both LERP and Speex resample
 	// We can do one or neither
-	assert((do_lerp_upsample && !do_resample) || (!do_lerp_upsample && do_resample) || (!do_lerp_upsample && !do_resample));
+	assert((do_lerp_upsample && !do_resample) ||
+	       (!do_lerp_upsample && do_resample) ||
+	       (!do_lerp_upsample && !do_resample));
 
-	ConvertSamplesAndMaybeZohUpsample<Type, stereo, signeddata, nativeorder>(data, num_frames);
+	ConvertSamplesAndMaybeZohUpsample<Type, stereo, signeddata, nativeorder>(
+	        data, num_frames);
 
 	// Starting index this function will start writing to
 	// The audio_frames vector can contain previously converted/resampled audio
@@ -2086,13 +2053,13 @@ void MixerChannel::AddSamples(const int num_frames, const Type* data)
 
 			assert(s.pos >= 0.0f && s.pos <= 1.0f);
 			AudioFrame lerped_frame = {};
-			lerped_frame.left = lerp(s.last_frame.left,
-			                           curr_frame.left,
-			                           s.pos);
+			lerped_frame.left       = lerp(s.last_frame.left,
+                                                 curr_frame.left,
+                                                 s.pos);
 
 			lerped_frame.right = lerp(s.last_frame.right,
-			                            curr_frame.right,
-			                            s.pos);
+			                          curr_frame.right,
+			                          s.pos);
 
 			audio_frames.push_back(lerped_frame);
 
@@ -2126,14 +2093,18 @@ void MixerChannel::AddSamples(const int num_frames, const Type* data)
 		        estimate_max_out_frames(speex_resampler.state, in_frames));
 
 		// Store this as a temporary variable
-		// out_frames gets modified by Speex to reflect the actual frames it wrote
+		// out_frames gets modified by Speex to reflect the actual
+		// frames it wrote
 		const auto estimated_frames = out_frames;
 
 		audio_frames.resize(audio_frames_starting_size + estimated_frames);
 
 		// These are vectors of AudioFrame which is just 2 packed floats
-		const auto input_ptr = reinterpret_cast<const float*>(convert_buffer.data());
-		auto output_ptr = reinterpret_cast<float*>(audio_frames.data() + audio_frames_starting_size);
+		const auto input_ptr = reinterpret_cast<const float*>(
+		        convert_buffer.data());
+
+		auto output_ptr = reinterpret_cast<float*>(
+		        audio_frames.data() + audio_frames_starting_size);
 
 		speex_resampler_process_interleaved_float(speex_resampler.state,
 		                                          input_ptr,
@@ -2147,19 +2118,25 @@ void MixerChannel::AddSamples(const int num_frames, const Type* data)
 		assert(out_frames <= estimated_frames);
 		audio_frames.resize(audio_frames_starting_size + out_frames); // only shrinks
 	} else {
-		audio_frames.insert(audio_frames.end(), convert_buffer.begin(), convert_buffer.end());
+		audio_frames.insert(audio_frames.end(),
+		                    convert_buffer.begin(),
+		                    convert_buffer.end());
 	}
 
 	// Optionally filter, apply crossfeed
 	// Runs in-place over newly added frames
 	for (size_t i = audio_frames_starting_size; i < audio_frames.size(); ++i) {
 		if (filters.highpass.state == FilterState::On) {
-			audio_frames[i] = {filters.highpass.hpf[0].filter(audio_frames[i].left),
-			                   filters.highpass.hpf[1].filter(audio_frames[i].right)};
+			auto& hpf = filters.highpass.hpf;
+
+			audio_frames[i] = {hpf[0].filter(audio_frames[i].left),
+			                   hpf[1].filter(audio_frames[i].right)};
 		}
 		if (filters.lowpass.state == FilterState::On) {
-			audio_frames[i] = {filters.lowpass.lpf[0].filter(audio_frames[i].left),
-			                   filters.lowpass.lpf[1].filter(audio_frames[i].right)};
+			auto& lpf = filters.lowpass.lpf;
+
+			audio_frames[i] = {lpf[0].filter(audio_frames[i].left),
+			                   lpf[1].filter(audio_frames[i].right)};
 		}
 
 		if (do_crossfeed) {
@@ -2292,32 +2269,44 @@ static void mix_samples(const int frames_requested)
 
 	mixer.output_buffer.clear();
 	mixer.output_buffer.resize(frames_requested);
+
 	mixer.reverb_buffer.clear();
 	mixer.reverb_buffer.resize(frames_requested);
+
 	mixer.chorus_buffer.clear();
 	mixer.chorus_buffer.resize(frames_requested);
 
 	// Render all channels and accumulate results in the master mixbuffer
 	for (const auto& [_, channel] : mixer.channels) {
 		channel->Mix(frames_requested);
+
 		std::lock_guard lock(channel->mutex);
-		const size_t num_frames = std::min(mixer.output_buffer.size(), channel->audio_frames.size());
+
+		const size_t num_frames = std::min(mixer.output_buffer.size(),
+		                                   channel->audio_frames.size());
+
 		for (size_t i = 0; i < num_frames; ++i) {
 			if (channel->do_sleep) {
-				mixer.output_buffer[i] += channel->sleeper.MaybeFadeOrListen(channel->audio_frames[i]);
+				mixer.output_buffer[i] += channel->sleeper.MaybeFadeOrListen(
+				        channel->audio_frames[i]);
 			} else {
 				mixer.output_buffer[i] += channel->audio_frames[i];
 			}
 
 			if (mixer.do_reverb && channel->do_reverb_send) {
-				mixer.reverb_buffer[i] += channel->audio_frames[i] * channel->reverb.send_gain;
+				mixer.reverb_buffer[i] += channel->audio_frames[i] *
+				                          channel->reverb.send_gain;
 			}
 
 			if (mixer.do_chorus && channel->do_chorus_send) {
-				mixer.chorus_buffer[i] += channel->audio_frames[i] * channel->chorus.send_gain;
+				mixer.chorus_buffer[i] += channel->audio_frames[i] *
+				                          channel->chorus.send_gain;
 			}
 		}
-		channel->audio_frames.erase(channel->audio_frames.begin(), channel->audio_frames.begin() + num_frames);
+
+		channel->audio_frames.erase(channel->audio_frames.begin(),
+		                            channel->audio_frames.begin() + num_frames);
+
 		if (channel->do_sleep) {
 			channel->sleeper.MaybeSleep();
 		}
@@ -2330,8 +2319,8 @@ static void mix_samples(const int frames_requested)
 
 			// MVerb operates on two non-interleaved sample streams
 			AudioFrame in_frame = mixer.reverb_buffer[i];
-			in_frame.left = hpf[0].filter(in_frame.left);
-			in_frame.right = hpf[1].filter(in_frame.right);
+			in_frame.left       = hpf[0].filter(in_frame.left);
+			in_frame.right      = hpf[1].filter(in_frame.right);
 
 			float* in_buf[2] = {&in_frame.left, &in_frame.right};
 
@@ -2358,15 +2347,12 @@ static void mix_samples(const int frames_requested)
 	// Apply high-pass filter to the master output
 	for (auto& frame : mixer.output_buffer) {
 		auto& hpf = mixer.highpass_filter;
-		frame = {
-			hpf[0].filter(frame.left),
-			hpf[1].filter(frame.right)
-		};
+		frame = {hpf[0].filter(frame.left), hpf[1].filter(frame.right)};
 	}
 
 	if (mixer.do_compressor) {
 		// Apply compressor to the master output as the very last step
-		for (auto& frame: mixer.output_buffer) {
+		for (auto& frame : mixer.output_buffer) {
 			frame = mixer.compressor.Process(frame);
 		}
 	}
@@ -2383,24 +2369,30 @@ static void mix_samples(const int frames_requested)
 			const auto right = static_cast<uint16_t>(
 			        clamp_to_int16(static_cast<int>(frame.right)));
 
-			mixer.capture_buffer.push_back(static_cast<int16_t>(host_to_le16(left)));
-			mixer.capture_buffer.push_back(static_cast<int16_t>(host_to_le16(right)));
+			mixer.capture_buffer.push_back(
+			        static_cast<int16_t>(host_to_le16(left)));
+
+			mixer.capture_buffer.push_back(
+			        static_cast<int16_t>(host_to_le16(right)));
 		}
 
-		if (mixer.capture_queue.Size() + mixer.capture_buffer.size() > mixer.capture_queue.MaxCapacity()) {
-			// We're producing more audio than the capture is consuming.
-			// This usually happens when the main thread is being slowed down by video encoding.
-			// Ex: Slow host CPU or using zlib rather than zlib_ng
-			// Not ideal as this results in an audible "skip forward"
-			// Without this, it's a complete stuttery mess though so it's the lesser of two evils
+		if (mixer.capture_queue.Size() + mixer.capture_buffer.size() >
+		    mixer.capture_queue.MaxCapacity()) {
+			// We're producing more audio than the capture is
+			// consuming. This usually happens when the main thread
+			// is being slowed down by video encoding. Ex: Slow host
+			// CPU or using zlib rather than zlib_ng Not ideal as
+			// this results in an audible "skip forward" Without
+			// this, it's a complete stuttery mess though so it's
+			// the lesser of two evils
 			mixer.capture_queue.Clear();
 		}
 		mixer.capture_queue.NonblockingBulkEnqueue(mixer.capture_buffer);
 	}
 
 	// Normalize the final output before sending to SDL
-	for (auto& frame: mixer.output_buffer) {
-		frame.left = normalize_sample(frame.left);
+	for (auto& frame : mixer.output_buffer) {
+		frame.left  = normalize_sample(frame.left);
 		frame.right = normalize_sample(frame.right);
 	}
 }
@@ -2414,21 +2406,27 @@ static void capture_callback()
 
 	static float frame_counter = 0.0f;
 	frame_counter += get_mixer_frames_per_tick();
+
 	const int num_frames = ifloor(frame_counter);
-	frame_counter -= static_cast<float>(num_frames);
 	assert(num_frames > 0);
+
+	frame_counter -= static_cast<float>(num_frames);
 
 	const int num_samples = num_frames * 2;
 
 	// We can't block waiting on the mixer thread
-	// Some mixer channels block waiting on the main thread and this would deadlock
+	// Some mixer channels block waiting on the main thread and this would
+	// deadlock
 	static std::vector<int16_t> frames = {};
 	frames.clear();
 
 	const int samples_available = check_cast<int>(mixer.capture_queue.Size());
 	const int samples_requested = std::min(num_samples, samples_available);
+
 	if (samples_requested > 0) {
-		mixer.capture_queue.BulkDequeue(frames, std::min(num_samples, samples_available));
+		mixer.capture_queue.BulkDequeue(frames,
+		                                std::min(num_samples,
+		                                         samples_available));
 	}
 
 	// Fill with silence if needed
@@ -2448,9 +2446,11 @@ static void SDLCALL mixer_callback([[maybe_unused]] void* userdata,
 
 	const auto frames_requested = check_cast<size_t>(bytes_requested /
 	                                                 BytesPerAudioFrame);
-	// Mac OSX has been observed to be problematic if we ever block inside SDL's callback
-	// This ensures that we do not block waiting for more audio
-	// In the queue has run dry, we write what we have available and the rest of the request is silence
+
+	// Mac OSX has been observed to be problematic if we ever block inside
+	// SDL's callback This ensures that we do not block waiting for more
+	// audio In the queue has run dry, we write what we have available and
+	// the rest of the request is silence
 	const auto frames_to_dequeue = std::min(mixer.final_output.Size(),
 	                                        frames_requested);
 
@@ -2472,61 +2472,88 @@ static void mixer_thread_loop()
 		assert(mixer.state != MixerState::Uninitialized);
 
 		// This code is mostly for the fast-forward button (hold Alt + F12)
-		const double now = PIC_FullIndex();
+		const double now         = PIC_FullIndex();
 		const double actual_time = now - last_mixed;
-		const double expected_time = (static_cast<double>(mixer.blocksize) / static_cast<double>(mixer.sample_rate_hz)) * 1000.0;
+		const double expected_time = (static_cast<double>(mixer.blocksize) /
+		                              static_cast<double>(mixer.sample_rate_hz)) *
+		                             1000.0;
 		last_mixed = now;
 
 		// "Underflow" is not a concern since moving to a threaded mixer
-		// If the CPU is running slower than real-time, the audio drivers will naturally slow down the audio
-		// Therefore, we can always request at least a blocksize worth of audio
+		// If the CPU is running slower than real-time, the audio
+		// drivers will naturally slow down the audio Therefore, we can
+		// always request at least a blocksize worth of audio
 		int frames_requested = mixer.blocksize;
 
 		if (mixer.fast_forward_mode) {
 			// Flag is set only by the fast-forward hotkey handler
-			// Usually this means the emulation core is running much faster than real-time
-			// We must consume more audio to "catch up" but always request at least a blocksize
-			frames_requested = std::max(mixer.blocksize, ifloor(actual_time * get_mixer_frames_per_tick()));
+			// Usually this means the emulation core is running much
+			// faster than real-time We must consume more audio to
+			// "catch up" but always request at least a blocksize
+			frames_requested = std::max(
+			        mixer.blocksize,
+			        ifloor(actual_time * get_mixer_frames_per_tick()));
 		}
 
 		mix_samples(frames_requested);
-		assert(mixer.output_buffer.size() == check_cast<size_t>(frames_requested));
+		assert(mixer.output_buffer.size() ==
+		       check_cast<size_t>(frames_requested));
 
 		lock.unlock();
 
 		if (mixer.state == MixerState::NoSound) {
-			// SDL callback is not running. Mixed sound gets discarded.
-			// Sleep for the expected duration to simulate the time it would have taken to playback the audio.
+			// SDL callback is not running. Mixed sound gets
+			// discarded. Sleep for the expected duration to
+			// simulate the time it would have taken to playback the
+			// audio.
 			constexpr double NanosecondsPerMillisecond = 1000000.0;
-			const uint64_t nap_time = static_cast<uint64_t>(expected_time * NanosecondsPerMillisecond);
-			std::this_thread::sleep_for(std::chrono::nanoseconds(nap_time));
+
+			const uint64_t nap_time = static_cast<uint64_t>(
+			        expected_time * NanosecondsPerMillisecond);
+
+			std::this_thread::sleep_for(
+			        std::chrono::nanoseconds(nap_time));
 			continue;
+
 		} else if (mixer.state == MixerState::Muted) {
 			// SDL callback remains active. Enqueue silence.
 			mixer.output_buffer.clear();
 			mixer.output_buffer.resize(mixer.blocksize);
+
 			mixer.final_output.BulkEnqueue(mixer.output_buffer);
 			continue;
 		}
 
-		// Only true if we were in fast-forward mode at the time we calculated frames_requested
-		// That variable could have changed by now but we need to always squash down to a blocksize of audio
+		// Only true if we were in fast-forward mode at the time we
+		// calculated frames_requested That variable could have changed
+		// by now but we need to always squash down to a blocksize of audio
 		const bool audio_needs_squashing = frames_requested > mixer.blocksize;
-		auto& to_mix = audio_needs_squashing ? mixer.fast_forward_buffer : mixer.output_buffer;
+
+		auto& to_mix = audio_needs_squashing ? mixer.fast_forward_buffer
+		                                     : mixer.output_buffer;
 
 		if (audio_needs_squashing) {
 			// This is "chipmunk mode" meant for fast-forward
-			// It's basic sample skipping to compress a large amount of audio into a single blocksize
+			// It's basic sample skipping to compress a large amount
+			// of audio into a single blocksize
 			assert(frames_requested > mixer.blocksize);
 
 			mixer.fast_forward_buffer.clear();
 			mixer.fast_forward_buffer.reserve(mixer.blocksize);
-			const float index_add = static_cast<float>(frames_requested) / static_cast<float>(mixer.blocksize);
+
+			const float index_add = static_cast<float>(frames_requested) /
+			                        static_cast<float>(mixer.blocksize);
+
 			float float_index = 0.0f;
 
 			for (int i = 0; i < mixer.blocksize; ++i) {
-				const size_t src_index = std::min(check_cast<size_t>(iroundf(float_index)), mixer.output_buffer.size() - 1);
-				mixer.fast_forward_buffer.push_back(mixer.output_buffer[src_index]);
+				const size_t src_index = std::min(
+				        check_cast<size_t>(iroundf(float_index)),
+				        mixer.output_buffer.size() - 1);
+
+				mixer.fast_forward_buffer.push_back(
+				        mixer.output_buffer[src_index]);
+
 				float_index += index_add;
 			}
 		}
@@ -2566,9 +2593,10 @@ static void set_mixer_state(const MixerState new_state)
 	if (mixer.state == MixerState::Uninitialized) {
 		mixer.final_output.Start();
 		if (mixer.sdl_device > 0) {
-			// SDL starts out paused so unpause it when we first set the mixer state.
-			// We always keep SDL running in the future.
-			// When the mixer becomes muted, we just write silence.
+			// SDL starts out paused so unpause it when we first set
+			// the mixer state. We always keep SDL running in the
+			// future. When the mixer becomes muted, we just write
+			// silence.
 			constexpr int Unpause = 0;
 			SDL_PauseAudioDevice(mixer.sdl_device, Unpause);
 		}
@@ -2651,8 +2679,8 @@ static bool init_sdl_sound(const int requested_sample_rate_hz,
 	// Opening SDL audio device succeeded
 	//
 	// An opened audio device starts out paused, and should be enabled for
-	// playing by calling `SDL_PauseAudioDevice()` when you are ready for your
-	// audio callback function to be called. We do that in
+	// playing by calling `SDL_PauseAudioDevice()` when you are ready for
+	// your audio callback function to be called. We do that in
 	// `set_mixer_state()`.
 	//
 	const auto obtained_sample_rate_hz = obtained.freq;
@@ -2720,10 +2748,12 @@ static void init_master_highpass_filter()
 	// chain, instead of doing it on every single mixer channel.
 	//
 	MIXER_LockMixerThread();
+
 	constexpr auto HighpassCutoffFreqHz = 20.0;
 	for (auto& f : mixer.highpass_filter) {
 		f.setup(mixer.sample_rate_hz, HighpassCutoffFreqHz);
 	}
+
 	MIXER_UnlockMixerThread();
 }
 
@@ -2758,8 +2788,8 @@ void MIXER_Init(Section* sec)
 
 		} else {
 			if (init_sdl_sound(secprop->Get_int("rate"),
-							   secprop->Get_int("blocksize"),
-							   secprop->Get_bool("negotiate"))) {
+			                   secprop->Get_int("blocksize"),
+			                   secprop->Get_bool("negotiate"))) {
 
 				// This also unpauses the audio device which is
 				// opened in paused mode by SDL.
@@ -2826,6 +2856,7 @@ void MIXER_Mute()
 	if (mixer.state == MixerState::On) {
 		set_mixer_state(MixerState::Muted);
 		MIDI_Mute();
+
 		GFX_NotifyAudioMutedStatus(true);
 		LOG_MSG("MIXER: Muted audio output");
 	}
@@ -2836,6 +2867,7 @@ void MIXER_Unmute()
 	if (mixer.state == MixerState::Muted) {
 		set_mixer_state(MixerState::On);
 		MIDI_Unmute();
+
 		GFX_NotifyAudioMutedStatus(false);
 		LOG_MSG("MIXER: Unmuted audio output");
 	}

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -962,7 +962,34 @@ void MixerChannel::ConfigureResampler()
 
 		// Only init the resampler once
 		if (!speex_resampler.state) {
-			constexpr auto NumChannels     = 2; // always stereo
+
+			// Always stereo
+			constexpr auto NumChannels = 2;
+
+			// According to the Speex authors, a quality of 3 is
+			// acceptable for most desktop uses and even a qualitiy
+			// of 0 has decent enough sound (but artifacts might be
+			// heard).
+			//
+			// In our testing on a large number of DOS soundtracks,
+			// a quality of 4 yielded virtually identical sounding
+			// resampled audio (e.g., on OPL music with lots of
+			// treble-heavy fast transients), so we went with a
+			// quality 5 to be on the safe side. This has a good
+			// balance between quality, and latency, and processing
+			// power.
+			//
+			// Relevant comment from an Opus developer:
+			//
+			// "The higher settings are mostly for audiophiles,
+			// spectrograms and bragging rights. In practice, I
+			// cannot hear the difference between settings 5 and 10,
+			// despite the large difference in complexity (and
+			// overly sensitive spectrograms)."
+			//
+			// Source:
+			// https://hydrogenaud.io/index.php/topic,113655.msg935704.html#msg935704
+			//
 			constexpr auto ResampleQuality = 5;
 
 			speex_resampler.state = speex_resampler_init(NumChannels,

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -157,13 +157,18 @@ struct ChorusSettings {
 	}
 };
 
+// This shows up nicely as 50% and -6.00 dB in the MIXER command's output
+constexpr auto Minus6db = 0.501f;
+
 struct MixerSettings {
 	RWQueue<AudioFrame> final_output{1};
 	RWQueue<int16_t> capture_queue{1};
 
 	std::thread thread = {};
 
-	AudioFrame master_gain = {1.0f, 1.0f};
+	// The default master gain is -6dB (50% volume) to minimise the change
+	// for clipping.
+	AudioFrame master_gain = {Minus6db, Minus6db};
 
 	// Output by mix_samples, to be enqueud into the final_output queue
 	std::vector<AudioFrame> output_buffer = {};

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -284,12 +284,13 @@ bool MIXER_FastForwardModeEnabled()
 	return mixer.fast_forward_mode;
 }
 
-// The queues listed here are for audio devices that run on the main thread
+// The queues listed here are for audio devices that run on the main thread.
 // The mixer thread can be waiting on the main thread to produce audio in these
-// queues We need to stop them before aquiring a mutex lock to avoid a deadlock
-// These are called infrequently when global mixer state is changed (mostly on
-// device init/destroy and in the MIXER command line program) Individual channels
-// also have a mutex which can be safely aquired without stopping these queues
+// queues. We need to stop them before aquiring a mutex lock to avoid a
+// deadlock. These are called infrequently when global mixer state is changed
+// (mostly on device init/destroy and in the MIXER command line program).
+// Individual channels also have a mutex which can be safely aquired without
+// stopping these queues.
 void MIXER_LockMixerThread()
 {
 	PCSPEAKER_NotifyLockMixer();
@@ -2484,9 +2485,9 @@ static void SDLCALL mixer_callback([[maybe_unused]] void* userdata,
 	                                                 BytesPerAudioFrame);
 
 	// Mac OSX has been observed to be problematic if we ever block inside
-	// SDL's callback This ensures that we do not block waiting for more
-	// audio In the queue has run dry, we write what we have available and
-	// the rest of the request is silence
+	// SDL's callback. This ensures that we do not block waiting for more
+	// audio. In the queue has run dry, we write what we have available and
+	// the rest of the request is silence.
 	const auto frames_to_dequeue = std::min(mixer.final_output.Size(),
 	                                        frames_requested);
 
@@ -2515,17 +2516,17 @@ static void mixer_thread_loop()
 		                             1000.0;
 		last_mixed = now;
 
-		// "Underflow" is not a concern since moving to a threaded mixer
-		// If the CPU is running slower than real-time, the audio
-		// drivers will naturally slow down the audio Therefore, we can
-		// always request at least a blocksize worth of audio
+		// "Underflow" is not a concern since moving to a threaded
+		// mixer. If the CPU is running slower than real-time, the audio
+		// drivers will naturally slow down the audio. Therefore, we can
+		// always request at least a blocksize worth of audio.
 		int frames_requested = mixer.blocksize;
 
 		if (mixer.fast_forward_mode) {
-			// Flag is set only by the fast-forward hotkey handler
+			// Flag is set only by the fast-forward hotkey handler.
 			// Usually this means the emulation core is running much
-			// faster than real-time We must consume more audio to
-			// "catch up" but always request at least a blocksize
+			// faster than real-time. We must consume more audio to
+			// "catch up" but always request at least a blocksize.
 			frames_requested = std::max(
 			        mixer.blocksize,
 			        ifloor(actual_time * get_mixer_frames_per_tick()));
@@ -2561,17 +2562,18 @@ static void mixer_thread_loop()
 		}
 
 		// Only true if we were in fast-forward mode at the time we
-		// calculated frames_requested That variable could have changed
-		// by now but we need to always squash down to a blocksize of audio
+		// calculated frames_requested. That variable could have changed
+		// by now but we need to always squash down to a blocksize of
+		// audio.
 		const bool audio_needs_squashing = frames_requested > mixer.blocksize;
 
 		auto& to_mix = audio_needs_squashing ? mixer.fast_forward_buffer
 		                                     : mixer.output_buffer;
 
 		if (audio_needs_squashing) {
-			// This is "chipmunk mode" meant for fast-forward
+			// This is "chipmunk mode" meant for fast-forward.
 			// It's basic sample skipping to compress a large amount
-			// of audio into a single blocksize
+			// of audio into a single blocksize.
 			assert(frames_requested > mixer.blocksize);
 
 			mixer.fast_forward_buffer.clear();


### PR DESCRIPTION
# Description

I've been using DOSBox with 50% master volume (`mixer master 50` in my primary config) for years now as the default volume levels are just too hot. The default levels can easily result in clipping or overworking the compressor, which results in audible pumping.

Other users have come to the similar conclusions that it's best to reduce the master volume to the 40-60 range as a starting point (see [here](https://github.com/dosbox-staging/dosbox-staging/issues/2992#issuecomment-2480921229)).

Reducing the master volume is preferable to changing the volume balance of individual sound devices. First of all, we can never get it right as all Sound Blaster models and their clones have different volume levels and OPL / DAC balances, and even more importantly, we don't want to upset the fine-tuned channel balances people have achieved in their configs. See my detailed analysis [in this comment](https://github.com/dosbox-staging/dosbox-staging/issues/2992#issuecomment-2480907604)

Also related, emulating the actual headroom of the audio devices is out of scope as emulating running out of headroom is a non-desirable characteristic (similarly to hiss, crosstalk, and hearing the hard drive motor's activity in the Sound Blaster's output 😆). We use a float mixing path now with infinite per-device headroom, so the only thing we need to get right is not overloading the host audio interface at the final float to 16-bit integer conversion of the summed stereo master channel.

## Related issues

- https://github.com/dosbox-staging/dosbox-staging/issues/2992

# Release notes

The default master channel volume has been reduced to 50% (-6 dB) in the mixer to avoid clipping.

You can use the `mixer master 100` DOS command to restore the previous behaviour, but it's advised to only do that for games that are too quiet on a case by case basis, and only raise the volume of the channels that needs a bit of a boost (e.g., `mixer sb 200` to make the Sound Blaster digital output twice as loud).

# Manual testing

<img width="1215" alt="image" src="https://github.com/user-attachments/assets/94fd43e1-607c-4e7d-8b4b-6715db6a8f9e" />

The change has been manually tested on:

- [ ] Windows
- [x] macOS (trivial change)
- [x] Linux

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [x] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

