### PR TITLE
Fix SoundBlaster Notify Unlock

### DIFF
--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -312,7 +312,7 @@ void MIXER_UnlockMixerThread()
 	LPTDAC_NotifyUnlockMixer();
 	GUS_NotifyUnlockMixer();
 	REELMAGIC_NotifyUnlockMixer();
-	SBLASTER_NotifyLockMixer();
+	SBLASTER_NotifyUnlockMixer();
 
 	mixer.mutex.unlock();
 }


### PR DESCRIPTION
# Description

This was my first commit from #4165 and is just a clear bug and regression fix.  I wanted to go ahead and get this in while I work on SoundBlaster stuff more.  This should be fixed regardless of where we land on that.

~~Should be considered for backport if we have a v0.82.1.~~  v0.82.0 does not have this bug and this won't cleanly merge as it was part of a refactor that introduced these `NotifyLock` calls.  v0.82.0 correctly manually starts the queue here.

Typo in MIXER_UnlockMixer() was stopping the SoundBlaster queue instead of starting it
This caused an assertion failure when resuming from pause and possibly other problems that went unnoticed

Regression from 9579fb213d571fbd16f7af778f2373635e5fa8a8 (refactor to use device locking functions, removed the original SB Start/Stop)
Next commit bf2c6a7a12aa4f6f1901d7cd6fbd63637cb04e24 had the typo of Lock instead of Unlock

# Release notes

EDIT:  Actually definitely nothing for release notes.  Just realized the commit that introduced this bug was never in a release.  It regressed after v0.82.0.

Nothing user-facing that I noticed.  The only affect this bug had is that the `RWQueue` wasn't being re-started after a mixer lock.  It triggers an assert fail in a debug build.  It could possibly lead to some audio frames being dropped but nothing that I could prove.

Current SoundBlaster code re-starts the queue every tick in DMA mode and whenever a port write happens in DAC mode so that left this bug mostly hidden.

# Manual testing

- No more assert failures on resuming from pause.
- Doom, Tyrian, Alone in the Dark, and Duke3D sound the same as in `main`

Only tested in Linux but it is a fairly trivial change.

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [x] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

