### PR TITLE
Fix crash if opening the `soundfont_dir` directory failed

### DIFF
--- a/src/dos/cdrom_ioctl_linux.cpp
+++ b/src/dos/cdrom_ioctl_linux.cpp
@@ -302,7 +302,11 @@ bool CDROM_Interface_Ioctl::SetDevice(const char* path)
 		return false;
 	}
 
-	std_fs::path cannonical_path = std_fs::canonical(path);
+	std::error_code err = {};
+	const auto cannonical_path = std_fs::canonical(path, err);
+	if (err) {
+		return false;
+	}
 
 	while (mntent *entry = getmntent(mounts)) {
 		// Don't try to open names that aren't a full path. Ex: "tmpfs" "sysfs"

--- a/src/midi/midi_fluidsynth.cpp
+++ b/src/midi/midi_fluidsynth.cpp
@@ -197,7 +197,7 @@ static std::vector<std_fs::path> get_data_dirs()
 		// `find_sf_file()` as well).
 		if (path_exists(sf_dir)) {
 			std::error_code err = {};
-			const auto canonical_path = std_fs::canonical(sf_dir, err);
+			const auto canonical_path = std_fs::canonical(sf_dir, err); //-V821
 			if (!err) {
 				dirs.insert(dirs.begin(), canonical_path);
 			}

--- a/src/midi/midi_fluidsynth.cpp
+++ b/src/midi/midi_fluidsynth.cpp
@@ -68,8 +68,8 @@ static void init_fluidsynth_dosbox_settings(Section_prop& secprop)
 	        "the standard system locations.");
 
 	constexpr auto DefaultVolume = 100;
-	constexpr auto MinVolume = 1;
-	constexpr auto MaxVolume = 800;
+	constexpr auto MinVolume     = 1;
+	constexpr auto MaxVolume     = 800;
 
 	auto int_prop = secprop.Add_int("soundfont_volume", WhenIdle, DefaultVolume);
 	int_prop->SetMinMax(MinVolume, MaxVolume);
@@ -463,9 +463,7 @@ static void setup_reverb(fluid_synth_t* synth)
 // Current API calls as of 2.2
 #if FLUIDSYNTH_VERSION_MINOR >= 2
 	fluid_synth_reverb_on(synth, FxGroup, reverb_enabled);
-	fluid_synth_set_reverb_group_roomsize(synth,
-	                                      FxGroup,
-	                                      reverb_room_size);
+	fluid_synth_set_reverb_group_roomsize(synth, FxGroup, reverb_room_size);
 
 	fluid_synth_set_reverb_group_damp(synth, FxGroup, reverb_damping);
 	fluid_synth_set_reverb_group_width(synth, FxGroup, reverb_width);

--- a/src/midi/midi_fluidsynth.cpp
+++ b/src/midi/midi_fluidsynth.cpp
@@ -494,8 +494,8 @@ MidiDeviceFluidSynth::MidiDeviceFluidSynth()
 	FluidSynthSettingsPtr fluid_settings(new_fluid_settings(),
 	                                     delete_fluid_settings);
 	if (!fluid_settings) {
-		const auto msg = "FSYNTH: new_fluid_settings failed";
-		LOG_WARNING("%s", msg);
+		const auto msg = "FSYNTH: Failed to initialise the FluidSynth settings";
+		LOG_ERR("%s", msg);
 		throw std::runtime_error(msg);
 	}
 
@@ -515,8 +515,8 @@ MidiDeviceFluidSynth::MidiDeviceFluidSynth()
 	FluidSynthPtr fluid_synth(new_fluid_synth(fluid_settings.get()),
 	                          delete_fluid_synth);
 	if (!fluid_synth) {
-		const auto msg = "FSYNTH: Failed to create the FluidSynth synthesizer.";
-		LOG_WARNING("%s", msg);
+		const auto msg = "FSYNTH: Failed to create the FluidSynth synthesizer";
+		LOG_ERR("%s", msg);
 		throw std::runtime_error(msg);
 	}
 
@@ -532,11 +532,10 @@ MidiDeviceFluidSynth::MidiDeviceFluidSynth()
 	}
 
 	if (fluid_synth_sfcount(fluid_synth.get()) == 0) {
-		const auto msg = format_str(
-		        "FSYNTH: FluidSynth failed to load '%s', check the path.",
-		        sf_name.c_str());
+		const auto msg = format_str("FSYNTH: Error loading SoundFont '%s'",
+		                            sf_name.c_str());
 
-		LOG_WARNING("%s", msg.c_str());
+		LOG_ERR("%s", msg.c_str());
 		throw std::runtime_error(msg);
 	}
 

--- a/src/midi/midi_mt32.cpp
+++ b/src/midi/midi_mt32.cpp
@@ -593,12 +593,12 @@ static mt32emu_report_handler_i get_report_handler_interface()
 
 		static void onErrorControlROM(void*)
 		{
-			LOG_WARNING("MT32: Couldn't open Control ROM file");
+			LOG_ERR("MT32: Error opening Control ROM file");
 		}
 
 		static void onErrorPCMROM(void*)
 		{
-			LOG_WARNING("MT32: Couldn't open PCM ROM file");
+			LOG_ERR("MT32: Error opening PCM ROM file");
 		}
 
 		static void showLCDMessage(void*, const char* message)
@@ -705,7 +705,7 @@ MidiDeviceMt32::MidiDeviceMt32()
 	if (rc != MT32EMU_RC_OK) {
 		const auto msg = format_str("MT32: Error initialising emulation, error code: %i",
 		                            rc);
-		LOG_WARNING("%s", msg.c_str());
+		LOG_ERR("%s", msg.c_str());
 		throw std::runtime_error(msg);
 	}
 


### PR DESCRIPTION
# Description

Setting `soundfont_dir` to a directory that cannot be opened and then executing `mixer /listmidi` or `mididevice fluidsynth` resulted in a crash. Nasty! Somehow this evaded my attention when I introduced the setting...

This PR fixes that.

## Related issues

N/A

# Release notes

N/A (`soundfont_dir` was introduced in the current dev cycles)

# Manual testing

Let me tell you in pictures 😎 

![image](https://github.com/user-attachments/assets/7f3b7efd-bf70-4b0a-968b-d278e22e5335)


The change has been manually tested on:

- [x] Windows
- [x] macOS
- [x] Linux (I assume it works too, but can someone verify, please?)


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

