### PR TITLE
Consider keyboard layout list random on GNOME

### DIFF
--- a/src/misc/host_locale_macos.cpp
+++ b/src/misc/host_locale_macos.cpp
@@ -385,22 +385,22 @@ static std::string get_locale(const CFLocaleKey key)
 	return result;
 }
 
-static std::optional<DosCountry> get_dos_country(std::string& log_info)
+static std::optional<DosCountry> get_dos_country(std::string& out_log_info)
 {
 	const auto language = get_locale(kCFLocaleLanguageCode);
 	const auto country  = get_locale(kCFLocaleCountryCode);
 
-	log_info = language + "_" + country;
+	out_log_info = language + "_" + country;
 
 	return IsoToDosCountry(language, country);
 }
 
-static std::string get_language_file(std::string& log_info)
+static std::string get_language_file(std::string& out_log_info)
 {
 	const auto language = get_locale(kCFLocaleLanguageCode);
 	const auto country  = get_locale(kCFLocaleCountryCode);
 
-	log_info = language + "_" + country;
+	out_log_info = language + "_" + country;
 
 	if (language == "pt" && country == "BR") {
 		// We have a dedicated Brazilian translation
@@ -414,16 +414,16 @@ using AppleLayouts = std::vector<std::pair<int64_t, std::string>>;
 
 static std::vector<KeyboardLayoutMaybeCodepage> get_layouts_maybe_codepages(
 	const AppleLayouts &apple_layouts,
-	std::string& log_info)
+	std::string& out_log_info)
 {
 	std::vector<KeyboardLayoutMaybeCodepage> result = {};
 	for (const auto& [layout_id, layout_name] : apple_layouts) {
 		// LOG_MSG("{ %- lld, { \"\" }         }, // %s",
 		//         layout_id, layout_name.c_str());
-		if (!log_info.empty()) {
-			log_info += "; ";
+		if (!out_log_info.empty()) {
+			out_log_info += "; ";
 		}
-		log_info += std::to_string(layout_id) + " (" + layout_name + ")";
+		out_log_info += std::to_string(layout_id) + " (" + layout_name + ")";
 
 		if (MacToDosKeyboard.contains(layout_id)) {
 			result.push_back(MacToDosKeyboard.at(layout_id));
@@ -504,7 +504,7 @@ static CFPropertyListRef read_plist_file()
 	return plist_ref;
 }
 
-static std::vector<KeyboardLayoutMaybeCodepage> get_layouts_maybe_codepages(std::string& log_info)
+static std::vector<KeyboardLayoutMaybeCodepage> get_layouts_maybe_codepages(std::string& out_log_info)
 {
 	constexpr auto MaxIntSize = static_cast<CFIndex>(sizeof(int64_t));
 
@@ -599,7 +599,7 @@ static std::vector<KeyboardLayoutMaybeCodepage> get_layouts_maybe_codepages(std:
 	}
 
 	CFRelease(plist_ref);
-	return get_layouts_maybe_codepages(apple_layouts, log_info);
+	return get_layouts_maybe_codepages(apple_layouts, out_log_info);
 }
 
 const HostLocale& GetHostLocale()

--- a/src/misc/host_locale_win32.cpp
+++ b/src/misc/host_locale_win32.cpp
@@ -422,9 +422,9 @@ static std::map<std::string, std::string> read_layouts_registry(const std::strin
 	return layouts;
 }
 
-static std::vector<KeyboardLayoutMaybeCodepage> get_layouts_maybe_codepages(std::string& log_info)
+static std::vector<KeyboardLayoutMaybeCodepage> get_layouts_maybe_codepages(std::string& out_log_info)
 {
-	log_info = {};
+	out_log_info = {};
 
 	std::vector<KeyboardLayoutMaybeCodepage> layouts = {};
 
@@ -432,12 +432,12 @@ static std::vector<KeyboardLayoutMaybeCodepage> get_layouts_maybe_codepages(std:
 	const auto substitutes = read_layouts_registry(TEXT("Substitutes"));
 	for (const auto& entry : substitutes) {
 		// Get information for log
-		if (!log_info.empty()) {
-			log_info += ";";
+		if (!out_log_info.empty()) {
+			out_log_info += ";";
 		}
-		log_info += std::string(entry.first);
-		log_info += "->";
-		log_info += entry.second;
+		out_log_info += std::string(entry.first);
+		out_log_info += "->";
+		out_log_info += entry.second;
 
 		// Check if we know a matching keyboard layout
 		auto key = entry.second;
@@ -455,10 +455,10 @@ static std::vector<KeyboardLayoutMaybeCodepage> get_layouts_maybe_codepages(std:
 	const auto preload = read_layouts_registry(TEXT("Preload"));
 	for (const auto& entry : preload) {
 		// Get information for log
-		if (!log_info.empty()) {
-			log_info += ";";
+		if (!out_log_info.empty()) {
+			out_log_info += ";";
 		}
-		log_info += entry.second;
+		out_log_info += entry.second;
 
                 auto key = entry.second;
                 lowcase(key);
@@ -470,7 +470,7 @@ static std::vector<KeyboardLayoutMaybeCodepage> get_layouts_maybe_codepages(std:
 	return layouts;
 }
 
-static std::optional<DosCountry> get_dos_country(std::string& log_info)
+static std::optional<DosCountry> get_dos_country(std::string& out_log_info)
 {
 	wchar_t buffer[LOCALE_NAME_MAX_LENGTH];
 	if (!GetUserDefaultLocaleName(buffer, LOCALE_NAME_MAX_LENGTH)) {
@@ -480,7 +480,7 @@ static std::optional<DosCountry> get_dos_country(std::string& log_info)
 	}
 	const auto locale_name = to_string(&buffer[0], LOCALE_NAME_MAX_LENGTH);
 
-	log_info = locale_name;
+	out_log_info = locale_name;
 
 	const auto tokens = split(locale_name, "-");
 	if (tokens.size() < 2) {
@@ -490,7 +490,7 @@ static std::optional<DosCountry> get_dos_country(std::string& log_info)
 	return IsoToDosCountry(tokens[0], tokens[1]);
 }
 
-static std::string get_language_file(std::string& log_info)
+static std::string get_language_file(std::string& out_log_info)
 {
 	wchar_t buffer[LOCALE_NAME_MAX_LENGTH];
 
@@ -505,7 +505,7 @@ static std::string get_language_file(std::string& log_info)
 
 	const auto language_territory = to_string(&buffer[0], LOCALE_NAME_MAX_LENGTH);
 
-	log_info = language_territory;
+	out_log_info = language_territory;
 
 	if (language_territory == "pt-BR") {
 		// We have a dedicated Brazilian translation


### PR DESCRIPTION
# Description

At least some GNOME variants start with the last used keyboard layout - therefore it is quite possible the user did not reorder the keyboard layouts according to his preference. Thus, consider the order random for the purpose of autodetection.


## Related issues

Fixes https://github.com/dosbox-staging/dosbox-staging/issues/4093


# Release notes

(not needed; new keyboard layout autodetection is not yet present in any release)


# Manual testing

Set `keyboard_layout = auto`. Now:

- on KDE, DOSBox should, in general, honor the order of keyboard layouts; if English is present before German, English sohuld be selected, if German is present before English, german should be selected
-on GNOME, DOSBox should not care about order when deciding whether English or German layout should be selected; it should now always select German, regardless how the layouts are ordered in the configuration tool

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [x] Linux (only the Linux-specific code was changed)


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

