### PR TITLE
Document Microsoft Digital Media Pro Keyboard scancodes

### DIFF
--- a/include/keyboard.h
+++ b/include/keyboard.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2022-2023  The DOSBox Staging Team
+ *  Copyright (C) 2022-2025  The DOSBox Staging Team
  *  Copyright (C) 2002-2021  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -63,14 +63,46 @@ enum KBD_KEYS {
 
 	KBD_LAST,
 
-	// TODO: add support (GFX, mapper, etc.) for the keys below. For now
-	// they are put after KBD_LAST on purpose.
-	// Scancodes for them were taken from various sources - if possible,
-	// test on real hardware before enabling them.
-	// Note, that our BIOS might be unable to handle the scancodes of
-	// these keys correctly - this also needs to be tested.
+	// The keys below are not currently supported, thus they are placed
+	// after KBD_LAST.
+	// Note that our BIOS might be unable to handle the scancodes of these
+	// keys correctly - this needs to be tested before the support is added.
 
-	KBD_application, // application menu key
+	// Scancodes 1 and 2 for these keys were confirmed using the Microsoft
+	// 'Digital Media Pro Keyboard':
+	// - model 1031 (as printed on the box)
+	// - model KC-0405 (as printed on the bottom side sticker)
+	// - part number X809745-002 (as printed on the bottom side sticker)
+	// If querried, the keyboard returns ID 0x41.
+
+	KBD_guimenu,
+
+	KBD_acpi_sleep, KBD_log_off,
+
+	KBD_undo, KBD_redo, KBD_help,
+
+	KBD_vol_mute, KBD_vol_up, KBD_vol_down,
+
+	KBD_media_play, KBD_media_stop,
+	KBD_media_prev, KBD_media_next,
+	KBD_media_music, KBD_media_pictures,
+
+	KBD_zoom_in, KBD_zoom_out,
+
+	KBD_calculator, KBD_email, KBD_messenger, KBD_www_home,
+
+	KBD_my_documents,
+
+	KBD_new, KBD_open, KBD_close, KBD_save, KBD_print, KBD_spell,
+	KBD_reply, KBD_forward, KBD_send,
+
+	KBD_favorites, KBD_favorite1, KBD_favorite2,
+	KBD_favorite3, KBD_favorite4, KBD_favorite5,
+
+	// Scancodes below were taken from various sources - if possible, test
+	// on real hardware before enabling them.
+
+	KBD_acpi_power, KBD_acpi_wake,
 
 	KBD_f13, KBD_f14, KBD_f15, KBD_f16, KBD_f17, KBD_f18,
 	KBD_f19, KBD_f20, KBD_f21, KBD_f22, KBD_f23, KBD_f24,
@@ -79,22 +111,15 @@ enum KBD_KEYS {
 	KBD_intl1, KBD_intl2, KBD_intl4, KBD_intl5,
 	KBD_katakana, KBD_fugirana, KBD_kanji, KBD_hiragana,
 
-	KBD_acpi_power, KBD_acpi_sleep, KBD_acpi_wake,
+	KBD_cut, KBD_copy, KBD_paste,
 
-	KBD_cut, KBD_copy, KBD_paste, KBD_undo, KBD_redo, KBD_help,
-
-	KBD_vol_mute, KBD_vol_up, KBD_vol_down,
-
-	KBD_media_play, KBD_media_stop,
-	KBD_media_prev, KBD_media_next,
 	KBD_media_eject,
 	KBD_media_select, // media_video according to some sources
-	KBD_media_music, KBD_media_pictures,
 
-	KBD_www_home, KBD_www_search, KBD_www_favorites, KBD_www_refresh,
+	KBD_www_search, KBD_www_favorites, KBD_www_refresh,
 	KBD_www_stop, KBD_www_forward, KBD_www_back,
 
-	KBD_my_computer, KBD_email, KBD_calculator,
+	KBD_my_computer,
 
 	// clang-format on
 };

--- a/include/keyboard.h
+++ b/include/keyboard.h
@@ -61,65 +61,11 @@ enum KBD_KEYS {
 	KBD_kpdivide, KBD_kpmultiply, KBD_kpminus, KBD_kpplus,
 	KBD_kpenter, KBD_kpperiod,
 
+	// If you intend to add multimedia keyboard scancodes, please check the
+	// 'README.md' from the implementation directory for the list of known
+	// scancodes.
+
 	KBD_LAST,
-
-	// The keys below are not currently supported, thus they are placed
-	// after KBD_LAST.
-	// Note that our BIOS might be unable to handle the scancodes of these
-	// keys correctly - this needs to be tested before the support is added.
-
-	// Scancodes 1 and 2 for these keys were confirmed using the Microsoft
-	// 'Digital Media Pro Keyboard':
-	// - model 1031 (as printed on the box)
-	// - model KC-0405 (as printed on the bottom side sticker)
-	// - part number X809745-002 (as printed on the bottom side sticker)
-	// If querried, the keyboard returns ID 0x41.
-
-	KBD_guimenu,
-
-	KBD_acpi_sleep, KBD_log_off,
-
-	KBD_undo, KBD_redo, KBD_help,
-
-	KBD_vol_mute, KBD_vol_up, KBD_vol_down,
-
-	KBD_media_play, KBD_media_stop,
-	KBD_media_prev, KBD_media_next,
-	KBD_media_music, KBD_media_pictures,
-
-	KBD_zoom_in, KBD_zoom_out,
-
-	KBD_calculator, KBD_email, KBD_messenger, KBD_www_home,
-
-	KBD_my_documents,
-
-	KBD_new, KBD_open, KBD_close, KBD_save, KBD_print, KBD_spell,
-	KBD_reply, KBD_forward, KBD_send,
-
-	KBD_favorites, KBD_favorite1, KBD_favorite2,
-	KBD_favorite3, KBD_favorite4, KBD_favorite5,
-
-	// Scancodes below were taken from various sources - if possible, test
-	// on real hardware before enabling them.
-
-	KBD_acpi_power, KBD_acpi_wake,
-
-	KBD_f13, KBD_f14, KBD_f15, KBD_f16, KBD_f17, KBD_f18,
-	KBD_f19, KBD_f20, KBD_f21, KBD_f22, KBD_f23, KBD_f24,
-	KBD_sys_req,
-
-	KBD_intl1, KBD_intl2, KBD_intl4, KBD_intl5,
-	KBD_katakana, KBD_fugirana, KBD_kanji, KBD_hiragana,
-
-	KBD_cut, KBD_copy, KBD_paste,
-
-	KBD_media_eject,
-	KBD_media_select, // media_video according to some sources
-
-	KBD_www_search, KBD_www_favorites, KBD_www_refresh,
-	KBD_www_stop, KBD_www_forward, KBD_www_back,
-
-	KBD_my_computer,
 
 	// clang-format on
 };

--- a/src/hardware/input/README.md
+++ b/src/hardware/input/README.md
@@ -1,4 +1,7 @@
+
 # Input code
+
+## Existing code layout
 
 Few comments on input device emulation code organization:
 
@@ -81,3 +84,106 @@ code, under GPL2-or-above license
 Serial mice emulation - idea is similar to `mouseif_*.cpp` files, but
 implemented in object-oriented way, as a serial port device; multiple
 instances can exist, for each serial port.
+
+## Not implemented keyboard scancodes
+
+Multimedia keyboards are not emulated yet - this chapter contains a list of
+known scancodes (taken from various sources, many confirmed using a real
+keyboard) which can be added.
+Note that our BIOS might be unable to handle these scancodes  correctly - this
+needs to be tested before the support is added.
+
+| Key              | Scancode set 1 | Scancode set 2 | Remarks |
+|------------------|----------------|----------------|---------|
+| SysReq           | `0x54`         | `0x84`         |         |
+| Menu             | `0xe0 0x5d`    | `0xe0 0x2f`    | (1)     |
+| Log Off          | `0xe0 0x16`    | `0xe0 0x3c`    | (1)     |
+| ACPI Sleep       | `0xe0 0x5f`    | `0xe0 0x3f`    | (1)     |
+| ACPI Wake        | `0xe0 0x63`    | `0xe0 0x5e`    |         |
+| ACPI Power       | `0xe0 0x5e`    | `0xe0 0x37`    |         |
+| F13              | `0x5b`         | `0x1f`         |         |
+| F14              | `0x5c`         | `0x27`         |         |
+| F15              | `0x5d`         | `0x2f`         |         |
+| F16              | `0x63`         | `0x5e`         |         |
+| F17              | `0x64`         | `0x08`         |         |
+| F18              | `0x65`         | `0x10`         |         |
+| F19              | `0x66`         | `0x18`         |         |
+| F20              | `0x67`         | `0x20`         |         |
+| F21              | `0x68`         | `0x28`         |         |
+| F22              | `0x69`         | `0x30`         |         |
+| F23              | `0x6a`         | `0x38`         |         |
+| F24              | `0x6b`         | `0x40`         |         |
+| Intl 1           | `0x59`         | (unknown)      |         |
+| Intl 2           |                |                | (A)     |
+| Intl 4           | `0x7d`         | `0x6a`         |         |
+| Intl 5           | `0x7e`         | `0x6d`         |         |
+| Katakana         | `0x70`         | `0x13`         |         |
+| Fugirana         | `0x77`         | `0x62`         |         |
+| Kanji            | `0x79`         | `0x64`         |         |
+| Hiragana         | `0x7b`         | `0x67`         |         |
+| Undo             | `0xe0 0x08`    | `0xe0 0x3d`    | (1)     |
+| Redo             | `0xe0 0x07`    | `0xe0 0x36`    | (1)     |
+| Help             | `0xe0 0x3b`    | `0xe0 0x05`    | (1)     |
+| Volume Mute      | `0xe0 0x20`    | `0xe0 0x23`    | (1)     |
+| Volume+          | `0xe0 0x30`    | `0xe0 0x32`    | (1)     |
+| Volume-          | `0xe0 0x2e`    | `0xe0 0x21`    | (1)     |
+| Media Play/Pause | `0xe0 0x22`    | `0xe0 0x34`    | (1)     |
+| Media Stop       | `0xe0 0x24`    | `0xe0 0x3b`    | (1)     |
+| Media Previous   | `0xe0 0x10`    | `0xe0 0x15`    | (1)     |
+| Media Next       | `0xe0 0x19`    | `0xe0 0x4d`    | (1)     |
+| Media Music      | `0xe0 0x3c`    | `0xe0 0x06`    | (1)     |
+| Media Pictures   | `0xe0 0x64`    | `0xe0 0x08`    | (1)     |
+| Media Select     | `0xe0 0x6d`    | `0xe0 0x50`    | (B)     |
+| Media Eject      | `0xe0 0x2c`    | `0xe0 0x1a`    |         |
+| Zoom+            | `0xe0 0x0b`    | `0xe0 0x45`    | (1)     |
+| Zoom-            | `0xe0 0x11`    | `0xe0 0x1d`    | (1)     |
+| Calculator       | `0xe0 0x21`    | `0xe0 0x2b`    | (1)     |
+| E-Mail           | `0xe0 0x6c`    | `0xe0 0x48`    | (1)     |
+| Messenger        | `0xe0 0x05`    | `0xe0 0x25`    | (1)     |
+| WWW Home         | `0xe0 0x32`    | `0xe0 0x3a`    | (1)     |
+| WWW Forward      | `0xe0 0x69`    | `0xe0 0x30`    |         |
+| WWW Back         | `0xe0 0x6a`    | `0xe0 0x38`    |         |
+| WWW Stop         | `0xe0 0x68`    | `0xe0 0x28`    |         |
+| WWW Refresh      | `0xe0 0x67`    | `0xe0 0x20`    |         |
+| WWW Search       | `0xe0 0x65`    | `0xe0 0x10`    |         |
+| WWW Favorites    | `0xe0 0x66`    | `0xe0 0x18`    |         |
+| My Computer      | `0xe0 0x6b`    | `0xe0 0x40`    |         |
+| My Documents     | `0xe0 0x4c`    | `0xe0 0x73`    | (1)     |
+| Cut              | `0xe0 0x17`    | `0xe0 0x43`    |         |
+| Copy             | `0xe0 0x18`    | `0xe0 0x44`    |         |
+| Paste            | `0xe0 0x1a`    | `0xe0 0x46`    |         |
+| New              | `0xe0 0x3e`    | `0xe0 0x0c`    | (1)     |
+| Open             | `0xe0 0x3f`    | `0xe0 0x03`    | (1)     |
+| Close            | `0xe0 0x40`    | `0xe0 0x0b`    | (1)     |
+| Save             | `0xe0 0x57`    | `0xe0 0x78`    | (1)     |
+| Print            | `0xe0 0x58`    | `0xe0 0x07`    | (1)     |
+| Spell            | `0xe0 0x23`    | `0xe0 0x33`    | (1)     |
+| Reply            | `0xe0 0x41`    | `0xe0 0x83`    | (1)     |
+| Forward          | `0xe0 0x42`    | `0xe0 0x0a`    | (1)     |
+| Send             | `0xe0 0x43`    | `0xe0 0x01`    | (1)     |
+| My Favorites     | `0xe0 0x78`    | `0xe0 0x63`    | (1)     |
+| My Favorite 1    | `0xe0 0x73`    | `0xe0 0x51`    | (1)     |
+| My Favorite 2    | `0xe0 0x74`    | `0xe0 0x53`    | (1)     |
+| My Favorite 3    | `0xe0 0x75`    | `0xe0 0x5c`    | (1)     |
+| My Favorite 4    | `0xe0 0x76`    | `0xe0 0x5f`    | (1)     |
+| My Favorite 5    | `0xe0 0x77`    | `0xe0 0x62`    | (1)     |
+
+| Key              | Scancode set 3 | Remarks |
+|------------------|----------------|---------|
+| Menu             | `0x8d`         |         |
+| F13              | `0x08`         |         |
+| Intl 2           | `0x53`         |         |
+| Intl 4           | `0x5d`         |         |
+| Intl 5           | `0x7b`         |         |
+| Hiragana         | `0x85`         |         |
+| Kanji            | `0x86`         |         |
+| katagana         | `0x87`         |         |
+
+(1) Scancodes confirmed using the Microsoft 'Digital Media Pro Keyboard':
+- model 1031 (as printed on the box)
+- model KC-0405 (as printed on the bottom side sticker)
+- part number X809745-002 (as printed on the bottom side sticker)
+- if querried, the keyboard returns ID 0x41
+
+(A) Intl 2 and backslash have same scancodes 1 and 2
+(B) Media Video according to some sources

--- a/src/hardware/input/keyboard_scancodes.cpp
+++ b/src/hardware/input/keyboard_scancodes.cpp
@@ -104,7 +104,6 @@ std::vector<uint8_t> KEYBOARD_GetScanCode1(const KBD_KEYS key_type,
         case KBD_quote:          code = 0x28; break;
         case KBD_grave:          code = 0x29; break;
         case KBD_leftshift:      code = 0x2a; break;
-        case KBD_intl2: // intl2 and backslash are the same in this code set
         case KBD_backslash:      code = 0x2b; break;
 
         case KBD_z:              code = 0x2c; break;
@@ -152,102 +151,30 @@ std::vector<uint8_t> KEYBOARD_GetScanCode1(const KBD_KEYS key_type,
         case KBD_kp0:            code = 0x52; break;
         case KBD_kpperiod:       code = 0x53; break;
 
-        case KBD_sys_req:        code = 0x54; break;
-        case KBD_oem102:         code = 0x56; break;
+        case KBD_oem102:         code = 0x56; break; // XXX
         case KBD_f11:            code = 0x57; break;
         case KBD_f12:            code = 0x58; break;
-        case KBD_intl1:          code = 0x59; break;
 
-        case KBD_f13:            code = 0x5b; break;
-        case KBD_f14:            code = 0x5c; break;
-        case KBD_f15:            code = 0x5d; break;
-        case KBD_f16:            code = 0x63; break;
-        case KBD_f17:            code = 0x64; break;
-        case KBD_f18:            code = 0x65; break;
-        case KBD_f19:            code = 0x66; break;
-        case KBD_f20:            code = 0x67; break;
-        case KBD_f21:            code = 0x68; break;
-        case KBD_f22:            code = 0x69; break;
-        case KBD_f23:            code = 0x6a; break;
-        case KBD_f24:            code = 0x6b; break;
-
-        case KBD_katakana:       code = 0x70; break;
         case KBD_abnt1:          code = 0x73; break;
-        case KBD_fugirana:       code = 0x77; break;
-        case KBD_kanji:          code = 0x79; break;
-        case KBD_hiragana:       code = 0x7b; break;
-        case KBD_intl4:          code = 0x7d; break;
-        case KBD_intl5:          code = 0x7e; break;
 
         // Extended keys
 
-        case KBD_messenger:      extend = true; code = 0x05; break;
-        case KBD_redo:           extend = true; code = 0x07; break;
-        case KBD_undo:           extend = true; code = 0x08; break;
-        case KBD_zoom_in:        extend = true; code = 0x0b; break;
-        case KBD_media_prev:     extend = true; code = 0x10; break;
-        case KBD_zoom_out:       extend = true; code = 0x11; break;
-        case KBD_log_off:        extend = true; code = 0x16; break;
-        case KBD_cut:            extend = true; code = 0x17; break;
-        case KBD_copy:           extend = true; code = 0x18; break;
-        case KBD_media_next:     extend = true; code = 0x19; break;
-        case KBD_paste:          extend = true; code = 0x1a; break;
         case KBD_kpenter:        extend = true; code = 0x1c; break;
         case KBD_rightctrl:      extend = true; code = 0x1d; break;
-        case KBD_vol_mute:       extend = true; code = 0x20; break;
-        case KBD_calculator:     extend = true; code = 0x21; break;
-        case KBD_media_play:     extend = true; code = 0x22; break;
-        case KBD_spell:          extend = true; code = 0x23; break;
-        case KBD_media_stop:     extend = true; code = 0x24; break;
-        case KBD_media_eject:    extend = true; code = 0x2c; break;
-        case KBD_vol_down:       extend = true; code = 0x2e; break;
-        case KBD_vol_up:         extend = true; code = 0x30; break;
-        case KBD_www_home:       extend = true; code = 0x32; break;
         case KBD_kpdivide:       extend = true; code = 0x35; break;
         case KBD_rightalt:       extend = true; code = 0x38; break;
-        case KBD_help:           extend = true; code = 0x3b; break;
-        case KBD_media_music:    extend = true; code = 0x3c; break;
-        case KBD_new:            extend = true; code = 0x3e; break;
-        case KBD_open:           extend = true; code = 0x3f; break;
-        case KBD_close:          extend = true; code = 0x40; break;
-        case KBD_reply:          extend = true; code = 0x41; break;
-        case KBD_forward:        extend = true; code = 0x42; break;
-        case KBD_send:           extend = true; code = 0x43; break;
         case KBD_home:           extend = true; code = 0x47; break;
         case KBD_up:             extend = true; code = 0x48; break;
         case KBD_pageup:         extend = true; code = 0x49; break;
         case KBD_left:           extend = true; code = 0x4b; break;
-        case KBD_my_documents:   extend = true; code = 0x4c; break;
         case KBD_right:          extend = true; code = 0x4d; break;
         case KBD_end:            extend = true; code = 0x4f; break;
         case KBD_down:           extend = true; code = 0x50; break;
         case KBD_pagedown:       extend = true; code = 0x51; break;
         case KBD_insert:         extend = true; code = 0x52; break;
         case KBD_delete:         extend = true; code = 0x53; break;
-        case KBD_save:           extend = true; code = 0x57; break;
-        case KBD_print:          extend = true; code = 0x58; break;
         case KBD_leftgui:        extend = true; code = 0x5b; break;
         case KBD_rightgui:       extend = true; code = 0x5c; break;
-        case KBD_guimenu:        extend = true; code = 0x5d; break;
-        case KBD_acpi_power:     extend = true; code = 0x5e; break;
-        case KBD_acpi_sleep:     extend = true; code = 0x5f; break;
-        case KBD_acpi_wake:      extend = true; code = 0x63; break;
-        case KBD_media_pictures: extend = true; code = 0x64; break;
-        case KBD_www_search:     extend = true; code = 0x65; break;
-        case KBD_www_favorites:  extend = true; code = 0x66; break;
-        case KBD_www_refresh:    extend = true; code = 0x67; break;
-        case KBD_www_stop:       extend = true; code = 0x68; break;
-        case KBD_www_forward:    extend = true; code = 0x69; break;
-        case KBD_www_back:       extend = true; code = 0x6a; break;
-        case KBD_my_computer:    extend = true; code = 0x6b; break;
-        case KBD_email:          extend = true; code = 0x6c; break;
-        case KBD_media_select:   extend = true; code = 0x6d; break;
-        case KBD_favorite1:      extend = true; code = 0x73; break;
-        case KBD_favorite2:      extend = true; code = 0x74; break;
-        case KBD_favorite3:      extend = true; code = 0x75; break;
-        case KBD_favorite4:      extend = true; code = 0x76; break;
-        case KBD_favorite5:      extend = true; code = 0x77; break;
-        case KBD_favorites:      extend = true; code = 0x78; break;
 
 	// clang-format on
 
@@ -304,57 +231,45 @@ std::vector<uint8_t> KEYBOARD_GetScanCode2(const KBD_KEYS key_type,
         case KBD_f1:             code = 0x05; break;
         case KBD_f2:             code = 0x06; break;
         case KBD_f12:            code = 0x07; break;
-        case KBD_f17:            code = 0x08; break;
         case KBD_f10:            code = 0x09; break;
         case KBD_f8:             code = 0x0a; break;
         case KBD_f6:             code = 0x0b; break;
         case KBD_f4:             code = 0x0c; break;
         case KBD_tab:            code = 0x0d; break;
         case KBD_grave:          code = 0x0e; break;
-        case KBD_f18:            code = 0x10; break;
         case KBD_leftalt:        code = 0x11; break;
         case KBD_leftshift:      code = 0x12; break;
-        case KBD_katakana:       code = 0x13; break;
         case KBD_leftctrl:       code = 0x14; break;
         case KBD_q:              code = 0x15; break;
         case KBD_1:              code = 0x16; break;
-        case KBD_f19:            code = 0x18; break;
         case KBD_z:              code = 0x1a; break;
         case KBD_s:              code = 0x1b; break;
         case KBD_a:              code = 0x1c; break;
         case KBD_w:              code = 0x1d; break;
         case KBD_2:              code = 0x1e; break;
-        case KBD_f13:            code = 0x1f; break;
-        case KBD_f20:            code = 0x20; break;
         case KBD_c:              code = 0x21; break;
         case KBD_x:              code = 0x22; break;
         case KBD_d:              code = 0x23; break;
         case KBD_e:              code = 0x24; break;
         case KBD_4:              code = 0x25; break;
         case KBD_3:              code = 0x26; break;
-        case KBD_f14:            code = 0x27; break;
-        case KBD_f21:            code = 0x28; break;
         case KBD_space:          code = 0x29; break;
         case KBD_v:              code = 0x2a; break;
         case KBD_f:              code = 0x2b; break;
         case KBD_t:              code = 0x2c; break;
         case KBD_r:              code = 0x2d; break;
         case KBD_5:              code = 0x2e; break;
-        case KBD_f15:            code = 0x2f; break;
-        case KBD_f22:            code = 0x30; break;
         case KBD_n:              code = 0x31; break;
         case KBD_b:              code = 0x32; break;
         case KBD_h:              code = 0x33; break;
         case KBD_g:              code = 0x34; break;
         case KBD_y:              code = 0x35; break;
         case KBD_6:              code = 0x36; break;
-        case KBD_f23:            code = 0x38; break;
         case KBD_m:              code = 0x3a; break;
         case KBD_j:              code = 0x3b; break;
         case KBD_u:              code = 0x3c; break;
         case KBD_7:              code = 0x3d; break;
         case KBD_8:              code = 0x3e; break;
-        case KBD_f24:            code = 0x40; break;
         case KBD_comma:          code = 0x41; break;
         case KBD_k:              code = 0x42; break;
         case KBD_i:              code = 0x43; break;
@@ -375,19 +290,12 @@ std::vector<uint8_t> KEYBOARD_GetScanCode2(const KBD_KEYS key_type,
         case KBD_rightshift:     code = 0x59; break;
         case KBD_enter:          code = 0x5a; break;
         case KBD_rightbracket:   code = 0x5b; break;
-        case KBD_intl2: // intl2 and backslash are the same in this code set
         case KBD_backslash:      code = 0x5d; break;    
-        case KBD_f16:            code = 0x5e; break;
         case KBD_oem102:         code = 0x61; break;
-        case KBD_fugirana:       code = 0x62; break;
-        case KBD_kanji:          code = 0x64; break;
         case KBD_backspace:      code = 0x66; break;
-        case KBD_hiragana:       code = 0x67; break;
         case KBD_kp1:            code = 0x69; break;
-        case KBD_intl4:          code = 0x6a; break;
         case KBD_kp4:            code = 0x6b; break;
         case KBD_kp7:            code = 0x6c; break;
-        case KBD_intl5:          code = 0x6d; break;
         case KBD_kp0:            code = 0x70; break;
         case KBD_kpperiod:       code = 0x71; break;
         case KBD_kp2:            code = 0x72; break;
@@ -404,77 +312,25 @@ std::vector<uint8_t> KEYBOARD_GetScanCode2(const KBD_KEYS key_type,
         case KBD_kp9:            code = 0x7d; break;
         case KBD_scrolllock:     code = 0x7e; break;
         case KBD_f7:             code = 0x83; break;
-        case KBD_sys_req:        code = 0x84; break;
 
         // Extended keys
 
-        case KBD_send:           extend = true; code = 0x01; break;
-        case KBD_open:           extend = true; code = 0x03; break;
-        case KBD_help:           extend = true; code = 0x05; break;
-        case KBD_media_music:    extend = true; code = 0x06; break;
-        case KBD_print:          extend = true; code = 0x07; break;
-        case KBD_media_pictures: extend = true; code = 0x08; break;
-        case KBD_forward:        extend = true; code = 0x0a; break;
-        case KBD_close:          extend = true; code = 0x0b; break;
-        case KBD_new:            extend = true; code = 0x0c; break;
-        case KBD_www_search:     extend = true; code = 0x10; break;
         case KBD_rightalt:       extend = true; code = 0x11; break;
         case KBD_rightctrl:      extend = true; code = 0x14; break;
-        case KBD_media_prev:     extend = true; code = 0x15; break;
-        case KBD_www_favorites:  extend = true; code = 0x18; break;
-        case KBD_media_eject:    extend = true; code = 0x1a; break;
-        case KBD_zoom_out:       extend = true; code = 0x1d; break;
         case KBD_leftgui:        extend = true; code = 0x1f; break;
-        case KBD_www_refresh:    extend = true; code = 0x20; break;
-        case KBD_vol_down:       extend = true; code = 0x21; break;
-        case KBD_vol_mute:       extend = true; code = 0x23; break;
-        case KBD_messenger:      extend = true; code = 0x25; break;
         case KBD_rightgui:       extend = true; code = 0x27; break;
-        case KBD_www_stop:       extend = true; code = 0x28; break;
-        case KBD_calculator:     extend = true; code = 0x2b; break;
-        case KBD_guimenu:        extend = true; code = 0x2f; break;
-        case KBD_www_forward:    extend = true; code = 0x30; break;
-        case KBD_vol_up:         extend = true; code = 0x32; break;
-        case KBD_spell:          extend = true; code = 0x33; break;
-        case KBD_media_play:     extend = true; code = 0x34; break;
-        case KBD_redo:           extend = true; code = 0x36; break;
-        case KBD_acpi_power:     extend = true; code = 0x37; break;
-        case KBD_www_back:       extend = true; code = 0x38; break;
-        case KBD_www_home:       extend = true; code = 0x3a; break;
-        case KBD_media_stop:     extend = true; code = 0x3b; break;
-        case KBD_log_off:        extend = true; code = 0x3c; break;
-        case KBD_undo:           extend = true; code = 0x3d; break;
-        case KBD_acpi_sleep:     extend = true; code = 0x3f; break;
-        case KBD_my_computer:    extend = true; code = 0x40; break;
-        case KBD_cut:            extend = true; code = 0x43; break;
-        case KBD_copy:           extend = true; code = 0x44; break;
-        case KBD_zoom_in:        extend = true; code = 0x45; break;
-        case KBD_paste:          extend = true; code = 0x46; break;
-        case KBD_email:          extend = true; code = 0x48; break;
         case KBD_kpdivide:       extend = true; code = 0x4a; break;
-        case KBD_media_next:     extend = true; code = 0x4d; break;
-        case KBD_media_select:   extend = true; code = 0x50; break;
-        case KBD_favorite1:      extend = true; code = 0x51; break;
-        case KBD_favorite2:      extend = true; code = 0x53; break;
         case KBD_kpenter:        extend = true; code = 0x5a; break;
-        case KBD_favorite3:      extend = true; code = 0x5c; break;
-        case KBD_acpi_wake:      extend = true; code = 0x5e; break;
-        case KBD_favorite4:      extend = true; code = 0x5f; break;
-        case KBD_favorite5:      extend = true; code = 0x62; break;
-        case KBD_favorites:      extend = true; code = 0x63; break;
         case KBD_end:            extend = true; code = 0x69; break;
         case KBD_left:           extend = true; code = 0x6b; break;
         case KBD_home:           extend = true; code = 0x6c; break;
         case KBD_insert:         extend = true; code = 0x70; break;
         case KBD_delete:         extend = true; code = 0x71; break;
         case KBD_down:           extend = true; code = 0x72; break;
-        case KBD_my_documents:   extend = true; code = 0x73; break;
         case KBD_right:          extend = true; code = 0x74; break;
         case KBD_up:             extend = true; code = 0x75; break;
-        case KBD_save:           extend = true; code = 0x78; break;
         case KBD_pagedown:       extend = true; code = 0x7a; break;
         case KBD_pageup:         extend = true; code = 0x7d; break;
-        case KBD_reply:          extend = true; code = 0x83; break;
 
 	// clang-format on
 
@@ -506,14 +362,6 @@ std::vector<uint8_t> KEYBOARD_GetScanCode2(const KBD_KEYS key_type,
 			};
 		}
 		break;
-
-	case KBD_intl1: {
-		static bool already_warned = false;
-		if (!already_warned) {
-			LOG_WARNING("KEYBAORD: INTL1 key scan code for codeset 2 not known");
-			already_warned = true;
-		}
-	} break;
 
 	default: E_Exit("Missing key in codeset 2"); return {};
 	}
@@ -551,10 +399,9 @@ std::vector<uint8_t> KEYBOARD_GetScanCode3(const KBD_KEYS key_type,
 	uint8_t code = 0x00;
 
 	switch (key_type) {
-		// clang-format off
+	// clang-format off
 
         case KBD_f1:             code = 0x07; break;
-        case KBD_f13:            code = 0x08; break;
         case KBD_esc:            code = 0x08; break;
         case KBD_tab:            code = 0x0d; break;
         case KBD_grave:          code = 0x0e; break;
@@ -619,7 +466,6 @@ std::vector<uint8_t> KEYBOARD_GetScanCode3(const KBD_KEYS key_type,
         case KBD_f10:            code = 0x4f; break;
         case KBD_abnt1:          code = 0x51; break;
         case KBD_quote:          code = 0x52; break;
-        case KBD_intl2:          code = 0x53; break;
         case KBD_leftbracket:    code = 0x54; break;
         case KBD_equals:         code = 0x55; break;
         case KBD_f11:            code = 0x56; break;
@@ -629,7 +475,6 @@ std::vector<uint8_t> KEYBOARD_GetScanCode3(const KBD_KEYS key_type,
         case KBD_enter:          code = 0x5a; break;
         case KBD_rightbracket:   code = 0x5b; break;
         case KBD_backslash:      code = 0x5c; break;
-        case KBD_intl4:          code = 0x5d; break;
         case KBD_f12:            code = 0x5e; break;
         case KBD_scrolllock:     code = 0x5f; break;
         case KBD_down:           code = 0x60; break;
@@ -656,88 +501,13 @@ std::vector<uint8_t> KEYBOARD_GetScanCode3(const KBD_KEYS key_type,
         case KBD_numlock:        code = 0x76; break;
         case KBD_kpenter:        code = 0x79; break;
         case KBD_kp3:            code = 0x7a; break;
-        case KBD_intl5:          code = 0x7b; break;
         case KBD_kpplus:         code = 0x7c; break;
         case KBD_kp9:            code = 0x7d; break;
         case KBD_kpmultiply:     code = 0x7e; break;
-        case KBD_hiragana:       code = 0x85; break;
-        case KBD_kanji:          code = 0x86; break;
-        case KBD_katakana:       code = 0x87; break;
         case KBD_leftgui:        code = 0x8b; break;
         case KBD_rightgui:       code = 0x8c; break;
-        case KBD_guimenu :       code = 0x8d; break;
 
-		// clang-format on
-
-		// Unsupported
-
-	case KBD_intl1:
-	case KBD_fugirana:
-	case KBD_sys_req:
-	case KBD_f14:
-	case KBD_f15:
-	case KBD_f16:
-	case KBD_f17:
-	case KBD_f18:
-	case KBD_f19:
-	case KBD_f20:
-	case KBD_f21:
-	case KBD_f22:
-	case KBD_f23:
-	case KBD_f24:
-	case KBD_acpi_power:
-	case KBD_acpi_sleep:
-	case KBD_acpi_wake:
-	case KBD_log_off:
-	case KBD_zoom_in:
-	case KBD_zoom_out:
-	case KBD_cut:
-	case KBD_copy:
-	case KBD_paste:
-	case KBD_help:
-	case KBD_redo:
-	case KBD_undo:
-	case KBD_calculator:
-	case KBD_my_computer:
-	case KBD_my_documents:
-	case KBD_email:
-	case KBD_messenger:
-	case KBD_new:
-	case KBD_open:
-	case KBD_close:
-	case KBD_save:
-	case KBD_print:
-	case KBD_spell:
-	case KBD_reply:
-	case KBD_forward:
-	case KBD_send:
-	case KBD_media_prev:
-	case KBD_media_next:
-	case KBD_media_play:
-	case KBD_media_stop:
-	case KBD_media_select:
-	case KBD_media_eject:
-	case KBD_media_music:
-	case KBD_media_pictures:
-	case KBD_vol_mute:
-	case KBD_vol_up:
-	case KBD_vol_down:
-	case KBD_www_home:
-	case KBD_www_search:
-	case KBD_www_favorites:
-	case KBD_www_refresh:
-	case KBD_www_stop:
-	case KBD_www_forward:
-	case KBD_www_back:
-	case KBD_favorites:
-	case KBD_favorite1:
-	case KBD_favorite2:
-	case KBD_favorite3:
-	case KBD_favorite4:
-	case KBD_favorite5:
-
-		// TODO: do scan codes exist at all for these keys in set 3?
-		return {};
+	// clang-format on
 
 	default: E_Exit("Missing key in codeset 3"); return {};
 	}

--- a/src/hardware/input/keyboard_scancodes.cpp
+++ b/src/hardware/input/keyboard_scancodes.cpp
@@ -1,7 +1,7 @@
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *
- *  Copyright (C) 2022-2023  The DOSBox Staging Team
+ *  Copyright (C) 2022-2025  The DOSBox Staging Team
  *  Copyright (C) 2002-2022  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -40,13 +40,13 @@ CHECK_NARROWING();
 
 // Reserved codes:
 //
-// 0x00         key detection error or internall buffer overflow - for set 1
+// 0x00         key detection error or internal buffer overflow - for set 1
 // 0xaa         keyboard self test passed
 // 0xee         echo response
 // 0xfa         acknowledge
 // 0xfc, 0xfd   keyboard self test failed
 // 0xfe         resend request
-// 0xff         key detection error or internall buffer overflow - for sets 2 & 3
+// 0xff         key detection error or internal buffer overflow - for sets 2 & 3
 
 std::vector<uint8_t> KEYBOARD_GetScanCode1(const KBD_KEYS key_type,
                                            const bool is_pressed)
@@ -55,7 +55,7 @@ std::vector<uint8_t> KEYBOARD_GetScanCode1(const KBD_KEYS key_type,
 	bool extend  = false;
 
 	switch (key_type) {
-		// clang-format off
+	// clang-format off
 
         case KBD_esc:            code = 0x01; break;
         case KBD_1:              code = 0x02; break;
@@ -181,9 +181,13 @@ std::vector<uint8_t> KEYBOARD_GetScanCode1(const KBD_KEYS key_type,
 
         // Extended keys
 
+        case KBD_messenger:      extend = true; code = 0x05; break;
         case KBD_redo:           extend = true; code = 0x07; break;
         case KBD_undo:           extend = true; code = 0x08; break;
+        case KBD_zoom_in:        extend = true; code = 0x0b; break;
         case KBD_media_prev:     extend = true; code = 0x10; break;
+        case KBD_zoom_out:       extend = true; code = 0x11; break;
+        case KBD_log_off:        extend = true; code = 0x16; break;
         case KBD_cut:            extend = true; code = 0x17; break;
         case KBD_copy:           extend = true; code = 0x18; break;
         case KBD_media_next:     extend = true; code = 0x19; break;
@@ -193,6 +197,7 @@ std::vector<uint8_t> KEYBOARD_GetScanCode1(const KBD_KEYS key_type,
         case KBD_vol_mute:       extend = true; code = 0x20; break;
         case KBD_calculator:     extend = true; code = 0x21; break;
         case KBD_media_play:     extend = true; code = 0x22; break;
+        case KBD_spell:          extend = true; code = 0x23; break;
         case KBD_media_stop:     extend = true; code = 0x24; break;
         case KBD_media_eject:    extend = true; code = 0x2c; break;
         case KBD_vol_down:       extend = true; code = 0x2e; break;
@@ -202,19 +207,28 @@ std::vector<uint8_t> KEYBOARD_GetScanCode1(const KBD_KEYS key_type,
         case KBD_rightalt:       extend = true; code = 0x38; break;
         case KBD_help:           extend = true; code = 0x3b; break;
         case KBD_media_music:    extend = true; code = 0x3c; break;
+        case KBD_new:            extend = true; code = 0x3e; break;
+        case KBD_open:           extend = true; code = 0x3f; break;
+        case KBD_close:          extend = true; code = 0x40; break;
+        case KBD_reply:          extend = true; code = 0x41; break;
+        case KBD_forward:        extend = true; code = 0x42; break;
+        case KBD_send:           extend = true; code = 0x43; break;
         case KBD_home:           extend = true; code = 0x47; break;
         case KBD_up:             extend = true; code = 0x48; break;
         case KBD_pageup:         extend = true; code = 0x49; break;
         case KBD_left:           extend = true; code = 0x4b; break;
+        case KBD_my_documents:   extend = true; code = 0x4c; break;
         case KBD_right:          extend = true; code = 0x4d; break;
         case KBD_end:            extend = true; code = 0x4f; break;
         case KBD_down:           extend = true; code = 0x50; break;
         case KBD_pagedown:       extend = true; code = 0x51; break;
         case KBD_insert:         extend = true; code = 0x52; break;
         case KBD_delete:         extend = true; code = 0x53; break;
+        case KBD_save:           extend = true; code = 0x57; break;
+        case KBD_print:          extend = true; code = 0x58; break;
         case KBD_leftgui:        extend = true; code = 0x5b; break;
         case KBD_rightgui:       extend = true; code = 0x5c; break;
-        case KBD_application:    extend = true; code = 0x5d; break;
+        case KBD_guimenu:        extend = true; code = 0x5d; break;
         case KBD_acpi_power:     extend = true; code = 0x5e; break;
         case KBD_acpi_sleep:     extend = true; code = 0x5f; break;
         case KBD_acpi_wake:      extend = true; code = 0x63; break;
@@ -228,8 +242,14 @@ std::vector<uint8_t> KEYBOARD_GetScanCode1(const KBD_KEYS key_type,
         case KBD_my_computer:    extend = true; code = 0x6b; break;
         case KBD_email:          extend = true; code = 0x6c; break;
         case KBD_media_select:   extend = true; code = 0x6d; break;
+        case KBD_favorite1:      extend = true; code = 0x73; break;
+        case KBD_favorite2:      extend = true; code = 0x74; break;
+        case KBD_favorite3:      extend = true; code = 0x75; break;
+        case KBD_favorite4:      extend = true; code = 0x76; break;
+        case KBD_favorite5:      extend = true; code = 0x77; break;
+        case KBD_favorites:      extend = true; code = 0x78; break;
 
-		// clang-format on
+	// clang-format on
 
 	case KBD_pause:
 		if (is_pressed) {
@@ -276,7 +296,7 @@ std::vector<uint8_t> KEYBOARD_GetScanCode2(const KBD_KEYS key_type,
 	bool extend  = false;
 
 	switch (key_type) {
-		// clang-format off
+	// clang-format off
 
         case KBD_f9:             code = 0x01; break;
         case KBD_f5:             code = 0x03; break;
@@ -388,55 +408,75 @@ std::vector<uint8_t> KEYBOARD_GetScanCode2(const KBD_KEYS key_type,
 
         // Extended keys
 
+        case KBD_send:           extend = true; code = 0x01; break;
+        case KBD_open:           extend = true; code = 0x03; break;
         case KBD_help:           extend = true; code = 0x05; break;
         case KBD_media_music:    extend = true; code = 0x06; break;
+        case KBD_print:          extend = true; code = 0x07; break;
         case KBD_media_pictures: extend = true; code = 0x08; break;
+        case KBD_forward:        extend = true; code = 0x0a; break;
+        case KBD_close:          extend = true; code = 0x0b; break;
+        case KBD_new:            extend = true; code = 0x0c; break;
         case KBD_www_search:     extend = true; code = 0x10; break;
         case KBD_rightalt:       extend = true; code = 0x11; break;
         case KBD_rightctrl:      extend = true; code = 0x14; break;
         case KBD_media_prev:     extend = true; code = 0x15; break;
         case KBD_www_favorites:  extend = true; code = 0x18; break;
         case KBD_media_eject:    extend = true; code = 0x1a; break;
+        case KBD_zoom_out:       extend = true; code = 0x1d; break;
         case KBD_leftgui:        extend = true; code = 0x1f; break;
         case KBD_www_refresh:    extend = true; code = 0x20; break;
         case KBD_vol_down:       extend = true; code = 0x21; break;
         case KBD_vol_mute:       extend = true; code = 0x23; break;
+        case KBD_messenger:      extend = true; code = 0x25; break;
         case KBD_rightgui:       extend = true; code = 0x27; break;
         case KBD_www_stop:       extend = true; code = 0x28; break;
         case KBD_calculator:     extend = true; code = 0x2b; break;
-        case KBD_application:    extend = true; code = 0x2f; break;
+        case KBD_guimenu:        extend = true; code = 0x2f; break;
         case KBD_www_forward:    extend = true; code = 0x30; break;
         case KBD_vol_up:         extend = true; code = 0x32; break;
+        case KBD_spell:          extend = true; code = 0x33; break;
         case KBD_media_play:     extend = true; code = 0x34; break;
         case KBD_redo:           extend = true; code = 0x36; break;
         case KBD_acpi_power:     extend = true; code = 0x37; break;
         case KBD_www_back:       extend = true; code = 0x38; break;
         case KBD_www_home:       extend = true; code = 0x3a; break;
         case KBD_media_stop:     extend = true; code = 0x3b; break;
+        case KBD_log_off:        extend = true; code = 0x3c; break;
         case KBD_undo:           extend = true; code = 0x3d; break;
         case KBD_acpi_sleep:     extend = true; code = 0x3f; break;
         case KBD_my_computer:    extend = true; code = 0x40; break;
         case KBD_cut:            extend = true; code = 0x43; break;
         case KBD_copy:           extend = true; code = 0x44; break;
+        case KBD_zoom_in:        extend = true; code = 0x45; break;
         case KBD_paste:          extend = true; code = 0x46; break;
         case KBD_email:          extend = true; code = 0x48; break;
         case KBD_kpdivide:       extend = true; code = 0x4a; break;
         case KBD_media_next:     extend = true; code = 0x4d; break;
         case KBD_media_select:   extend = true; code = 0x50; break;
+        case KBD_favorite1:      extend = true; code = 0x51; break;
+        case KBD_favorite2:      extend = true; code = 0x53; break;
         case KBD_kpenter:        extend = true; code = 0x5a; break;
+        case KBD_favorite3:      extend = true; code = 0x5c; break;
         case KBD_acpi_wake:      extend = true; code = 0x5e; break;
+        case KBD_favorite4:      extend = true; code = 0x5f; break;
+        case KBD_favorite5:      extend = true; code = 0x62; break;
+        case KBD_favorites:      extend = true; code = 0x63; break;
         case KBD_end:            extend = true; code = 0x69; break;
         case KBD_left:           extend = true; code = 0x6b; break;
         case KBD_home:           extend = true; code = 0x6c; break;
         case KBD_insert:         extend = true; code = 0x70; break;
         case KBD_delete:         extend = true; code = 0x71; break;
         case KBD_down:           extend = true; code = 0x72; break;
+        case KBD_my_documents:   extend = true; code = 0x73; break;
         case KBD_right:          extend = true; code = 0x74; break;
         case KBD_up:             extend = true; code = 0x75; break;
+        case KBD_save:           extend = true; code = 0x78; break;
         case KBD_pagedown:       extend = true; code = 0x7a; break;
         case KBD_pageup:         extend = true; code = 0x7d; break;
+        case KBD_reply:          extend = true; code = 0x83; break;
 
-		// clang-format on
+	// clang-format on
 
 	case KBD_printscreen:
 		if (!is_pressed) {
@@ -625,7 +665,7 @@ std::vector<uint8_t> KEYBOARD_GetScanCode3(const KBD_KEYS key_type,
         case KBD_katakana:       code = 0x87; break;
         case KBD_leftgui:        code = 0x8b; break;
         case KBD_rightgui:       code = 0x8c; break;
-        case KBD_application :   code = 0x8d; break;
+        case KBD_guimenu :       code = 0x8d; break;
 
 		// clang-format on
 
@@ -648,6 +688,9 @@ std::vector<uint8_t> KEYBOARD_GetScanCode3(const KBD_KEYS key_type,
 	case KBD_acpi_power:
 	case KBD_acpi_sleep:
 	case KBD_acpi_wake:
+	case KBD_log_off:
+	case KBD_zoom_in:
+	case KBD_zoom_out:
 	case KBD_cut:
 	case KBD_copy:
 	case KBD_paste:
@@ -656,7 +699,18 @@ std::vector<uint8_t> KEYBOARD_GetScanCode3(const KBD_KEYS key_type,
 	case KBD_undo:
 	case KBD_calculator:
 	case KBD_my_computer:
+	case KBD_my_documents:
 	case KBD_email:
+	case KBD_messenger:
+	case KBD_new:
+	case KBD_open:
+	case KBD_close:
+	case KBD_save:
+	case KBD_print:
+	case KBD_spell:
+	case KBD_reply:
+	case KBD_forward:
+	case KBD_send:
 	case KBD_media_prev:
 	case KBD_media_next:
 	case KBD_media_play:
@@ -675,6 +729,13 @@ std::vector<uint8_t> KEYBOARD_GetScanCode3(const KBD_KEYS key_type,
 	case KBD_www_stop:
 	case KBD_www_forward:
 	case KBD_www_back:
+	case KBD_favorites:
+	case KBD_favorite1:
+	case KBD_favorite2:
+	case KBD_favorite3:
+	case KBD_favorite4:
+	case KBD_favorite5:
+
 		// TODO: do scan codes exist at all for these keys in set 3?
 		return {};
 


### PR DESCRIPTION
# Description

I briefly got my hands on a retro keyboard (photos below) - I've used the keyboard testing tool from the _DosLib_ package (a _DOSBox-X_ sideproject) to capture the scancodes of all the extra keys and added them to _DOSBox Staging_.

These scancodes are not currently mapped to the SDL keyboard kodes - we are not emulating multimedia keyboards yet, as these are only useful starting from _Windows 9x_. But I would like to keep the codes documented - 10 years from now it might be much harder to get this information.

![IMG_1547](https://github.com/user-attachments/assets/6a2c15d9-d772-4d5e-92dc-aa5643b6882d)

![IMG_1548](https://github.com/user-attachments/assets/68f9f6dc-4033-42f6-a338-fcbb5a50517b)


# Release notes

(none - no user visible changes)


# Manual testing

Checked that the keyboard input still works - the change only touches constants which are currently not used for anything.

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [x] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [x] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [x] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

