### PR TITLE
Set CMAKE_EXPORT_COMPILE_COMMANDS by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.22)
 
 set(VCPKG_USE_HOST_TOOLS ON)
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON CACHE BOOL "Generate compile_commands.json for use with LSPs")
+
 project(dosbox-staging
 		LANGUAGES C CXX
 		VERSION 0.83.0


### PR DESCRIPTION
# Description

This generates the compile_commands.json file for use with LSPs.
Meson generates this file by default so this brings us to parity.
There's not any downside to having this on other than using 247KB of disk space.

# Manual testing

Did a successful build on Linux using vcpkg and confirmed it generated the compile_commands.json which works the same as Meson does for VSCode + clangd.

I think this will have no affect on Visual Studio builds (doesn't generate the file but doesn't hurt anything either).  It does work on Windows using Ninja though.  Haven't tested with this PR but I was manually setting `-DCMAKE_GENERATE_COMPILE_COMMANDS=ON` before.

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [x] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

