### PR TITLE
Replace #if WIN32 with #ifdef WIN32

### DIFF
--- a/src/dos/program_intro.cpp
+++ b/src/dos/program_intro.cpp
@@ -57,7 +57,7 @@ void INTRO::DisplayMount(void) {
     /* Basic mounting has a version for each operating system.
         * This is done this way so both messages appear in the language file*/
     WriteOut(MSG_Get("PROGRAM_INTRO_MOUNT_START"));
-#if (WIN32)
+#ifdef WIN32
     WriteOut(MSG_Get("PROGRAM_INTRO_MOUNT_WINDOWS"));
 #else
     WriteOut(MSG_Get("PROGRAM_INTRO_MOUNT_OTHER"));

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -78,7 +78,7 @@
 
 static void switch_console_to_utf8()
 {
-#if WIN32
+#ifdef WIN32
 	constexpr uint16_t CodePageUtf8 = 65001;
 	if (!sdl.original_code_page) {
 		sdl.original_code_page = GetConsoleOutputCP();
@@ -92,7 +92,7 @@ static void switch_console_to_utf8()
 
 static void restore_console_encoding()
 {
-#if WIN32
+#ifdef WIN32
 	if (sdl.original_code_page) {
 		SetConsoleOutputCP(sdl.original_code_page);
 		sdl.original_code_page = 0;


### PR DESCRIPTION
# Description

Fixes a compile error when building with CMake + Ninja

My hunch I mentioned in #4189 was right.  Visual Studio inserts a preprocessor option to define `WIN32`.  It would be like compiling with `clang -DWIN32` which according to the Clang docs will define it to 1. "Define <macro> to <value> (or 1 if <value> omitted)"

Ninja does not insert this flag so it falls back to our `config.h` which defines it to nothing.

Most of these have been converted already.  After fixing these last 3 instances, it compiles successfully.

# Manual testing

Built with CMake + Ninja

The change has been manually tested on:

- [x] Windows
- [ ] macOS
- [ ] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

