### PR TITLE
Remove s390x and ppc64le platform builds & simplify workflow

### DIFF
--- a/.github/workflows/platforms.yml
+++ b/.github/workflows/platforms.yml
@@ -26,7 +26,7 @@ jobs:
   build_on_platform:
     name: ${{ matrix.name }}
     # The host should always be linux
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: repo-check
     if: needs.repo-check.outputs.has-commits == 'true'
     strategy:
@@ -36,22 +36,18 @@ jobs:
           - name: ARMv6 (Raspbian)
             arch: armv6
             distro: bookworm
+
           - name: ARMv7 (Debian “bookworm”)
             arch: armv7
             distro: bookworm
+
           - name: ARM64 (Ubuntu 22.04)
             arch: aarch64
             distro: ubuntu22.04
+
           - name: riscv64 (Ubuntu 22.04)
             arch: riscv64
-            distro: ubuntu22.04   
-          - name: s390x (Debian "bookworm")
-            arch: s390x
-            distro: bookworm
-          - name: ppc64le (Debian "bookworm")
-            arch: ppc64le
-            distro: bookworm
-            
+            distro: ubuntu22.04
 
     steps:
       - uses: actions/checkout@v4
@@ -87,19 +83,6 @@ jobs:
           # no secrets are present in the container state or logs.
           install: |
             case "${{ matrix.distro }}" in
-              ubuntu20.04|jessie|stretch|buster|bullseye)
-                # we only care about issues
-                apt-get -qq update  < /dev/null > /dev/null
-                apt-get -qq install git curl findutils procps tar zstd screenfetch \
-                                    < /dev/null > /dev/null
-                apt-get -qq install cmake g++ build-essential ccache libasound2-dev libgtest-dev \
-                                    libopusfile-dev libsdl2-dev zlib1g-dev libspeexdsp-dev libpng-dev \
-                                    < /dev/null > /dev/null
-                # Meson from Debian repository is too old for DOSBox Staging
-                apt-get -qq install python3-setuptools python3-pip \
-                                    < /dev/null > /dev/null
-                pip3 install meson ninja
-                ;;
               ubuntu22.04|bookworm)
                 # we only care about issues
                 apt-get -qq update  < /dev/null > /dev/null
@@ -108,17 +91,6 @@ jobs:
                 apt-get -qq install cmake g++ build-essential ccache meson libasound2-dev libgtest-dev \
                                     libopusfile-dev libsdl2-dev zlib1g-dev libspeexdsp-dev libpng-dev \
                                     < /dev/null > /dev/null
-                ;;
-              fedora*)
-                dnf -q -y update
-                dnf -q -y install git which curl findutils procps-ng tar zstd screenfetch
-                dnf -q -y install cmake desktop-file-utils gcc gcc-c++ gmock-devel gtest-devel \
-                                  libappstream-glib libatomic meson opusfile-devel SDL2-devel zlib-devel
-                ;;
-              alpine*)
-                apk update
-                apk add git
-                ;;
             esac
 
           run: |
@@ -139,7 +111,9 @@ jobs:
                   -Duse_alsa=false \
                   -Duse_zlib_ng=false \
                   build
+
             # Build
             meson compile -C build
+
             # Test
             meson test --num-processes 128 -t 0 -C build

--- a/.github/workflows/platforms.yml
+++ b/.github/workflows/platforms.yml
@@ -9,26 +9,10 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  repo-check:
-    name: Repository commit check
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          submodules: false
-
-      - id: commit-check
-        run: echo "has-commits=$(./scripts/has-commits-since.sh '24 hours ago')"  >> $GITHUB_OUTPUT
-    outputs:
-      has-commits: ${{ steps.commit-check.outputs.has-commits }}
-
   build_on_platform:
     name: ${{ matrix.name }}
     # The host should always be linux
     runs-on: ubuntu-22.04
-    needs: repo-check
-    if: needs.repo-check.outputs.has-commits == 'true'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
# Description

As per title. These were kcgen's pet projects, nobody is interested in maintaining them and they're extremely niche things.

The platform builds task runs every 24 hours via a cron trigger, but there was also an additional check to only run if there were actual commits in the last 24 hours. The problem with this is that when this condition is triggered, that counts as a successful run, but of course the workflow does nothing. This is confusing if one or more of the platform builds are broken because then we have failing builds interspersed with "fake" passing builds that do nothing.

Remainig platform builds are all green now here:
https://github.com/dosbox-staging/dosbox-staging/actions/runs/13329218085/job/37229233844?pr=4192

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

