### PR TITLE
Fix fast-forward when the Sound Canvas can't keep up

### DIFF
--- a/include/midi.h
+++ b/include/midi.h
@@ -239,9 +239,9 @@ void MIDI_Mute();
 void MIDI_Unmute();
 
 struct MidiWork {
-	std::vector<uint8_t> message      = {};
-	int num_pending_audio_frames      = 0;
-	MessageType message_type          = {};
+	std::vector<uint8_t> message = {};
+	int num_pending_audio_frames = 0;
+	MessageType message_type     = {};
 
 	// Default value constructor
 	MidiWork()                      = default;
@@ -250,8 +250,7 @@ struct MidiWork {
 
 	// Construct from movable values
 	MidiWork(std::vector<uint8_t>&& _message,
-	         const int _num_audio_frames_pending,
-	         const MessageType _message_type)
+	         const int _num_audio_frames_pending, const MessageType _message_type)
 	        : message(std::move(_message)),
 	          num_pending_audio_frames(_num_audio_frames_pending),
 	          message_type(_message_type)

--- a/include/midi.h
+++ b/include/midi.h
@@ -242,6 +242,7 @@ struct MidiWork {
 	std::vector<uint8_t> message = {};
 	int num_pending_audio_frames = 0;
 	MessageType message_type     = {};
+	double timestamp             = 0.0;
 
 	// Default value constructor
 	MidiWork()                      = default;
@@ -249,11 +250,12 @@ struct MidiWork {
 	MidiWork& operator=(MidiWork&&) = default;
 
 	// Construct from movable values
-	MidiWork(std::vector<uint8_t>&& _message,
-	         const int _num_audio_frames_pending, const MessageType _message_type)
+	MidiWork(std::vector<uint8_t>&& _message, const int _num_audio_frames_pending,
+	         const MessageType _message_type, const double _timestamp)
 	        : message(std::move(_message)),
 	          num_pending_audio_frames(_num_audio_frames_pending),
-	          message_type(_message_type)
+	          message_type(_message_type),
+	          timestamp(_timestamp)
 	{
 		// leave the source in a valid state
 		_message.clear();

--- a/src/midi/midi_fluidsynth.cpp
+++ b/src/midi/midi_fluidsynth.cpp
@@ -695,7 +695,8 @@ void MidiDeviceFluidSynth::SendMidiMessage(const MidiMessage& msg)
 
 	MidiWork work{std::move(message),
 	              GetNumPendingAudioFrames(),
-	              MessageType::Channel};
+	              MessageType::Channel,
+	              PIC_AtomicIndex()};
 
 	work_fifo.Enqueue(std::move(work));
 }
@@ -704,7 +705,12 @@ void MidiDeviceFluidSynth::SendMidiMessage(const MidiMessage& msg)
 void MidiDeviceFluidSynth::SendSysExMessage(uint8_t* sysex, size_t len)
 {
 	std::vector<uint8_t> message(sysex, sysex + len);
-	MidiWork work{std::move(message), GetNumPendingAudioFrames(), MessageType::SysEx};
+
+	MidiWork work{std::move(message),
+	              GetNumPendingAudioFrames(),
+	              MessageType::SysEx,
+	              PIC_AtomicIndex()};
+
 	work_fifo.Enqueue(std::move(work));
 }
 

--- a/src/midi/midi_mt32.cpp
+++ b/src/midi/midi_mt32.cpp
@@ -841,9 +841,12 @@ int MidiDeviceMt32::GetNumPendingAudioFrames()
 void MidiDeviceMt32::SendMidiMessage(const MidiMessage& msg)
 {
 	std::vector<uint8_t> message(msg.data.begin(), msg.data.end());
+
 	MidiWork work{std::move(message),
 	              GetNumPendingAudioFrames(),
-	              MessageType::Channel};
+	              MessageType::Channel,
+	              PIC_AtomicIndex()};
+
 	work_fifo.Enqueue(std::move(work));
 }
 
@@ -851,7 +854,12 @@ void MidiDeviceMt32::SendMidiMessage(const MidiMessage& msg)
 void MidiDeviceMt32::SendSysExMessage(uint8_t* sysex, size_t len)
 {
 	std::vector<uint8_t> message(sysex, sysex + len);
-	MidiWork work{std::move(message), GetNumPendingAudioFrames(), MessageType::SysEx};
+
+	MidiWork work{std::move(message),
+	              GetNumPendingAudioFrames(),
+	              MessageType::SysEx,
+	              PIC_AtomicIndex()};
+
 	work_fifo.Enqueue(std::move(work));
 }
 

--- a/src/midi/midi_soundcanvas.cpp
+++ b/src/midi/midi_soundcanvas.cpp
@@ -440,7 +440,7 @@ MidiDeviceSoundCanvas::~MidiDeviceSoundCanvas()
 
 int MidiDeviceSoundCanvas::GetNumPendingAudioFrames()
 {
-	const auto now_ms = PIC_FullIndex();
+	const auto now_ms = PIC_AtomicIndex();
 
 	// Wake up the channel and update the last rendered time datum.
 	assert(mixer_channel);

--- a/src/midi/midi_soundcanvas.cpp
+++ b/src/midi/midi_soundcanvas.cpp
@@ -469,7 +469,8 @@ void MidiDeviceSoundCanvas::SendMidiMessage(const MidiMessage& msg)
 
 	MidiWork work{std::move(message),
 	              GetNumPendingAudioFrames(),
-	              MessageType::Channel};
+	              MessageType::Channel,
+	              PIC_AtomicIndex()};
 
 	work_fifo.Enqueue(std::move(work));
 }
@@ -478,7 +479,12 @@ void MidiDeviceSoundCanvas::SendMidiMessage(const MidiMessage& msg)
 void MidiDeviceSoundCanvas::SendSysExMessage(uint8_t* sysex, size_t len)
 {
 	std::vector<uint8_t> message(sysex, sysex + len);
-	MidiWork work{std::move(message), GetNumPendingAudioFrames(), MessageType::SysEx};
+
+	MidiWork work{std::move(message),
+	              GetNumPendingAudioFrames(),
+	              MessageType::SysEx,
+	              PIC_AtomicIndex()};
+
 	work_fifo.Enqueue(std::move(work));
 }
 

--- a/src/midi/midi_soundcanvas.cpp
+++ b/src/midi/midi_soundcanvas.cpp
@@ -545,13 +545,25 @@ void MidiDeviceSoundCanvas::RenderAudioFramesToFifo(const int num_audio_frames)
 	}
 }
 
+bool is_work_fifo_backlogged = false;
+
 // The next MIDI work task is processed, which includes rendering audio frames
 // prior to sending channel and sysex messages to the plugin
 void MidiDeviceSoundCanvas::ProcessWorkFromFifo()
 {
-	const auto work = work_fifo.Dequeue();
+	auto work = work_fifo.Dequeue();
 	if (!work) {
 		return;
+	}
+
+	// Detect if the work FIFO is heavily backlogged and enter the special
+	// backlogged rendering mode. This happens in fast-forward mode if the
+	// Sound Canvas emulation can't keep up with the sped-up CPU emulation.
+	const auto delta_from_now    = PIC_AtomicIndex() - work->timestamp;
+	constexpr auto OneSecondInMs = 1000.0;
+
+	if (delta_from_now > OneSecondInMs) {
+		is_work_fifo_backlogged = true;
 	}
 
 #if 0
@@ -570,22 +582,99 @@ void MidiDeviceSoundCanvas::ProcessWorkFromFifo()
 		RenderAudioFramesToFifo(work->num_pending_audio_frames);
 	}
 
-	if (work->message_type == MessageType::Channel) {
-		assert(work->message.size() >= MaxMidiMessageLen);
-		clap.event_list.AddMidiEvent(work->message, 0);
+	AddClapEvent(*work);
+}
+
+void MidiDeviceSoundCanvas::AddClapEvent(const MidiWork& work)
+{
+	if (work.message_type == MessageType::Channel) {
+		assert(work.message.size() >= MaxMidiMessageLen);
+		clap.event_list.AddMidiEvent(work.message, 0);
 
 	} else {
-		assert(work->message_type == MessageType::SysEx);
-		clap.event_list.AddMidiSysExEvent(work->message, 0);
+		assert(work.message_type == MessageType::SysEx);
+		clap.event_list.AddMidiSysExEvent(work.message, 0);
 	}
+}
+
+void MidiDeviceSoundCanvas::RenderBacklogged()
+{
+	// This will only keep the MIDI events we must process (e.g. program
+	// change and SysEx messages).
+	ProcessWorkFromFifoBacklogged();
+
+	// We must drip-feed these essential MIDI events to the Sound Canvas
+	// emulation while in fast-forward mode and render a nominal sample now
+	// and then to keep the emulation ticking along. Batching them up in
+	// groups of 10 does the job fine.
+	//
+	// If we'd let them pile up and send them to the Sound Canvas in one big
+	// batch when exiting fast-forward mode, we'd overload the Sound Canvas'
+	// input buffers so not all messages would be processed. This would
+	// result in wrong-sounding instruments in many cases.
+	//
+	if (clap.event_list.Size() > 10) {
+		RenderAudioFramesToFifo();
+	}
+
+	if (!MIXER_FastForwardModeEnabled()) {
+		is_work_fifo_backlogged = false;
+
+		// Send All Notes Off message to all MIDI channels when exiting
+		// from fast-forward mode. This is the best we can do as we've
+		// skipped processing any Note On or Note Off messages while in
+		// fast-forward mode. There would be a lot of hanging notes if
+		// we don't do this.
+		for (uint8_t ch = 0; ch < NumMidiChannels; ++ch) {
+			const uint8_t status = MidiStatus::ControlChange | ch;
+			const std::vector<uint8_t> all_notes_off_msg = {
+			        status, MidiChannelMode::AllNotesOff};
+
+			clap.event_list.AddMidiEvent(all_notes_off_msg, 0);
+		}
+	}
+}
+
+void MidiDeviceSoundCanvas::ProcessWorkFromFifoBacklogged()
+{
+	auto work = work_fifo.Dequeue();
+	if (!work) {
+		return;
+	}
+
+	// If we're in backlogged mode when fast-forward is activated, it means
+	// the Sound Canvas can't keep up with the sped-up CPU emulation.
+	// Therefore, we need to minise the work to catch up. We can't just not
+	// process any MIDI evecnts at all; we need to keep processing program
+	// change, control change, etc. events, otherwise there's real chance
+	// the instrument sounds will be wrong when we resume normal playback.
+	// But we can drop all MIDI notes and bypass the actual audio rendering
+	// (we'll just render a few sample to keep the Sound Canvas emulation
+	// ticking along), and this way we can catch up and stay in sync with
+	// the CPU emulation.
+	//
+	if (const auto status = get_midi_status(work->message[0]);
+	    get_midi_message_type(status) == MessageType::Channel) {
+
+		if (status == MidiStatus::NoteOn || status == MidiStatus::NoteOff) {
+			// Drop all MIDI note messages as we won't render any audio
+			return;
+		}
+	}
+
+	AddClapEvent(*work);
 }
 
 // Keep the FIFO populated with freshly rendered buffers
 void MidiDeviceSoundCanvas::Render()
 {
 	while (work_fifo.IsRunning()) {
-		work_fifo.IsEmpty() ? RenderAudioFramesToFifo()
-		                    : ProcessWorkFromFifo();
+		if (is_work_fifo_backlogged) {
+			RenderBacklogged();
+		} else {
+			work_fifo.IsEmpty() ? RenderAudioFramesToFifo()
+			                    : ProcessWorkFromFifo();
+		}
 	}
 }
 

--- a/src/midi/midi_soundcanvas.h
+++ b/src/midi/midi_soundcanvas.h
@@ -92,10 +92,14 @@ public:
 private:
 	void MixerCallback(const int requested_audio_frames);
 	void ProcessWorkFromFifo();
+	void ProcessWorkFromFifoBacklogged();
 
 	int GetNumPendingAudioFrames();
 	void RenderAudioFramesToFifo(const int num_frames = 1);
 	void Render();
+	void RenderBacklogged();
+
+	void AddClapEvent(const MidiWork& work);
 
 	// Managed objects
 	MixerChannelPtr mixer_channel = nullptr;


### PR DESCRIPTION
# Description

This fixes a whole range of annoying issues and malfunctions when the Sound Canvas cannot keep up with the emulated machine in fast-forward mode. The issues include comically sped up music while the Sound Canvas is trying to catch up, music lagging far behind, music that keeps playing when exiting back to DOS, no music for a long period of time after releasing the fast-forward hotkey, and probably a few more.

Other audio devices are prone to the same issue (e.g. the MT-32 and the IMFC). This is a side-effect of the mixer rework, so a sort of a regression. I'll address those devices in subsequent PRs (the method will be the same).

# Release notes

N/A

# Manual testing

Tested with (Sound Canvas music + SB sound in all games):

- **Space Quest V: The Next Mutation**
- **Discworld**
- **Azrael's Tear** 

Space Quest V is a particularly good test because there are frequent program changes and MIDI chanel reprogrammings during the intro. One good test is to press fast-forward when the flashing ALERT sign appears in the intro and keep it down until the actual game starts. If not everything is done 100% correctly, there would be a lots of wrong instruments playing at the start of the game. Fast-forwarding during the first half of the intro is also a good test; that would result in hanging notes if the "All Notes Off" stuff is not done correctly.

Also tested with holding fast-forward down a minute. The audio almost instantenaously recovers when releasing the hotkey. Doing many short bursts in rapid succession also works fine. An extreme stress test is with cycles 1000 to make the CPU emulation run waaaaay faster than the Sound Canvas (do this in a release build for max speed) -- that works perfectly too.

The change has been manually tested on:

- [x] Windows
- [ ] macOS
- [ ] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

