### PR TITLE
Enable hotplugging joysticks (2nd attempt)

### DIFF
--- a/include/mapper.h
+++ b/include/mapper.h
@@ -87,4 +87,17 @@ void MAPPER_CheckEvent(SDL_Event *event);
 // for good measure.
 constexpr int MaxBindNameLength = 100;
 
+/**
+ * Handle a game controller being connected or disconnected by reinitializing
+ * binds. Caller is responsible for any user interface updates, e.g. updating
+ * the mapper UI buttons to reflect joystick binds being added / removed.
+ *
+ * @param event A pointer to an SDL_JoyDeviceEvent whose type must be one of:
+ * - SDL_CONTROLLERDEVICEADDED
+ * - SDL_CONTROLLERDEVICEREMOVED
+ * - SDL_JOYDEVICEADDED
+ * - SDL_JOYDEVICEREMOVED
+ */
+void MAPPER_HandleJoyDeviceEvent(SDL_JoyDeviceEvent* event);
+
 #endif

--- a/include/setup.h
+++ b/include/setup.h
@@ -557,4 +557,9 @@ public:
 
 bool config_file_is_valid(const std_fs::path& path);
 
+// Helper functions for retrieving common configuration sections
+
+Section_prop* get_joystick_section();
+Section_prop* get_sdl_section();
+
 #endif

--- a/include/video.h
+++ b/include/video.h
@@ -69,8 +69,6 @@
 //   postfixes is highly recommended in such cases to remove ambiguity.
 //
 
-#define REDUCE_JOYSTICK_POLLING
-
 enum class RenderingBackend {
 	Texture,
 	OpenGl
@@ -432,9 +430,7 @@ void GFX_SetMouseRawInput(const bool requested_raw_input);
 // Detects the presence of a desktop environment or window manager
 bool GFX_HaveDesktopEnvironment();
 
-#if defined(REDUCE_JOYSTICK_POLLING)
 void MAPPER_UpdateJoysticks(void);
-#endif
 
 DosBox::Rect GFX_CalcDrawRectInPixels(const DosBox::Rect& canvas_size_px,
                                       const DosBox::Rect& render_size_px,

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -453,16 +453,6 @@ static double get_host_refresh_rate()
 	return refresh_rate;
 }
 
-static Section_prop* get_sdl_section()
-{
-	assert(control);
-
-	auto sdl_section = static_cast<Section_prop*>(control->GetSection("sdl"));
-	assert(sdl_section);
-
-	return sdl_section;
-}
-
 // Reset and populate the vsync settings from the config. This is
 // called on-demand after startup and on output mode changes (e.g., switching
 // from the 'texture' backend to 'opengl').
@@ -3829,7 +3819,6 @@ bool GFX_Events()
 #endif
 
 	SDL_Event event;
-#if defined (REDUCE_JOYSTICK_POLLING)
 	static auto last_check_joystick = GetTicks();
 	auto current_check_joystick = GetTicks();
 	if (GetTicksDiff(current_check_joystick, last_check_joystick) > 20) {
@@ -3837,7 +3826,6 @@ bool GFX_Events()
 		if (MAPPER_IsUsingJoysticks()) SDL_JoystickUpdate();
 		MAPPER_UpdateJoysticks();
 	}
-#endif
 	while (SDL_PollEvent(&event)) {
 #if C_DEBUG
 		if (is_debugger_event(event)) {
@@ -5094,6 +5082,7 @@ int sdl_main(int argc, char* argv[])
 		// All subsystems' hotkeys need to be registered at this point
 		// to ensure their hotkeys appear in the graphical mapper.
 		MAPPER_BindKeys(sdl_sec);
+		GFX_RegenerateWindow(sdl_sec);
 
 		if (arguments->startmapper) {
 			MAPPER_DisplayUI();

--- a/src/hardware/joystick.cpp
+++ b/src/hardware/joystick.cpp
@@ -390,7 +390,7 @@ double JOYSTICK_GetMove_Y(uint8_t which)
 
 void JOYSTICK_ParseConfiguredType()
 {
-	const auto conf = control->GetSection("joystick");
+	const auto conf    = get_joystick_section();
 	const auto section = static_cast<Section_prop *>(conf);
 	const auto type = section->Get_string("joysticktype");
 

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -1980,3 +1980,24 @@ bool config_file_is_valid(const std_fs::path& path)
 	fclose(file);
 	return false;
 }
+
+// Get up-to-date in-memory model of a config section
+static Section_prop* get_section(const char* section_name)
+{
+	assert(control);
+
+	const auto sec = static_cast<Section_prop*>(control->GetSection(section_name));
+	assert(sec);
+
+	return sec;
+}
+
+Section_prop* get_joystick_section()
+{
+	return get_section("joystick");
+}
+
+Section_prop* get_sdl_section()
+{
+	return get_section("sdl");
+}


### PR DESCRIPTION
# Description

* fixes #946
* partially remove REDUCE_JOYSTICK_POLLING hack, which prevented detection of joystick hotplug events:
  * delete inactive code paths assuming REDUCE_JOYSTICK_POLLING not defined
  * preserve code guarded by `REDUCE_JOYSTICK_POLLING` define, except:
    * remove calls to SDL_JoystickEventState (always active now)
* re-initialize mapper when receiving following events:
  * SDL_CONTROLLERDEVICEADDED
  * SDL_CONTROLLERDEVICEREMOVED
  * SDL_JOYDEVICEADDED
  * SDL_JOYDEVICEREMOVED


## Related issues

* Fixes #946
* Re-attempts hotplug support introduced in reverted PRs: #4122, #4138,#4143 (reverted by #4145)


# Release notes
* Added support for hot-plugging of game controllers after program start

# Manual testing

### Linux/Windows/macOS testing

In addition to testing performed for #4122 (inlined below), also tested for *absence* of following regressions introduced by #4122:
* spurious emulated button presses triggered by unmapped host joystick buttons
* non-functional autofire

Specifically, tested with this PR and also compared with main @ a02719911688d4005c772bee86123bf5839bf86f using [JOYCHECK.EXE](https://www.vogons.org/download/file.php?id=7643) as follows:
* with attached mapper configuration: [[mapper-sdl2-0.83.0-alpha.map.zip](https://github.com/user-attachments/files/18309401/mapper-sdl2-0.83.0-alpha.map.zip)] for all runs
* with attached configuration [[dosbox-staging.conf.zip](https://github.com/user-attachments/files/18309418/dosbox-staging.conf.zip)] except as follows:
  * with `autofire=true`, with and without `timed=false`, pressed and held all buttons mapped to virtual joystick buttons
    * with `timed=true`:
      * reported repeat rate on main and PR averaged around 23Hz with minimal variance (Linux/Windows/macOS)
(Linux / Windows)  / ~**4Hz typically, occasionally increasing to up to 8Hz (macOS)**~ 18-40 averaging around 30Hz (macOS with macOS polling hack removed)
    * with `timed=false`:
      * reported repeat rate on main and PR averaged around 23Hz with minimal variance (Linux/Windows/macOS)
(Linux) / 40-50Hz (Windows) /   ~**9Hz typically, occasionally increasing to up to 17Hz (macOS)**~ 28-44Hz (macOS with mac polling hack removed)
      * with `autofire=false`, with and without `timed=false`
        * tested all sticks and buttons which appeared to work correctly
        * pressing unmapped buttons on the host joystick did not result in emulated button presses (spurious button presses occurred in original hotplug work)
      * with `joysticktype=fcs`
        * set joystick type to FC in joycheck, and observed no difference in functionality between main and PR (Windows)
        * **FCS hat did not function properly in main nor in PR on macOS**
      * with `joysticktype=ch`
        * set joystick type to CH in joycheck, and observed no difference in functionality between main and PR (Windows/macOS)
* Additional autofire testing:
  * One must fall 2097 repeated punching and kicking worked fine with corresponding buttons held (needed timed=false for joystick axes to function correctly some but not all of the time, in both main and PR)
  * Commander Keen 1, repeated jumping and repeated pogo toggling worked fine both when buttons held separately and when held while also moving using sticks (did not function correctly in original hotplug work)
* Tested that buttonwrap functions correctly in OMF 2097  in PR (Windows/macOS)
* Repeated previous testing:
   > I tested on Ubuntu 24.04 with XBox 360 Wireless Controller (ID 045e:0719 Microsoft Corp. Xbox 360 Wireless Adapter).
   > I ran DOSBox with and without controller turned on. I verified that controller still functioned in game in each case after power cycling the controller (which causes device to disconnect and reconnect).
* Benchmarking
  * Ran Quake benchmark with no joystick, with joystick improperly calibrated, with joystick properly calibrated, with joystick properly calibrated and left stick held at bottom right following calibration, with each test repeated 3 times
    * There was no noticeable difference between main and PR in frame rate distribution for any of these tests

The change has been manually tested on:

- [X] Windows
- [X] macOS
- [X] Linux


# Checklist

I have:

- [X] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [X] performed a self-review of my code.
- [X] commented on the particularly hard-to-understand areas of my code.
- [X] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [ ] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [X] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [X] my change has been manually tested on Windows, macOS, and Linux.
- [X] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [X] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

