### PR TITLE
Do not open or create files on Windows with FILE_SHARE_DELETE

### DIFF
--- a/src/misc/fs_utils_win32.cpp
+++ b/src/misc/fs_utils_win32.cpp
@@ -95,7 +95,7 @@ NativeFileHandle open_native_file(const std_fs::path& path, const bool write_acc
 
 	return CreateFileW(path.c_str(),
 	                   access,
-	                   FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+	                   FILE_SHARE_READ | FILE_SHARE_WRITE,
 	                   nullptr,
 	                   OPEN_EXISTING,
 	                   FILE_ATTRIBUTE_NORMAL,
@@ -111,7 +111,7 @@ NativeFileHandle create_native_file(const std_fs::path& path,
 
 	return CreateFileW(path.c_str(),
 	                   GENERIC_READ | GENERIC_WRITE,
-	                   FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+	                   FILE_SHARE_READ | FILE_SHARE_WRITE,
 	                   nullptr,
 	                   CREATE_ALWAYS,
 	                   win32_attributes,


### PR DESCRIPTION
# Description
Fixes the game Abuse failure to launch

It attempts to delete a file while it is holding open a file handle to it
Removing this flag causes the delete to fail but it re-creates the file anyway and successfully launches

This may not be the best fix.  It causes different behavior than POSIX where the delete will always succeed.  I can do some more verification of real DOS behavior later.

I think this is what the old C library `fopen` calls were doing differently.  Again, I'd like to confirm behavior on older versions of Staging.

Setting this to Draft PR until I verify the above.  It's just late and I'm not doing this tonight.

## Related issues

#4123

# Release notes

Fixes Abuse error on launch on Windows 7 and on Windows 10+ network drives.


# Manual testing

Tested that Crystal Caves regression #3262 did not come back.  This game depends on the read and write share flags but not delete.

Tested that Abuse launches from a network drive on Windows 10

The change has been manually tested on:

- [x] Windows

This is a Windows specific change.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [x] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

