### PR TITLE
Fix `INT10_SetVideoMode()` regression

### DIFF
--- a/src/ints/int10_modes.cpp
+++ b/src/ints/int10_modes.cpp
@@ -2002,7 +2002,7 @@ bool INT10_SetVideoMode(uint16_t mode)
 			}
 		}
 	} else {
-		for (auto ct = 0; ct < NumVgaAttributeRegisters; ++ct) {
+		for (auto ct = 0x10; ct < NumVgaAttributeRegisters; ++ct) {
 			// Skip overscan register
 			if (ct == 0x11) {
 				continue;


### PR DESCRIPTION
# Description

Fixes palette regression in the intro of DreamWeb.

## Related issues

#4178


# Release notes

Fix DreamWeb regression introduced in 0.81.2 where the grayscale text in the intro appeared "quantised" to pure black and white colours.

# Manual testing

Tested DreamWeb (CD) from eXoDOS:

![image](https://github.com/user-attachments/assets/6cb9aa4f-d217-4670-92d2-9b32e47e9f2f)

The change has been manually tested on:

- [x] Windows
- [ ] macOS
- [ ] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [x] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

