### PR TITLE
On Windows, create a temp file when deleting a DOS file with handles still open

### DIFF
--- a/include/fs_utils.h
+++ b/include/fs_utils.h
@@ -39,6 +39,8 @@
 	// Cannot be constexpr due to Win32 macro
 	#define InvalidNativeFileHandle INVALID_HANDLE_VALUE
 
+	std_fs::path create_temp_file();
+
 #else // Linux, macOS
 	using NativeFileHandle = int;
 	constexpr NativeFileHandle InvalidNativeFileHandle = -1;

--- a/src/dos/drive_local.h
+++ b/src/dos/drive_local.h
@@ -38,6 +38,7 @@ public:
 	void Close() override;
 	uint16_t GetInformation() override;
 	bool IsOnReadOnlyMedium() const override { return read_only_medium; }
+	void ReplaceNativeFileHandle(const NativeFileHandle new_handle, const std_fs::path& new_path);
 	const char* GetBaseDir() const
 	{
 		return basedir;
@@ -51,7 +52,7 @@ public:
 
 private:
 	void MaybeFlushTime();
-	const std_fs::path path = {};
+	std_fs::path path = {};
 	const char* basedir     = nullptr;
 
 	const bool read_only_medium = false;

--- a/src/misc/fs_utils_win32.cpp
+++ b/src/misc/fs_utils_win32.cpp
@@ -256,4 +256,28 @@ void set_dos_file_time(const NativeFileHandle handle, const uint16_t date,
 	SetFileTime(handle, nullptr, nullptr, &write_time);
 }
 
+std_fs::path create_temp_file()
+{
+	// Max path length plus null terminator
+	constexpr DWORD BUFFER_SIZE = MAX_PATH + 1;
+	wchar_t temp_path[BUFFER_SIZE] = {};
+	const DWORD path_len = GetTempPathW(BUFFER_SIZE, temp_path);
+	if (path_len == 0) {
+		return {};
+	}
+	assert(path_len <= BUFFER_SIZE);
+
+	// Prefix only uses first 3 letters, abreviate DosBox Staging
+	const wchar_t *prefix = L"DBS";
+	// Zero for unique_number uses system time
+	// Zero also means it creates the file and ensures it is unique
+	constexpr UINT unique_number = 0;
+	wchar_t full_temp_path[BUFFER_SIZE] = {};
+	UINT full_len = GetTempFileNameW(temp_path, prefix, unique_number, full_temp_path);
+	if (full_len > 0) {
+		return full_temp_path;
+	}
+	return {};
+}
+
 #endif


### PR DESCRIPTION
# Description

See comments on #4142 for context

Regression first appeared in eeb5374bbe29cf9c298cc816b1cd85a3eca90ca6 with the move to Win32 API I/O.  `FLAG_SHARE_DELETE` broke an old (less accurate than this) hack to workaround this behavior.

b8f9015b577f79efe3d7f74d3b51352def9b97a9 - Later commit where I removed the old hack.  `FLAG_SHARE_DELETE` made the delete succeed with open handles so it never got executed to close existing handles after the switch to Win32 API I/O.

This more accurately emulates how real DOS handles files.  This PR handles an edge case when a DOS game deletes a file with handles still open and then tries to create a new file with the same name.  This only affects Windows.  POSIX systems handle this correctly by default.

My solution is to create a temp file using the Windows API to find a location.  The Visual Studio build places this in `AppData\Local\Temp`.  MSYS2 places it in `C:\msys64\tmp` but I think that's because I was launching it from the MSYS terminal with whatever enviornment variables it sets.  Both builds work correctly however.

When a file is deleted, it scans the open DOS handles to see if there is a local (native/host) file open at the same place we're trying to delete from.  If so, copy the contents to a temp file and replace the native file handle with the temp file.  At the end, we can delete the temp file and the handles remain valid (to avoid cluttering the user's temp folder on multiple launches).

This happens with the DOS layer being none the wiser that the file got moved on the host.

## Related issues

#4123


# Release notes

Fixed an issue where the game Abuse failed to launch on Windows 7 and on newer versions of Windows when using a network drive.

# Manual testing

- Abuse works
- Tested Visual Studio and MSYS2 builds
- Crystal Caves saves work
- Doom saves work
- Read after delete works - Tested with https://gist.github.com/weirddan455/5cae02fc3d6f932fe55025138ed2f47c

The change has been manually tested on:

- [x] Windows
- [ ] macOS
- [ ] Linux

This change only affects Windows.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [x] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

