### PR TITLE
Keyboard layout autodetection priorities

### DIFF
--- a/src/dos/dos_locale.cpp
+++ b/src/dos/dos_locale.cpp
@@ -1501,28 +1501,28 @@ static void load_keyboard_layout()
 	bool using_detected     = false; // if layout list is autodetected
 	bool code_page_supplied = false; // if code page given in the parameter
 
-	if (config.keyboard_str == "auto") {
+	const auto tokens = split(config.keyboard_str);
+	if (tokens.size() > 2) {
+		LOG_WARNING("LOCALE: Invalid 'keyboard_layout' setting '%s', using 'auto'",
+		            config.keyboard_str.c_str());
+		set_section_property_value("dos", "keyboard_layout", "auto");
+		config.keyboard_str = "auto";
+	}
+
+	if (tokens.empty() || config.keyboard_str == "auto") {
 		keyboard_layouts = get_detected_keyboard_layouts();
 		using_detected   = true;
 	} else {
-		const auto tokens = split(config.keyboard_str);
-		if (tokens.size() != 1 && tokens.size() != 2) {
-			LOG_WARNING("LOCALE: Invalid 'keyboard_layout' setting '%s', using 'us'",
-			            config.keyboard_str.c_str());
-			keyboard_layouts.push_back({"us"});
-			set_section_property_value("dos", "keyboard_layout", "us");
-		} else {
-			keyboard_layouts.push_back({tokens[0]});
-			if (tokens.size() >= 2) {
-				const auto result = parse_int(tokens[1]);
-				if (!result || *result < 1 || *result > UINT16_MAX) {
-					LOG_WARNING("LOCALE: Invalid 'keyboard_layout' code page '%s', ignoring",
-					            tokens[1].c_str());
-				} else {
-					keyboard_layouts[0].code_page =
-					        static_cast<uint16_t>(*result);
-					code_page_supplied = true;
-				}
+		keyboard_layouts.push_back({tokens[0]});
+		if (tokens.size() == 2) {
+			const auto result = parse_int(tokens[1]);
+			if (!result || *result < 1 || *result > UINT16_MAX) {
+				LOG_WARNING("LOCALE: Invalid 'keyboard_layout' code page '%s', ignoring",
+				            tokens[1].c_str());
+			} else {
+				keyboard_layouts[0].code_page =
+				        static_cast<uint16_t>(*result);
+				code_page_supplied = true;
 			}
 		}
 	}

--- a/src/dos/dos_locale.cpp
+++ b/src/dos/dos_locale.cpp
@@ -1503,7 +1503,7 @@ static void load_keyboard_layout()
 
 	const auto tokens = split(config.keyboard_str);
 	if (tokens.size() > 2) {
-		LOG_WARNING("LOCALE: Invalid 'keyboard_layout' setting '%s', using 'auto'",
+		LOG_WARNING("LOCALE: Invalid 'keyboard_layout' setting: '%s', using 'auto'",
 		            config.keyboard_str.c_str());
 		set_section_property_value("dos", "keyboard_layout", "auto");
 		config.keyboard_str = "auto";
@@ -1517,7 +1517,7 @@ static void load_keyboard_layout()
 		if (tokens.size() == 2) {
 			const auto result = parse_int(tokens[1]);
 			if (!result || *result < 1 || *result > UINT16_MAX) {
-				LOG_WARNING("LOCALE: Invalid 'keyboard_layout' code page '%s', ignoring",
+				LOG_WARNING("LOCALE: Invalid 'keyboard_layout' code page: '%s', ignoring",
 				            tokens[1].c_str());
 			} else {
 				keyboard_layouts[0].code_page =
@@ -1561,14 +1561,14 @@ static void load_keyboard_layout()
 			                                {},
 			                                prefer_rom_font);
 			if (result != KeyboardLayoutResult::OK) {
-				LOG_WARNING("LOCALE: Unable to use specified 'keyboard_layout' setting '%s', using 'us'",
+				LOG_WARNING("LOCALE: Unable to use specified 'keyboard_layout' setting: '%s', using 'us'",
 				            config.keyboard_str.c_str());
 			}
 		} else if (result == KeyboardLayoutResult::IncompatibleMachine) {
-			LOG_WARNING("LOCALE: Invalid 'keyboard_layout' setting '%s' for this display adapter, using 'us'",
+			LOG_WARNING("LOCALE: Invalid 'keyboard_layout' setting: '%s' for this display adapter, using 'us'",
 			            config.keyboard_str.c_str());
 		} else {
-			LOG_WARNING("LOCALE: Unable to use specified 'keyboard_layout' setting '%s', using 'us'",
+			LOG_WARNING("LOCALE: Unable to use specified 'keyboard_layout' setting: '%s', using 'us'",
 			            config.keyboard_str.c_str());
 		}
 	}

--- a/src/dos/dos_locale.cpp
+++ b/src/dos/dos_locale.cpp
@@ -1291,6 +1291,12 @@ static void sort_detected_keyboard_layouts(
 		assert(info_map.contains(detected_deduplicated));
 	}
 
+	auto get_layout_priority = [&](const KeyboardLayoutMaybeCodepage& entry) {
+		const auto& info_entry = info_map.at(
+		        deduplicate_layout(entry.keyboard_layout));
+		return info_entry.priority;
+	};
+
 	auto has_script_above = [&](const KeyboardLayoutMaybeCodepage& entry,
 	                            const KeyboardScript script) {
 		const auto& info_entry = info_map.at(
@@ -1376,6 +1382,13 @@ static void sort_detected_keyboard_layouts(
 			// with the list already sorted by user preference
 			if (is_layout_list_sorted) {
 				return false;
+			}
+
+			// Prefer safer keyboard layout choices
+			const auto l_priority = get_layout_priority(l);
+			const auto r_priority = get_layout_priority(r);
+			if (l_priority != r_priority) {
+				return (l_priority > r_priority);
 			}
 
 			// Prefer keyboard layouts containing a non-Latin script

--- a/src/dos/dos_locale.h
+++ b/src/dos/dos_locale.h
@@ -436,6 +436,11 @@ struct ScriptInfoEntry {
 	std::string GetMsgName() const;
 };
 
+enum class AutodetectionPriority {
+	Low,
+	High
+};
+
 struct CodePageInfoEntry {
 	std::string description = {};
 	Script script           = {};
@@ -473,6 +478,10 @@ struct KeyboardLayoutInfoEntry {
 
 	// A long, user-friendly name, to be displayed in verbose output
 	std::string layout_name = {};
+
+	// High - for well-known layouts, widespread in the given country/region
+	// Low  - for exotic layouts, not even widely used by the natives
+	AutodetectionPriority priority = {};
 
 	uint16_t default_code_page = {};
 

--- a/src/dos/dos_locale_data.cpp
+++ b/src/dos/dos_locale_data.cpp
@@ -231,6 +231,8 @@ const std::vector<KeyboardLayoutInfoEntry> LocaleData::KeyboardLayoutInfo = {
 	// Layouts for English - 1.456 billion speakers worldwide
 	{
 		{ "us" }, "US (standard, QWERTY/national)",
+		// A very popular keyboard layout
+		AutodetectionPriority::High,
 		437,
 		KeyboardScript::LatinQwerty,
 		{
@@ -239,47 +241,65 @@ const std::vector<KeyboardLayoutInfoEntry> LocaleData::KeyboardLayoutInfo = {
 	},
 	{
 		{ "ux" }, "US (international, QWERTY)",
+		// The QWERTY layer is almost identical to the US layout
+		AutodetectionPriority::High,
 		850,
 		KeyboardScript::LatinQwerty,
 	},
 	{
 		{ "co" }, "US (Colemak)",
+		// A very niche/exotic layout
+		AutodetectionPriority::Low,
 	 	437,
 	 	KeyboardScript::LatinColemak,
 	},
 	{
 		{ "dv" }, "US (Dvorak)",
+		// A very niche/exotic layout
+		AutodetectionPriority::Low,
 		437,
 		KeyboardScript::LatinDvorak,
 	},
 	{
 		{ "lh" }, "US (left-hand Dvorak)",
+		// A very niche/exotic layout
+		AutodetectionPriority::Low,
 		437,
 		KeyboardScript::LatinDvorak,
 	},
 	{
 		{ "rh" }, "US (right-hand Dvorak)",
+		// A very niche/exotic layout
+		AutodetectionPriority::Low,
 	 	437,
 	 	KeyboardScript::LatinDvorak,
 	},
 	{
 		{ "uk" }, "UK (standard, QWERTY)",
+		// A very popular keyboard layout
+		AutodetectionPriority::High,
 		437,
 		KeyboardScript::LatinQwerty,
 	},
 	{
 		{ "uk168" }, "UK (alternate, QWERTY)",
+		// Not sure if the layout is popular, low priority for now
+		AutodetectionPriority::Low,
 		437,
 		KeyboardScript::LatinQwerty,
 	},
 	{
 		{ "kx" }, "UK (international, QWERTY)",
+		// The QWERTY layer is almost identical to the UK layout
+		AutodetectionPriority::High,
 		30023,
 		KeyboardScript::LatinQwerty,
 	},
 	// Layouts for other languages, sorted by the main symbol
 	{
 		{ "ar462" }, "Arabic (AZERTY/Arabic)",
+		// QWERTY/AZERTY variant is selected later by a specialized code
+		AutodetectionPriority::High,
 		864,
 		KeyboardScript::LatinAzerty,
 		{
@@ -288,6 +308,8 @@ const std::vector<KeyboardLayoutInfoEntry> LocaleData::KeyboardLayoutInfo = {
 	},
 	{
 		{ "ar470" }, "Arabic (QWERTY/Arabic)",
+		// The QWERTY layer seems to be identical to the US layout
+		AutodetectionPriority::High,
 		864,
 		KeyboardScript::LatinQwerty,
 		{
@@ -296,6 +318,8 @@ const std::vector<KeyboardLayoutInfoEntry> LocaleData::KeyboardLayoutInfo = {
 	},
 	{
 		{ "az" }, "Azeri (QWERTY/Cyrillic)",
+		// The QWERTY layer seems to be identical to the US layout
+		AutodetectionPriority::High,
 		58210, // 60258 replaces ASCII 'I' with other symbol, avoid it!
 		KeyboardScript::LatinQwerty,
 		{
@@ -305,22 +329,33 @@ const std::vector<KeyboardLayoutInfoEntry> LocaleData::KeyboardLayoutInfo = {
 	},
 	{
 		{ "ba" }, "Bosnian (QWERTZ)",
+		// Balkan countries seem to be mostly using the QWERTZ layouts
+		AutodetectionPriority::High,
 		852,
 		KeyboardScript::LatinQwertz,
 	},
 	{
 		{ "be" }, "Belgian (AZERTY)",
+		// Assuming French speaking countries are mostly using the
+		// AZERTY layouts
+		AutodetectionPriority::High,
 		850,
 		KeyboardScript::LatinAzerty,
 	},
 	{
 		{ "bx" }, "Belgian (international, AZERTY)",
+		// Assuming French speaking countries are mostly using the
+		// AZERTY layouts
+		AutodetectionPriority::High,
 		30026,
 		KeyboardScript::LatinAzerty,
 	},
 	{
 		{ "bg" }, "Bulgarian (QWERTY/national)",
-		3021, // MIK encoding, approved by a native speaker
+		// The QWERTY layer seems to be identical to the US layout
+		AutodetectionPriority::High,
+		// Code page approved by a native speaker
+		3021, // MIK encoding
 		KeyboardScript::LatinQwerty,
 		{
 			{ 808,  KeyboardScript::Cyrillic },
@@ -332,7 +367,10 @@ const std::vector<KeyboardLayoutInfoEntry> LocaleData::KeyboardLayoutInfo = {
 	},
 	{
 		{ "bg103" }, "Bulgarian (QWERTY/phonetic)",
-		3021, // MIK encoding, approved by a native speaker
+		// The QWERTY layer seems to be identical to the US layout
+		AutodetectionPriority::High,
+		// Code page approved by a native speaker
+		3021, // MIK encoding
 		KeyboardScript::LatinQwerty,
 		{
 			{ 808,  KeyboardScript::CyrillicPhonetic },
@@ -344,7 +382,10 @@ const std::vector<KeyboardLayoutInfoEntry> LocaleData::KeyboardLayoutInfo = {
 	},
 	{
 		{ "bg241" }, "Bulgarian (JCUKEN/national)",
-		3021, // MIK encoding, approved by a native speaker
+		// Latin layer is atypical
+		AutodetectionPriority::Low,
+		// Code page approved by a native speaker
+		3021, // MIK encoding
 		KeyboardScript::LatinJcuken,
 		{
 			{ 808,  KeyboardScript::Cyrillic },
@@ -357,21 +398,29 @@ const std::vector<KeyboardLayoutInfoEntry> LocaleData::KeyboardLayoutInfo = {
 	}, 
 	{
 		{ "bn" }, "Beninese (AZERTY)",
+		// Not sure if the layout is popular, low priority for now
+		AutodetectionPriority::Low,
 		30027,
 		KeyboardScript::LatinAzerty,
 	},
 	{
 		{ "br" }, "Brazilian (ABNT layout, QWERTY)",
+		// Not sure if the layout is popular, low priority for now
+		AutodetectionPriority::Low,
 		860,
 		KeyboardScript::LatinQwerty,
 	},
 	{
 		{ "br274" }, "Brazilian (US layout, QWERTY)",
+		// The QWERTY layer is almost identical to the US layout
+		AutodetectionPriority::High,
 		860,
 		KeyboardScript::LatinQwerty,
 	},
 	{
 		{ "by", "bl" }, "Belarusian (QWERTY/national)",
+		// The QWERTY layer is almost identical to the US layout
+		AutodetectionPriority::High,
 		1131,
 		KeyboardScript::LatinQwerty,
 		{
@@ -383,6 +432,8 @@ const std::vector<KeyboardLayoutInfoEntry> LocaleData::KeyboardLayoutInfo = {
 	},
 	{
 		{ "ce", }, "Chechen (standard, QWERTY/national)",
+		// Not sure if the layout is popular, low priority for now
+		AutodetectionPriority::Low,
 		30019,
 		KeyboardScript::LatinQwerty,
 		{
@@ -392,6 +443,8 @@ const std::vector<KeyboardLayoutInfoEntry> LocaleData::KeyboardLayoutInfo = {
 	},
 	{
 		{ "ce443", }, "Chechen (typewriter, QWERTY/national)",
+		// Not sure if the layout is popular, low priority for now
+		AutodetectionPriority::Low,
 		30019,
 		KeyboardScript::LatinQwerty,
 		{
@@ -401,16 +454,22 @@ const std::vector<KeyboardLayoutInfoEntry> LocaleData::KeyboardLayoutInfo = {
 	},
 	{
 		{ "cf", "ca" }, "Canadian (standard, QWERTY)",
+		// Not sure if the layout is popular, low priority for now
+		AutodetectionPriority::Low,
 		863,
 		KeyboardScript::LatinQwerty,
 	},
 	{
 		{ "cf445" }, "Canadian (dual-layer, QWERTY)",
+		// Not sure if the layout is popular, low priority for now
+		AutodetectionPriority::Low,
 		863,
 		KeyboardScript::LatinQwerty,
 	},
 	{
 		{ "cg" }, "Montenegrin (QWERTZ)",
+		// Balkan countries seem to be mostly using the QWERTZ layouts
+		AutodetectionPriority::High,
 		852,
 		KeyboardScript::LatinQwertz,
 	},
@@ -418,51 +477,73 @@ const std::vector<KeyboardLayoutInfoEntry> LocaleData::KeyboardLayoutInfo = {
 	// it is said to be much more popular.
 	{
 		{ "cz" }, "Czech (QWERTZ)",
+		// Not sure if the layout is popular, low priority for now
+		AutodetectionPriority::Low,
 		867, // Kamenický encoding; no EUR variant, unfortunately
 		KeyboardScript::LatinQwertz,
 	},
 	{
 		{ "cz243" }, "Czech (standard, QWERTZ)",
+		// Not sure if the layout is popular, low priority for now
+		AutodetectionPriority::Low,
 		867, // Kamenický encoding; no EUR variant, unfortunately
 		KeyboardScript::LatinQwertz,
 	},
 	{
 		{ "cz489" }, "Czech (programmers, QWERTY)",
+		// Unintrusive US layout modification, uses right ALT for
+		// entering the national characters
+		AutodetectionPriority::High,
 		867, // Kamenický encoding; no EUR variant, unfortunately
 		KeyboardScript::LatinQwerty,
 	},
 	{
 		{ "de", "gr" }, "German (standard, QWERTZ)",
+		// Priority approved by a native speaker
+		AutodetectionPriority::High,
 		850,
 		KeyboardScript::LatinQwertz,
 	},
 	{
 		{ "gr453" }, "German (dual-layer, QWERTZ)",
+		// German speaking countries seem to be mostly using the QWERTZ
+		// layouts
+		AutodetectionPriority::High,
 		850,
 		KeyboardScript::LatinQwertz,
 	},
 	{
 		{ "dk" }, "Danish (QWERTY)",
+		// National layouts seem to be popular in the Nordic region
+		AutodetectionPriority::High,
 		865,
 		KeyboardScript::LatinQwerty,
 	},
 	{
 		{ "ee", "et" }, "Estonian (QWERTY)",
+		// Not sure if the layout is popular, low priority for now
+		AutodetectionPriority::Low,
 		1116, // No EUR currency variant, unfortunately
 		KeyboardScript::LatinQwerty,
 	},
 	{
 		{ "es", "sp" }, "Spanish (QWERTY)",
+		// Not sure if the layout is popular, low priority for now
+		AutodetectionPriority::Low,
 		850,
 		KeyboardScript::LatinQwerty,
 	},
 	{
 		{ "sx" }, "Spanish (international, QWERTY)",
+		// Not sure if the layout is popular, low priority for now
+		AutodetectionPriority::Low,
 		30026,
 		KeyboardScript::LatinQwerty,
 	},
 	{
 		{ "fi", "su" }, "Finnish (QWERTY/ASERTT)",
+		// National layouts seem to be popular in the Nordic region
+		AutodetectionPriority::High,
 		850,
 		KeyboardScript::LatinQwerty,
 		{
@@ -471,21 +552,30 @@ const std::vector<KeyboardLayoutInfoEntry> LocaleData::KeyboardLayoutInfo = {
 	},
 	{
 		{ "fo" }, "Faroese (QWERTY)",
+		// National layouts seem to be popular in the Nordic region
+		AutodetectionPriority::High,
 		861,
 		KeyboardScript::LatinQwerty,
 	},
 	{
 		{ "fr" }, "French (standard, AZERTY)",
+		// Priority approved by a native speaker
+		AutodetectionPriority::High,
 		850,
 		KeyboardScript::LatinAzerty,
 	},
 	{
 		{ "fx" }, "French (international, AZERTY)",
+		// Assuming French speaking countries are mostly using the
+		// AZERTY layouts
+		AutodetectionPriority::High,
 		30026,
 		KeyboardScript::LatinAzerty,
 	},
 	{
 		{ "gk", "el" }, "Greek (319, QWERTY/national)",
+		// Not sure if the layout is popular, low priority for now
+		AutodetectionPriority::Low,
 		869, // chosen because it has EUR currency symbol;
                      // TODO: native speaker feedback would be appreciated
 		KeyboardScript::LatinQwerty,
@@ -497,6 +587,8 @@ const std::vector<KeyboardLayoutInfoEntry> LocaleData::KeyboardLayoutInfo = {
 	},
 	{
 		{ "gk220" }, "Greek (220, QWERTY/national)",
+		// Not sure if the layout is popular, low priority for now
+		AutodetectionPriority::Low,
 		869, // chosen because it has EUR currency symbol;
                      // TODO: native speaker feedback would be appreciated
 		KeyboardScript::LatinQwerty,
@@ -508,6 +600,8 @@ const std::vector<KeyboardLayoutInfoEntry> LocaleData::KeyboardLayoutInfo = {
 	},
 	{
 		{ "gk459" }, "Greek (459, non-standard/national)",
+		// Not sure if the layout is popular, low priority for now
+		AutodetectionPriority::Low,
 		869, // chosen because it has EUR currency symbol;
                      // TODO: native speaker feedback would be appreciated
 		KeyboardScript::LatinNonStandard,
@@ -519,21 +613,29 @@ const std::vector<KeyboardLayoutInfoEntry> LocaleData::KeyboardLayoutInfo = {
 	},
 	{
 		{ "hr" }, "Croatian (QWERTZ/national)",
+		// Balkan countries seem to be mostly using the QWERTZ layouts
+		AutodetectionPriority::High,
 		852,
 		KeyboardScript::LatinQwertz,
 	},
 	{
 		{ "hu" }, "Hungarian (101-key, QWERTY)",
+		// Priority approved by a native speaker
+		AutodetectionPriority::Low,
 		3845, // CWI-2 encoding
 		KeyboardScript::LatinQwerty,
 	},
 	{
 		{ "hu208" }, "Hungarian (102-key, QWERTZ)",
+		// Priority approved by a native speaker
+		AutodetectionPriority::Low,
 		3845, // CWI-2 encoding
 		KeyboardScript::LatinQwertz,
 	},
 	{
 		{ "hy" }, "Armenian (QWERTY/national)",
+		// The QWERTY layer is almost identical to the US layout
+		AutodetectionPriority::High,
 		899,
 		KeyboardScript::LatinQwerty,
 		{
@@ -542,6 +644,8 @@ const std::vector<KeyboardLayoutInfoEntry> LocaleData::KeyboardLayoutInfo = {
 	},
 	{
 		{ "il" }, "Hebrew (QWERTY/national)",
+		// The QWERTY layer seems to be identical to the US layout
+		AutodetectionPriority::High,
 		862,
 		KeyboardScript::LatinQwerty,
 		{
@@ -551,16 +655,22 @@ const std::vector<KeyboardLayoutInfoEntry> LocaleData::KeyboardLayoutInfo = {
 	},
 	{
 		{ "is" }, "Icelandic (101-key, QWERTY)",
+		// National layouts seem to be popular in the Nordic region
+		AutodetectionPriority::High,
 		861,
 		KeyboardScript::LatinQwerty,
 	},
 	{
 		{ "is161" }, "Icelandic (102-key, QWERTY)",
+		// National layouts seem to be popular in the Nordic region
+		AutodetectionPriority::High,
 		861,
 		KeyboardScript::LatinQwerty,
 	},
 	{
 		{ "it" }, "Italian (standard, QWERTY/national)",
+		// Not sure if the layout is popular, low priority for now
+		AutodetectionPriority::Low,
 		850,
 		KeyboardScript::LatinQwerty,
 		{
@@ -569,6 +679,8 @@ const std::vector<KeyboardLayoutInfoEntry> LocaleData::KeyboardLayoutInfo = {
 	},
 	{
 		{ "it142" }, "Italian (142, QWERTY/national)",
+		// Not sure if the layout is popular, low priority for now
+		AutodetectionPriority::Low,
 		850,
 		KeyboardScript::LatinQwerty,
 		{
@@ -577,6 +689,8 @@ const std::vector<KeyboardLayoutInfoEntry> LocaleData::KeyboardLayoutInfo = {
 	},
 	{
 		{ "ix" }, "Italian (international, QWERTY)",
+		// Not sure if the layout is popular, low priority for now
+		AutodetectionPriority::Low,
 		30024,
 		KeyboardScript::LatinQwerty,
 	},
@@ -584,6 +698,8 @@ const std::vector<KeyboardLayoutInfoEntry> LocaleData::KeyboardLayoutInfo = {
 	// { { "jp" }, "Japanese", 932, ... },
 	{
 		{ "ka" }, "Georgian (QWERTY/national)",
+		// The QWERTY layer seems to be identical to the US layout
+		AutodetectionPriority::High,
 		59829,
 		KeyboardScript::LatinQwerty,
 		{
@@ -594,6 +710,8 @@ const std::vector<KeyboardLayoutInfoEntry> LocaleData::KeyboardLayoutInfo = {
 	},
 	{
 		{ "kk" }, "Kazakh (QWERTY/national)",
+		// The QWERTY layer seems to be identical to the US layout
+		AutodetectionPriority::High,
 		58152,
 		KeyboardScript::LatinQwerty,
 		{
@@ -602,6 +720,8 @@ const std::vector<KeyboardLayoutInfoEntry> LocaleData::KeyboardLayoutInfo = {
 	},
 	{
 		{ "kk476" }, "Kazakh (476, QWERTY/national)",
+		// The QWERTY layer seems to be identical to the US layout
+		AutodetectionPriority::High,
 		58152,
 		KeyboardScript::LatinQwerty,
 		{
@@ -610,6 +730,8 @@ const std::vector<KeyboardLayoutInfoEntry> LocaleData::KeyboardLayoutInfo = {
 	},
 	{
 		{ "ky" }, "Kyrgyz (QWERTY/national)",
+		// The QWERTY layer seems to be identical to the US layout
+		AutodetectionPriority::High,
 		58152,
 		KeyboardScript::LatinQwerty,
 		{
@@ -618,11 +740,15 @@ const std::vector<KeyboardLayoutInfoEntry> LocaleData::KeyboardLayoutInfo = {
 	},
 	{
 		{ "la" }, "Latin American (QWERTY)",
+		// Not sure if the layout is popular, low priority for now
+		AutodetectionPriority::Low,
 		850,
 		KeyboardScript::LatinQwerty,
 	},
 	{
 		{ "lt" }, "Lithuanian (Baltic, QWERTY/phonetic)",
+		// Not sure if the layout is popular, low priority for now
+		AutodetectionPriority::Low,
 		774, // No EUR currency variant, unfortunately
 		KeyboardScript::LatinQwerty,
 		{
@@ -632,6 +758,9 @@ const std::vector<KeyboardLayoutInfoEntry> LocaleData::KeyboardLayoutInfo = {
 	},
 	{
 		{ "lt210" }, "Lithuanian (programmers, QWERTY/phonetic)",
+		// Unintrusive US layout modification, uses right ALT for
+		// entering the national characters
+		AutodetectionPriority::High,
 		774, // No EUR currency variant, unfortunately
 		KeyboardScript::LatinQwerty,
 		{
@@ -641,6 +770,8 @@ const std::vector<KeyboardLayoutInfoEntry> LocaleData::KeyboardLayoutInfo = {
 	},
 	{
 		{ "lt211" }, "Lithuanian (AZERTY/phonetic)",
+		// Not sure if the layout is popular, low priority for now
+		AutodetectionPriority::Low,
 		774, // No EUR currency variant, unfortunately
 		KeyboardScript::LatinAzerty,
 		{
@@ -650,6 +781,8 @@ const std::vector<KeyboardLayoutInfoEntry> LocaleData::KeyboardLayoutInfo = {
 	},
 	{
 		{ "lt221" }, "Lithuanian (LST 1582, AZERTY/phonetic)",
+		// Not sure if the layout is popular, low priority for now
+		AutodetectionPriority::Low,
 		774, // No EUR currency variant, unfortunately
 		KeyboardScript::LatinAzerty,
 		{
@@ -659,6 +792,8 @@ const std::vector<KeyboardLayoutInfoEntry> LocaleData::KeyboardLayoutInfo = {
 	},
 	{
 		{ "lt456" }, "Lithuanian (QWERTY/AZERTY/phonetic)",
+		// The QWERTY layer seems to be identical to the US layout
+		AutodetectionPriority::High,
 		774, // No EUR currency variant, unfortunately
 		KeyboardScript::LatinQwerty,
 		{
@@ -678,6 +813,9 @@ const std::vector<KeyboardLayoutInfoEntry> LocaleData::KeyboardLayoutInfo = {
 	},
 	{
 		{ "lv" }, "Latvian (standard, QWERTY/phonetic)",
+		// Unintrusive US layout modification, uses right ALT for
+		// entering the national characters
+		AutodetectionPriority::High,
 		1117, // No EUR currency variant, unfortunately
 		KeyboardScript::LatinQwerty,
 		{
@@ -686,6 +824,8 @@ const std::vector<KeyboardLayoutInfoEntry> LocaleData::KeyboardLayoutInfo = {
 	},
 	{
 		{ "lv455" }, "Latvian (QWERTY/UGJRMV/phonetic)",
+		// The QWERTY layer is almost identical to the US layout
+		AutodetectionPriority::High,
 		1117, // No EUR currency variant, unfortunately
 		KeyboardScript::LatinQwerty,
 		{
@@ -701,6 +841,8 @@ const std::vector<KeyboardLayoutInfoEntry> LocaleData::KeyboardLayoutInfo = {
 	},
 	{
 		{ "mk" }, "Macedonian (QWERTZ/national)",
+		// Balkan countries seem to be mostly using the QWERTZ layouts
+		AutodetectionPriority::High,
 		855,
 		KeyboardScript::LatinQwertz,
 		{
@@ -710,6 +852,8 @@ const std::vector<KeyboardLayoutInfoEntry> LocaleData::KeyboardLayoutInfo = {
 	},
 	{
 		{ "mn", "mo" }, "Mongolian (QWERTY/national)",
+		// The QWERTY layer seems to be identical to the US layout
+		AutodetectionPriority::High,
 		58152,
 		KeyboardScript::LatinQwerty,
 		{
@@ -718,31 +862,44 @@ const std::vector<KeyboardLayoutInfoEntry> LocaleData::KeyboardLayoutInfo = {
 	},
 	{
 		{ "mt", "ml" }, "Maltese (UK layout, QWERTY)",
+		// Not sure if the layout is popular, low priority for now
+		AutodetectionPriority::Low,
 		853,
 		KeyboardScript::LatinQwerty,
 	},
 	{
 		{ "mt103" }, "Maltese (US layout, QWERTY)",
+		// Not sure if the layout is popular, low priority for now
+		AutodetectionPriority::Low,
 		853,
 		KeyboardScript::LatinQwerty,
 	},
 	{
 		{ "ne" }, "Nigerien (AZERTY)",
+		// Not sure if the layout is popular, low priority for now
+		AutodetectionPriority::Low,
 		30028,
 		KeyboardScript::LatinAzerty,
 	},
 	{
 		{ "ng" }, "Nigerian (QWERTY)",
+		// Unintrusive US layout modification, uses right ALT for
+		// entering the national characters
+		AutodetectionPriority::High,
 		30005,
 		KeyboardScript::LatinQwerty,
 	},
 	{
 		{ "nl" }, "Dutch (QWERTY)",
+		// Not sure if the layout is popular, low priority for now
+		AutodetectionPriority::Low,
 		850,
 		KeyboardScript::LatinQwerty,
 	},
 	{
 		{ "no" }, "Norwegian (QWERTY/ASERTT)",
+		// National layouts seem to be popular in the Nordic region
+		AutodetectionPriority::High,
 		865,
 		KeyboardScript::LatinQwerty,
 		{
@@ -751,6 +908,8 @@ const std::vector<KeyboardLayoutInfoEntry> LocaleData::KeyboardLayoutInfo = {
 	},
 	{
 		{ "ph" }, "Filipino (QWERTY)",
+		// Not sure if the layout is popular, low priority for now
+		AutodetectionPriority::Low,
 		850,
 		KeyboardScript::LatinQwerty,
 	},
@@ -758,7 +917,10 @@ const std::vector<KeyboardLayoutInfoEntry> LocaleData::KeyboardLayoutInfo = {
 	// which preserves much more table drawing characters.
 	{
 		{ "pl" }, "Polish (programmers, QWERTY/phonetic)",
-		668, // stripped-down 852, approved by a native speaker
+		// Priority approved by a native speaker
+		AutodetectionPriority::High,
+		// Code page approved by a native speaker
+		668, // stripped-down 852
 		KeyboardScript::LatinQwerty,
 		{
 			{ 848, KeyboardScript::CyrillicPhonetic },
@@ -767,7 +929,10 @@ const std::vector<KeyboardLayoutInfoEntry> LocaleData::KeyboardLayoutInfo = {
 	},
 	{
 		{ "pl214" }, "Polish (typewriter, QWERTZ/phonetic)",
-		668, // stripped-down 852, approved by a native speaker
+		// Priority approved by a native speaker
+		AutodetectionPriority::Low,
+		// Code page approved by a native speaker
+		668, // stripped-down 852
 		KeyboardScript::LatinQwertz,
 		{
 			{ 848, KeyboardScript::CyrillicPhonetic },
@@ -776,16 +941,22 @@ const std::vector<KeyboardLayoutInfoEntry> LocaleData::KeyboardLayoutInfo = {
 	},
 	{
 		{ "po" }, "Portuguese (QWERTY)",
+		// Not sure if the layout is popular, low priority for now
+		AutodetectionPriority::Low,
 		860, // No EUR currency variant, unfortunately
 		KeyboardScript::LatinQwerty,
 	},
 	{
 		{ "px" }, "Portuguese (international, QWERTY)",
+		// Not sure if the layout is popular, low priority for now
+		AutodetectionPriority::Low,
 		30026,
 		KeyboardScript::LatinQwerty,
 	},
 	{
 		{ "ro" }, "Romanian (standard, QWERTZ/phonetic)",
+		// Not sure if the layout is popular, low priority for now
+		AutodetectionPriority::Low,
 		852,
 		KeyboardScript::LatinQwertz,
 		{
@@ -795,6 +966,8 @@ const std::vector<KeyboardLayoutInfoEntry> LocaleData::KeyboardLayoutInfo = {
 	},
 	{
 		{ "ro446" }, "Romanian (QWERTY/phonetic)",
+		// Not sure if the layout is popular, low priority for now
+		AutodetectionPriority::Low,
 		852,
 		KeyboardScript::LatinQwerty,
 		{
@@ -804,6 +977,8 @@ const std::vector<KeyboardLayoutInfoEntry> LocaleData::KeyboardLayoutInfo = {
 	},
 	{
 		{ "ru" }, "Russian (standard, QWERTY/national)",
+		// The QWERTY layer is almost identical to the US layout
+		AutodetectionPriority::High,
 		866,
 		KeyboardScript::LatinQwerty,
 		{
@@ -815,6 +990,8 @@ const std::vector<KeyboardLayoutInfoEntry> LocaleData::KeyboardLayoutInfo = {
 	},
 	{
 		{ "ru443" }, "Russian (typewriter, QWERTY/national)",
+		// The QWERTY layer is almost identical to the US layout
+		AutodetectionPriority::High,
 		866,
 		KeyboardScript::LatinQwerty,
 		{
@@ -826,6 +1003,8 @@ const std::vector<KeyboardLayoutInfoEntry> LocaleData::KeyboardLayoutInfo = {
 	},
 	{
 		{ "rx" }, "Russian (extended standard, QWERTY/national)",
+		// The QWERTY layer is almost identical to the US layout
+		AutodetectionPriority::High,
 		30011,
 		KeyboardScript::LatinQwerty,
 		{
@@ -840,6 +1019,8 @@ const std::vector<KeyboardLayoutInfoEntry> LocaleData::KeyboardLayoutInfo = {
 	},
 	{
 		{ "rx443" }, "Russian (extended typewriter, QWERTY/national)",
+		// The QWERTY layer is almost identical to the US layout
+		AutodetectionPriority::High,
 		30011,
 		KeyboardScript::LatinQwerty,
 		{
@@ -854,16 +1035,23 @@ const std::vector<KeyboardLayoutInfoEntry> LocaleData::KeyboardLayoutInfo = {
 	},
 	{
 		{ "sd", "sg" }, "Swiss (German, QWERTZ)",
+		// Priority approved by a native speaker
+		AutodetectionPriority::High,
 		850,
 		KeyboardScript::LatinQwertz,
 	},
 	{
 		{ "sf" }, "Swiss (French, QWERTZ)",
+		// Assuming French speaking part of Switzerland also uses the
+		// QWERTZ layouts
+		AutodetectionPriority::High,
 		850,
 		KeyboardScript::LatinQwertz,
 	},
 	{
 		{ "si" }, "Slovenian (QWERTZ)",
+		// Balkan countries seem to be mostly using the QWERTZ layouts
+		AutodetectionPriority::High,
 		852,
 		KeyboardScript::LatinQwertz,
 	},
@@ -871,21 +1059,29 @@ const std::vector<KeyboardLayoutInfoEntry> LocaleData::KeyboardLayoutInfo = {
 	// it is said to be much more popular.
 	{
 		{ "sk" }, "Slovak (QWERTZ)",
+		// Not sure if the layout is popular, low priority for now
+		AutodetectionPriority::Low,
 		867, // Kamenický encoding; no EUR variant, unfortunately
 		KeyboardScript::LatinQwertz,
 	},
 	{
 		{ "sq" }, "Albanian (no deadkeys, QWERTY)",
+		// Not sure if the layout is popular, low priority for now
+		AutodetectionPriority::Low,
 		852,
 		KeyboardScript::LatinQwerty,
 	},
 	{
 		{ "sq448" }, "Albanian (deadkeys, QWERTZ)",
+		// Not sure if the layout is popular, low priority for now
+		AutodetectionPriority::Low,
 		852,
 		KeyboardScript::LatinQwertz,
 	},
 	{
 		{ "sv" }, "Swedish (QWERTY/ASERTT)",
+		// A popular layout in Sweden (personal experience)
+		AutodetectionPriority::High,
 		850,
 		KeyboardScript::LatinQwerty,
 		{
@@ -894,6 +1090,8 @@ const std::vector<KeyboardLayoutInfoEntry> LocaleData::KeyboardLayoutInfo = {
 	},
 	{
 		{ "tj" }, "Tajik (QWERTY/national)",
+		// The QWERTY layer seems to be identical to the US layout
+		AutodetectionPriority::High,
 		30002,
 		KeyboardScript::LatinQwerty,
 		{
@@ -902,6 +1100,8 @@ const std::vector<KeyboardLayoutInfoEntry> LocaleData::KeyboardLayoutInfo = {
 	},
 	{
 		{ "tm" }, "Turkmen (QWERTY/phonetic)",
+		// The QWERTY layer seems to be identical to the US layout
+		AutodetectionPriority::High,
 		59234,
 		KeyboardScript::LatinQwerty,
 		{
@@ -910,16 +1110,22 @@ const std::vector<KeyboardLayoutInfoEntry> LocaleData::KeyboardLayoutInfo = {
 	}, 
 	{
 		{ "tr" }, "Turkish (QWERTY)",
+		// Not sure if the layout is popular, low priority for now
+		AutodetectionPriority::Low,
 		857,
 		KeyboardScript::LatinQwerty,
 	},
 	{
 		{ "tr440" }, "Turkish (non-standard)",
+		// Latin layer is atypical
+		AutodetectionPriority::Low,
 		857,
 		KeyboardScript::LatinNonStandard,
 	}, 
 	{
 		{ "tt" }, "Tatar (standard, QWERTY/national)",
+		// The QWERTY layer is almost identical to the US layout
+		AutodetectionPriority::High,
 		30018,
 		KeyboardScript::LatinQwerty,
 		{
@@ -929,6 +1135,8 @@ const std::vector<KeyboardLayoutInfoEntry> LocaleData::KeyboardLayoutInfo = {
 	},
 	{
 		{ "tt443" }, "Tatar (typewriter, QWERTY/national)",
+		// The QWERTY layer is almost identical to the US layout
+		AutodetectionPriority::High,
 		30018,
 		KeyboardScript::LatinQwerty,
 		{
@@ -938,6 +1146,8 @@ const std::vector<KeyboardLayoutInfoEntry> LocaleData::KeyboardLayoutInfo = {
 	},
 	{
 		{ "ur", "ua" }, "Ukrainian (101-key, QWERTY/national)",
+		// The QWERTY layer seems to be identical to the US layout
+		AutodetectionPriority::High,
 		1125,
 		KeyboardScript::LatinQwerty,
 		{
@@ -952,6 +1162,8 @@ const std::vector<KeyboardLayoutInfoEntry> LocaleData::KeyboardLayoutInfo = {
 	},
 	{
 		{ "ur1996" }, "Ukrainian (101-key, 1996, QWERTY/national)",
+		// The QWERTY layer seems to be identical to the US layout
+		AutodetectionPriority::High,
 		1125,
 		KeyboardScript::LatinQwerty,
 		{
@@ -966,6 +1178,8 @@ const std::vector<KeyboardLayoutInfoEntry> LocaleData::KeyboardLayoutInfo = {
 	},
 	{
 		{ "ur2001" }, "Ukrainian (102-key, 2001, QWERTY/national)",
+		// The QWERTY layer seems to be identical to the US layout
+		AutodetectionPriority::High,
 		1125,
 		KeyboardScript::LatinQwerty,
 		{
@@ -980,6 +1194,8 @@ const std::vector<KeyboardLayoutInfoEntry> LocaleData::KeyboardLayoutInfo = {
 	},
 	{
 		{ "ur2007" }, "Ukrainian (102-key, 2007, QWERTY/national)",
+		// The QWERTY layer seems to be identical to the US layout
+		AutodetectionPriority::High,
 		1125,
 		KeyboardScript::LatinQwerty,
 		{
@@ -994,6 +1210,8 @@ const std::vector<KeyboardLayoutInfoEntry> LocaleData::KeyboardLayoutInfo = {
 	},
 	{
 		{ "ur465" }, "Ukrainian (101-key, 465, QWERTY/national)",
+		// The QWERTY layer seems to be identical to the US layout
+		AutodetectionPriority::High,
 		1125,
 		KeyboardScript::LatinQwerty,
 		{
@@ -1008,6 +1226,8 @@ const std::vector<KeyboardLayoutInfoEntry> LocaleData::KeyboardLayoutInfo = {
 	},
 	{
 		{ "uz" }, "Uzbek (QWERTY/national)",
+		// The QWERTY layer seems to be identical to the US layout
+		AutodetectionPriority::High,
 		62306,
 		KeyboardScript::LatinQwerty,
 		{
@@ -1016,11 +1236,15 @@ const std::vector<KeyboardLayoutInfoEntry> LocaleData::KeyboardLayoutInfo = {
 	},
 	{
 		{ "vi" }, "Vietnamese (QWERTY)",
+		// The layout differs a lot from the standard QWERTY
+		AutodetectionPriority::Low,
 		30006,
 		KeyboardScript::LatinQwerty,
 	},
 	{
 		{ "yc", "sr" }, "Serbian (deadkey, QWERTZ/national)",
+		// Balkan countries seem to be mostly using the QWERTZ layouts
+		AutodetectionPriority::High,
 		855,
 		KeyboardScript::LatinQwertz,
 		{
@@ -1031,6 +1255,8 @@ const std::vector<KeyboardLayoutInfoEntry> LocaleData::KeyboardLayoutInfo = {
 	},
 	{
 		{ "yc450" }, "Serbian (no deadkey, QWERTZ/national)",
+		// Balkan countries seem to be mostly using the QWERTZ layouts
+		AutodetectionPriority::High,
 		855,
 		KeyboardScript::LatinQwertz,
 		{
@@ -1041,6 +1267,8 @@ const std::vector<KeyboardLayoutInfoEntry> LocaleData::KeyboardLayoutInfo = {
 	},
 	{
 		{ "yu" }, "Yugoslavian (QWERTZ)",
+		// Balkan countries seem to be mostly using the QWERTZ layouts
+		AutodetectionPriority::High,
 		113,
 		KeyboardScript::LatinQwertz,
 	}

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -1224,9 +1224,9 @@ void DOSBOX_Init()
 	pstring = secprop->Add_string("keyboardlayout", deprecated, "");
 	pstring->Set_help("Renamed to 'keyboard_layout'.");
 
-	pstring = secprop->Add_string("keyboard_layout", only_at_start, "us");
+	pstring = secprop->Add_string("keyboard_layout", only_at_start, "auto");
 	pstring->Set_help(
-	        "Keyboard layout code ('us' by default).\n"
+	        "Keyboard layout code ('auto' by default).\n"
 	        "The list of supported keyboard layout codes can be displayed using the\n"
 	        "'--list-layouts' command-line argument, e.g., 'uk' is the British English\n"
 	        "layout. The layout can be followed by the code page number, e.g., 'uk 850'\n"


### PR DESCRIPTION
# Description

This PR introduces priorities for keyboard layout autodetection to prevent setting controversial/exotic layouts if something safer is configured in the host OS:

- English layouts have high priority
- layouts which are unobtrusive modifications of English layouts (for example _Polish - Programmer's_) have high priority
- German/French/etc. layouts are high priority, as QWERTZ/AZERTY layouts are very popular in this region and (for example) German users are upset if we prefer English layout over German
- similarly for Nordic and Balkan national layouts - according to my knowledge they are popular in their countries, too
- exotic layouts, or layouts I wasn't sure are low priority - these include _Polish - Typewritter_ or _Hungarian_ (we have a native speakers' feedback here)

In addition, default `keyboard_layout` is now `auto` again - after this PR it should be a safe option. Moreover, we need as much feedback from the native speakers as possible.

# Release notes

(not needed - this only tweaks the functionality which wasn't delivered to any release yet)


# Manual testing

- Set `keyboard_layout = pl`, start DOSBox, execute command `KEYB` - should report Polish keyboard layout.
- Set `keyboard_layout = pl 667`, start DOSBox, execute command `KEYB` - should report Polish keyboard layout with code page 667.
- Set `keyboard_layout = pl 852`, start DOSBox, execute command `KEYB` - should report Polish keyboard layout with code page 852.
- Set `keyboard_layout = pl 852 53`, start DOSBox, observe the logs - they should complain about invalid setting and revert to `auto`.

---

Set `keyboard_layout = auto` for the tests below.

Set the following keyboard layouts in the host OS:
- _US English_
- _Polish_ (but not _Polish QWERTZ_, or _Polish Typewritter_, etc.)

Launch DOSBox, execute internal command `KEYB` - should report **Polish** keyboard layout

---

Set the following keyboard layouts in the host OS:
- _US English_
- _German_ 

Launch DOSBox, execute internal command `KEYB` - should report **German** keyboard layout

---

Set the following keyboard layouts in the host OS:
- _US English_
- _Hungarian_ 

Launch DOSBox, execute internal command `KEYB` - should report **US English** keyboard layout

---

Set the following keyboard layouts in the host OS:
- _Hungarian_ 

Launch DOSBox, execute internal command `KEYB` - should report **Hungarian** keyboard layout

---

Set the following keyboard layouts in the host OS:
- _Polish_ 

Launch DOSBox, execute internal command `KEYB` - should report **Polish** keyboard layout

---

The change has been manually tested on:

- [ ] Windows (business logic is trivial)
- [X] macOS
- [ ] Linux (mostly untestable; Linux users can set priorities manually and we follow these)


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

