### PR TITLE
Improve our GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -40,7 +40,6 @@ body:
         - Windows 10
         - Windows 8
         - Windows 7
-        - Windows Other
         - macOS (Intel)
         - macOS (Apple Silicon)
         - Linux x86

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,41 +1,45 @@
-name: Bug Report
-description: File a Bug report
-labels: bug
-#assignees: 'anonymous@temp'
+name:        Bug report
+description: File a bug report
+title:       Think about the title, twice
+labels:      bug
 
 body:
   - type: markdown
     attributes:
       value: |
-        ## Please fill out forms as cleanly as possible.
-        #### Make sure that you have
-        * properly edited & filled in the title of this bug report
+        ## Please fill out the form completely. Incomplete submissions will be closed!
+        #### Make sure that you have:
+        - provided a descriptive and succinct title
+        - have read all questions carefully have answered **all** of them
+        [Please consider a donation to the DOSBox Staging project](https://www.dosbox-staging.org/get-involved/#make-a-donation).
+
   - type: checkboxes
     id: version
     attributes:
-      label: Are you using the latest Dosbox-Staging Version?
+      label: Are you using the latest DOSBox Staging version?
       description: |
-        What version are you using? Check the [latest release](https://github.com/dosbox-staging/dosbox-staging/releases)
-        Run `dosbox --version`
-        Type `ver` command inside DOSBox shell; If the version is reported as `git` (meaning you compiled it yourself), use `git describe` command.
-        Provide 'git' version or 'other' in description
+        Look up the latest release version [on our website](https://github.com/dosbox-staging/dosbox-staging/releases) or the [releases page](https://github.com/dosbox-staging/dosbox-staging/releases).
+        To check your version, run `dosbox --version` or execute the `VER` command inside DOSBox Staging. If the version is reported as `git` (meaning you compiled it yourself), put the result of `git describe` in the version field below.
       options:
-        - label: I have checked releases and am using the latest release.
+        - label: I have checked and I'm using the latest release.
           required: true
+
   - type: input
     id: verinfo
     attributes:
       label: Different version than latest?
-      description: Alpha, Git, or Branch?
-      placeholder: "Ex. 0.83.0-alpha, git version, branch testing."
+      description: alpha, git, or custom branch?
+      placeholder: "E.g., 0.83.0-alpha, git version, branch testing."
     validations:
       required: false
+
   - type: dropdown
     id: OS
     attributes:
-      label: What Operating System are you using?
+      label: What operating system are you using?
       multiple: false
       options:
+        - Please select
         - Windows 11
         - Windows 10
         - Windows 8
@@ -47,85 +51,100 @@ body:
         - Linux ARM (Raspberry Pi)
         - Other
     validations:
-      required: false
+      required: true
+
   - type: input
     id: other
     attributes:
-      label: If Other OS, please describe
-      description: Other details
-      placeholder: "Windows, Mac OSX version, Debian, Ubuntu, Arch, etc."
+      label: If other OS or Linux, please describe
+      placeholder: "Details about your OS; if Linux, state your desktop environment (KDE, Gnome, XFCE, etc.)"
     validations:
       required: false
+
+  - type: checkboxes
+    id: checked
+    attributes:
+      label: Are you running DOSBox Staging on a native OS?
+      description: We only support running DOSBox Staging on a native operating system; running on a guest OS in a VM or hypervisor is not supported.
+      options:
+        - label: I am running Staging on a native OS
+          required: true
+
   - type: input
     id: hardware
     attributes:
       label: Relevant hardware info
-      description: Hardware
-      placeholder: "CPU, GPU, device brand/model: e.g. Raspberry Pi3B+, Nvidia, etc"
+      placeholder: "CPU, GPU, device brand/model (e.g., Raspberry Pi3B+, Nvidia RTX 3060, etc.)"
     validations:
       required: false
+
   - type: checkboxes
     id: checked
     attributes:
       label: Have you checked that no other similar issue already exists?
-      description: Searched issues before creating report?
       options:
-        - label: I have searched and not found similar issues.
+        - label: I have searched and have not found similar issues.
           required: true
+
   - type: textarea
     id: description
     attributes:
-      label: A clear and concise description of what the bug is.
-      description: Describe what happens, what software were you running? _Include screenshot if possible_
-      placeholder: "How & When does this occur?"
+      label: A clear and concise description of what the bug is
+      description: Describe what happens, what software were you running? Try to specify the exact version of the game you're running. _Include screenshots if possible._
+      placeholder: "How and when does this occur?"
     validations:
       required: true
+
   - type: textarea
     id: steps
     attributes:
-      label: Steps to reproduce the behaviour.
-      description: How can we reproduce this?
+      label: Steps to reproduce the behaviour
+      description: If we can't reproduce what you're experiencing, we can't fix it. Provide detailed steps on how to reproduce the bug; don't assume we're familiar with the software. For games, you can attach save game file in a ZIP archive if that helps.
       value: |
-        Explain how to reproduce
+        Explain in detail how to reproduce the bug. Assume no familiarity with the software.
         1. 
         2.
         3.
     validations:
       required: false
+
   - type: input
     id: package_url
     attributes:
       label: Download URL of affected game or software
       description: |
         If a single game or program is affected, provide a download link to ensure we're using binary-exact files and version(s).
-        This is required unless the issue broadly applies.
-      placeholder: "example: https://archive.org/details/StarWarsX-wingDemo"
+        This is _required_ unless the issue broadly applies.
+      placeholder: "E.g., https://archive.org/details/StarWarsX-wingDemo"
     validations:
       required: false
+
   - type: textarea
     id: config_file
     attributes:
       label: Your configuration
       description: |
-        Share the config file(s) you've been using to run the program. (`dosbox-staging.conf`) 
-        Please avoid pasting the full config, _use attachments or links_ in a [Gist](https://gist.github.com/)
-      placeholder: "example: texture_renderer = opengl"
+        Share the config file(s) you are using to run the program. (`dosbox-staging.conf`) 
+        Please avoid pasting the full config; _use attachments or links_ in a [Gist](https://gist.github.com/) instead.
+      placeholder: "Your configuration (if short), or provide Gist link"
       render: ini # syntax highlighting
     validations:
       required: false
+
   - type: textarea
     id: log
     attributes:
-      label: Provide a Log
-      description: Please avoid pasting the full log, _use attachments or links_ in a [Gist](https://gist.github.com/)
-      placeholder: "Copy & paste error log section or provide link"
+      label: Provide a log
+      description: Please avoid pasting the full log; _use attachments or links_ in a [Gist](https://gist.github.com/) instead.
+      placeholder: "Relevant part of the log (if short), or provide Gist link"
       render: text
     validations:
       required: false
+
   - type: checkboxes
     id: terms
     attributes:
-      label: Code of Conduct & Contributing Guidelines
+      label: Code of conduct and contributing guidelines
       description: By submitting this issue, you agree to follow our [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
       options:
         - label: Yes, I agree.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -44,7 +44,6 @@ body:
         - macOS (Apple Silicon)
         - Linux x86
         - Linux x86_64
-        - Linux ppc64le
         - Linux ARM (Raspberry Pi)
         - Other
     validations:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -40,7 +40,6 @@ body:
         - Windows 10
         - Windows 8
         - Windows 7
-        - Windows Other
         - macOS (Intel)
         - macOS (Apple Silicon)
         - Linux x86

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,41 +1,45 @@
-name: Feature Request
-description: Suggest an idea (a new feature or other improvement) for this project
-labels: enhancement
-#assignees: 'anonymous@temp'
+name:        Feature request
+description: Suggest an idea (a new feature or other improvement)
+title:       Think about the title, twice
+labels:      enhancement
 
 body:
   - type: markdown
     attributes:
       value: |
-        ## Please fill out forms as cleanly as possible.
-        #### Make sure that you have
-        * properly edited & filled in the title of this bug report
+        ## Please fill out the form completely. Incomplete submissions will be closed!
+        #### Make sure that you have:
+        - provided a descriptive and succinct title
+        - have read all questions carefully have answered **all** of them
+        [Please consider a donation to the DOSBox Staging project](https://www.dosbox-staging.org/get-involved/#make-a-donation).
+
   - type: checkboxes
     id: version
     attributes:
-      label: Are you using the latest Dosbox-Staging Version?
+      label: Are you using the latest DOSBox Staging version?
       description: |
-        What version are you using? Check the [latest release](https://github.com/dosbox-staging/dosbox-staging/releases)
-        Run `dosbox --version`
-        Type `ver` command inside DOSBox shell; If the version is reported as `git` (meaning you compiled it yourself), use `git describe` command.
-        Provide 'git' version or 'other' in description
+        Look up the latest release version [on our website](https://github.com/dosbox-staging/dosbox-staging/releases) or the [releases page](https://github.com/dosbox-staging/dosbox-staging/releases).
+        To check your version, run `dosbox --version` or execute the `VER` command inside DOSBox Staging. If the version is reported as `git` (meaning you compiled it yourself), put the result of `git describe` in the version field below.
       options:
-        - label: I have checked releases and am using the latest release.
+        - label: I have checked and I'm using the latest release.
           required: true
+
   - type: input
     id: verinfo
     attributes:
       label: Different version than latest?
-      description: Alpha, Git, or Branch?
-      placeholder: "Ex. 0.83.0-alpha, git version, branch testing."
+      description: alpha, git, or custom branch?
+      placeholder: "E.g., 0.83.0-alpha, git version, branch testing."
     validations:
       required: false
+
   - type: dropdown
     id: OS
     attributes:
-      label: What Operating System are you using?
+      label: What operating system are you using?
       multiple: false
       options:
+        - Please select
         - Windows 11
         - Windows 10
         - Windows 8
@@ -47,30 +51,41 @@ body:
         - Linux ARM (Raspberry Pi)
         - Other
     validations:
-      required: false
+      required: true
+
   - type: input
     id: other
     attributes:
-      label: If Other OS, please describe
-      description: Other details
-      placeholder: "Windows, Mac OSX version, Debian, Ubuntu, Arch, etc."
+      label: If other OS or Linux, please describe
+      placeholder: "Details about your OS; if Linux, state your desktop environment (KDE, Gnome, XFCE, etc.)"
     validations:
       required: false
+
+  - type: checkboxes
+    id: checked
+    attributes:
+      label: Are you running DOSBox Staging on a native OS?
+      description: We only support running DOSBox Staging on a native operating system; running on a guest OS in a VM or hypervisor is not supported.
+      options:
+        - label: I am running Staging on a native OS
+          required: true
+
   - type: textarea
     id: related
     attributes:
       label: Is your feature request related to a problem? Please describe.
-      description: Related
-      placeholder: "Ex. I'm always frustrated when"
+      placeholder: "E.g., I would love if Staging could do ..."
     validations:
       required: true
+
   - type: textarea
     id: solution
     attributes:
       label: Describe the solution you'd like
-      placeholder: "Ex. How can we make it better?"
+      placeholder: "How can we make things better?"
     validations:
       required: false
+
   - type: textarea
     id: alternative
     attributes:
@@ -79,18 +94,19 @@ body:
       placeholder: "Similar idea or software"
     validations:
       required: false
+
   - type: textarea
     id: additional
     attributes:
       label: Add any other context or screenshots about the feature request here.
-      description: Screenshots or Links?
-      placeholder: "Ex. Screenshot or Link"
+      placeholder: "Screenshots, links, mockups, etc."
     validations:
       required: false
+
   - type: checkboxes
     id: terms
     attributes:
-      label: Code of Conduct & Contributing Guidelines
+      label: Code of Conduct and Contributing Guidelines
       description: By submitting this issue, you agree to follow our [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
       options:
         - label: Yes, I agree.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -44,7 +44,6 @@ body:
         - macOS (Apple Silicon)
         - Linux x86
         - Linux x86_64
-        - Linux ppc64le
         - Linux ARM (Raspberry Pi)
         - Other
     validations:

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -40,7 +40,6 @@ body:
         - Windows 10
         - Windows 8
         - Windows 7
-        - Windows Other
         - macOS (Intel)
         - macOS (Apple Silicon)
         - Linux x86

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,41 +1,45 @@
-name: Question
-description: Ask for support or start a discussion.
-labels: question
-#assignees: 'anonymous@temp'
+name:        Question
+description: Ask for support or start a discussion
+title:       Think about the title, twice
+labels:      question
 
 body:
   - type: markdown
     attributes:
       value: |
-        ## Please fill out forms as cleanly as possible.
-        #### Make sure that you have
-        * properly edited & filled in the title of this bug report
+        ## Please fill out the form completely. Incomplete submissions will be closed!
+        #### Make sure that you have:
+        - provided a descriptive and succinct title
+        - have read all questions carefully have answered **all** of them
+        [Please consider a donation to the DOSBox Staging project](https://www.dosbox-staging.org/get-involved/#make-a-donation).
+
   - type: checkboxes
     id: version
     attributes:
-      label: Are you using the latest Dosbox-Staging Version?
+      label: Are you using the latest DOSBox Staging version?
       description: |
-        What version are you using? Check the [latest release](https://github.com/dosbox-staging/dosbox-staging/releases)
-        Run `dosbox --version`
-        Type `ver` command inside DOSBox shell; If the version is reported as `git` (meaning you compiled it yourself), use `git describe` command.
-        Provide 'git' version or 'other' in description
+        Look up the latest release version [on our website](https://github.com/dosbox-staging/dosbox-staging/releases) or the [releases page](https://github.com/dosbox-staging/dosbox-staging/releases).
+        To check your version, run `dosbox --version` or execute the `VER` command inside DOSBox Staging. If the version is reported as `git` (meaning you compiled it yourself), put the result of `git describe` in the version field below.
       options:
-        - label: I have checked releases and am using the latest release.
+        - label: I have checked and I'm using the latest release.
           required: true
+
   - type: input
     id: verinfo
     attributes:
       label: Different version than latest?
-      description: Alpha, Git, or Branch?
-      placeholder: "Ex. 0.83.0-alpha, git version, branch testing."
+      description: alpha, git, or custom branch?
+      placeholder: "E.g., 0.83.0-alpha, git version, branch testing."
     validations:
       required: false
+
   - type: dropdown
     id: OS
     attributes:
-      label: What Operating System are you using?
+      label: What operating system are you using?
       multiple: false
       options:
+        - Please select
         - Windows 11
         - Windows 10
         - Windows 8
@@ -47,19 +51,38 @@ body:
         - Linux ARM (Raspberry Pi)
         - Other
     validations:
+      required: true
+
+  - type: input
+    id: other
+    attributes:
+      label: If other OS or Linux, please describe
+      placeholder: "Details about your OS; if Linux, state your desktop environment (KDE, Gnome, XFCE, etc.)"
+    validations:
       required: false
+
+  - type: checkboxes
+    id: checked
+    attributes:
+      label: Are you running DOSBox Staging on a native OS?
+      description: We only support running DOSBox Staging on a native operating system; running on a guest OS in a VM or hypervisor is not supported.
+      options:
+        - label: I am running Staging on a native OS
+          required: true
+
   - type: textarea
     id: question
     attributes:
-      label: Whats your question and how can we help?
+      label: What's your question and how can we help?
       description: Ask us a question
       placeholder: "How do I ..."
     validations:
       required: true
+
   - type: checkboxes
     id: terms
     attributes:
-      label: Code of Conduct & Contributing Guidelines
+      label: Code of conduct and contributing guidelines
       description: By submitting this issue, you agree to follow our [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
       options:
         - label: Yes, I agree.

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -44,7 +44,6 @@ body:
         - macOS (Apple Silicon)
         - Linux x86
         - Linux x86_64
-        - Linux ppc64le
         - Linux ARM (Raspberry Pi)
         - Other
     validations:

--- a/README.md
+++ b/README.md
@@ -7,6 +7,16 @@ This repository attempts to modernize the DOSBox codebase by using current
 development practices and tools, fixing issues, and adding features that better
 support today's systems.
 
+## Donations
+
+If you enjoy using DOSBox Staging, please [consider a
+donation](https://www.dosbox-staging.org/get-involved/#make-a-donation) to the
+project.
+
+If you want to help but can't afford a donation, check out the [Get
+involved](https://www.dosbox-staging.org/get-involved/) page of our website
+for other ways to contribute.
+
 
 ## Build status
 


### PR DESCRIPTION
# Description

Should be quite straightforward, I hope. I've also added a donation section to the README and to all issue templates.

Apart from improving the wording and consistency in general, the main change is dropping **ppc64le** from our OS list (we don't support it officially, after all), and adding a confirmation checkbox that the person is running Staging on a native OS (so not on a guest OS in a VM or something).

We've had about 4-5 issue tickets that were the result of running Staging in a VM in the past few months; it's a waste of time to deal with these (usually the person only tells us he's using a VM when after we've already spent time investigating the problem...)

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

