### PR TITLE
Increase bind name display length in the mapper to avoid truncation

### DIFF
--- a/include/mapper.h
+++ b/include/mapper.h
@@ -83,4 +83,8 @@ void MAPPER_AutoType(std::vector<std::string> &sequence,
                      const uint32_t pacing_ms);
 void MAPPER_CheckEvent(SDL_Event *event);
 
+// Screen fits ~89 characters total without clipping. Allocate a few more bytes
+// for good measure.
+constexpr int MaxBindNameLength = 100;
+
 #endif

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -503,7 +503,7 @@ public:
 
 	std::string GetBindName() const override
 	{
-		char buf[30];
+		char buf[MaxBindNameLength];
 		safe_sprintf(buf, "%s Axis %d%s", group->BindStart(), axis,
 		             positive ? "+" : "-");
 		return buf;
@@ -533,7 +533,7 @@ public:
 
 	std::string GetBindName() const override
 	{
-		char buf[30];
+		char buf[MaxBindNameLength];
 		safe_sprintf(buf, "%s Button %d", group->BindStart(), button);
 		return buf;
 	}
@@ -576,7 +576,7 @@ public:
 
 	std::string GetBindName() const override
 	{
-		char buf[30];
+		char buf[MaxBindNameLength];
 		safe_sprintf(buf, "%s Hat %" PRIu8 " %s", group->BindStart(), hat,
 		             ((dir == SDL_HAT_UP)      ? "up"
 		              : (dir == SDL_HAT_RIGHT) ? "right"


### PR DESCRIPTION
# Description

* Increase the maximum length of the display name of a bind above the maximum that can fit on screen
* Any longer names will be clipped, which is no worse than prior situation of arbitrary truncation at 30 chars

## Related issues

Noted in [comment in #4122](https://github.com/dosbox-staging/dosbox-staging/pull/4122#issuecomment-2564318717)

# Release notes

* When remapping an input, bind names (e.g. `some-joystick-name-axis1`) can now fill the line instead of being truncated early

# Manual testing

The change has been manually tested on:

- [x] Windows
- [x] macOS
- [X] Linux

* Linux.

   See before and after pics:
   Before:
   ![before](https://github.com/user-attachments/assets/40a0fc61-12d1-4514-9955-b6638a98d71e)

   After:
   ![after](https://github.com/user-attachments/assets/8f850493-06b2-4aeb-b21b-0373c08d2c39)

* Windows and macOS tests yielded similar results (with slightly different reported controller names): Without this commit, truncation occurs. With this commit, it does not.


# Checklist

I have:

- [X] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [X] performed a self-review of my code.
- [X] commented on the particularly hard-to-understand areas of my code.
- [X] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [X] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

