### PR TITLE
Remove reinterpret_cast for accessing SDL Events

### DIFF
--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -2789,8 +2789,7 @@ void MAPPER_CheckEvent(SDL_Event *event)
 	case SDL_CONTROLLERDEVICEREMOVED:
 	case SDL_JOYDEVICEREMOVED:
 	case SDL_JOYDEVICEADDED:
-		MAPPER_HandleJoyDeviceEvent(
-		        reinterpret_cast<SDL_JoyDeviceEvent*>(event));
+		MAPPER_HandleJoyDeviceEvent(&event->jdevice);
 		return;
 	default: break;
 	}
@@ -2847,8 +2846,7 @@ void BIND_MappingEvents()
 		case SDL_CONTROLLERDEVICEREMOVED:
 		case SDL_JOYDEVICEREMOVED:
 		case SDL_JOYDEVICEADDED:
-			MAPPER_HandleJoyDeviceEvent(
-			        reinterpret_cast<SDL_JoyDeviceEvent*>(&event));
+			MAPPER_HandleJoyDeviceEvent(&event.jdevice);
 			mapper.redraw = true;
 			break;
 		case SDL_MOUSEBUTTONDOWN:


### PR DESCRIPTION
# Description

SDL_Event is a tagged union. We can just access the relevant member rather than casting.
This fixes a PVS warning.


# Manual testing

Tested that hotplug still works in Quake.

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [x] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

