### PR TITLE
Rename files on Windows before delete

### DIFF
--- a/include/fs_utils.h
+++ b/include/fs_utils.h
@@ -226,4 +226,6 @@ bool truncate_native_file(const NativeFileHandle handle);
 DosDateTime get_dos_file_time(const NativeFileHandle handle);
 void set_dos_file_time(const NativeFileHandle handle, const uint16_t date, const uint16_t time);
 
+bool delete_native_file(const std_fs::path& path);
+
 #endif

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -257,7 +257,7 @@ bool localDrive::FileUnlink(const char* name)
 	const char* fullname = dirCache.GetExpandNameAndNormaliseCase(newname);
 
 	// Can we remove the file without issue?
-	if (remove(fullname) == 0) {
+	if (delete_native_file(fullname)) {
 		timestamp_cache.erase(fullname);
 		dirCache.DeleteEntry(newname);
 		return true;

--- a/src/misc/fs_utils_posix.cpp
+++ b/src/misc/fs_utils_posix.cpp
@@ -482,4 +482,9 @@ void set_dos_file_time(const NativeFileHandle handle, const uint16_t date, const
 	futimens(handle, unix_times);
 }
 
+bool delete_native_file(const std_fs::path& path)
+{
+	return remove(path.c_str()) == 0;
+}
+
 #endif

--- a/src/misc/fs_utils_posix.cpp
+++ b/src/misc/fs_utils_posix.cpp
@@ -484,7 +484,7 @@ void set_dos_file_time(const NativeFileHandle handle, const uint16_t date, const
 
 bool delete_native_file(const std_fs::path& path)
 {
-	return remove(path.c_str()) == 0;
+	return unlink(path.c_str()) == 0;
 }
 
 #endif

--- a/src/misc/fs_utils_win32.cpp
+++ b/src/misc/fs_utils_win32.cpp
@@ -256,4 +256,9 @@ void set_dos_file_time(const NativeFileHandle handle, const uint16_t date,
 	SetFileTime(handle, nullptr, nullptr, &write_time);
 }
 
+bool delete_native_file(const std_fs::path& path)
+{
+	return remove(path.string().c_str()) == 0;
+}
+
 #endif

--- a/src/misc/fs_utils_win32.cpp
+++ b/src/misc/fs_utils_win32.cpp
@@ -256,9 +256,50 @@ void set_dos_file_time(const NativeFileHandle handle, const uint16_t date,
 	SetFileTime(handle, nullptr, nullptr, &write_time);
 }
 
+// Includes a Windows specific hack.
+// We move the file to be deleted to a temp file before delete.
+// This allows a file with the same name to be created even if there are open file handles.
+// See bug report about the game Abuse: https://github.com/dosbox-staging/dosbox-staging/issues/4123
 bool delete_native_file(const std_fs::path& path)
 {
-	return remove(path.string().c_str()) == 0;
+	// Prefix of the temp file. Only uses 3 characters.
+	// $ as convention to designate temp file followed by DB for DosBox.
+	const wchar_t *prefix = L"$DB";
+
+	// Zero for UniqueNumber uses system time.
+	// Zero also means it creates the file and ensures it is unique.
+	constexpr UINT UniqueNumber = 0;
+
+	// Maximum return size of GetTempFileNameW() is MAX_PATH plus a null terminator.
+	wchar_t temp_file[MAX_PATH + 1] = {};
+
+	// Create a temporary file inside the same directory as the file to be deleted.
+	// Returns unique identifier on success and 0 on failure.
+	if (GetTempFileNameW(path.parent_path().c_str(), prefix, UniqueNumber, temp_file) == 0) {
+		LOG_ERR("FS: Failed to create temp file. Deleting '%s' directly.", path.string().c_str());
+		// We failed to create a temp file but we should still try to delete the original file.
+		return DeleteFileW(path.c_str());
+	}
+
+	// Above function creates the temp file so we replace it here with the flag MOVEFILE_REPLACE_EXISTING.
+	if (MoveFileExW(path.c_str(), temp_file, MOVEFILE_REPLACE_EXISTING)) {
+		// We can immediately delete the temporary file.
+		// Any open handles can be still be read from or written to.
+		// A new file can be created with the original file name.
+		if (!DeleteFileW(temp_file)) {
+			LOG_ERR("FS: Failed to delete temporary file: '%s'", std_fs::path(temp_file).string().c_str());
+			// Failed to delete the temp file but the original file was moved.
+			// We should still return success so that the filesystem removes the original file from the cache.
+		}
+		return true;
+	}
+
+	// We failed to move the file. We need to delete both the temp file and the original file.
+	LOG_ERR("FS: Failed to move '%s' to temp file '%s' before delete.", path.string().c_str(), std_fs::path(temp_file).string().c_str());
+	if (!DeleteFileW(temp_file)) {
+		LOG_ERR("FS: Failed to delete temporary file: '%s'", std_fs::path(temp_file).string().c_str());
+	}
+	return DeleteFileW(path.c_str());
 }
 
 #endif


### PR DESCRIPTION
# Description

Second attempt at #4149

Same basic principle of creating a temp file but now we create it in the same directory as the existing file to avoid copying potentially large files to a separate drive/partition.

It ended up being quite a bit cleaner on the code side as well as I was able to encapsulate all the Windows specific jank inside `fs_utils_win32.cpp` and there's no more need to move file handles.  Existing file handles remain valid after a rename/move.

## Related issues

#4123

# Release notes

Fixed an issue where the game Abuse failed to launch on Windows 7 and on newer versions of Windows when using a network drive.

# Manual testing

- Abuse Works
- Crystal Caves saves works
- Read after delete works - Tested with https://gist.github.com/weirddan455/5cae02fc3d6f932fe55025138ed2f47c

The change has been manually tested on:

- [x] Windows
- [ ] macOS
- [x] Linux

~~Will test Linux later.~~  Tested above on Linux as well.  Only change there was to use `unlink()` over `remove()` but `remove()` was a very thin wrapper over `unlink()` so I don't expect any regressions.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [x] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

