### PR TITLE
Add Windows presets for CMake

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -38,6 +38,32 @@
       }
     },
     {
+      "name": "release-windows",
+      "displayName": "Release (Windows host CPU)",
+      "description": "Configure for Release build",
+      "generator": "Visual Studio 17 2022",
+      "binaryDir": "${sourceDir}/build/release-windows",
+      "cacheVariables": {
+        "CMAKE_GENERATOR_TOOLSET": "ClangCL",      
+        "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
+        "CMAKE_BUILD_TYPE": "Release",
+        "RESOURCE_COPY_PATH": "/Resources"
+      }
+    },
+    {
+      "name": "debug-windows",
+      "displayName": "Debug (Windows host CPU)",
+      "description": "Configure for Debug build",
+      "generator": "Visual Studio 17 2022",
+      "binaryDir": "${sourceDir}/build/debug-windows",
+      "cacheVariables": {
+        "CMAKE_GENERATOR_TOOLSET": "ClangCL",      
+        "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
+        "CMAKE_BUILD_TYPE": "Debug",
+        "RESOURCE_COPY_PATH": "/Resources"
+      }
+    },
+    {
       "name": "release-macos",
       "displayName": "Release (macOS host CPU)",
       "description": "Configure for Release build",
@@ -84,6 +110,16 @@
     {
       "name": "release",
       "configurePreset": "release"
+    },
+    {
+      "name": "debug-windows",
+      "configurePreset" : "debug-windows",
+      "configuration": "Debug"
+    },
+    {
+      "name": "release-windows",
+      "configurePreset" : "release-windows",
+      "configuration": "Release"
     },
     {
       "name": "debug-macos",

--- a/src/hardware/CMakeLists.txt
+++ b/src/hardware/CMakeLists.txt
@@ -93,5 +93,5 @@ target_link_libraries(libhardware PRIVATE
 		libmidi
 		libshell
 		PkgConfig::SPEEXDSP
-		iir::iir_static
+		$<IF:$<TARGET_EXISTS:iir::iir>,iir::iir,iir::iir_static>
 		$<IF:$<TARGET_EXISTS:SDL2_net::SDL2_net>,SDL2_net::SDL2_net,SDL2_net::SDL2_net-static>)


### PR DESCRIPTION
# Description

This PR adds CMake presets for Windows builds using the VS backend generators, and also updates the iir library declaration to work for both static and dynamic builds.

# Manual testing

The change has been manually tested on:

- [x] Windows
- [x] macOS
- [ ] Linux

I tested:

- Quake and QTD
- Sunflower (demo)
- MCPDiag (test floating-point is still 100% on x86)

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

