### PR TITLE
Increase the number of audio frames generated by SoundBlaster when the mixer is underflowing

### DIFF
--- a/src/hardware/sblaster.h
+++ b/src/hardware/sblaster.h
@@ -39,6 +39,7 @@ public:
 	// Public members used by MIXER_PullFromQueueCallback
 	RWQueue<AudioFrame> output_queue{1};
 	MixerChannelPtr channel = nullptr;
+	std::atomic<int> frames_needed = 0;
 
 private:
 	IO_ReadHandleObject read_handlers[0x10]   = {};
@@ -50,6 +51,7 @@ private:
 
 	void SetupEnvironment();
 	void ClearEnvironment();
+	void MixerCallback(const int frames_requested);
 };
 
 #endif


### PR DESCRIPTION
# Description

Second attempt at #4165 but this one is much more minimalistic in number of changes.

I'm keeping the per-frame callbacks.  Triton's Crystal Dream demo is an extreme example of why we need them.  That demo sets up DMA to read a single 2 byte frame from the same memory location repeatedly.  The demo code is modifying that 2 byte memory location on-demand and we have to read at a 44 microsecond interval to keep up.

`PIC_AddEvent()` is the cleanest way to achieve this.  It modifies the `CPU_Cycles` variable to ensure that we return from the CPU core in time to run the next event.

# Release notes

Reduce audio stuttering in games using SoundBlaster's DMA and Direct DAC modes.

# Manual testing

Still need to do more testing but this is what I've done so far.

- Tyrian (fixes stuttering in main menu and Esc in-game menu)
- Duke3D (fixes stuttering on the 3DRealms screen)
- Quake
- Doom
- Archimedean Dynasty (fixes stuttering at 80k cycles with 3dfx patch)
- Blood

Demo's from @interloper98 's test suite

- Crystal Dreams
- Buttman (lol)
- Overlord (best test-case of DAC I've seen as it outputs constant audio)

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [x] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [x] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

