### PR TITLE
Clean up vertical bars fix FPU code

### DIFF
--- a/include/fpu.h
+++ b/include/fpu.h
@@ -92,7 +92,7 @@ struct FPU_rec {
 	FPU_Reg regs[9]         = {};
 #if !C_FPU_X86
     // for FILD/FIST 64-bit memcpy fix
-	std::optional<int64_t> regs_memcpy[9] = {};
+	int64_t regs_memcpy[9] = {};
 #endif
 	FPU_P_Reg p_regs[9]     = {};
 	MMX_reg mmx_regs[8]     = {};

--- a/src/cpu/core_dynrec/dyn_fpu.h
+++ b/src/cpu/core_dynrec/dyn_fpu.h
@@ -40,9 +40,6 @@ static void FPU_FNSTCW(PhysPt addr){
 
 static void FPU_FFREE(Bitu st) {
 	fpu.tags[st] = TAG_Empty;
-#if !C_FPU_X86
-	fpu.regs_memcpy[st].reset();
-	#endif
 }
 
 	#if C_FPU_X86

--- a/src/cpu/mmx.cpp
+++ b/src/cpu/mmx.cpp
@@ -116,10 +116,4 @@ void setFPUTagEmpty()
 	fpu.tags[6] = TAG_Empty;
 	fpu.tags[7] = TAG_Empty;
 	fpu.tags[8] = TAG_Valid; // is only used by us
-
-#if !C_FPU_X86
-	for (auto& reg_memcpy : fpu.regs_memcpy) {
-		reg_memcpy.reset();
-	}
-#endif
 }

--- a/src/fpu/fpu.cpp
+++ b/src/fpu/fpu.cpp
@@ -476,11 +476,7 @@ void FPU_ESC5_Normal(Bitu rm) {
 	const uint8_t group = (rm >> 3) & 7;
 	const uint8_t sub   = (rm & 7);
 	switch (group) {
-	case 0x00: /* FFREE STi */ fpu.tags[STV(sub)] = TAG_Empty;
-	#if !C_FPU_X86
-		fpu.regs_memcpy[STV(sub)].reset();
-	#endif
-		break;
+	case 0x00: /* FFREE STi */ fpu.tags[STV(sub)] = TAG_Empty; break;
 	case 0x01: /* FXCH STi*/
 		FPU_FXCH(TOP,STV(sub));
 		break;
@@ -592,10 +588,8 @@ void FPU_ESC7_Normal(Bitu rm) {
 	const uint8_t group = (rm >> 3) & 7;
 	const uint8_t sub   = (rm & 7);
 	switch (group) {
-	case 0x00: /* FFREEP STi*/ fpu.tags[STV(sub)] = TAG_Empty;
-	#if !C_FPU_X86
-		fpu.regs_memcpy[STV(sub)].reset();
-	#endif
+	case 0x00: /* FFREEP STi*/
+		fpu.tags[STV(sub)] = TAG_Empty;
 		FPU_FPOP();
 		break;
 	case 0x01: /* FXCH STi*/


### PR DESCRIPTION
# Description

The vertical bars fix in DOSBox Pure is much more elegant and efficient than the solution I came up with, so I stole it.

# Manual testing

The change has been manually tested on:

- [x] Windows
- [x] macOS
- [ ] Linux

with:

- sunflower (demo)
- Carmageddon
- moralhardcandy (demo)
- multikolor (demo)
- toontown (demo)
- Quake (to verify the FILD/FIST instructions still work when the memcpy trick isn't used)

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

