### PR TITLE
Fix some warnings in Windows CDROM code as shown by MSYS2

### DIFF
--- a/src/dos/cdrom_win32.cpp
+++ b/src/dos/cdrom_win32.cpp
@@ -281,20 +281,20 @@ bool CDROM_Interface_Win32::GetMediaTrayStatus(bool& mediaPresent,
 // LaserLock currently does not work with CDROM_Interface_Image or
 // CDROM_Interface_Ioctl either which does implement these. I could not find any
 // other game that uses this.
-bool CDROM_Interface_Win32::ReadSector(uint8_t* buffer, const bool raw,
-                                       const uint32_t sector)
+bool CDROM_Interface_Win32::ReadSector([[maybe_unused]]uint8_t* buffer, [[maybe_unused]]const bool raw,
+                                       [[maybe_unused]]const uint32_t sector)
 {
 	return false;
 }
 
-bool CDROM_Interface_Win32::ReadSectors(PhysPt buffer, const bool raw,
-                                        const uint32_t sector, const uint16_t num)
+bool CDROM_Interface_Win32::ReadSectors([[maybe_unused]]PhysPt buffer, [[maybe_unused]]const bool raw,
+                                        [[maybe_unused]]const uint32_t sector, [[maybe_unused]]const uint16_t num)
 {
 	return false;
 }
 
-bool CDROM_Interface_Win32::ReadSectorsHost(void* buffer, bool raw,
-                                            unsigned long sector, unsigned long num)
+bool CDROM_Interface_Win32::ReadSectorsHost([[maybe_unused]]void* buffer, [[maybe_unused]]bool raw,
+                                            [[maybe_unused]]unsigned long sector, [[maybe_unused]]unsigned long num)
 {
 	return false;
 }

--- a/src/dos/cdrom_win32.cpp
+++ b/src/dos/cdrom_win32.cpp
@@ -374,7 +374,7 @@ std::vector<int16_t> CDROM_Interface_Win32::ReadAudio(const uint32_t sector,
 	LPVOID input_buffer      = &read_info;
 	DWORD input_buffer_size  = sizeof(read_info);
 	LPVOID output_buffer     = audio_frames.data();
-	DWORD output_buffer_size = audio_frames.size() * sizeof(int16_t);
+	DWORD output_buffer_size = static_cast<DWORD>(audio_frames.size() * sizeof(int16_t));
 	LPDWORD bytes_returned   = NULL;
 	LPOVERLAPPED overlapped  = NULL;
 


### PR DESCRIPTION
# Description

Pretty trivial changes but I decided to finally fix these warnings I've been getting on MSYS2 while I'm in Windows since I don't boot into it too often 😄 

# Manual testing

I tested that it compiles but these are trivial changes.


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

