### PR TITLE
Make SoundBlaster minimally blocking on other mixer channels

### DIFF
--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -312,7 +312,7 @@ void MIXER_UnlockMixerThread()
 	LPTDAC_NotifyUnlockMixer();
 	GUS_NotifyUnlockMixer();
 	REELMAGIC_NotifyUnlockMixer();
-	SBLASTER_NotifyLockMixer();
+	SBLASTER_NotifyUnlockMixer();
 
 	mixer.mutex.unlock();
 }

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -2986,11 +2986,10 @@ static void generate_frames(const int frames_requested)
 	switch (sb.mode) {
 	case DspMode::None:
 	case DspMode::DmaPause:
-	case DspMode::DmaMasked: {
-		static std::vector<AudioFrame> empty_frames = {};
-		empty_frames.resize(frames_requested);
-		enqueue_frames(empty_frames);
-	} break;
+	case DspMode::DmaMasked:
+		sblaster->output_queue.Stop();
+		frames_added_this_tick += frames_requested;
+		break;
 
 	case DspMode::Dac:
 		// Frames get added synchronously inside dsp_do_command

--- a/src/hardware/sblaster.h
+++ b/src/hardware/sblaster.h
@@ -39,6 +39,7 @@ public:
 	// Public members used by MIXER_PullFromQueueCallback
 	RWQueue<AudioFrame> output_queue{1};
 	MixerChannelPtr channel = nullptr;
+	std::atomic<int> num_frames_needed = 0;
 
 private:
 	IO_ReadHandleObject read_handlers[0x10]   = {};

--- a/src/hardware/sblaster.h
+++ b/src/hardware/sblaster.h
@@ -48,8 +48,11 @@ private:
 
 	OplMode oplmode = OplMode::None;
 
+	std::vector<AudioFrame> mixer_buffer = {};
+
 	void SetupEnvironment();
 	void ClearEnvironment();
+	void AudioCallback(const int frames_requested);
 };
 
 #endif


### PR DESCRIPTION
# Description

The main goal of this PR is to stop OPL and MIDI from stuttering while SoundBlaster DAC/DMA are playing.  I also did away with the per-frame callbacks (which was mostly used by DAC but also sometimes DMA if the writes are small).

# Release notes

Less audio stuttering in games using SoundBlaster

# Manual testing

- Alone in the Dark (only SoundBlaster DAC game I know of)
- Tyrian
- Doom
- Duke3D

Tyrian had stuttering in the main menu and while pressing Esc to access the in-game menu.

Duke3D had even worse stuttering at the 3DRealms logo at game start.

Both of these are reproducible all of the time in a debug build and also in release build with high cycles.  It now "slows down" the audio rather than producing a crackling/stuttery mess.

I'll do some more testing later but if you know a good test-case let me know.

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [x] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [x] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

