### PR TITLE
Fix regression introduced by re-enabling joystick events in #4122

### DIFF
--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -758,32 +758,7 @@ public:
 	}
 
 	bool CheckEvent(SDL_Event * event) override {
-		SDL_JoyAxisEvent * jaxis = nullptr;
-		SDL_JoyButtonEvent *jbutton = nullptr;
-
-		switch(event->type) {
-			case SDL_JOYAXISMOTION:
-				jaxis = &event->jaxis;
-				if(jaxis->which == stick_id) {
-					if(jaxis->axis == 0)
-						JOYSTICK_Move_X(emustick, jaxis->value);
-					else if (jaxis->axis == 1)
-						JOYSTICK_Move_Y(emustick, jaxis->value);
-				}
-				break;
-			case SDL_JOYBUTTONDOWN:
-			case SDL_JOYBUTTONUP:
-				jbutton = &event->jbutton;
-			        if (jbutton->which != stick_id) {
-				        break;
-			        }
-			        const bool state = jbutton->type == SDL_JOYBUTTONDOWN;
-			        const auto but = check_cast<uint8_t>(
-			                jbutton->button % emulated_buttons);
-			        JOYSTICK_Button(emustick, but, state);
-			        break;
-		        }
-		        return false;
+		return false;
 	}
 
 	virtual void UpdateJoystick() {
@@ -1024,34 +999,6 @@ public:
 		JOYSTICK_Enable(1, true);
 	}
 
-	bool CheckEvent(SDL_Event * event) override {
-		SDL_JoyAxisEvent * jaxis = nullptr;
-		SDL_JoyButtonEvent *jbutton = nullptr;
-
-		switch(event->type) {
-			case SDL_JOYAXISMOTION:
-				jaxis = &event->jaxis;
-				if(jaxis->which == stick_id && jaxis->axis < 4) {
-					if(jaxis->axis & 1)
-						JOYSTICK_Move_Y(jaxis->axis >> 1 & 1, jaxis->value);
-					else
-						JOYSTICK_Move_X(jaxis->axis >> 1 & 1, jaxis->value);
-		        }
-		        break;
-			case SDL_JOYBUTTONDOWN:
-			case SDL_JOYBUTTONUP:
-				jbutton = &event->jbutton;
-				bool state;
-				state = jbutton->type == SDL_JOYBUTTONDOWN;
-				const auto but = check_cast<uint8_t>(jbutton->button % emulated_buttons);
-				if (jbutton->which == stick_id) {
-					JOYSTICK_Button((but >> 1), (but & 1), state);
-				}
-				break;
-		}
-		return false;
-	}
-
 	void UpdateJoystick() override {
 		/* query SDL joystick and activate bindings */
 		ActivateJoystickBoundEvents();
@@ -1086,42 +1033,6 @@ public:
 		if (button_wrapping_enabled) button_wrap=emulated_buttons;
 		JOYSTICK_Enable(1,true);
 		JOYSTICK_Move_Y(1, INT16_MAX);
-	}
-
-	bool CheckEvent(SDL_Event * event) override {
-		SDL_JoyAxisEvent * jaxis = nullptr;
-		SDL_JoyButtonEvent * jbutton = nullptr;
-		SDL_JoyHatEvent *jhat = nullptr;
-
-		switch(event->type) {
-			case SDL_JOYAXISMOTION:
-				jaxis = &event->jaxis;
-				if(jaxis->which == stick_id) {
-					if(jaxis->axis == 0)
-						JOYSTICK_Move_X(0, jaxis->value);
-					else if (jaxis->axis == 1)
-						JOYSTICK_Move_Y(0, jaxis->value);
-					else if (jaxis->axis == 2)
-						JOYSTICK_Move_X(1, jaxis->value);
-				}
-				break;
-			case SDL_JOYHATMOTION:
-				jhat = &event->jhat;
-				if (jhat->which == stick_id)
-					DecodeHatPosition(jhat->value);
-				break;
-			case SDL_JOYBUTTONDOWN:
-			case SDL_JOYBUTTONUP:
-				jbutton = &event->jbutton;
-			bool state;
-			state=jbutton->type==SDL_JOYBUTTONDOWN;
-				const auto but = check_cast<uint8_t>(jbutton->button % emulated_buttons);
-				if (jbutton->which == stick_id) {
-					JOYSTICK_Button((but >> 1), (but & 1), state);
-				}
-				break;
-		}
-		return false;
 	}
 
 	void UpdateJoystick() override {
@@ -1212,66 +1123,6 @@ public:
 		emulated_hats=1;
 		if (button_wrapping_enabled) button_wrap=emulated_buttons;
 		JOYSTICK_Enable(1,true);
-	}
-
-	bool CheckEvent(SDL_Event * event) override {
-		SDL_JoyAxisEvent * jaxis = nullptr;
-		SDL_JoyButtonEvent * jbutton = nullptr;
-		SDL_JoyHatEvent * jhat = nullptr;
-		Bitu but = 0;
-		static const unsigned button_magic[6] = {
-		        0x02, 0x04, 0x10, 0x100, 0x20, 0x200};
-		static const unsigned hat_magic[2][5] = {
-		        {0x8888, 0x8000, 0x800, 0x80, 0x08},
-		        {0x5440, 0x4000, 0x400, 0x40, 0x1000}};
-		switch(event->type) {
-			case SDL_JOYAXISMOTION:
-				jaxis = &event->jaxis;
-				if(jaxis->which == stick_id && jaxis->axis < 4) {
-					if(jaxis->axis & 1)
-						JOYSTICK_Move_Y(jaxis->axis >> 1 & 1, jaxis->value);
-					else
-						JOYSTICK_Move_X(jaxis->axis >> 1 & 1, jaxis->value);
-				}
-				break;
-			case SDL_JOYHATMOTION:
-				jhat = &event->jhat;
-				if (jhat->which == stick_id && jhat->hat < 2) {
-					if (jhat->value == SDL_HAT_CENTERED)
-						button_state &= ~hat_magic[jhat->hat][0];
-					if (jhat->value & SDL_HAT_UP)
-						button_state|=hat_magic[jhat->hat][1];
-					if(jhat->value & SDL_HAT_RIGHT)
-						button_state|=hat_magic[jhat->hat][2];
-					if(jhat->value & SDL_HAT_DOWN)
-						button_state|=hat_magic[jhat->hat][3];
-					if(jhat->value & SDL_HAT_LEFT)
-						button_state|=hat_magic[jhat->hat][4];
-				}
-				break;
-			case SDL_JOYBUTTONDOWN:
-				jbutton = &event->jbutton;
-				but = jbutton->button % emulated_buttons;
-				if (jbutton->which == stick_id)
-					button_state|=button_magic[but];
-				break;
-			case SDL_JOYBUTTONUP:
-				jbutton = &event->jbutton;
-				but = jbutton->button % emulated_buttons;
-				if (jbutton->which == stick_id)
-					button_state&=~button_magic[but];
-				break;
-		}
-
-		unsigned i;
-		uint16_t j;
-		j=button_state;
-		for(i=0;i<16;i++) if (j & 1) break; else j>>=1;
-		JOYSTICK_Button(0,0,i&1);
-		JOYSTICK_Button(0,1,(i>>1)&1);
-		JOYSTICK_Button(1,0,(i>>2)&1);
-		JOYSTICK_Button(1,1,(i>>3)&1);
-		return false;
 	}
 
 	void UpdateJoystick() override {


### PR DESCRIPTION
# Description

* previously dead, incorrect code within CheckEvent implementations under subclasses of and including JStickBindGroup was made active by 9b029420c18606233e4339554a939c6d76126e92
* actual joystick processing was previously done in UpdateJoystick, which continues to be called
* post 9b029420c18606233e4339554a939c6d76126e92, emulated joystick events are being triggered by the previously dead code irrespective of whether a host joystick event is actually bound to the emulated action
* fix by simply deleting all of the previously dead code

## Related issues

#4122

# Manual testing

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [X] Linux


# Checklist

I have:

- [X] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [X] performed a self-review of my code.
- [X] commented on the particularly hard-to-understand areas of my code.
- [X] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [ ] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [X] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

