### PR TITLE
Fix double free in TCPClientSocket destructor

### DIFF
--- a/src/hardware/serialport/misc_util.cpp
+++ b/src/hardware/serialport/misc_util.cpp
@@ -622,16 +622,21 @@ TCPClientSocket::TCPClientSocket(const char *destination, uint16_t port)
 TCPClientSocket::~TCPClientSocket()
 {
 #ifdef NATIVESOCKETS
-	delete nativetcpstruct;
+	if (nativetcpstruct) {
+		delete nativetcpstruct;
+	}
+	// Very important else. If we're using a native TCP socket, we can't call SDL's close.
+	// nativetcpstruct == mysock so it's a double free and it wasn't created by SDL to begin with
+	else
 #endif
 	if(mysock) {
-		if(listensocketset)
-			SDLNet_TCP_DelSocket(listensocketset, mysock);
 		SDLNet_TCP_Close(mysock);
 		LOG_INFO("SDLNET: Closed client TCP listening socket");
 	}
 
-	if(listensocketset) SDLNet_FreeSocketSet(listensocketset);
+	if (listensocketset) {
+		SDLNet_FreeSocketSet(listensocketset);
+	}
 }
 
 bool TCPClientSocket::GetRemoteAddressString(char *buffer)

--- a/src/hardware/serialport/misc_util.cpp
+++ b/src/hardware/serialport/misc_util.cpp
@@ -622,7 +622,7 @@ TCPClientSocket::TCPClientSocket(const char *destination, uint16_t port)
 TCPClientSocket::~TCPClientSocket()
 {
 #ifdef NATIVESOCKETS
-	if (nativetcpstruct) {
+	if (nativetcpstruct) { //-V809
 		delete nativetcpstruct;
 	}
 	// Very important else. If we're using a native TCP socket, we can't call SDL's close.


### PR DESCRIPTION
# Description

Regression from DOSBox SVN

Bug was triggered when using the inhsocket feature.
This inherits a native socket from a parent process. It must not be closed by SDL_net.

Also removed a call to `SDLNet_TCP_DelSocket`.  All it does is remove it from the "socket set" which we're deleting the entire thing anyway.  It doesn't actually free any memory and isn't needed.

I put "set" in quotes because:

```c
for ( i=0; i<set->numsockets; ++i ) {
    if ( set->sockets[i] == (struct SDLNet_Socket *)sock ) {
        break;
    }
}
```

![set](https://github.com/user-attachments/assets/ebd501a2-4db2-4312-bb94-0779598c4e6c)


## Related issues

Fixes #4112


# Release notes

Fix a crash on exit when using nullmodem inhsocket

# Manual testing

Ran test program provided by @jpetriejr here: https://github.com/dosbox-staging/dosbox-staging/issues/4112#issuecomment-2556078212

The change has been manually tested on:

- [x] Windows
- [ ] macOS
- [ ] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [x] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

