### PR TITLE
Add WIN32 compile definition to CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ include(CheckSymbolExists)
 
 if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
 	set(DOSBOX_PLATFORM_WINDOWS ON)
-	set(WIN32 ON)
+	add_compile_definitions(WIN32)
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
 	set(DOSBOX_PLATFORM_MACOS ON)
 	set(MACOSX ON)


### PR DESCRIPTION
# Description

I got Staging to build without the Visual Studio generator or msbuild at all.  I installed native Windows versions of CMake, Ninja, and LLVM and it works just like in Linux from the command line.  I'm using the same `release` template that uses Ninja.

Only small problem I ran into was some compile errors that `WIN32` is not defined.  I think the Windows headers have it defined as `__WIN32__` or something.  We were manually defining it in Meson.

I think that `set(WIN32, TRUE)` was trying to do this but that only sets a variable for use in CMake itself and I didn't see any other usage of `WIN32` in the build scripts.

# Manual testing

It builds!  It runs Doom!

The change has been manually tested on:

- [x] Windows
- [ ] macOS
- [ ] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

