### PR TITLE
Improve language (translation) autodetection

### DIFF
--- a/src/dos/dos_locale.cpp
+++ b/src/dos/dos_locale.cpp
@@ -445,10 +445,11 @@ static void populate_all_country_info()
 	                                   ? get_info(DosCountry::International)
 	                                   : get_info(static_cast<DosCountry>(
 	                                              dos.country_code));
-	if (!config.country && !populated.is_country_overriden && host_locale.numeric) {
-		populated.separate_numeric = *host_locale.numeric;
-		const auto& [period_specific,
-		             info_specific] = get_info(*host_locale.numeric);
+	if (!config.country && !populated.is_country_overriden &&
+	    host_locale.numeric.country_code) {
+		const auto country_code = *host_locale.numeric.country_code;
+		populated.separate_numeric = country_code;
+		const auto& [period_specific, info_specific] = get_info(country_code);
 		populate_numeric_format(info_specific);
 		if (period_specific != config.locale_period) {
 			populated.is_using_fallback_period = true;
@@ -466,10 +467,10 @@ static void populate_all_country_info()
 
 	// Populate time/date format
 	if (!config.country && !populated.is_country_overriden &&
-	    host_locale.time_date) {
-		populated.separate_time_date = *host_locale.time_date;
-		const auto& [period_specific,
-		             info_specific]  = get_info(*host_locale.time_date);
+	    host_locale.time_date.country_code) {
+		const auto country_code = *host_locale.time_date.country_code;
+		populated.separate_time_date = country_code;
+		const auto& [period_specific, info_specific] = get_info(country_code);
 		populate_time_date_format(info_specific);
 		if (period_specific != config.locale_period) {
 			populated.is_using_fallback_period = true;
@@ -489,10 +490,10 @@ static void populate_all_country_info()
 
 	// Populate currency format
 	if (!config.country && !populated.is_country_overriden &&
-	    host_locale.currency) {
-		populated.separate_currency = *host_locale.currency;
-		const auto& [period_specific,
-		             info_specific] = get_info(*host_locale.currency);
+	    host_locale.currency.country_code) {
+		const auto country_code = *host_locale.currency.country_code;
+		populated.separate_currency = country_code;
+		const auto& [period_specific, info_specific] = get_info(country_code);
 		populate_currency_format(info_specific);
 		if (period_specific != config.locale_period) {
 			populated.is_using_fallback_period = true;
@@ -1054,7 +1055,7 @@ static void log_country_locale(const bool only_changed_period = false)
 
 	if (!config.country && !only_changed_period) {
 		LOG_MSG("LOCALE: Country detected from '%s'",
-		        host_locale.log_info.country.c_str());
+		        host_locale.country.log_info.c_str());
 	}
 
 	std::string country_name = {};
@@ -1075,7 +1076,7 @@ static void log_country_locale(const bool only_changed_period = false)
 		LOG_MSG("LOCALE: Using numeric format for country %d - '%s', detected from '%s'",
 		        enum_val(extra_country),
 		        get_country_name_for_log(extra_country).c_str(),
-		        host_locale.log_info.numeric.c_str());
+		        host_locale.numeric.log_info.c_str());
 	}
 
 	if (populated.separate_time_date &&
@@ -1084,7 +1085,7 @@ static void log_country_locale(const bool only_changed_period = false)
 		LOG_MSG("LOCALE: Using time/date format for country %d - '%s', detected from '%s'",
 		        enum_val(extra_country),
 		        get_country_name_for_log(extra_country).c_str(),
-		        host_locale.log_info.time_date.c_str());
+		        host_locale.time_date.log_info.c_str());
 	}
 
 	if (populated.separate_currency &&
@@ -1093,7 +1094,7 @@ static void log_country_locale(const bool only_changed_period = false)
 		LOG_MSG("LOCALE: Using currency format for country %d - '%s', detected from '%s'",
 		        enum_val(extra_country),
 		        get_country_name_for_log(extra_country).c_str(),
-		        host_locale.log_info.currency.c_str());
+		        host_locale.currency.log_info.c_str());
 	}
 
 	if (populated.is_using_native_numeric || populated.is_using_native_time ||
@@ -1153,8 +1154,8 @@ static void load_country()
 		current_country = *config.country;
 	} else {
 		const auto& host_locale = GetHostLocale();
-		if (host_locale.country) {
-			current_country = *host_locale.country;
+		if (host_locale.country.country_code) {
+			current_country = *host_locale.country.country_code;
 			if (current_country == DosCountry::International) {
 				current_country = get_default_country();
 			}

--- a/src/misc/host_locale.cpp
+++ b/src/misc/host_locale.cpp
@@ -320,8 +320,8 @@ static const std::unordered_map<std::string, DosCountry> IsoToDosCountryMap = {
 };
 // clang-format on
 
-std::optional<DosCountry> IsoToDosCountry(const std::string& language,
-                                          const std::string& territory)
+std::optional<DosCountry> iso_to_dos_country(const std::string& language,
+                                             const std::string& territory)
 {
 	std::string key_language  = language;
 	std::string key_territory = territory;

--- a/src/misc/host_locale.cpp
+++ b/src/misc/host_locale.cpp
@@ -323,22 +323,42 @@ static const std::unordered_map<std::string, DosCountry> IsoToDosCountryMap = {
 std::optional<DosCountry> iso_to_dos_country(const std::string& language,
                                              const std::string& territory)
 {
-	std::string key_language  = language;
-	std::string key_territory = territory;
+	std::string language_lower_case  = language;
+	std::string territory_upper_case = territory;
 
-	lowcase(key_language);
-	upcase(key_territory);
+	lowcase(language_lower_case);
+	upcase(territory_upper_case);
 
-	const auto key = key_language + "_" + key_territory;
+	const auto key = language_lower_case + "_" + territory_upper_case;
 
 	if (IsoToDosCountryMap.contains(key)) {
 		return IsoToDosCountryMap.at(key);
 	}
-	if (IsoToDosCountryMap.contains(key_territory)) {
-		return IsoToDosCountryMap.at(key_territory);
+	if (IsoToDosCountryMap.contains(territory_upper_case)) {
+		return IsoToDosCountryMap.at(territory_upper_case);
 	}
 
 	return {};
+}
+
+std::string iso_to_language_file(const std::string& language,
+                                 const std::string& territory)
+{
+	std::string language_lower_case  = language;
+	std::string territory_upper_case = territory;
+
+	lowcase(language_lower_case);
+	upcase(territory_upper_case);
+
+	if (language_lower_case == "pt" && territory_upper_case == "BR") {
+		// We have a dedicated Brazilian translation
+		return "br";
+	} else if (language_lower_case == "c" || language_lower_case == "posix") {
+		// Default (dummy) language, used on POSIX systems
+		return "en";
+	}
+	
+	return language_lower_case;
 }
 
 // ***************************************************************************

--- a/src/misc/host_locale.h
+++ b/src/misc/host_locale.h
@@ -32,6 +32,11 @@
 std::optional<DosCountry> iso_to_dos_country(const std::string& language,
                                              const std::string& territory);
 
+// Convert language and territory (using 'ISO 3166-1 alpha-2' codes, also
+// supports POSIX dummy languages) to a language file name (without extension)
+std::string iso_to_language_file(const std::string& language,
+                                 const std::string& territory);
+
 struct KeyboardLayoutMaybeCodepage {
 	// Keyboard layout, as supported by the FreeDOS
 	std::string keyboard_layout = {};
@@ -129,19 +134,23 @@ struct HostKeyboardLayouts {
 	std::string log_info = {};
 };
 
-struct HostLanguage {
-	// If the host OS support code cannot determine the UI language, leave
-	// it as default
-	std::string language_file = {}; // translation (messages)
+struct HostLanguages {
+	// Put here the name of the language file corresponding to the host UI
+	// language. Leave empty if it can't be determined.
+	std::string language_file_gui = {};
+
+	// If the OS allows to get the list of UI languages preferred by the
+	// user, put it here.
+	std::vector<std::string> language_files = {};
 
 	// If detection was successful, always provide info for the log output,
-	// telling which host OS property/value was used to determine the
+	// telling which host OS properties/values were used to determine the
 	// language.
 	std::string log_info = {};
 };
 
 const HostLocale&          GetHostLocale();
 const HostKeyboardLayouts& GetHostKeyboardLayouts();
-const HostLanguage&        GetHostLanguage();
+const HostLanguages&       GetHostLanguages();
 
 #endif

--- a/src/misc/host_locale.h
+++ b/src/misc/host_locale.h
@@ -27,11 +27,10 @@
 #include <optional>
 #include <vector>
 
-// Converts language and territory in the typical POSIX format (with underscore
-// or hyphen - "en_US" or "en-US"), using 'ISO 3166-1 alpha-2' codes, to a
-// DOS country code
-std::optional<DosCountry> IsoToDosCountry(const std::string& language,
-                                          const std::string& territory);
+// Convert language and territory (using 'ISO 3166-1 alpha-2' codes) to a DOS
+// country code
+std::optional<DosCountry> iso_to_dos_country(const std::string& language,
+                                             const std::string& territory);
 
 struct KeyboardLayoutMaybeCodepage {
 	// Keyboard layout, as supported by the FreeDOS

--- a/src/misc/host_locale.h
+++ b/src/misc/host_locale.h
@@ -87,6 +87,15 @@ struct StdLibLocale {
 	char time_separator = {};
 };
 
+struct HostLocaleElement {
+	std::optional<DosCountry> country_code = {};
+
+	// If detection was successful, always provide info for the log output,
+	// telling which host OS property/value was used to determine the given
+	// locale.
+	std::string log_info = {};
+};
+
 struct HostLocale {
 	// These are locale detected by the portable routines of C++ library.
 	// Override them if the host-specific code can do a better job detecting
@@ -98,23 +107,13 @@ struct HostLocale {
 	// should leave them as default
 
 	// DOS country code
-	std::optional<DosCountry> country = {};
+	HostLocaleElement country = {};
 
 	// These are completely optional; leave them unset if you can't get the
 	// concrete value from the host OS, do not blindly copy 'country' here!
-	std::optional<DosCountry> numeric   = {};
-	std::optional<DosCountry> time_date = {};
-	std::optional<DosCountry> currency  = {};
-
-	// If detection was successful, always provide info for the log output,
-	// telling which host OS property/value was used to determine the given
-	// locale.
-	struct {
-		std::string country   = {};
-		std::string numeric   = {};
-		std::string time_date = {};
-		std::string currency  = {};
-	} log_info = {};
+	HostLocaleElement numeric   = {};
+	HostLocaleElement time_date = {};
+	HostLocaleElement currency  = {};
 };
 
 struct HostKeyboardLayouts {

--- a/src/misc/host_locale_macos.cpp
+++ b/src/misc/host_locale_macos.cpp
@@ -385,14 +385,17 @@ static std::string get_locale(const CFLocaleKey key)
 	return result;
 }
 
-static std::optional<DosCountry> get_dos_country(std::string& out_log_info)
+static HostLocaleElement get_dos_country()
 {
+	HostLocaleElement result = {};
+
 	const auto language = get_locale(kCFLocaleLanguageCode);
 	const auto country  = get_locale(kCFLocaleCountryCode);
 
-	out_log_info = language + "_" + country;
+	result.log_info = language + "_" + country;
 
-	return IsoToDosCountry(language, country);
+	result.country_code = IsoToDosCountry(language, country);
+	return result;
 }
 
 static HostLanguage get_host_language()
@@ -613,7 +616,7 @@ const HostLocale& GetHostLocale()
 	if (!locale) {
 		locale = HostLocale();
 
-		locale->country = get_dos_country(locale->log_info.country);
+		locale->country = get_dos_country();
 	}
 
 	return *locale;

--- a/src/misc/host_locale_macos.cpp
+++ b/src/misc/host_locale_macos.cpp
@@ -398,9 +398,9 @@ static HostLocaleElement get_dos_country()
 	return result;
 }
 
-static HostLanguage get_host_language()
+static HostLanguages get_host_languages()
 {
-	HostLanguage result = {};
+	HostLanguages result = {};
 
 	const auto language = get_locale(kCFLocaleLanguageCode);
 	const auto country  = get_locale(kCFLocaleCountryCode);
@@ -409,9 +409,9 @@ static HostLanguage get_host_language()
 
 	if (language == "pt" && country == "BR") {
 		// We have a dedicated Brazilian translation
-		result.language_file = "br";
+		result.language_file_gui = "br";
 	} else {
-		result.language_file = language;
+		result.language_file_gui = language;
 	}
 
 	return result;
@@ -633,12 +633,12 @@ const HostKeyboardLayouts& GetHostKeyboardLayouts()
 	return *locale;
 }
 
-const HostLanguage& GetHostLanguage()
+const HostLanguages& GetHostLanguages()
 {
-	static std::optional<HostLanguage> locale = {};
+	static std::optional<HostLanguages> locale = {};
 
 	if (!locale) {
-		locale = get_host_language();
+		locale = get_host_languages();
 	}
 
 	return *locale;

--- a/src/misc/host_locale_macos.cpp
+++ b/src/misc/host_locale_macos.cpp
@@ -395,19 +395,23 @@ static std::optional<DosCountry> get_dos_country(std::string& out_log_info)
 	return IsoToDosCountry(language, country);
 }
 
-static std::string get_language_file(std::string& out_log_info)
+static HostLanguage get_host_language()
 {
+	HostLanguage result = {};
+
 	const auto language = get_locale(kCFLocaleLanguageCode);
 	const auto country  = get_locale(kCFLocaleCountryCode);
 
-	out_log_info = language + "_" + country;
+	result.log_info = language + "_" + country;
 
 	if (language == "pt" && country == "BR") {
 		// We have a dedicated Brazilian translation
-		return "br";
+		result.language_file = "br";
+	} else {
+		result.language_file = language;
 	}
 
-	return language;
+	return result;
 }
 
 using AppleLayouts = std::vector<std::pair<int64_t, std::string>>;
@@ -633,9 +637,7 @@ const HostLanguage& GetHostLanguage()
 	static std::optional<HostLanguage> locale = {};
 
 	if (!locale) {
-		locale = HostLanguage();
-
-		locale->language_file = get_language_file(locale->log_info);
+		locale = get_host_language();
 	}
 
 	return *locale;

--- a/src/misc/host_locale_macos.cpp
+++ b/src/misc/host_locale_macos.cpp
@@ -394,7 +394,7 @@ static HostLocaleElement get_dos_country()
 
 	result.log_info = language + "_" + country;
 
-	result.country_code = IsoToDosCountry(language, country);
+	result.country_code = iso_to_dos_country(language, country);
 	return result;
 }
 

--- a/src/misc/host_locale_posix.cpp
+++ b/src/misc/host_locale_posix.cpp
@@ -909,12 +909,14 @@ static std::pair<std::string, std::string> split_posix_locale(const std::string&
 
 	// Get the language
 	result.first = tmp.substr(0, tmp.find('_'));
+	trim(result.first);
 	lowcase(result.first);
 
 	const auto position = tmp.rfind('_');
 	if (position != std::string::npos) {
 		// Get the territory
 		result.second = tmp.substr(position + 1);
+		trim(result.second);
 		upcase(result.second);
 	}
 

--- a/src/misc/host_locale_posix.cpp
+++ b/src/misc/host_locale_posix.cpp
@@ -940,8 +940,10 @@ static std::optional<DosCountry> get_dos_country(const std::string& category,
 	return IsoToDosCountry(language, teritory);
 }
 
-static std::string get_language_file(std::string& out_log_info)
+static HostLanguage get_host_language()
 {
+	HostLanguage result = {};
+
 	const std::vector<std::string> Variables = {
 	        VariableLanguage,
 	        LcAll,
@@ -953,19 +955,20 @@ static std::string get_language_file(std::string& out_log_info)
 	if (value.empty()) {
 		return {};
 	}
-	out_log_info = variable + "=" + value;
+	result.log_info = variable + "=" + value;
 
 	const auto [language, teritory] = split_posix_locale(value);
 
 	if (language == "pt" && teritory == "BR") {
 		// We have a dedicated Brazilian translation
-		return "br";
-	}
-	if (language == "c" || language == "posix") {
-		return "en";
+		result.language_file = "br";
+	} else if (language == "c" || language == "posix") {
+		result.language_file = "en";
+	} else {
+		result.language_file = language;
 	}
 
-	return language;
+	return result;
 }
 
 static DesktopKeyboardLayouts consolidate_layouts_variants(
@@ -1435,9 +1438,7 @@ const HostLanguage& GetHostLanguage()
 	static std::optional<HostLanguage> locale = {};
 
 	if (!locale) {
-		locale = HostLanguage();
-
-		locale->language_file = get_language_file(locale->log_info);
+		locale = get_host_language();
 	}
 
 	return *locale;

--- a/src/misc/host_locale_posix.cpp
+++ b/src/misc/host_locale_posix.cpp
@@ -944,9 +944,9 @@ static HostLocaleElement get_dos_country(const std::string& category)
 	return result;
 }
 
-static HostLanguage get_host_language()
+static HostLanguages get_host_languages()
 {
-	HostLanguage result = {};
+	HostLanguages result = {};
 
 	const std::vector<std::string> Variables = {
 	        VariableLanguage,
@@ -965,11 +965,11 @@ static HostLanguage get_host_language()
 
 	if (language == "pt" && teritory == "BR") {
 		// We have a dedicated Brazilian translation
-		result.language_file = "br";
+		result.language_file_gui = "br";
 	} else if (language == "c" || language == "posix") {
-		result.language_file = "en";
+		result.language_file_gui = "en";
 	} else {
-		result.language_file = language;
+		result.language_file_gui = language;
 	}
 
 	return result;
@@ -1432,12 +1432,12 @@ const HostKeyboardLayouts& GetHostKeyboardLayouts()
 	return *locale;
 }
 
-const HostLanguage& GetHostLanguage()
+const HostLanguages& GetHostLanguages()
 {
-	static std::optional<HostLanguage> locale = {};
+	static std::optional<HostLanguages> locale = {};
 
 	if (!locale) {
-		locale = get_host_language();
+		locale = get_host_languages();
 	}
 
 	return *locale;

--- a/src/misc/host_locale_posix.cpp
+++ b/src/misc/host_locale_posix.cpp
@@ -921,23 +921,25 @@ static std::pair<std::string, std::string> split_posix_locale(const std::string&
 	return result;
 }
 
-static std::optional<DosCountry> get_dos_country(const std::string& category,
-                                                 std::string& out_log_info)
+static HostLocaleElement get_dos_country(const std::string& category)
 {
+	HostLocaleElement result = {};
+
 	const std::vector<std::string> Variables = {LcAll, category, VariableLang};
 
 	const auto [variable, value] = get_env_variable_from_list(Variables);
 	if (value.empty()) {
 		return {};
 	}
-	out_log_info = variable + "=" + value;
+	result.log_info = variable + "=" + value;
 
 	const auto [language, teritory] = split_posix_locale(value);
 	if (is_language_generic(language)) {
 		return {};
 	}
 
-	return IsoToDosCountry(language, teritory);
+	result.country_code = IsoToDosCountry(language, teritory);
+	return result;
 }
 
 static HostLanguage get_host_language()
@@ -1405,15 +1407,13 @@ const HostLocale& GetHostLocale()
 	if (!locale) {
 		locale = HostLocale();
 
-		auto& log_info = locale->log_info;
-
 		// There is no "LC_*" variable specifying a concrete country,
 		// so we are using a telephone format - as MS-DOS locale is
 		// telephone-code based
-		locale->country   = get_dos_country(LcTelephone, log_info.country);
-		locale->numeric   = get_dos_country(LcNumeric, log_info.numeric);
-		locale->time_date = get_dos_country(LcTime, log_info.time_date);
-		locale->currency  = get_dos_country(LcMonetary, log_info.currency);
+		locale->country   = get_dos_country(LcTelephone);
+		locale->numeric   = get_dos_country(LcNumeric);
+		locale->time_date = get_dos_country(LcTime);
+		locale->currency  = get_dos_country(LcMonetary);
 	}
 
 	return *locale;

--- a/src/misc/host_locale_posix.cpp
+++ b/src/misc/host_locale_posix.cpp
@@ -940,7 +940,7 @@ static HostLocaleElement get_dos_country(const std::string& category)
 		return {};
 	}
 
-	result.country_code = IsoToDosCountry(language, teritory);
+	result.country_code = iso_to_dos_country(language, teritory);
 	return result;
 }
 

--- a/src/misc/host_locale_win32.cpp
+++ b/src/misc/host_locale_win32.cpp
@@ -490,8 +490,10 @@ static std::optional<DosCountry> get_dos_country(std::string& out_log_info)
 	return IsoToDosCountry(tokens[0], tokens[1]);
 }
 
-static std::string get_language_file(std::string& out_log_info)
+static HostLanguage get_host_language()
 {
+	HostLanguage result = {};
+
 	wchar_t buffer[LOCALE_NAME_MAX_LENGTH];
 
 	// Get the main language name
@@ -505,14 +507,17 @@ static std::string get_language_file(std::string& out_log_info)
 
 	const auto language_territory = to_string(&buffer[0], LOCALE_NAME_MAX_LENGTH);
 
-	out_log_info = language_territory;
+	result.log_info = language_territory;
 
 	if (language_territory == "pt-BR") {
 		// We have a dedicated Brazilian translation
-		return "br";
+		result.language_file = "br";
+	} else {
+		const auto it = language_territory.find('-');
+		result.language_file = language_territory.substr(0, it);
 	}
 
-	return language_territory.substr(0, language_territory.find('-'));
+	return result;
 }
 
 const HostLocale& GetHostLocale()
@@ -546,9 +551,7 @@ const HostLanguage& GetHostLanguage()
 	static std::optional<HostLanguage> locale = {};
 
 	if (!locale) {
-		locale = HostLanguage();
-
-		locale->language_file = get_language_file(locale->log_info);
+		locale = get_host_language();
 	}
 
 	return *locale;

--- a/src/misc/host_locale_win32.cpp
+++ b/src/misc/host_locale_win32.cpp
@@ -492,9 +492,9 @@ static HostLocaleElement get_dos_country()
 	return result;
 }
 
-static HostLanguage get_host_language()
+static HostLanguages get_host_languages()
 {
-	HostLanguage result = {};
+	HostLanguages result = {};
 
 	wchar_t buffer[LOCALE_NAME_MAX_LENGTH];
 
@@ -513,10 +513,10 @@ static HostLanguage get_host_language()
 
 	if (language_territory == "pt-BR") {
 		// We have a dedicated Brazilian translation
-		result.language_file = "br";
+		result.language_file_gui = "br";
 	} else {
 		const auto it = language_territory.find('-');
-		result.language_file = language_territory.substr(0, it);
+		result.language_file_gui = language_territory.substr(0, it);
 	}
 
 	return result;
@@ -546,12 +546,12 @@ const HostKeyboardLayouts& GetHostKeyboardLayouts()
 	return *locale;
 }
 
-const HostLanguage& GetHostLanguage()
+const HostLanguages& GetHostLanguages()
 {
-	static std::optional<HostLanguage> locale = {};
+	static std::optional<HostLanguages> locale = {};
 
 	if (!locale) {
-		locale = get_host_language();
+		locale = get_host_languages();
 	}
 
 	return *locale;

--- a/src/misc/host_locale_win32.cpp
+++ b/src/misc/host_locale_win32.cpp
@@ -488,7 +488,7 @@ static HostLocaleElement get_dos_country()
 		return {};
 	}
 
-	result.country_code = IsoToDosCountry(tokens[0], tokens[1]);
+	result.country_code = iso_to_dos_country(tokens[0], tokens[1]);
 	return result;
 }
 

--- a/src/misc/host_locale_win32.cpp
+++ b/src/misc/host_locale_win32.cpp
@@ -469,8 +469,10 @@ static HostKeyboardLayouts get_host_keyboard_layouts()
 	return result;
 }
 
-static std::optional<DosCountry> get_dos_country(std::string& out_log_info)
+static HostLocaleElement get_dos_country()
 {
+	HostLocaleElement result = {};
+
 	wchar_t buffer[LOCALE_NAME_MAX_LENGTH];
 	if (!GetUserDefaultLocaleName(buffer, LOCALE_NAME_MAX_LENGTH)) {
 		LOG_WARNING("LOCALE: Could not get default locale name, error code %lu",
@@ -479,14 +481,15 @@ static std::optional<DosCountry> get_dos_country(std::string& out_log_info)
 	}
 	const auto locale_name = to_string(&buffer[0], LOCALE_NAME_MAX_LENGTH);
 
-	out_log_info = locale_name;
+	result.log_info = locale_name;
 
 	const auto tokens = split(locale_name, "-");
 	if (tokens.size() < 2) {
 		return {};
 	}
 
-	return IsoToDosCountry(tokens[0], tokens[1]);
+	result.country_code = IsoToDosCountry(tokens[0], tokens[1]);
+	return result;
 }
 
 static HostLanguage get_host_language()
@@ -526,7 +529,7 @@ const HostLocale& GetHostLocale()
 	if (!locale) {
 		locale = HostLocale();
 
-		locale->country = get_dos_country(locale->log_info.country);
+		locale->country = get_dos_country();
 	}
 
 	return *locale;


### PR DESCRIPTION
# Description

- some minor refactoring/cleanup
- improved language autodetection, see the _Release notes_ proposal

# Release notes

Language (translation) autodetection now checks the host OS list of user preferred languages (not just the current GUI language) - if it can't find the translation into the most preferred language, it tries with the second one from the list, and so on.

# Manual testing

1. Start DOSBox by command `dosbox -lang en`, `dosbox -lang pl`, etc. - check that the correct translation is loaded (pay attention to the first `LOCALE` log). If the startup banner is hidden, but the translation is up to date, a localized text is probably (depending on the configuration) visible even on the DOSBox window title bar.
If unknown language is specified, it should use internal English; `dosbox -lang auto` should trigger language autodetection (see the other steps).
The command line option should have a priority over `language = ` setting from the config file.

2. Set `language = en`, `language = pl`, etc. - check that the correct translation is loaded when DOSBox is started. If unknown language is specified, it should use internal English.

3. **[Linux]**  For this test set `language = auto` in the config file.
Modern Linux GUIs do not allow to set language priorities, we have to manually set environment variables for testing - see https://www.gnu.org/software/gettext/manual/html_node/The-LANGUAGE-variable.html for the `LANGUAGE` variable description (it allows to specify multiple languages and has a priority over `LC_ALL`, `LC_MESSAGES` and `LANG` variables).
Example commands:
- `LANGUAGE=pl LC_ALL=de dosbox` - should select the Polish translation.
- `LANGUAGE=pl_PL:cz_CZ LC_ALL=de dosbox` - should select the Polish translation.
- `LANGUAGE=cz_CZ:pl_US LC_ALL=de dosbox` - should select the Polish translation (we have no Czech messages).
- `LANGUAGE= LC_ALL=de dosbox` - should select the German translation.
- `LANGUAGE=cz LC_ALL=de dosbox` - should select  the internal English translation (on POSIX systems the higher priority variables override the lower priority ones).

4.  **[macOS]**  For this test set `language = auto` in the config file.
- Press the Apple logo, _System Settings..._ -> _General_ -> _Language & Region_.
- Manipulate the _Preferred Languages_ list - add/remove/reorder (you don't have to reboot).
BE REASONABLE. If you end up with your Macintosh communicating in Sindarin and now you have no idea how to get back - this is not my fault :D
- Start DOSBox - it should use the first language from the list we have a translation for.

5.  **[Windows 11]**  For this test set `language = auto` in the config file.
- Start the _Settings_ app, select _Time & language_ -> _Language & region_.
- Manipulate (reorder) the _Preferred languages_ list.
- Start DOSBox - it should use the first language from the list we have a translation for.

6. General regression testing (to test the refactoring).
Set the following options in the config file:
- `locale_period = modern`
- `country = auto`
- `keyboard_layout = auto`
Check that detected locale settings (check the `LOCALE` logs) are the same as before (translation can differ - see tests above).


The change has been manually tested on:

- [x] Windows
- [x] macOS
- [x] Linux


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [x] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

