### PR TITLE
Review auto-detection priorities for Italian keyboard layouts

### DIFF
--- a/src/dos/dos_locale_data.cpp
+++ b/src/dos/dos_locale_data.cpp
@@ -669,8 +669,8 @@ const std::vector<KeyboardLayoutInfoEntry> LocaleData::KeyboardLayoutInfo = {
 	},
 	{
 		{ "it" }, "Italian (standard, QWERTY/national)",
-		// Not sure if the layout is popular, low priority for now
-		AutodetectionPriority::Low,
+		// Priority approved by a native speaker
+		AutodetectionPriority::High,
 		850,
 		KeyboardScript::LatinQwerty,
 		{
@@ -679,7 +679,7 @@ const std::vector<KeyboardLayoutInfoEntry> LocaleData::KeyboardLayoutInfo = {
 	},
 	{
 		{ "it142" }, "Italian (142, QWERTY/national)",
-		// Not sure if the layout is popular, low priority for now
+		// Priority approved by a native speaker
 		AutodetectionPriority::Low,
 		850,
 		KeyboardScript::LatinQwerty,
@@ -689,7 +689,7 @@ const std::vector<KeyboardLayoutInfoEntry> LocaleData::KeyboardLayoutInfo = {
 	},
 	{
 		{ "ix" }, "Italian (international, QWERTY)",
-		// Not sure if the layout is popular, low priority for now
+		// Priority approved by a native speaker
 		AutodetectionPriority::Low,
 		30024,
 		KeyboardScript::LatinQwerty,


### PR DESCRIPTION
# Description

Updates the auto-detection priorities for keyboard layouts for the Italian language. 

- The standard `it` layout is the one that is the most common in Italy. Few people use non-Italian layouts, mostly gamers or programmers that prefer the US layout. 
- The `it142` is a failed attempt at improving the original `it` layout, extremely uncommon. 
- I've never even heard of the `ix` international layout to be fair. Couldn't find any information on the web either, so it's safe to say it isn't common either :P

# Manual testing

I couldn't unfortunately, because all my OS installations are in English. If you think manual testing is necessary I'll see what I can do.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [ ] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

