### PR TITLE
Fix support for space in the directory name argument

### DIFF
--- a/src/shell/autoexec.cpp
+++ b/src/shell/autoexec.cpp
@@ -359,7 +359,7 @@ AutoExecModule::AutoExecModule(Section* configuration)
 		}
 
 		if (is_directory) {
-			drive_c_directory = Quote + argument + Quote;
+			drive_c_directory  = argument;
 			has_dir_or_command = true;
 			continue;
 		}


### PR DESCRIPTION
# Description

Fixed a problem were path name supplied to DOSBox was encircled with quotes twice, leading to a problem described in the issue mentioned below.

![image](https://github.com/user-attachments/assets/d251227b-d47c-4e07-830a-c99e03d83063)


## Related issues

Fixes https://github.com/dosbox-staging/dosbox-staging/issues/4148


# Release notes

Executing DOSBox with space in the directory parameter should now work as expected - the directory should be mouted as drive C.


# Manual testing

1. Create some directory with space in it's name/path. Put some file in it.
2. Run DOSBox with command `dosbox <directory> --noprimaryconf` - `dir` command should show the file.

How to submit the parameter with space, depends on host OS, shell, etc. Either put it in quotes, like `"directory name"`, or use a backslash character, like `directory\ name` - at least one should work.

The change has been manually tested on:

- [x] Windows
- [x] macOS
- [x] Linux


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [ ] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

