### PR TITLE
Remove std::atomic from performance critical global variables

### DIFF
--- a/include/cpu.h
+++ b/include/cpu.h
@@ -54,18 +54,13 @@ enum class ArchitectureType {
 	Mixed           = 0xff,
 };
 
-// PIC_FullIndex() is used by the mixer thread for determining timing
-// Variables used in this calculation must be atomic or Clang's thread sanitizer complains
-// This includes CPU_Cycles, CPU_CycleLeft, and CPU_CycleMax
-// The rest can be left as normal variables
-
 // Current cycles values
-extern std::atomic<int> CPU_Cycles;
-extern std::atomic<int> CPU_CycleLeft;
+extern int CPU_Cycles;
+extern int CPU_CycleLeft;
 
 // Cycles settings for both "legacy" and "modern" modes
 extern bool CPU_CycleAutoAdjust;
-extern std::atomic<int> CPU_CycleMax;
+extern int CPU_CycleMax;
 extern int CPU_CyclePercUsed;
 extern int CPU_CycleLimit;
 

--- a/include/pic.h
+++ b/include/pic.h
@@ -29,7 +29,7 @@
 typedef void(PIC_EOIHandler)();
 typedef void (*PIC_EventHandler)(uint32_t val);
 
-extern std::atomic<uint32_t> PIC_IRQCheck;
+extern uint32_t PIC_IRQCheck;
 
 // Elapsed milliseconds since starting DOSBox
 // Holds ~4.2 B milliseconds or ~48 days before rolling over

--- a/include/pic.h
+++ b/include/pic.h
@@ -33,7 +33,7 @@ extern uint32_t PIC_IRQCheck;
 
 // Elapsed milliseconds since starting DOSBox
 // Holds ~4.2 B milliseconds or ~48 days before rolling over
-extern std::atomic<uint32_t> PIC_Ticks;
+extern uint32_t PIC_Ticks;
 
 extern std::atomic<double> atomic_pic_index;
 

--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -55,13 +55,13 @@ CPUBlock cpu      = {};
 Segments Segs     = {};
 
 // Current cycles values
-std::atomic<int> CPU_Cycles    = 0;
-std::atomic<int> CPU_CycleLeft = CpuCyclesRealModeDefault;
+int CPU_Cycles    = 0;
+int CPU_CycleLeft = CpuCyclesRealModeDefault;
 
 // Cycles settings for both "legacy" and "modern" modes
-std::atomic<int> CPU_CycleMax = CpuCyclesRealModeDefault;
-int CPU_CyclePercUsed         = 100;
-int CPU_CycleLimit            = -1;
+int CPU_CycleMax      = CpuCyclesRealModeDefault;
+int CPU_CyclePercUsed = 100;
+int CPU_CycleLimit    = -1;
 
 static int old_cycle_max       = CpuCyclesRealModeDefault;
 static bool legacy_cycles_mode = false;
@@ -2416,7 +2416,7 @@ static void cpu_increase_cycles_legacy()
 		CPU_Cycles    = 0;
 
 		if (!maybe_display_switch_to_dynamic_core_warning(CPU_CycleMax)) {
-			LOG_MSG("CPU: Fixed %d cycles", CPU_CycleMax.load());
+			LOG_MSG("CPU: Fixed %d cycles", CPU_CycleMax);
 		}
 	}
 }
@@ -2538,7 +2538,7 @@ static void cpu_decrease_cycles_legacy()
 		CPU_CycleLeft = 0;
 		CPU_Cycles    = 0;
 
-		LOG_MSG("CPU: Fixed %d cycles.", CPU_CycleMax.load());
+		LOG_MSG("CPU: Fixed %d cycles.", CPU_CycleMax);
 	}
 }
 
@@ -2612,7 +2612,7 @@ std::string CPU_GetCyclesConfigAsString()
 				s += format_str("max %d%%", CPU_CyclePercUsed);
 			}
 		} else {
-			s += format_str("%d", CPU_CycleMax.load());
+			s += format_str("%d", CPU_CycleMax);
 		}
 
 		s += " ";
@@ -2919,9 +2919,8 @@ public:
 	void ConfigureCyclesLegacy(Section_prop* secprop)
 	{
 		// Sets the value if the string in within the min and max values
-		// Output value is either int or std::atomic<int>
-		auto set_if_in_range = []<typename T>(const std::string& str,
-		                          T& value,
+		auto set_if_in_range = [](const std::string& str,
+		                          int& value,
 		                          const int min_value = 1,
 		                          const int max_value = 0) {
 			std::istringstream stream(str);

--- a/src/dos/cdrom.cpp
+++ b/src/dos/cdrom.cpp
@@ -86,7 +86,7 @@ void CDROM_Interface::LagDriveResponse() const
 
 	// Handle tick-rollover
 	static decltype(PIC_Ticks) prev_ticks = 0;
-	prev_ticks = std::min(PIC_Ticks.load(), prev_ticks.load());
+	prev_ticks = std::min(PIC_Ticks, prev_ticks);
 
 	// Ensure results a monotonically increasing
 	auto since_last_response_ms = [=]() { return PIC_Ticks - prev_ticks; };
@@ -95,7 +95,7 @@ void CDROM_Interface::LagDriveResponse() const
 		CALLBACK_Idle();
 	}
 
-	prev_ticks = PIC_Ticks.load();
+	prev_ticks = PIC_Ticks;
 }
 
 void CDROM_Interface_Physical::CdReaderLoop()

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -297,7 +297,7 @@ static void increase_ticks()
 		auto ratio = (ticks.scheduled * (CPU_CyclePercUsed * 1024 / 100)) /
 		             ticks.done;
 
-		auto new_cycle_max = CPU_CycleMax.load();
+		auto new_cycle_max = CPU_CycleMax;
 
 		auto cproc = static_cast<int64_t>(CPU_CycleMax) *
 		             static_cast<int64_t>(ticks.scheduled);
@@ -417,7 +417,7 @@ static void increase_ticks()
 		// ticks.added > 15 but ticks.scheduled < 5, lower the cycles
 		// but do not reset the scheduled/done ticks to take them into
 		// account during the next auto cycle adjustment.
-		CPU_CycleMax = CPU_CycleMax / 3;
+		CPU_CycleMax /= 3;
 
 		if (CPU_CycleMax < auto_cpu_cycles_min) {
 			CPU_CycleMax = auto_cpu_cycles_min;
@@ -462,7 +462,7 @@ static void DOSBOX_UnlockSpeed( bool pressed ) {
 		if (CPU_CycleAutoAdjust) {
 			autoadjust = true;
 			CPU_CycleAutoAdjust = false;
-			CPU_CycleMax = CPU_CycleMax / 3;
+			CPU_CycleMax /= 3;
 			if (CPU_CycleMax<1000) CPU_CycleMax=1000;
 		}
 	} else {

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -257,8 +257,6 @@ static void halt_render()
 	render.active   = false;
 }
 
-extern uint32_t PIC_Ticks;
-
 void RENDER_EndUpdate(bool abort)
 {
 	if (!render.updating) {

--- a/src/hardware/gameblaster.cpp
+++ b/src/hardware/gameblaster.cpp
@@ -250,7 +250,7 @@ void GameBlaster::AudioCallback(const int requested_frames)
 		channel->AddSamples_sfloat(1, &frame[0]);
 		--frames_remaining;
 	}
-	last_rendered_ms = PIC_FullIndex();
+	last_rendered_ms = PIC_AtomicIndex();
 }
 
 void GameBlaster::WriteToDetectionPort(io_port_t port, io_val_t value, io_width_t)

--- a/src/hardware/imfc.cpp
+++ b/src/hardware/imfc.cpp
@@ -4995,7 +4995,7 @@ AudioFrame ym2151_device::RenderFrame()
 
 void ym2151_device::RenderUpToNow()
 {
-	const auto now = PIC_FullIndex();
+	const auto now = PIC_AtomicIndex();
 	// Keep rendering until we're current
 	while (last_rendered_ms < now) {
 		last_rendered_ms += ms_per_render;
@@ -5032,7 +5032,7 @@ void ym2151_device::sound_stream_update(const int requested_frames)
 		audio_channel->AddSamples_sfloat(1, &frame[0]);
 		--frames_remaining;
 	}
-	last_rendered_ms = PIC_FullIndex();
+	last_rendered_ms = PIC_AtomicIndex();
 }
 
 // clang-format off

--- a/src/hardware/innovation.cpp
+++ b/src/hardware/innovation.cpp
@@ -256,7 +256,7 @@ void Innovation::AudioCallback(const int requested_frames)
 		}
 		--frames_remaining;
 	}
-	last_rendered_ms = PIC_FullIndex();
+	last_rendered_ms = PIC_AtomicIndex();
 }
 
 Innovation innovation;

--- a/src/hardware/input/mouse_manymouse.cpp
+++ b/src/hardware/input/mouse_manymouse.cpp
@@ -249,7 +249,7 @@ bool ManyMouseGlue::ProbeForMapping(uint8_t &physical_device_idx)
 
 	// Wait a little to speedup screen update
 	constexpr uint32_t ticks_threshold = 50; // time to wait idle in PIC ticks
-	const auto pic_ticks_start = PIC_Ticks.load();
+	const auto pic_ticks_start = PIC_Ticks;
 	while (PIC_Ticks >= pic_ticks_start &&
 	       PIC_Ticks - pic_ticks_start < ticks_threshold)
 		CALLBACK_Idle();

--- a/src/hardware/input/mouseif_ps2_bios.cpp
+++ b/src/hardware/input/mouseif_ps2_bios.cpp
@@ -824,7 +824,7 @@ static void bios_flush_aux()
 			IO_ReadB(port_num_i8042_data);
 		}
 
-		const auto start_ticks = PIC_Ticks.load();
+		const auto start_ticks = PIC_Ticks;
 		while (PIC_Ticks - start_ticks <= max_wait_ms) {
 			CALLBACK_Idle();
 			has_more = bios_is_aux_byte_waiting();

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -2509,7 +2509,7 @@ static void mixer_thread_loop()
 		assert(mixer.state != MixerState::Uninitialized);
 
 		// This code is mostly for the fast-forward button (hold Alt + F12)
-		const double now         = PIC_FullIndex();
+		const double now         = PIC_AtomicIndex();
 		const double actual_time = now - last_mixed;
 		const double expected_time = (static_cast<double>(mixer.blocksize) /
 		                              static_cast<double>(mixer.sample_rate_hz)) *

--- a/src/hardware/opl.cpp
+++ b/src/hardware/opl.cpp
@@ -466,7 +466,7 @@ void Opl::AudioCallback(const int requested_frames)
 		channel->AddSamples_sfloat(1, &frame[0]);
 		--frames_remaining;
 	}
-	last_rendered_ms = PIC_FullIndex();
+	last_rendered_ms = PIC_AtomicIndex();
 }
 
 void Opl::CacheWrite(const io_port_t port, const uint8_t val)

--- a/src/hardware/pic.cpp
+++ b/src/hardware/pic.cpp
@@ -24,8 +24,6 @@
 #include "timer.h"
 #include "setup.h"
 
-#include <mutex>
-
 // PIC Controllers
 // ~~~~~~~~~~~~~~~
 // The sources here identify the two Programmable Interrupt Controllers
@@ -133,7 +131,6 @@ struct PIC_Controller {
 	void start_irq(uint8_t val);
 };
 
-static std::mutex pic_mutex = {};
 static PIC_Controller pics[2];
 static PIC_Controller &primary_controller = pics[0];
 static PIC_Controller &secondary_controller = pics[1];
@@ -324,7 +321,6 @@ static uint8_t read_data(io_port_t port, io_width_t)
 // DOS managed up to 15 IRQs
 void PIC_ActivateIRQ(const uint8_t irq)
 {
-	std::lock_guard lock(pic_mutex);
 	const uint8_t t = irq > 7 ? (irq - 8) : irq;
 	PIC_Controller *pic = &pics[irq > 7 ? 1 : 0];
 
@@ -351,7 +347,6 @@ void PIC_ActivateIRQ(const uint8_t irq)
 // DOS managed up to 15 IRQs
 void PIC_DeActivateIRQ(const uint8_t irq)
 {
-	std::lock_guard lock(pic_mutex);
 	const uint8_t t = irq > 7 ? (irq - 8) : irq;
 	PIC_Controller *pic = &pics[irq > 7 ? 1 : 0];
 	pic->lower_irq(t);
@@ -388,7 +383,6 @@ static void inline primary_startIRQ(uint8_t i)
 }
 
 void PIC_runIRQs(void) {
-	std::lock_guard lock(pic_mutex);
 	if (!GETFLAG(IF)) return;
 	if (!PIC_IRQCheck) {
 		return;

--- a/src/hardware/pic.cpp
+++ b/src/hardware/pic.cpp
@@ -136,6 +136,7 @@ static PIC_Controller &primary_controller = pics[0];
 static PIC_Controller &secondary_controller = pics[1];
 std::atomic<uint32_t> PIC_Ticks = 0;
 uint32_t PIC_IRQCheck = 0; // x86 dynamic core expects a 32 bit variable size
+std::atomic<double> atomic_pic_index = 0.0;
 
 void PIC_Controller::set_imr(uint8_t val) {
 	if (machine == MCH_PCJR) {
@@ -527,6 +528,8 @@ void PIC_RemoveEvents(PIC_EventHandler handler) {
 
 
 bool PIC_RunQueue(void) {
+	PIC_UpdateAtomicIndex();
+
 	/* Check to see if a new millisecond needs to be started */
 	CPU_CycleLeft+=CPU_Cycles;
 	CPU_Cycles=0;

--- a/src/hardware/pic.cpp
+++ b/src/hardware/pic.cpp
@@ -208,7 +208,6 @@ static struct {
 
 static void write_command(io_port_t port, io_val_t value, io_width_t)
 {
-	std::lock_guard lock(pic_mutex);
 	const auto val = check_cast<uint8_t>(value);
 	PIC_Controller *pic = &pics[port == 0x20 ? 0 : 1];
 
@@ -265,7 +264,6 @@ static void write_command(io_port_t port, io_val_t value, io_width_t)
 
 static void write_data(io_port_t port, io_val_t value, io_width_t)
 {
-	std::lock_guard lock(pic_mutex);
 	const auto val = check_cast<uint8_t>(value);
 	PIC_Controller *pic = &pics[port == 0x21 ? 0 : 1];
 	switch (pic->icw_index) {
@@ -309,7 +307,6 @@ static void write_data(io_port_t port, io_val_t value, io_width_t)
 
 static uint8_t read_command(io_port_t port, io_width_t)
 {
-	std::lock_guard lock(pic_mutex);
 	PIC_Controller *pic = &pics[port == 0x20 ? 0 : 1];
 	if (pic->request_issr) {
 		return pic->isr;
@@ -320,7 +317,6 @@ static uint8_t read_command(io_port_t port, io_width_t)
 
 static uint8_t read_data(io_port_t port, io_width_t)
 {
-	std::lock_guard lock(pic_mutex);
 	PIC_Controller *pic = &pics[port == 0x21 ? 0 : 1];
 	return pic->imr;
 }

--- a/src/hardware/pic.cpp
+++ b/src/hardware/pic.cpp
@@ -134,7 +134,7 @@ struct PIC_Controller {
 static PIC_Controller pics[2];
 static PIC_Controller &primary_controller = pics[0];
 static PIC_Controller &secondary_controller = pics[1];
-std::atomic<uint32_t> PIC_Ticks = 0;
+uint32_t PIC_Ticks = 0;
 uint32_t PIC_IRQCheck = 0; // x86 dynamic core expects a 32 bit variable size
 std::atomic<double> atomic_pic_index = 0.0;
 
@@ -566,9 +566,9 @@ bool PIC_RunQueue(void) {
 		if (cycles < CPU_CycleLeft) {
 			CPU_Cycles = cycles;
 		} else {
-			CPU_Cycles = CPU_CycleLeft.load();
+			CPU_Cycles=CPU_CycleLeft;
 		}
-	} else CPU_Cycles = CPU_CycleLeft.load();
+	} else CPU_Cycles=CPU_CycleLeft;
 	CPU_CycleLeft-=CPU_Cycles;
 	PIC_runIRQs();
 	return true;
@@ -606,8 +606,8 @@ void TIMER_AddTickHandler(TIMER_TickHandler handler) {
 
 void TIMER_AddTick(void) {
 	/* Setup new amount of cycles for PIC */
-	CPU_CycleLeft = CPU_CycleMax.load();
-	CPU_Cycles = 0;
+	CPU_CycleLeft=CPU_CycleMax;
+	CPU_Cycles=0;
 	PIC_Ticks++;
 	/* Go through the list of scheduled events and lower their index with 1000 */
 	PICEntry * entry=pic_queue.next_entry;

--- a/src/hardware/pic.cpp
+++ b/src/hardware/pic.cpp
@@ -138,7 +138,7 @@ static PIC_Controller pics[2];
 static PIC_Controller &primary_controller = pics[0];
 static PIC_Controller &secondary_controller = pics[1];
 std::atomic<uint32_t> PIC_Ticks = 0;
-std::atomic<uint32_t> PIC_IRQCheck = 0; // x86 dynamic core expects a 32 bit variable size
+uint32_t PIC_IRQCheck = 0; // x86 dynamic core expects a 32 bit variable size
 
 void PIC_Controller::set_imr(uint8_t val) {
 	if (machine == MCH_PCJR) {

--- a/src/hardware/ps1audio.cpp
+++ b/src/hardware/ps1audio.cpp
@@ -535,7 +535,7 @@ void Ps1Synth::AudioCallback(const int requested_frames)
 		channel->AddSamples_mfloat(1, &sample);
 		--frames_remaining;
 	}
-	last_rendered_ms = PIC_FullIndex();
+	last_rendered_ms = PIC_AtomicIndex();
 }
 
 Ps1Synth::~Ps1Synth()

--- a/src/hardware/tandy_sound.cpp
+++ b/src/hardware/tandy_sound.cpp
@@ -592,7 +592,7 @@ void TandyPSG::AudioCallback(const int requested_frames)
 		channel->AddSamples_mfloat(1, &sample);
 		--frames_remaining;
 	}
-	last_rendered_ms = PIC_FullIndex();
+	last_rendered_ms = PIC_AtomicIndex();
 }
 
 // The Tandy DAC and PSG (programmable sound generator) managed pointers

--- a/src/midi/midi_fluidsynth.cpp
+++ b/src/midi/midi_fluidsynth.cpp
@@ -812,7 +812,7 @@ void MidiDeviceFluidSynth::MixerCallback(const int requested_audio_frames)
 		mixer_channel->AddSamples_sfloat(requested_audio_frames,
 		                                 &audio_frames[0][0]);
 
-		last_rendered_ms = PIC_FullIndex();
+		last_rendered_ms = PIC_AtomicIndex();
 	} else {
 		assert(!audio_frame_fifo.IsRunning());
 		mixer_channel->AddSilence();

--- a/src/midi/midi_mt32.cpp
+++ b/src/midi/midi_mt32.cpp
@@ -883,7 +883,7 @@ void MidiDeviceMt32::MixerCallback(const int requested_audio_frames)
 		channel->AddSamples_sfloat(requested_audio_frames,
 		                           &audio_frames[0][0]);
 
-		last_rendered_ms = PIC_FullIndex();
+		last_rendered_ms = PIC_AtomicIndex();
 	} else {
 		assert(!audio_frame_fifo.IsRunning());
 		channel->AddSilence();

--- a/src/midi/midi_soundcanvas.cpp
+++ b/src/midi/midi_soundcanvas.cpp
@@ -509,7 +509,7 @@ void MidiDeviceSoundCanvas::MixerCallback(const int requested_audio_frames)
 		mixer_channel->AddSamples_sfloat(requested_audio_frames,
 		                                 &audio_frames[0][0]);
 
-		last_rendered_ms = PIC_FullIndex();
+		last_rendered_ms = PIC_AtomicIndex();
 	} else {
 		assert(!audio_frame_fifo.IsRunning());
 		mixer_channel->AddSilence();


### PR DESCRIPTION
# Description

First few commits revert some mutexes and atomics that were only used by GUS.  GUS has since been moved to the main thread so these are no longer needed.

GUS was raising some IRQs and that's probably part of the reason it didn't work out so well threaded.  These are unlikely to return.  If I find a way to (partially) thread GUS, it will still need a main thread callback to get the timings right for Blood.  IRQ stuff should stay on the main thread.  It just never works out well with timing and trying to guarantee thread safety is also a headache.

I then implemented `PIC_AtomicIndex()`.  This gets updated by the main thread inside `PIC_RunQueue` which runs at least once per millisecond.  In practice, it runs much more frequently and at 300k cycles it's somewhere close to every microsecond.

This is precise enough for our needs in the mixer and audio callbacks.  It's only used to update `last_rendered_ms` variables and for some special fast-forward code.  It won't work globally though.  VGA had some regressions when I tried so I'm not going there and added a warning comment.

Finally, remove the `std::atomics` from the CPU cycles variables.  These get updated at least once every cycle inside CPU core emulation.  In hindsight, not a good idea to add that many atomic operations to performance critical sections.

It wasn't even correct before anyway.  Calculating `PIC_FullIndex()` was using multiple atomic operations on 3 different variables.  We never guaranteed atomicity of the entire thing.  Now we do.

## Related issues

Fixes #4176


# Release notes

Fix audio stuttering at high cycle count in Nethack — Falcon's Eye


# Manual testing

- Nethack — Falcon's Eye now runs stutter free on my system up to 300k cycles.  This is independent of my changes on #4175  I based and tested this from `main` without the other PR applied.
- Could not measure any significant change in FPS from a Quake timedemo.  If anyone knows of a good DOS benchmark, I'd be curious to see if we get improvements.

Regression testing for affected audio devices:

- OPL - Tyrian
- MT-32 - Eric the Unready, Space Quest 3
- Fluidsynth - Doom, Duke3D
- SoundCanvas - Doom, Duke3D
- IMFC - Police Quest 2
- GameBlaster - Silpheed
- Innovation - Red Storm Rising
- PS1 Audio - Sierra's Christmas Card
- Tandy - Thexder

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [x] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [x] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

