### PR TITLE
Revert "Ensure physical host buttons only perform one bound event"

### DIFF
--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -1892,8 +1892,6 @@ public:
 		        defmod & MMOD1 ? " mod1" : "",
 		        defmod & MMOD2 ? " mod2" : "",
 		        defmod & MMOD3 ? " mod3" : "");
-
-		drop_other_bound_events(this);
 	}
 
 protected:

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -404,16 +404,6 @@ public:
 		return sdl_scancode_name;
 	}
 
-	bool HasSameBinding(const CKeyBind* other) const
-	{
-		return other && key == other->key && mods == other->mods;
-	}
-
-	const char* GetEventName() const
-	{
-		return event ? event->GetName() : "";
-	}
-
 	void ConfigName(char *buf) override
 	{
 		sprintf(buf, "key %d", key);
@@ -1869,16 +1859,6 @@ public:
 	CHandlerEvent& operator=(const CHandlerEvent&) = delete; // prevent assignment
 
 	void Active(bool yesno) override { (*handler)(yesno); }
-
-	bool HasSameBinding(const CKeyBind* other) const
-	{
-		return other && defkey == other->key && defmod == other->mods;
-	}
-
-	const char* GetEventName() const
-	{
-		return entry;
-	}
 
 	void MakeDefaultBind(char *buf)
 	{

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -266,9 +266,6 @@ public:
 	}
 
 	void ActivateBind(Bits _value,bool ev_trigger,bool skip_action=false) {
-		if (!event) {
-			return;
-		}
 		if (event->IsTrigger()) {
 			/* use value-boundary for on/off events */
 			if (_value>25000) {
@@ -289,9 +286,6 @@ public:
 		}
 	}
 	void DeActivateBind(bool ev_trigger) {
-		if (!event) {
-			return;
-		}
 		if (event->IsTrigger()) {
 			if (!active) return;
 			active=false;

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -2097,10 +2097,6 @@ static void SetActiveEvent(CEvent * event) {
 		mapper.abindit=event->bindlist.begin();
 		if (mapper.abindit!=event->bindlist.end()) {
 			SetActiveBind(*(mapper.abindit));
-
-			const auto new_bind = dynamic_cast<CKeyBind*>(*mapper.abindit);
-			drop_other_bound_events(new_bind);
-
 		} else SetActiveBind(nullptr);
 		bind_but.add->Enable(true);
 	}


### PR DESCRIPTION
# Description

Reverts 

- https://github.com/dosbox-staging/dosbox-staging/pull/4079/commits

to fix

- https://github.com/dosbox-staging/dosbox-staging/issues/4128

Reopens

- https://github.com/dosbox-staging/dosbox-staging/issues/4051

## Related issues

- https://github.com/dosbox-staging/dosbox-staging/issues/4126


# Release notes

N/A


# Manual testing

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [ ] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [ ] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [ ] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

