### PR TITLE
Add macOS CMake + vcpkg release build workflow

### DIFF
--- a/.github/workflows/macos-cmake.yml
+++ b/.github/workflows/macos-cmake.yml
@@ -1,0 +1,150 @@
+name: macOS CMake release builds
+permissions:  read-all
+
+on:
+  push:
+    paths-ignore:
+      - '.clang-format'
+      - '.mdl-styles'
+      - '*.md'
+      - 'docs/**'
+      - 'licenses/**'
+      - 'website/**'
+
+  pull_request:
+    paths-ignore:
+      - '.clang-format'
+      - '.mdl-styles'
+      - '*.md'
+      - 'docs/**'
+      - 'licenses/**'
+      - 'website/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build_macos_release:
+    name: Release build (${{ matrix.runner.arch }})
+    runs-on: ${{ matrix.runner.host }}
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+    env:
+      MACOSX_DEPLOYMENT_TARGET: ${{ matrix.runner.minimum_deployment }}
+      VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
+      VCPKG_ROOT: ${{ github.workspace }}/vcpkg
+
+    strategy:
+      matrix:
+        runner:
+          - host: macos-15
+            arch: x86_64
+            minimum_deployment: '10.15'
+
+          - host: macos-15
+            arch: arm64
+            minimum_deployment: '11.0'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: false
+
+      - name: Export GitHub Actions cache environment variables
+        uses: actions/github-script@v7
+        with:
+          script: |
+            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+  
+      - name: Setup CMake
+        uses: lukka/get-cmake@5f6e04f5267c8133f1273bf2103583fc72c46b17 # v3.31.5
+
+      - name: Clone vcpkg
+        run: git clone https://github.com/microsoft/vcpkg.git $VCPKG_ROOT
+  
+      - name: Bootstrap vcpkg
+        run: |
+          cd $VCPKG_ROOT
+          ./bootstrap-vcpkg.sh         
+            
+      - name: Log environment
+        run:  arch -arch=${{ matrix.runner.arch }} ./scripts/log-env.sh
+
+      - name: Inject version string
+        run: |
+          set -x
+          VERSION=$(./scripts/get-version.sh version-and-hash)
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+
+      - name: Setup and build release
+        run: |
+          set -x
+          cmake --preset release-macos-${{ matrix.runner.arch }}          
+          cmake --build --preset release-macos-${{ matrix.runner.arch }}
+
+      - name: Upload binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: dosbox-${{ matrix.runner.arch }}
+          path: build/release-macos-${{ matrix.runner.arch }}/Release/dosbox
+          overwrite: true
+
+      - name: Upload resources
+        uses: actions/upload-artifact@v4
+        with:
+          name: Resources
+          path: build/release-macos-${{ matrix.runner.arch }}/Resources
+          overwrite: true
+
+  publish_universal_build:
+    name: Publish universal build
+    needs: build_macos_release
+    runs-on: macos-15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: false
+
+      - name: Inject version string
+        run: |
+          set -x
+          VERSION=$(./scripts/get-version.sh version-and-hash)
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+
+      - name: Install brew depedencies
+        run: HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 brew install --overwrite librsvg
+
+      - name: Download binaries
+        uses: actions/download-artifact@v4
+
+      - name: Package
+        run: |
+          mv Resources ../
+          ./scripts/create-package.sh \
+            -p macos \
+            -v "${{ env.VERSION }}" \
+            -f \
+            "$(pwd)" \
+            "$(pwd)"
+
+      - name: Create dmg
+        run: |
+          ln -s /Applications dist/
+
+          codesign -s "-" "dist/DOSBox Staging.app" --force --deep -v
+
+          hdiutil create \
+              -volname "DOSBox Staging" \
+              -srcfolder dist \
+              -ov -format UDZO "dosbox-staging-macOS-universal-${{ env.VERSION }}.dmg"
+
+      - name: Upload disk image
+        uses: actions/upload-artifact@v4
+        # GitHub automatically zips the artifacts, and there's no option
+        # to skip it or upload a file only.
+        with:
+          name: dosbox-staging-macOS-universal-${{ env.VERSION }}
+          path: dosbox-staging-macOS-universal-${{ env.VERSION }}.dmg

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,4 +1,5 @@
 name: macOS builds
+permissions:  read-all
 
 on:
   push:

--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,6 @@ tools/unlock_the_magic_mpeg_ps.exe
 obj-*.-linux-gnu
 debian
 
+# CMake
+CMakeUserPresets.json
+cmake-build-*/

--- a/BUILD.md
+++ b/BUILD.md
@@ -34,9 +34,16 @@ CCACHE_SLOPPINESS="pch_defines,time_macros"
 > **Note**
 >
 > CMake support is currently an experimental internal-only, work-in-progress
-> feature; it's not ready for public consumption yet. Please ignore the
-> `CMakeLists.txt` files in the source tree.
-
+> feature; it's not ready for public consumption yet, but if you want to experiment:
+> 
+> **PLEASE DO NOT SUBMIT ANY BUGS OR HELP REQUESTS!**
+> 
+> You'll need vcpkg installed and your VCPKG_ROOT environment variable set to vcpkg's 
+> installed location. There are presets via CMakePresets.json for convenience. For the
+> generic `release` and `debug` presets, you'll need Ninja build installed. You should
+> then be able to run e.g. `cmake --preset=debug && cmake --build --preset=debug` to 
+> produce a debug build in the `build/debug` directory. vcpkg will automatically install
+> dependencies during the build; there is no need to explicitly run `vcpkg install`.
 
 ## OS-specific instructions
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,20 +21,24 @@ endif()
 
 include(CheckIncludeFile)
 include(CheckIncludeFiles)
+include(CheckCXXSourceCompiles)
 include(CheckSymbolExists)
 
 if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
 	set(DOSBOX_PLATFORM_WINDOWS ON)
+	set(WIN32 ON)
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
 	set(DOSBOX_PLATFORM_MACOS ON)
+	set(MACOSX ON)
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
 	set(DOSBOX_PLATFORM_LINUX ON)
+	set(LINUX ON)
 else()
 	message(FATAL_ERROR "Unknown system ${CMAKE_SYSTEM_NAME}")
 endif()
 
 # TODO: Proper compiler simulation detection (i.e. clang on MSVC)
-if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
 	set(DOSBOX_COMPILER_CLANG ON)
 elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
 	set(DOSBOX_COMPILER_GCC ON)
@@ -64,76 +68,96 @@ endif()
 
 ### config.h shenanigans
 
-file(READ src/config.h.in CONFIG_CONTENTS)
-string(REPLACE "#mesondefine" "#cmakedefine" CONFIG_CONTENTS "${CONFIG_CONTENTS}")
-string(REPLACE "#cmakedefine C_TARGETCPU" "#cmakedefine C_TARGETCPU @C_TARGETCPU@" CONFIG_CONTENTS "${CONFIG_CONTENTS}")
-string(REPLACE "#cmakedefine CUSTOM_DATADIR" "#cmakedefine CUSTOM_DATADIR \"@CUSTOM_DATADIR@\"" CONFIG_CONTENTS "${CONFIG_CONTENTS}")
+set(TEST_CODE_BUILTIN_AVAILABLE "
+int main() {
+    if (__builtin_available(macOS 11, *)) {
+        return 0;
+    }
+    return 0;
+}
+")
 
-set_property(GLOBAL PROPERTY FILE_CONTENTS "${CONFIG_CONTENTS}")
+check_cxx_source_compiles("${TEST_CODE_BUILTIN_AVAILABLE}" HAVE_BUILTIN_AVAILABLE)
 
-function(setConfig01 VAR VALUE)
-	get_property(fc GLOBAL PROPERTY FILE_CONTENTS)
-	string(REPLACE "#cmakedefine ${VAR}" "#cmakedefine01 ${VAR}" fc "${fc}")
-	set_property(GLOBAL PROPERTY FILE_CONTENTS "${fc}")
-	set(${VAR} ${VALUE} PARENT_SCOPE)
-endfunction()
+set(TEST_CODE_BUILTIN_CLEAR_CACHE "
+int main() {
+    char buffer[10];
+    __builtin___clear_cache(buffer, buffer + 10);
+    return 0;
+}
+")
 
-if (CMAKE_SYSTEM_PROCESSOR STREQUAL "AMD64")
+check_cxx_source_compiles("${TEST_CODE_BUILTIN_CLEAR_CACHE}" HAVE_BUILTIN_CLEAR_CACHE)
+
+if (CMAKE_SYSTEM_PROCESSOR STREQUAL "AMD64" OR CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64" OR CMAKE_OSX_ARCHITECTURES STREQUAL "x86_64")
 	set(C_TARGETCPU "X86_64")
+	set(C_DYNAMIC_X86 ON)
+	set(C_DYNREC OFF)
+	set(C_FPU_X86 ON)
+	set(C_UNALIGNED_MEMORY ON)
+elseif (CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64" OR CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64" OR CMAKE_OSX_ARCHITECTURES STREQUAL "arm64")
+	set(C_TARGETCPU "ARMV8LE")
+	set(C_DYNAMIC_X86 OFF)
+	set(C_DYNREC ON)
+	set(C_FPU_X86 OFF)
+	set(C_UNALIGNED_MEMORY OFF)
 else()
 	message(FATAL_ERROR "Unknown processor ${CMAKE_SYSTEM_PROCESSOR}")
 endif()
 
-setConfig01(C_UNALIGNED_MEMORY ON)
-setConfig01(C_PER_PAGE_W_OR_X ON)
-setConfig01(C_DYNAMIC_X86 ON)
-setConfig01(C_DYNREC OFF)
-setConfig01(C_FPU ON)
-setConfig01(C_FPU_X86 OFF)  # TODO: Only for x86
+check_include_file("sys/xattr.h" HAVE_SYS_XATTR_H)
+
+set(C_PER_PAGE_W_OR_X ON)
+set(C_FPU ON)
 
 # Networking (TODO: Option & dependent on SDL2_Net)
-setConfig01(C_MODEM ON)
-setConfig01(C_IPX ON)
+set(C_MODEM ON)
+set(C_IPX ON)
 
 # More networking (TODO: Option)
-setConfig01(C_SLIRP OFF)
-setConfig01(C_NE2000 OFF)
+set(C_SLIRP OFF)
+set(C_NE2000 OFF)
 
-setConfig01(C_OPENGL ON)
-setConfig01(C_FLUIDSYNTH ON)    # TODO: Option
-setConfig01(C_MT32EMU ON)       # TODO: Option
+set(C_OPENGL ON)
+set(C_FLUIDSYNTH ON)    # TODO: Option
+set(C_MT32EMU ON)       # TODO: Option
 
-setConfig01(C_TRACY OFF)        # TODO: Option
-setConfig01(C_DIRECTSERIAL ON)
+set(C_TRACY OFF)        # TODO: Option
+set(C_DIRECTSERIAL ON)
 
 if (OPT_DEBUG)
-	setConfig01(C_DEBUG ON)
+	set(C_DEBUG ON)
 
 	if (OPT_HEAVY_DEBUG)
-		setConfig01(C_HEAVY_DEBUG ON)
+		set(C_HEAVY_DEBUG ON)
 	endif()
 endif()
 
 # ManyMouse
-setConfig01(C_MANYMOUSE OFF)    # TODO
-setConfig01(SUPPORT_XINPUT2 OFF)    # TODO
+set(C_MANYMOUSE OFF)    # TODO
+set(SUPPORT_XINPUT2 OFF)    # TODO
 
 # macOS
-setConfig01(C_COREAUDIO "${DOSBOX_PLATFORM_MACOS}")
-setConfig01(C_COREMIDI "${DOSBOX_PLATFORM_MACOS}")
-setConfig01(C_COREFOUNDATION "${DOSBOX_PLATFORM_MACOS}")
-setConfig01(C_CORESERVICES "${DOSBOX_PLATFORM_MACOS}")
+set(C_COREAUDIO "${DOSBOX_PLATFORM_MACOS}")
+set(C_COREMIDI "${DOSBOX_PLATFORM_MACOS}")
+set(C_COREFOUNDATION "${DOSBOX_PLATFORM_MACOS}")
+set(C_CORESERVICES "${DOSBOX_PLATFORM_MACOS}")
 
 # Linux
-setConfig01(C_ALSA "${DOSBOX_PLATFORM_LINUX}")
+set(C_ALSA "${DOSBOX_PLATFORM_LINUX}")
 
 # Windows
-setConfig01(NOMINMAX ON)
+set(NOMINMAX ON)
 
-setConfig01(C_HAS_BUILTIN_EXPECT OFF)   # Needs porting to `[[likely]]` and friends?
+set(C_HAS_BUILTIN_EXPECT OFF)   # Needs porting to `[[likely]]` and friends?
 
 # TODO: Check other functions
 check_symbol_exists(strnlen "string.h" HAVE_STRNLEN)
+check_symbol_exists(mprotect "sys/mman.h" HAVE_MPROTECT)
+check_symbol_exists(pthread_jit_write_protect_np "pthread.h" HAVE_PTHREAD_WRITE_PROTECT_NP)
+check_symbol_exists(mmap "sys/mman.h" HAVE_MMAP)
+check_symbol_exists(sys_icache_invalidate "libkern/OSCacheControl.h" HAVE_SYS_ICACHE_INVALIDATE)
+check_symbol_exists(MAP_JIT "sys/mman.h" HAVE_MAP_JIT)
 
 set(_USE_MATH_DEFINES ON)
 set(CUSTOM_DATADIR " ")
@@ -141,9 +165,7 @@ set(CUSTOM_DATADIR " ")
 set(project_name "${PROJECT_NAME}")
 set(version "${PROJECT_VERSION}")
 
-get_property(CONFIG_CONTENTS GLOBAL PROPERTY FILE_CONTENTS)
-file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/config.h.in "${CONFIG_CONTENTS}")
-configure_file(${CMAKE_CURRENT_BINARY_DIR}/config.h.in ${CMAKE_CURRENT_BINARY_DIR}/include/config.h @ONLY)
+configure_file(src/config.h.in.cmake ${CMAKE_CURRENT_BINARY_DIR}/include/config.h @ONLY)
 
 ### end of config.h ###
 
@@ -155,8 +177,10 @@ add_executable(dosbox src/main.cpp src/dosbox.cpp)
 target_include_directories(dosbox PUBLIC include ${CMAKE_CURRENT_BINARY_DIR}/include)
 
 # TODO: This happens on every execution, better to have a target with dependencies instead
-add_custom_target(copy_assets
-		COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_LIST_DIR}/contrib/resources ${CMAKE_CURRENT_BINARY_DIR}
+add_custom_target(copy_assets ALL
+    COMMAND ${CMAKE_COMMAND} -E copy_directory
+        "${CMAKE_CURRENT_SOURCE_DIR}/contrib/resources"
+        "${CMAKE_CURRENT_BINARY_DIR}${RESOURCE_COPY_PATH}"
 )
 add_dependencies(dosbox copy_assets)
 
@@ -167,7 +191,7 @@ find_package(SDL2 CONFIG REQUIRED)
 #find_package(Tracy CONFIG REQUIRED)
 #target_link_libraries(dosbox PRIVATE Tracy::TracyClient)
 
-include_directories(include ${CMAKE_CURRENT_BINARY_DIR}/include)
+include_directories(include src/libs src/gui ${CMAKE_CURRENT_BINARY_DIR}/include)
 
 add_subdirectory(src)
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,109 @@
+{
+  "version": 3,
+  "configurePresets": [
+    {
+      "name": "debug",
+      "displayName": "Debug",
+      "description": "Configure for Debug build",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build/debug",
+      "cacheVariables": {
+        "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
+        "CMAKE_BUILD_TYPE": "Debug",
+        "RESOURCE_COPY_PATH": "/../resources"
+      }
+    },
+    {
+      "name": "release",
+      "displayName": "Release",
+      "description": "Configure for Release build",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build/release",
+      "cacheVariables": {
+        "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
+        "CMAKE_BUILD_TYPE": "Release",
+        "RESOURCE_COPY_PATH": "/../resources"
+      }
+    },
+    {
+      "name": "debug-macos",
+      "displayName": "Debug (macOS host CPU)",
+      "description": "Configure for Debug build",
+      "generator": "Xcode",
+      "binaryDir": "${sourceDir}/build/debug-macos",
+      "cacheVariables": {
+        "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
+        "CMAKE_BUILD_TYPE": "Debug",
+        "RESOURCE_COPY_PATH": "/Resources"
+      }
+    },
+    {
+      "name": "release-macos",
+      "displayName": "Release (macOS host CPU)",
+      "description": "Configure for Release build",
+      "generator": "Xcode",
+      "binaryDir": "${sourceDir}/build/release-macos",
+      "cacheVariables": {
+        "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
+        "CMAKE_BUILD_TYPE": "Release",
+        "RESOURCE_COPY_PATH": "/Resources"
+      }
+    },
+    {
+      "name": "release-macos-arm64",
+      "displayName": "Release (macOS arm64)",
+      "description": "Configure for Release build",
+      "generator": "Xcode",
+      "binaryDir": "${sourceDir}/build/release-macos-arm64",
+      "cacheVariables": {
+        "CMAKE_OSX_ARCHITECTURES": "arm64",
+        "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
+        "CMAKE_BUILD_TYPE": "Release",
+        "RESOURCE_COPY_PATH": "/Resources"
+      }
+    },
+    {
+      "name": "release-macos-x86_64",
+      "displayName": "Release (macOS x86_64)",
+      "description": "Configure for Release build",
+      "generator": "Xcode",
+      "binaryDir": "${sourceDir}/build/release-macos-x86_64",
+      "cacheVariables": {
+        "CMAKE_OSX_ARCHITECTURES": "x86_64",
+        "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
+        "CMAKE_BUILD_TYPE": "Release",
+        "RESOURCE_COPY_PATH": "/Resources"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "debug",
+      "configurePreset": "debug"
+    },
+    {
+      "name": "release",
+      "configurePreset": "release"
+    },
+    {
+      "name": "debug-macos",
+      "configurePreset" : "debug-macos",
+      "configuration": "Debug"
+    },
+    {
+      "name": "release-macos",
+      "configurePreset" : "release-macos",
+      "configuration": "Release"
+    },
+    {
+      "name": "release-macos-arm64",
+      "configurePreset" : "release-macos-arm64",
+      "configuration": "Release"
+    },
+    {
+      "name": "release-macos-x86_64",
+      "configurePreset" : "release-macos-x86_64",
+      "configuration": "Release"
+    }
+  ]
+}

--- a/scripts/verify-macos-dylibs.py
+++ b/scripts/verify-macos-dylibs.py
@@ -24,6 +24,7 @@ if __name__ == "__main__":
         "/System/Library/Frameworks/AppKit.framework/",
         "/System/Library/Frameworks/AudioToolbox.framework/",
         "/System/Library/Frameworks/AudioUnit.framework/",
+        "/System/Library/Frameworks/AVFoundation.framework/",
         "/System/Library/Frameworks/Carbon.framework/",
         "/System/Library/Frameworks/Cocoa.framework/",
         "/System/Library/Frameworks/CoreAudio.framework/",

--- a/src/capture/CMakeLists.txt
+++ b/src/capture/CMakeLists.txt
@@ -11,7 +11,7 @@ add_library(libcapture STATIC
 		image/png_writer.cpp
 )
 
-find_package(PNG REQUIRED)
+find_package(PNG CONFIG REQUIRED)
 
 target_link_libraries(libcapture PRIVATE
 		loguru

--- a/src/config.h.in.cmake
+++ b/src/config.h.in.cmake
@@ -1,0 +1,242 @@
+/*
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ *  Copyright (C) 2020-2024  The DOSBox Staging Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#ifndef DOSBOX_CONFIG_H
+#define DOSBOX_CONFIG_H
+
+// This file is a template for the CMake build process.
+//
+// Placeholders surrounded by '@' characters are substituted with concrete
+// values at the start of the build process, and a file `config.cpp` is
+// written to the build output directory.
+
+// Git hash of the build
+#define BUILD_GIT_HASH "@git_hash@"
+
+/* Operating System
+ */
+
+// Defined if compiling for OS from BSD family
+#cmakedefine BSD
+
+// Defined if compiling for Linux (non-Android)
+#cmakedefine LINUX
+
+// Defined if compiling for macOS
+#cmakedefine MACOSX
+
+// Defined if compiling for Windows (any option)
+#ifndef WIN32
+#cmakedefine WIN32
+#endif
+
+/* CPU and FPU emulation
+ *
+ * These defines are mostly relevant to modules src/cpu/ and src/fpu/
+ */
+
+// The type of cpu this target has
+#cmakedefine C_TARGETCPU @C_TARGETCPU@
+
+// Define to 1 if target CPU supports unaligned memory access
+#cmakedefine01 C_UNALIGNED_MEMORY
+
+// Define to 1 if the target platform needs per-page dynamic core write or execute (W^X) tagging
+#cmakedefine01 C_PER_PAGE_W_OR_X
+
+// Define to 1 to use x86/x86_64 dynamic cpu core
+// Can not be used together with C_DYNREC
+#cmakedefine01 C_DYNAMIC_X86
+
+// Define to 1 to use recompiling cpu core
+// Can not be used together with C_DYNAMIC_X86
+#cmakedefine01 C_DYNREC
+
+// Define to 1 to enable floating point emulation
+#cmakedefine01 C_FPU
+
+// Define to 1 to use  fpu core implemented in x86 assembler
+#cmakedefine01 C_FPU_X86
+
+// TODO Define to 1 to use inlined memory functions in cpu core
+#define C_CORE_INLINE 1
+
+/* Emulator features
+ *
+ * Turn on or off optional emulator features that depend on external libraries.
+ * This way it's easier to port or package on a new platform, where these
+ * libraries might be missing.
+ */
+
+// Define to 1 to enable internal modem emulation (using SDL2_net)
+#cmakedefine01 C_MODEM
+
+// Define to 1 to enable IPX over Internet networking (using SDL2_net)
+#cmakedefine01 C_IPX
+
+// Enable serial port passthrough support
+#cmakedefine01 C_DIRECTSERIAL
+
+// Define to 1 to use opengl display output support
+#cmakedefine01 C_OPENGL
+
+// Define to 1 to enable FluidSynth integration (built-in MIDI synth)
+#cmakedefine01 C_FLUIDSYNTH
+
+// Define to 1 to enable libslirp Ethernet support
+#cmakedefine01 C_SLIRP
+
+// Define to 1 to enable Novell NE 2000 NIC emulation
+#cmakedefine01 C_NE2000
+
+// Define to 1 to enable the Tracy profiling server
+#cmakedefine01 C_TRACY
+
+// Define to 1 to enable internal debugger (using ncurses or pdcurses)
+#cmakedefine01 C_DEBUG
+
+// Define to 1 to enable heavy debugging (requires C_DEBUG)
+#cmakedefine01 C_HEAVY_DEBUG
+
+// Define to 1 to enable MT-32 emulator
+#cmakedefine01 C_MT32EMU
+
+// Define to 1 to enable mouse mapping support
+#cmakedefine01 C_MANYMOUSE
+
+// ManyMouse optionally supports the X Input 2.0 protocol (regardless of OS). It
+// uses the following define to definitively indicate if it should or shouldn't
+// use the X Input 2.0 protocol. If this is left undefined, then ManyMouse makes
+// an assumption about availability based on OS type.
+#cmakedefine01 SUPPORT_XINPUT2
+
+// Compiler supports Core Audio headers
+#cmakedefine01 C_COREAUDIO
+
+// Compiler supports Core MIDI headers
+#cmakedefine01 C_COREMIDI
+
+// Compiler supports Core Foundation headers
+#cmakedefine01 C_COREFOUNDATION
+
+// Compiler supports Core Services headers
+#cmakedefine01 C_CORESERVICES
+
+// Define to 1 to enable ALSA MIDI support
+#cmakedefine01 C_ALSA
+
+/* Compiler features and extensions
+ *
+ * These are defines for compiler features we can't reliably verify during
+ * compilation time.
+ */
+
+#cmakedefine01 C_HAS_BUILTIN_EXPECT
+
+/* Defines for checking availability of standard functions and structs.
+ *
+ * Sometimes available functions, structs, or struct fields differ slightly
+ * between operating systems.
+ */
+
+// Define to 1 when zlib-ng support is provided by the system
+#cmakedefine01 C_SYSTEM_ZLIB_NG
+
+// Defined if function clock_gettime is available
+#cmakedefine HAVE_CLOCK_GETTIME
+
+// Defined if function __builtin_available is available
+#cmakedefine HAVE_BUILTIN_AVAILABLE
+
+// Defined if function __builtin___clear_cache is available
+#cmakedefine HAVE_BUILTIN_CLEAR_CACHE
+
+// Defined if function mprotect is available
+#cmakedefine HAVE_MPROTECT
+
+// Defined if function mmap is available
+#cmakedefine HAVE_MMAP
+
+// Defined if mmap flag MAPJIT is available
+#cmakedefine HAVE_MAP_JIT
+
+// Defined if function pthread_jit_write_protect_np is available
+#cmakedefine HAVE_PTHREAD_WRITE_PROTECT_NP
+
+// Defined if function sys_icache_invalidate is available
+#cmakedefine HAVE_SYS_ICACHE_INVALIDATE
+
+// Defined if function pthread_setname_np is available
+#cmakedefine HAVE_PTHREAD_SETNAME_NP
+
+// Defind if function setpriority is available
+#cmakedefine HAVE_SETPRIORITY
+
+// Defind if function strnlen is available
+#cmakedefine HAVE_STRNLEN
+
+// field d_type in struct dirent is not defined in POSIX
+// Some OSes do not implement it (e.g. Haiku)
+#cmakedefine HAVE_STRUCT_DIRENT_D_TYPE
+
+
+
+/* Available headers
+ *
+ * Checks for non-POSIX headers and POSIX headers not supported on Windows.
+ */
+
+#cmakedefine HAVE_LIBGEN_H
+#cmakedefine HAVE_NETINET_IN_H
+#cmakedefine HAVE_PWD_H
+#define HAVE_STDLIB_H
+#cmakedefine HAVE_STRINGS_H
+#cmakedefine HAVE_SYS_SOCKET_H
+#define HAVE_SYS_TYPES_H
+#cmakedefine HAVE_SYS_XATTR_H
+
+/* Hardware-related defines
+ */
+
+// Define to 1 when host/target processor uses big endian byte ordering
+#cmakedefine WORDS_BIGENDIAN
+
+// Non-4K page size (only on selected architectures)
+#cmakedefine PAGESIZE
+
+/* Windows-related defines
+ */
+
+// Prevent <windows.h> from clobbering std::min and std::max
+#cmakedefine NOMINMAX 1
+
+// Enables mathematical constants (such as M_PI) in Windows math.h header
+// https://docs.microsoft.com/en-us/cpp/c-runtime-library/math-constants
+#cmakedefine _USE_MATH_DEFINES
+
+// Modern MSVC provides POSIX-like routines, so prefer that over built-in
+#cmakedefine HAVE_STRNLEN
+
+// Holds the "--datadir" specified during project setup. This can
+// be used as a fallback if the user hasn't populated their
+// XDG_DATA_HOME or XDG_DATA_DIRS to include the --datadir.
+#cmakedefine CUSTOM_DATADIR
+
+#endif

--- a/src/dos/CMakeLists.txt
+++ b/src/dos/CMakeLists.txt
@@ -29,6 +29,7 @@ add_library(libdos STATIC
 		program_biostest.cpp
 		program_boot.cpp
 		program_choice.cpp
+		program_clip.cpp
 		program_help.cpp
 		program_imgmount.cpp
 		program_intro.cpp

--- a/src/dos/program_mount.cpp
+++ b/src/dos/program_mount.cpp
@@ -78,7 +78,7 @@ void MOUNT::ShowUsage()
 	output.AddString(MSG_Get("PROGRAM_MOUNT_HELP_LONG"));
 #ifdef WIN32
 	output.AddString(MSG_Get("PROGRAM_MOUNT_HELP_LONG_WIN32"));
-#elif MACOSX
+#elif defined(MACOSX)
 	output.AddString(MSG_Get("PROGRAM_MOUNT_HELP_LONG_MACOSX"));
 #else
 	output.AddString(MSG_Get("PROGRAM_MOUNT_HELP_LONG_OTHER"));

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -13,4 +13,5 @@ find_package(OpenGL REQUIRED)
 target_link_libraries(libgui PRIVATE
 		$<IF:$<TARGET_EXISTS:SDL2::SDL2>,SDL2::SDL2,SDL2::SDL2-static>
 		OpenGL::GL
+		libmisc
 )

--- a/src/hardware/CMakeLists.txt
+++ b/src/hardware/CMakeLists.txt
@@ -93,5 +93,5 @@ target_link_libraries(libhardware PRIVATE
 		libmidi
 		libshell
 		PkgConfig::SPEEXDSP
-		iir::iir
+		iir::iir_static
 		$<IF:$<TARGET_EXISTS:SDL2_net::SDL2_net>,SDL2_net::SDL2_net,SDL2_net::SDL2_net-static>)

--- a/src/midi/CMakeLists.txt
+++ b/src/midi/CMakeLists.txt
@@ -17,4 +17,6 @@ target_link_libraries(libmidi PRIVATE
 		$<IF:$<TARGET_EXISTS:SDL2::SDL2>,SDL2::SDL2,SDL2::SDL2-static>
 		MT32Emu::mt32emu
 		FluidSynth::libfluidsynth
+		libaudio
+		libhardware
 )

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -24,5 +24,5 @@
       "host": true
     }
   ],
-  "builtin-baseline": "6ebf8c123bc8077dc9216db6438eeabaa154c473"
+  "builtin-baseline": "117512d870c0f260f4914b6b4bb006b9054b06eb"
 }


### PR DESCRIPTION
# Description
This PR adds a new release build workflow to validate CMake + vcpkg on macOS. We certainly aren't anywhere near production-ready for CMake + vcpkg across the board, but it does give us macOS release builds on an arm-only runner without the need for homebrew or x86-64 for a host, which was really the only item creating time pressure.

# Manual testing

Downloaded the new macOS release artifacts and tested arm64 and x86-64 slices with a small handful of apps: QTD, Sunflower (demo), Panic! (demo), Carmageddon, moralhardcandy (demo).

I have done no optimization tweaking on the release build; whatever CMake spits out for a release build using the Xcode backend is what we're getting.

The change has been manually tested on:

- [ ] Windows
- [x] macOS
- [ ] Linux

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

