### PR TITLE
 Fix GUS resampling regression & emulate the GUS' output more authentically

### DIFF
--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -388,21 +388,45 @@ Gus::Gus(const io_port_t port_pref, const uint8_t dma_pref, const uint8_t irq_pr
 
 	assert(channel);
 
+	// We render at the GUS' internal mixer rate, then ZOH upsample to
+	// the native 44.1 kHz GUS rate. This emulates the behaviour of the
+	// real GF1 chip which always outputs a 44.1 kHz sample stream to
+	// the DAC, but starts dropping samples in the internal mixer above
+	// 14 active voices due to bandwidth limitations. Technically, we
+	// could emulate this exact behaviour, but in practice it would 
+	// make little to no difference compared to our current method.
+	//
+	channel->SetResampleMethod(ResampleMethod::ZeroOrderHoldAndResample);
+	channel->SetZeroOrderHoldUpsamplerTargetRate(GusOutputSampleRate);
+
 	// GUS is prone to accumulating beyond the 16-bit range so we scale back
 	// by RMS.
 	constexpr auto rms_squared = static_cast<float>(M_SQRT1_2);
 	channel->Set0dbScalar(rms_squared);
 
-	if (!channel->TryParseAndSetCustomFilter(filter_prefs)) {
-		if (filter_prefs != "off") {
-			LOG_WARNING("GUS: Invalid 'gus_filter' setting: '%s', using 'off'",
-			            filter_prefs.c_str());
+	// The filter parameters have been tweaked by analysing real hardware
+	// recordings of the GUS Classic (GF1 chip).
+	//
+	auto enable_filter = [&]() {
+		constexpr auto Order        = 1;
+		constexpr auto CutoffFreqHz = 8000;
+
+		channel->ConfigureLowPassFilter(Order, CutoffFreqHz);
+		channel->SetLowPassFilter(FilterState::On);
+	};
+
+	if (const auto maybe_bool = parse_bool_setting(filter_prefs)) {
+		if (*maybe_bool) {
+			enable_filter();
+		} else {
+			channel->SetLowPassFilter(FilterState::Off);
 		}
+	} else if (!channel->TryParseAndSetCustomFilter(filter_prefs)) {
+		LOG_WARNING("GUS: Invalid 'gus_filter' setting: '%s', using 'on'",
+		            filter_prefs.c_str());
 
-		channel->SetHighPassFilter(FilterState::Off);
-		channel->SetLowPassFilter(FilterState::Off);
-
-		set_section_property_value("gus", "gus_filter", "off");
+		set_section_property_value("gus", "gus_filter", "on");
+		enable_filter();
 	}
 
 	ms_per_render = MillisInSecond / channel->GetSampleRate();
@@ -434,9 +458,20 @@ void Gus::ActivateVoices(uint8_t requested_voices)
 		assert(active_voices <= voices.size());
 		active_voice_mask = 0xffffffffu >> (MAX_VOICES - active_voices);
 
-		// Gravis' calculation to convert from number of active voices
-		// to playback frame rate. Ref: UltraSound Lowlevel ToolKit
-		// v2.22 (21 December 1994), pp. 3 of 113.
+		// Authentically emulate the playback rate degradation
+		// dependent on the number of active voices (hardware
+		// channels) of the original GF1 chip found on the GUS
+		// Classic and MAX boards.
+		//
+		// The playback rate is 44.1 kHz up until 14 active voices,
+		// then it linearly drops to 19,293 Hz with all 32 voices
+		// enabled.
+		//
+		// Gravis' calculation to convert from number of active
+		// voices to playback frame rate. Ref: UltraSound
+		// Lowlevel ToolKit v2.22 (21 December 1994), pp. 3 of
+		// 113.
+		//
 		sample_rate_hz = ifloor(1000000.0 / (1.619695497 * active_voices));
 
 		ms_per_render = MillisInSecond / sample_rate_hz;
@@ -1571,11 +1606,12 @@ void init_gus_dosbox_settings(Section_prop& secprop)
 	int_prop->Set_values({"1", "3", "5", "6", "7"});
 	int_prop->Set_help("The DMA channel of the Gravis UltraSound (3 by default).");
 
-	auto* str_prop = secprop.Add_string("gus_filter", when_idle, "off");
+	auto* str_prop = secprop.Add_string("gus_filter", when_idle, "on");
 	assert(str_prop);
 	str_prop->Set_help(
 	        "Filter for the Gravis UltraSound audio output:\n"
-	        "  off:       Don't filter the output (default).\n"
+	        "  on:        Filter the output (default).\n"
+	        "  off:       Don't filter the output.\n"
 	        "  <custom>:  Custom filter definition; see 'sb_filter' for details.");
 
 	str_prop = secprop.Add_string("ultradir", when_idle, "C:\\ULTRASND");

--- a/src/hardware/gus.h
+++ b/src/hardware/gus.h
@@ -28,6 +28,8 @@
 // Global Constants
 // ----------------
 
+constexpr auto GusOutputSampleRate = 44100;
+
 // AdLib emulation state constant
 constexpr uint8_t ADLIB_CMD_DEFAULT = 85;
 


### PR DESCRIPTION
# Description

Previously, the output of the Gravis UltraSound was rendered at the GUS' internal mixer rate which is dependent on the number of active voices, then this output was LERP-upsampled to the host mixer rate, so typically to 44.1 or 48 kHz.

Typical GUS mixer rate examples:

- **Star Control II:** 28 active voices, 22050 Hz mixer sample rate

- **DOOM I & II:** 28 active voices, 22050 Hz mixer sample rate (with the maximum 8 sfx channels configured)

- **Pinball Fantasies:** 16 active voices, 38587 Hz mixer sample rate

This upsampling basically had a weird smoothing/low-pass filtering effect on the output which was not too far off from the GUS Classic sound _by fluke_.

My intention was to only keep the LERP upsampling for the `sb_filter = modern` mode, so nothing else would use it. But I made a mistake: I left the default resampling method at the LERP upsampler, so some audio devices like the GUS kept using it instead of the proper Speex resampler. I fixed the wrong default in this commit, and this is what introduced the "regression" (subtle change of behaviour is a better name for it): 76f6bd0744861d

So this changed the resampling method from LERP upsampling to Speex for the GUS, and that removed the high-end-smoothing effect of the LERP upsampler (if you use linear interpolation as a "poor man's upsampling method", that acts as wonky and slightly crappy lowpass filter). This made things sound subtly different in the high frequencies (subjectively, the top end became a bit harsher).

This PR introduces a better approach that gets us much closer to the actual GUS Classic sound:

- On real hardware, the GUS always outputs a 44.1 kHz sample stream to the DAC; the channel count dependent mixer rate degradation is achieved via dropping samples in the GUS mixer.

- Our GUS emulation renders at the mixer rate, but with ZOH upsampling to 44.1 kHz we can approximate this sample dropping and fixed 44.1 kHz output rate behaviour almost perfectly. We then resample this with Speex to the host rate which is usually 48 kHz.

- But this adds a lot of high-end, so we need to faithfully emulate the analog low-pass filter stage of the GUS as well. On real hardware, some gentle low-pass filtering starts from about 7-9 kHz; at 10kHz the drop is about -3 dB, and at 20kHz around -9 dB. A 6 dB/oct LPF from 8 kHz gets us very close to this sound (this has been tweaked by comparing the filtered output to real hardware GUS Classic recordings).

---

I'm also enabling the GUS by default in this PR. Why? Because the GUS is cool! 😎 It's configured not to conflict with the SB, should this shouldn't cause any problems with existing configs. @kklobe rejoice 🥳 

CPU usage is a non-issue as all audio channels are put to sleep after a few seconds of inactivity. So you'll only "pay for it" when something actually uses the GUS.

@Python-Exoproject You might wanna play it extra safe and add `gus = false` to your global config to disable the GUS by default.

## Reference recordings

- [Pinball Fantasies (GUS Classic)](https://www.youtube.com/watch?v=SyMMxKJN_cg)
- [Doom II (GUS Classic)](https://www.youtube.com/watch?v=yMZi-QPWnwU)
- [Star Control 2 (GUS ACE)](https://nerdlypleasures.blogspot.com/2016/10/reasons-for-owning-gravis-ultrasound.html)

## Other references

- [Gravis UltraSound frequency response](https://www.epanorama.net/documents/soundcardtest/gus_classic.html#)

From the article:

![gusout](https://github.com/user-attachments/assets/d1592ddb-9ae4-4854-9b67-b48297fd9d73)


## Related issues

Fixes https://github.com/dosbox-staging/dosbox-staging/issues/4212


# Release notes

### Gravis UltraSound changes

- The Gravis UltraSound is now enabled by default.

- Fix subtle Gravis UltraSound regression where the high-frequency content of the GUS's output was a little harsher than before. This was mostly only noticeable in music with lots of hi-hats and similar high-pitched sounds.

- Additionally, the sound of the Gravis UltraSound Classic and MAX models are emulated more faithfully now. This includes the emulation of the analog low-pass output filter which is enabled by default.


# Manual testing

Tested the following games and compared the output to real hardware recordings:

- Doom I
- Doom II
- Pinball Fantasies
- Star Control 2


The change has been manually tested on:

- [x] Windows
- [ ] macOS
- [ ] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [x] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

