### PR TITLE
Revert Hotplug Support #4122,#4138,#4143

### DIFF
--- a/include/mapper.h
+++ b/include/mapper.h
@@ -87,17 +87,4 @@ void MAPPER_CheckEvent(SDL_Event *event);
 // for good measure.
 constexpr int MaxBindNameLength = 100;
 
-/**
- * Handle a game controller being connected or disconnected by reiniitializing
- * binds. Caller is responsible for any user interface updates, e.g. updating
- * the mapper UI buttons to reflect joystick binds being added / removed.
- *
- * @param event A pointer to an SDL_JoyDeviceEvent whose type must be one of:
- * - SDL_CONTROLLERDEVICEADDED
- * - SDL_CONTROLLERDEVICEREMOVED
- * - SDL_JOYDEVICEADDED
- * - SDL_JOYDEVICEREMOVED
- */
-void MAPPER_HandleJoyDeviceEvent(SDL_JoyDeviceEvent* event);
-
 #endif

--- a/include/setup.h
+++ b/include/setup.h
@@ -557,9 +557,4 @@ public:
 
 bool config_file_is_valid(const std_fs::path& path);
 
-// Helper functions for retrieving common configuration sections
-
-Section_prop* get_joystick_section();
-Section_prop* get_sdl_section();
-
 #endif

--- a/include/video.h
+++ b/include/video.h
@@ -69,6 +69,8 @@
 //   postfixes is highly recommended in such cases to remove ambiguity.
 //
 
+#define REDUCE_JOYSTICK_POLLING
+
 enum class RenderingBackend {
 	Texture,
 	OpenGl
@@ -430,7 +432,9 @@ void GFX_SetMouseRawInput(const bool requested_raw_input);
 // Detects the presence of a desktop environment or window manager
 bool GFX_HaveDesktopEnvironment();
 
+#if defined(REDUCE_JOYSTICK_POLLING)
 void MAPPER_UpdateJoysticks(void);
+#endif
 
 DosBox::Rect GFX_CalcDrawRectInPixels(const DosBox::Rect& canvas_size_px,
                                       const DosBox::Rect& render_size_px,

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -111,9 +111,6 @@ static CBindList holdlist;
 
 static bool suppress_save_mapper_file_message = false;
 
-// In SDL ticks (msec)
-static auto joystick_subsystem_init_timestamp = std::numeric_limits<uint32_t>::max();
-
 class CEvent {
 public:
 	CEvent(const char *ev_entry) : bindlist{}
@@ -2805,11 +2802,6 @@ void MAPPER_CheckEvent(SDL_Event *event)
 
 void MAPPER_HandleJoyDeviceEvent(SDL_JoyDeviceEvent* event)
 {
-	// Hack to eliminate redundant initialization and corresponding log spam
-	// at startup
-	if (!SDL_TICKS_PASSED(event->timestamp, joystick_subsystem_init_timestamp)) {
-		return;
-	}
 	switch (event->type) {
 	case SDL_CONTROLLERDEVICEADDED:
 	case SDL_JOYDEVICEADDED: {
@@ -2970,10 +2962,8 @@ static void QueryJoysticks()
 		return;
 	}
 
-	if (SDL_WasInit(SDL_INIT_JOYSTICK) != SDL_INIT_JOYSTICK) {
+	if (SDL_WasInit(SDL_INIT_JOYSTICK) != SDL_INIT_JOYSTICK)
 		SDL_InitSubSystem(SDL_INIT_JOYSTICK);
-		joystick_subsystem_init_timestamp = SDL_GetTicks();
-	}
 
 	const bool wants_auto_config = joytype & (JOY_AUTO | JOY_ONLY_FOR_MAPPING);
 

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -2789,7 +2789,8 @@ void MAPPER_CheckEvent(SDL_Event *event)
 	case SDL_CONTROLLERDEVICEREMOVED:
 	case SDL_JOYDEVICEREMOVED:
 	case SDL_JOYDEVICEADDED:
-		MAPPER_HandleJoyDeviceEvent(&event->jdevice);
+		MAPPER_HandleJoyDeviceEvent(
+		        reinterpret_cast<SDL_JoyDeviceEvent*>(event));
 		return;
 	default: break;
 	}
@@ -2846,7 +2847,8 @@ void BIND_MappingEvents()
 		case SDL_CONTROLLERDEVICEREMOVED:
 		case SDL_JOYDEVICEREMOVED:
 		case SDL_JOYDEVICEADDED:
-			MAPPER_HandleJoyDeviceEvent(&event.jdevice);
+			MAPPER_HandleJoyDeviceEvent(
+			        reinterpret_cast<SDL_JoyDeviceEvent*>(&event));
 			mapper.redraw = true;
 			break;
 		case SDL_MOUSEBUTTONDOWN:

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -732,8 +732,10 @@ public:
 
 			if (event->jaxis.which != stick_id)
 				return nullptr;
+#if defined(REDUCE_JOYSTICK_POLLING)
 			if (axis_id >= axes)
 				return nullptr;
+#endif
 			if (abs(axis_position) < 25000)
 				return nullptr;
 
@@ -745,7 +747,11 @@ public:
 		} else if (event->type == SDL_JOYBUTTONDOWN) {
 			if (event->jbutton.which != stick_id)
 				return nullptr;
-			return CreateButtonBind(event->jbutton.button % button_wrap);
+#if defined (REDUCE_JOYSTICK_POLLING)
+			return CreateButtonBind(event->jbutton.button%button_wrap);
+#else
+			return CreateButtonBind(event->jbutton.button);
+#endif
 		} else if (event->type==SDL_JOYHATMOTION) {
 			if (event->jhat.which != stick_id) return nullptr;
 			if (event->jhat.value == 0) return nullptr;
@@ -771,16 +777,15 @@ public:
 			case SDL_JOYBUTTONDOWN:
 			case SDL_JOYBUTTONUP:
 				jbutton = &event->jbutton;
-			        if (jbutton->which != stick_id) {
-				        break;
-			        }
-			        const bool state = jbutton->type == SDL_JOYBUTTONDOWN;
-			        const auto but = check_cast<uint8_t>(
-			                jbutton->button % emulated_buttons);
-			        JOYSTICK_Button(emustick, but, state);
-			        break;
-		        }
-		        return false;
+				bool state;
+				state = jbutton->type == SDL_JOYBUTTONDOWN;
+				const auto but = check_cast<uint8_t>(jbutton->button % emulated_buttons);
+				if (jbutton->which == stick_id) {
+					JOYSTICK_Button(emustick, but, state);
+				}
+				break;
+			}
+			return false;
 	}
 
 	virtual void UpdateJoystick() {
@@ -2632,8 +2637,8 @@ static void ClearAllBinds()
 	}
 }
 
-static void CreateDefaultBinds()
-{
+static void CreateDefaultBinds() {
+	ClearAllBinds();
 	char buffer[512];
 	Bitu i=0;
 	while (DefaultKeys[i].eventend) {
@@ -2755,6 +2760,7 @@ static bool load_binds_from_file(const std::string_view mapperfile_path,
 
 		suppress_save_mapper_file_message = true;
 
+		ClearAllBinds();
 		for (auto &line : lines)
 			CreateStringBind(line.data());
 
@@ -2781,68 +2787,17 @@ static bool load_binds_from_file(const std::string_view mapperfile_path,
 
 void MAPPER_CheckEvent(SDL_Event *event)
 {
-	switch (event->type) {
-	case SDL_CONTROLLERDEVICEADDED:
-	case SDL_CONTROLLERDEVICEREMOVED:
-	case SDL_JOYDEVICEREMOVED:
-	case SDL_JOYDEVICEADDED:
-		MAPPER_HandleJoyDeviceEvent(
-		        reinterpret_cast<SDL_JoyDeviceEvent*>(event));
-		return;
-	default: break;
-	}
-
-	MAPPER_UpdateJoysticks();
-	for (auto& group : bindgroups) {
-		if (group->CheckEvent(event)) {
+	for (auto &group : bindgroups)
+		if (group->CheckEvent(event))
 			return;
-		}
-	}
 }
 
-void MAPPER_HandleJoyDeviceEvent(SDL_JoyDeviceEvent* event)
-{
-	switch (event->type) {
-	case SDL_CONTROLLERDEVICEADDED:
-	case SDL_JOYDEVICEADDED: {
-		auto index    = event->which;
-		auto joystick = SDL_JoystickOpen(index);
-		auto name     = SDL_JoystickName(joystick);
-		LOG_INFO("MAPPER: Game controller '%s' has been plugged in", name);
-		SDL_JoystickClose(joystick);
-		break;
-	}
-	case SDL_CONTROLLERDEVICEREMOVED:
-	case SDL_JOYDEVICEREMOVED: {
-		auto joystick = SDL_JoystickFromInstanceID(event->which);
-		auto name     = SDL_JoystickName(joystick);
-		LOG_INFO("MAPPER: Game controller '%s' has been disconnected", name);
-		SDL_JoystickClose(joystick);
-		break;
-	}
-	default:
-		LOG_DEBUG("MAPPER:  MAPPER_HandleJoyDeviceEvent: Unexpected event type '%d' received",
-		          event->type);
-		assert(false);
-	}
-	MAPPER_BindKeys(get_sdl_section());
-}
-
-void BIND_MappingEvents()
-{
+void BIND_MappingEvents() {
 	SDL_Event event;
 	static bool isButtonPressed = false;
 	static CButton *lastHoveredButton = nullptr;
 	while (SDL_PollEvent(&event)) {
 		switch (event.type) {
-		case SDL_CONTROLLERDEVICEADDED:
-		case SDL_CONTROLLERDEVICEREMOVED:
-		case SDL_JOYDEVICEREMOVED:
-		case SDL_JOYDEVICEADDED:
-			MAPPER_HandleJoyDeviceEvent(
-			        reinterpret_cast<SDL_JoyDeviceEvent*>(&event));
-			mapper.redraw = true;
-			break;
 		case SDL_MOUSEBUTTONDOWN:
 			isButtonPressed = true;
 			/* Further check where are we pointing at right now */
@@ -2929,17 +2884,6 @@ void BIND_MappingEvents()
 	}
 }
 
-static void ClearSticks()
-{
-	// Free any allocated sticks
-	for (int i = 0; i < MAXSTICKS; ++i) {
-		delete mapper.sticks.stick[i];
-		mapper.sticks.stick[i] = nullptr;
-	}
-	mapper.sticks.num        = 0;
-	mapper.sticks.num_groups = 0;
-}
-
 //  Initializes SDL's joystick subsystem an setups up initial joystick settings.
 
 // If the user wants auto-configuration, then this sets joytype based on queried
@@ -2952,7 +2896,7 @@ static void ClearSticks()
 static void QueryJoysticks()
 {
 	// Reset our joystick status
-	ClearSticks();
+	mapper.sticks.num = 0;
 
 	JOYSTICK_ParseConfiguredType();
 
@@ -3028,23 +2972,8 @@ static void QueryJoysticks()
 	}
 }
 
-static void ClearBindGroups()
-{
-	for (auto& ptr : keybindgroups) {
-		delete ptr;
-	}
-	keybindgroups.clear();
-
-	for (auto& ptr : stickbindgroups) {
-		delete ptr;
-	}
-	stickbindgroups.clear();
-
+static void CreateBindGroups() {
 	bindgroups.clear();
-}
-
-static void CreateBindGroups()
-{
 	CKeyBindGroup* key_bind_group = new CKeyBindGroup(SDL_NUM_SCANCODES);
 	keybindgroups.push_back(key_bind_group);
 
@@ -3054,6 +2983,22 @@ static void CreateBindGroups()
 		return;
 
 	if (joytype != JOY_NONE_FOUND) {
+#if defined (REDUCE_JOYSTICK_POLLING)
+		// direct access to the SDL joystick, thus removed from the event handling
+		if (mapper.sticks.num)
+			SDL_JoystickEventState(SDL_DISABLE);
+#else
+		// enable joystick event handling
+		if (mapper.sticks.num)
+			SDL_JoystickEventState(SDL_ENABLE);
+		else
+			return;
+#endif
+		// Free up our previously assigned joystick slot before assinging below
+		if (mapper.sticks.stick[mapper.sticks.num_groups]) {
+			delete mapper.sticks.stick[mapper.sticks.num_groups];
+			mapper.sticks.stick[mapper.sticks.num_groups] = nullptr;
+		}
 
 		uint8_t joyno = 0;
 		switch (joytype) {
@@ -3102,12 +3047,18 @@ static void CreateBindGroups()
 	}
 }
 
+bool MAPPER_IsUsingJoysticks() {
+	return (mapper.sticks.num > 0);
+}
+
+#if defined (REDUCE_JOYSTICK_POLLING)
 void MAPPER_UpdateJoysticks() {
 	for (Bitu i=0; i<mapper.sticks.num_groups; i++) {
 		assert(mapper.sticks.stick[i]);
 		mapper.sticks.stick[i]->UpdateJoystick();
 	}
 }
+#endif
 
 void MAPPER_LosingFocus() {
 	for (const auto& event : events) {
@@ -3228,6 +3179,9 @@ void MAPPER_DisplayUI() {
 	mapper.exit = false;
 	mapper.redraw=true;
 	SetActiveEvent(nullptr);
+#if defined (REDUCE_JOYSTICK_POLLING)
+	SDL_JoystickEventState(SDL_ENABLE);
+#endif
 	while (!mapper.exit) {
 		if (mapper.redraw) {
 			mapper.redraw = false;
@@ -3260,6 +3214,9 @@ void MAPPER_DisplayUI() {
 		}
 	}
 #endif
+#if defined (REDUCE_JOYSTICK_POLLING)
+	SDL_JoystickEventState(SDL_DISABLE);
+#endif
 	GFX_ResetScreen();
 	MOUSE_NotifyTakeOver(false);
 }
@@ -3278,10 +3235,22 @@ static void MAPPER_Destroy(Section *sec) {
 
 	buttons.clear();
 
-	ClearBindGroups();
-	ClearSticks();
+	for (auto & ptr : keybindgroups)
+		delete ptr;
+	keybindgroups.clear();
+
+	for (auto & ptr : stickbindgroups)
+		delete ptr;
+	stickbindgroups.clear();
+
+	// Free any allocated sticks
+	for (int i = 0; i < MAXSTICKS; ++i) {
+		delete mapper.sticks.stick[i];
+		mapper.sticks.stick[i] = nullptr;
+	}
 
 	// Empty the remaining lists now that their pointers are defunct
+	bindgroups.clear();
 	handlergroup.clear();
 	holdlist.clear();
 
@@ -3323,15 +3292,14 @@ void MAPPER_BindKeys(Section* sec)
 	assert(property);
 	mapper.filename = property->realpath.string();
 
-	ClearAllBinds();
-	ClearBindGroups();
 	QueryJoysticks();
 
 	// Create the graphical layout for all registered key-binds
 	if (buttons.empty())
 		CreateLayout();
 
-	CreateBindGroups();
+	if (bindgroups.empty())
+		CreateBindGroups();
 
 	// Create binds from file or fallback to internals
 	if (!load_binds_from_file(mapper.filename, mapperfile_value))
@@ -3346,6 +3314,8 @@ void MAPPER_BindKeys(Section* sec)
 
 	if (SDL_GetModState()&KMOD_NUM)
 		MAPPER_TriggerEvent(num_lock_event, false);
+
+	GFX_RegenerateWindow(sec);
 }
 
 std::vector<std::string> MAPPER_GetEventNames(const std::string &prefix) {
@@ -3371,7 +3341,6 @@ void MAPPER_StartUp(Section* sec)
 	// mapperfile=file.map"` commands
 	constexpr auto changeable_at_runtime = true;
 	section->AddInitFunction(&MAPPER_BindKeys, changeable_at_runtime);
-	section->AddInitFunction(&GFX_RegenerateWindow, changeable_at_runtime);
 
 	// Runs one-time on shutdown
 	section->AddDestroyFunction(&MAPPER_Destroy);

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -453,6 +453,16 @@ static double get_host_refresh_rate()
 	return refresh_rate;
 }
 
+static Section_prop* get_sdl_section()
+{
+	assert(control);
+
+	auto sdl_section = static_cast<Section_prop*>(control->GetSection("sdl"));
+	assert(sdl_section);
+
+	return sdl_section;
+}
+
 // Reset and populate the vsync settings from the config. This is
 // called on-demand after startup and on output mode changes (e.g., switching
 // from the 'texture' backend to 'opengl').
@@ -3819,6 +3829,15 @@ bool GFX_Events()
 #endif
 
 	SDL_Event event;
+#if defined (REDUCE_JOYSTICK_POLLING)
+	static auto last_check_joystick = GetTicks();
+	auto current_check_joystick = GetTicks();
+	if (GetTicksDiff(current_check_joystick, last_check_joystick) > 20) {
+		last_check_joystick = current_check_joystick;
+		if (MAPPER_IsUsingJoysticks()) SDL_JoystickUpdate();
+		MAPPER_UpdateJoysticks();
+	}
+#endif
 	while (SDL_PollEvent(&event)) {
 #if C_DEBUG
 		if (is_debugger_event(event)) {
@@ -5075,7 +5094,6 @@ int sdl_main(int argc, char* argv[])
 		// All subsystems' hotkeys need to be registered at this point
 		// to ensure their hotkeys appear in the graphical mapper.
 		MAPPER_BindKeys(sdl_sec);
-		GFX_RegenerateWindow(sdl_sec);
 
 		if (arguments->startmapper) {
 			MAPPER_DisplayUI();

--- a/src/hardware/joystick.cpp
+++ b/src/hardware/joystick.cpp
@@ -390,7 +390,7 @@ double JOYSTICK_GetMove_Y(uint8_t which)
 
 void JOYSTICK_ParseConfiguredType()
 {
-	const auto conf    = get_joystick_section();
+	const auto conf = control->GetSection("joystick");
 	const auto section = static_cast<Section_prop *>(conf);
 	const auto type = section->Get_string("joysticktype");
 

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -1980,24 +1980,3 @@ bool config_file_is_valid(const std_fs::path& path)
 	fclose(file);
 	return false;
 }
-
-// Get up-to-date in-memory model of a config section
-static Section_prop* get_section(const char* section_name)
-{
-	assert(control);
-
-	const auto sec = static_cast<Section_prop*>(control->GetSection(section_name));
-	assert(sec);
-
-	return sec;
-}
-
-Section_prop* get_joystick_section()
-{
-	return get_section("joystick");
-}
-
-Section_prop* get_sdl_section()
-{
-	return get_section("sdl");
-}


### PR DESCRIPTION
# Description

* Reverts commits introduced in #4122 - as well as its follow-on commits from #4138 and #4143- due to various regressions

## Related issues
* Revert of #4122, #4138, #4143
* Reopens #946

# Manual testing

Omitted manual testing because this is a full revert to a known state without any intervening conflicts

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [ ] Linux


# Checklist

I have:

- [X] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [X] performed a self-review of my code.
- [X] commented on the particularly hard-to-understand areas of my code.
- [X] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [ ] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

