### PR TITLE
Improve some mouse setting descriptions

### DIFF
--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -1126,7 +1126,7 @@ void DOSBOX_Init()
 	        "Can be disabled, dummy, mouse, modem, nullmodem, direct ('dummy' by default).\n"
 	        "Additional parameters must be on the same line in the form of\n"
 	        "parameter:value. The optional 'irq' parameter is common for all types.\n"
-	        "  - for 'mouse':      model (overrides the setting from the [mouse] section)\n"
+	        "  - for 'mouse':      model (optional; overrides the 'com_mouse_model' setting).\n"
 	        "  - for 'direct':     realport (required), rxdelay (optional).\n"
 	        "                      (e.g., realport:COM1, realport:ttyS0).\n"
 	        "  - for 'modem':      listenport, sock, bps (all optional).\n"

--- a/src/hardware/input/mouse_config.cpp
+++ b/src/hardware/input/mouse_config.cpp
@@ -383,10 +383,21 @@ static void config_init(Section_prop& secprop)
 	prop_bool = secprop.Add_bool("dos_mouse_driver", only_at_start, true);
 	assert(prop_bool);
 	prop_bool->Set_help(
-	        "Enable built-in DOS mouse driver (enabled by default).\n"
-	        "Notes:\n"
-	        "  - Disable if you intend to use original MOUSE.COM driver in emulated DOS.\n"
-	        "  - When guest OS is booted, built-in driver gets disabled automatically.");
+	        "Enable the built-in mouse driver (enabled by default). This results in the\n"
+	        "lowest possible latency and the smoothest mouse movement, so only disable it\n"
+	        "and load a real DOS mouse driver if it's really necessary (e.g., if a game is\n"
+	        "not compatible with the built-in driver).\n"
+	        "  on:   Enable the built-in mouse driver. `ps2_mouse_model` and\n"
+	        "        `com_mouse_model` have no effect on the built-in driver.\n"
+	        "  off:  Disable the built-in mouse driver (if you don't want mouse support or\n"
+	        "        you want to load a real DOS mouse driver). To use a real DOS driver\n"
+	        "        (e.g., MOUSE.COM or CTMOUSE.EXE), configure the mouse type with\n"
+	        "        `ps2_mouse_model` or `com_mouse_model`, then load the driver.\n"
+	        "        A real DOS driver might increase compatibility with some programs,\n"
+	        "        but will introduce more input latency.\n"
+	        "Note: The built-in driver is auto-disabled if you boot into real MS-DOS or\n"
+	        "      Windows 9x under DOSBox. Under Windows 3.x, the driver is not disabled,\n"
+	        "      but the Windows 3.x mouse driver takes over.");
 
 	prop_bool = secprop.Add_bool("dos_mouse_immediate", always, false);
 	assert(prop_bool);
@@ -413,11 +424,13 @@ static void config_init(Section_prop& secprop)
 	                      model_ps2_explorer_str,
 	                      model_ps2_nomouse_str});
 	prop_str->Set_help(
-	        "PS/2 AUX port mouse model:\n"
+	        "Set the PS/2 AUX port mouse model, or in other words, the type of the virtual\n"
+	        "mouse plugged into the emulated PS/2 mouse port ('explorer' by default).\n"
+	        "The setting has no effect on the built-in mouse driver (see 'dos_mouse_driver').\n"
 	        "  standard:      3 buttons, standard PS/2 mouse.\n"
 	        "  intellimouse:  3 buttons + wheel, Microsoft IntelliMouse.\n"
 	        "  explorer:      5 buttons + wheel, Microsoft IntelliMouse Explorer (default).\n"
-	        "  none:          no PS/2 mouse emulated.");
+	        "  none:          no PS/2 mouse.");
 
 	prop_str = secprop.Add_string("com_mouse_model",
 	                              only_at_start,
@@ -431,7 +444,9 @@ static void config_init(Section_prop& secprop)
 	                      model_com_3button_msm_str,
 	                      model_com_wheel_msm_str});
 	prop_str->Set_help(
-	        "COM (serial) port default mouse model:\n"
+	        "Set the default COM (serial) mouse model, or in other words, the type of the\n"
+	        "virtual mouse plugged into the emulated COM ports ('wheel+msm' by default).\n"
+	        "The setting has no effect on the built-in mouse driver (see 'dos_mouse_driver').\n"
 	        "  2button:      2 buttons, Microsoft mouse.\n"
 	        "  3button:      3 buttons, Logitech mouse;\n"
 	        "                mostly compatible with Microsoft mouse.\n"

--- a/src/hardware/input/mouse_config.cpp
+++ b/src/hardware/input/mouse_config.cpp
@@ -34,26 +34,26 @@
 
 CHECK_NARROWING();
 
-MouseConfig     mouse_config;
+MouseConfig mouse_config;
 MousePredefined mouse_predefined;
 
-constexpr auto capture_type_seamless_str  = "seamless";
-constexpr auto capture_type_onclick_str   = "onclick";
-constexpr auto capture_type_onstart_str   = "onstart";
-constexpr auto capture_type_nomouse_str   = "nomouse";
+constexpr auto capture_type_seamless_str = "seamless";
+constexpr auto capture_type_onclick_str  = "onclick";
+constexpr auto capture_type_onstart_str  = "onstart";
+constexpr auto capture_type_nomouse_str  = "nomouse";
 
 constexpr auto model_ps2_standard_str     = "standard";
 constexpr auto model_ps2_intellimouse_str = "intellimouse";
 constexpr auto model_ps2_explorer_str     = "explorer";
 constexpr auto model_ps2_nomouse_str      = "none";
 
-constexpr auto model_com_2button_str      = "2button";
-constexpr auto model_com_3button_str      = "3button";
-constexpr auto model_com_wheel_str        = "wheel";
-constexpr auto model_com_msm_str          = "msm";
-constexpr auto model_com_2button_msm_str  = "2button+msm";
-constexpr auto model_com_3button_msm_str  = "3button+msm";
-constexpr auto model_com_wheel_msm_str    = "wheel+msm";
+constexpr auto model_com_2button_str     = "2button";
+constexpr auto model_com_3button_str     = "3button";
+constexpr auto model_com_wheel_str       = "wheel";
+constexpr auto model_com_msm_str         = "msm";
+constexpr auto model_com_2button_msm_str = "2button+msm";
+constexpr auto model_com_3button_msm_str = "3button+msm";
+constexpr auto model_com_wheel_msm_str   = "wheel+msm";
 
 static const std::vector<uint16_t> list_rates = {
         // Commented out values are probably not interesting
@@ -61,7 +61,7 @@ static const std::vector<uint16_t> list_rates = {
         //  10",  // PS/2 mouse
         //  20",  // PS/2 mouse
         //  30",  // bus/InPort mouse
-        40,  // PS/2 mouse, approx. limit for 1200 baud serial mouse
+        40, // PS/2 mouse, approx. limit for 1200 baud serial mouse
         //  50,   // bus/InPort mouse
         60,  // PS/2 mouse, used by Microsoft Mouse Driver 8.20
         80,  // PS/2 mouse, approx. limit for 2400 baud serial mouse
@@ -251,21 +251,21 @@ static void SetSensitivity(const std::string_view sensitivity_str)
 	return;
 }
 
-static void config_read(Section *section)
+static void config_read(Section* section)
 {
 	assert(section);
-	const Section_prop *conf = dynamic_cast<Section_prop *>(section);
+	const Section_prop* conf = dynamic_cast<Section_prop*>(section);
 	assert(conf);
-	if (!conf)
+	if (!conf) {
 		return;
+	}
 
 	// Settings changeable during runtime
 
 	SetCaptureType(conf->Get_string("mouse_capture"));
 	SetSensitivity(conf->Get_string("mouse_sensitivity"));
 
-	mouse_config.multi_display_aware =
-		conf->Get_bool("mouse_multi_display_aware");
+	mouse_config.multi_display_aware = conf->Get_bool("mouse_multi_display_aware");
 
 	mouse_config.middle_release = conf->Get_bool("mouse_middle_release");
 	mouse_config.raw_input      = conf->Get_bool("mouse_raw_input");
@@ -303,15 +303,14 @@ static void config_read(Section *section)
 	mouse_config.is_vmware_mouse_enabled = conf->Get_bool("vmware_mouse");
 	mouse_config.is_virtualbox_mouse_enabled = conf->Get_bool("virtualbox_mouse");
 
-	if (!GFX_HaveDesktopEnvironment() &&
-	    mouse_config.is_virtualbox_mouse_enabled) {
-	    	// VirtualBox guest side driver is able to request us to re-use
-	    	// host side cursor (at least the 3rd party DOS driver does so)
-	    	// and we have no way to refuse, there seems to be no easy way
-	    	// to handle the situation gracefully in a no-desktop
-	    	// environment unless we want to display our own mouse cursor.
-	    	// Therefore, it is best to block the VirtualBox mouse API - it
-	    	// wasn't designed for such a use case.
+	if (!GFX_HaveDesktopEnvironment() && mouse_config.is_virtualbox_mouse_enabled) {
+		// VirtualBox guest side driver is able to request us to re-use
+		// host side cursor (at least the 3rd party DOS driver does so)
+		// and we have no way to refuse, there seems to be no easy way
+		// to handle the situation gracefully in a no-desktop
+		// environment unless we want to display our own mouse cursor.
+		// Therefore, it is best to block the VirtualBox mouse API - it
+		// wasn't designed for such a use case.
 		LOG_WARNING("MOUSE: VirtualBox interface cannot work in a no-desktop environment");
 		mouse_config.is_virtualbox_mouse_enabled = false;
 	}
@@ -321,7 +320,7 @@ static void config_read(Section *section)
 	MOUSE_StartupIfReady();
 }
 
-static void config_init(Section_prop &secprop)
+static void config_init(Section_prop& secprop)
 {
 	constexpr auto always        = Property::Changeable::Always;
 	constexpr auto only_at_start = Property::Changeable::OnlyAtStart;
@@ -331,8 +330,7 @@ static void config_init(Section_prop &secprop)
 
 	// General configuration
 
-	prop_str = secprop.Add_string("mouse_capture", always,
-	                              capture_type_onclick_str);
+	prop_str = secprop.Add_string("mouse_capture", always, capture_type_onclick_str);
 	assert(prop_str);
 	prop_str->Set_values({capture_type_seamless_str,
 	                      capture_type_onclick_str,
@@ -352,16 +350,18 @@ static void config_init(Section_prop &secprop)
 	        "For touch-screen control, use 'seamless'.");
 
 	prop_bool = secprop.Add_bool("mouse_middle_release", always, true);
-	prop_bool->Set_help("Release the captured mouse by middle-clicking, and also capture it in\n"
-	                    "seamless mode (enabled by default).");
+	prop_bool->Set_help(
+	        "Release the captured mouse by middle-clicking, and also capture it in\n"
+	        "seamless mode (enabled by default).");
 
 	prop_bool = secprop.Add_bool("mouse_multi_display_aware", always, true);
-	prop_bool->Set_help("Allow seamless mouse behavior and mouse pointer release to work in fullscreen\n"
-	                    "mode on systems with more than one display (enabled by default).\n"
-	                    "Note: You should disable this if it incorrectly detects multiple displays\n"
-	                    "      when only one should actually be used. This might happen if you are\n"
-	                    "      using mirrored display mode or using an AV receiver's HDMI input for\n"
-	                    "      audio-only listening.");
+	prop_bool->Set_help(
+	        "Allow seamless mouse behavior and mouse pointer release to work in fullscreen\n"
+	        "mode on systems with more than one display (enabled by default).\n"
+	        "Note: You should disable this if it incorrectly detects multiple displays\n"
+	        "      when only one should actually be used. This might happen if you are\n"
+	        "      using mirrored display mode or using an AV receiver's HDMI input for\n"
+	        "      audio-only listening.");
 
 	prop_str = secprop.Add_string("mouse_sensitivity", always, "100");
 	prop_str->Set_help(
@@ -447,13 +447,16 @@ static void config_init(Section_prop &secprop)
 	// VMM interfaces
 
 	prop_bool = secprop.Add_bool("vmware_mouse", only_at_start, true);
-	prop_bool->Set_help("VMware mouse interface (enabled by default).\n"
-	                    "Fully compatible only with experimental 3rd party Windows 3.1x driver.\n"
-	                    "Note: Requires PS/2 mouse to be enabled.");
+	prop_bool->Set_help(
+	        "VMware mouse interface (enabled by default).\n"
+	        "Fully compatible only with experimental 3rd party Windows 3.1x driver.\n"
+	        "Note: Requires PS/2 mouse to be enabled.");
+
 	prop_bool = secprop.Add_bool("virtualbox_mouse", only_at_start, true);
-	prop_bool->Set_help("VirtualBox mouse interface (enabled by default).\n"
-	                    "Fully compatible only with 3rd party Windows 3.1x driver.\n"
-	                    "Note: Requires PS/2 mouse to be enabled.");
+	prop_bool->Set_help(
+	        "VirtualBox mouse interface (enabled by default).\n"
+	        "Fully compatible only with 3rd party Windows 3.1x driver.\n"
+	        "Note: Requires PS/2 mouse to be enabled.");
 }
 
 void MOUSE_AddConfigSection(const ConfigPtr& conf)


### PR DESCRIPTION
# Description

This improves the descriptions of some mouse related settings. The main improvements are:

- Explain why the built-in driver is the preferred choice
- Spell out that `ps2_mouse_model` and `com_mouse_model` don't affect the built-in driver
- Spell out that you need to load a real DOS mouse driver manually if you want to use the serial mouse (or a PS/2 mouse with the built-in mouse driver disabled)

It was rather confusing to use these mouse-related settings without these extra details (see the discussion between @FeralChild64 and myself [here](https://github.com/dosbox-staging/dosbox-staging/issues/4197)).

One of the important points here is that we must spell out when a feature is only usable if the user _manually_ loads a driver -- this tripped me up big time!

Most of our features don't require the manual loading of a driver like on real DOS. E.g., Sound Blaster cards need some drivers or at least some mixer program to be loaded that initialises the card. But not so in DOSBox; you just set `sbtype`. Same deal for many other sound devices. Similarly, the various VESA extensions work without the user having to load a driver; you just set `vesa_mode`. 

One could argue that I should have known, yeah... but as all this mouse stuff is not in my head all the time like in @FeralChild64 's, it was not obvious to me what I needed to do. And if it's not obvious to me, it's rather likely that a not very technical user would be at least as confused as me. Then these nice features will remain unused, and we don't want that.

Also, `dos_mouse_driver` is not the greatest name, but I'm not changing that now. Maybe `emulated_mouse_driver` or `builtin_mouse_driver` would be better. I guess all DOS mouse drivers (real or emulated/built-in) qualify for the `dos_mouse_driver` name, so it doesn't say much 😏 

## Related issues

- https://github.com/dosbox-staging/dosbox-staging/issues/4197


# Release notes

Clarify the descriptions of some mouse related settings.


# Manual testing

![image](https://github.com/user-attachments/assets/0d18ffe4-1421-4494-85cc-eaf2e3ae9d56)

![image](https://github.com/user-attachments/assets/13345c93-99a1-4d52-97ec-131e9ea22d26)

![image](https://github.com/user-attachments/assets/c77cc81d-3907-4f49-ae8f-060d059dc5f7)

![image](https://github.com/user-attachments/assets/c0831fce-4218-4dbd-aaee-72085ef1a1ad)


The change has been manually tested on:

- [x] Windows
- [ ] macOS
- [ ] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

