### PR TITLE
Fix command line parser bug where an extension-less file prevents execution

### DIFF
--- a/include/shell.h
+++ b/include/shell.h
@@ -110,7 +110,7 @@ private:
 	bool WriteHelp(const std::string& command, char* args);
 	[[nodiscard]] std::string ReadCommand();
 	[[nodiscard]] std::string SubstituteEnvironmentVariables(std::string_view command);
-	[[nodiscard]] std::string Which(std::string_view name) const;
+	[[nodiscard]] std::string ResolvePath(std::string_view name) const;
 
 	friend class AutoexecEditor;
 

--- a/src/shell/shell_misc.cpp
+++ b/src/shell/shell_misc.cpp
@@ -498,7 +498,7 @@ bool DOS_Shell::ExecuteProgram(std::string_view name, std::string_view args)
 		return true;
 	}
 
-	const auto fullname                                = Which(name);
+	const auto fullname                                = ResolvePath(name);
 	constexpr decltype(fullname.size()) extension_size = 4;
 
 	if (fullname.empty() || fullname.size() <= extension_size) {
@@ -536,7 +536,7 @@ bool DOS_Shell::ExecuteProgram(std::string_view name, std::string_view args)
 	return false;
 }
 
-std::string DOS_Shell::Which(const std::string_view name) const
+std::string DOS_Shell::ResolvePath(const std::string_view name) const
 {
 	static constexpr auto extensions = {"", ".COM", ".EXE", ".BAT"};
 


### PR DESCRIPTION
# Description

Regression from 1ebea7216206f79e37a9e5712c824199c39f51b4 - Passed wrong pointer into execute_binary_file()
From the same PR ffd952cc6c0c7a28d7d1cfe8835610ff41c67f8a - Code detecting extension-less files was removed

If a directory contains both DOOM and DOOM.EXE and a user runs the command DOOM, this was previously thowing an error.

We should try appending (in order) .COM, .EXE, and .BAT if and only if the command contains no extension.

## Related issues

Fixes #4179


# Release notes

Fixed a bug where an extension-less file with the same name as an executable incorrectly threw an "Invalid command" error when attempting to launch the executable from the command line.

# Manual testing

- Create empty file `DOOM` in the same directory as `DOOM.EXE`.
- Type `DOOM` in the command line.
- Previously this threw invalid command error.  Now it doesn't.

Also confirmed Overkill fails to launch on `main` and works after this PR.

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [x] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [x] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

