### PR TITLE
Display the correct real or protected mode cycles value in the title bar

### DIFF
--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -254,6 +254,8 @@ static void set_modern_cycles_config(const CpuMode mode)
 	}
 }
 
+static bool is_protected_mode_program = false;
+
 void CPU_RestoreRealModeCyclesConfig()
 {
 	if (cpu.pmode || (!last_auto_determine_mode.auto_core &&
@@ -274,6 +276,7 @@ void CPU_RestoreRealModeCyclesConfig()
 			set_modern_cycles_config(CpuMode::Real);
 		}
 
+		is_protected_mode_program = false;
 		GFX_NotifyCyclesChanged();
 	}
 #if C_DYNAMIC_X86 || C_DYNREC
@@ -1776,6 +1779,8 @@ void CPU_SET_CRX(Bitu cr, Bitu value)
 				break;
 			}
 
+			is_protected_mode_program = true;
+
 #if C_DYNAMIC_X86
 			if (auto_determine_mode.auto_core) {
 				CPU_Core_Dyn_X86_Cache_Init(true);
@@ -2634,7 +2639,7 @@ std::string CPU_GetCyclesConfigAsString()
 			}
 		};
 
-		if (cpu.pmode) {
+		if (is_protected_mode_program) {
 			if (conf.protected_mode_auto) {
 				// 'cpu_cycles' controls both real and protected
 				// mode


### PR DESCRIPTION
# Description

This makes displaying the correct real or protected mode cycles value in the title bar 100% reliable and in sync with what's actually happening in the CPU emulation.

As it turns out, the `cpu.pmode` flag is being rapidly and continuously flip-flopping in many protected mode games and demos (e.g., in Nethack and DOOM). Not too sure why that's the case; maybe it happens when the program calls real-mode interrupts from pmode, or maybe it's some DOSBox-special quirk. But the flow-on effect is that looking at `cpu.pmode` is not a reliable way to update the cycles indicator in the title bar.

There is more info about dealing with real mode interrupts in pmode [here](https://www.delorie.com/djgpp/doc/ug/interrupts/inthandlers2.html), but frankly, I'm not going down that rabbit hole because the whole memory handling fiasco on pre-Windows 95 PCs is disgusting, and the good news is, I don't even need to do that to fix this 😎 

What we know for certain:

- Once a program switches to pmode, it stays there for good until the program exits back to DOS.
- The pmode / real mode switching in my revised `cpu_cycles` / `cpu_cycles_protected` model works correctly (if it wasn't, we'd be swamped with issue tickets by now).
- `cpu.pmode` is not a reliable way to detect whether the currently running _program_ uses pmode or not (regardless of the momentary state of the CPU emulation).

So we just need another flag that gets flipped when the program enters pmode for the first time, then reset it when it exits back to DOS. Which is exactly how my revised pmode/real mode cycles switching works.

Phew, this was an easy one, after all 🥳 


## Related issues

Fixed https://github.com/dosbox-staging/dosbox-staging/issues/4180


# Release notes

Fixed regression where sometimes the real mode cycles value was incorrectly displayed in the DOSBox Staging window's title bar in protected mode programs.


# Manual testing

- Nethack repro case from https://github.com/dosbox-staging/dosbox-staging/issues/4180 works fine.

- Also tested DOOM and Azrael's Tear with different real and protected mode cycles settings, then Alt-Tabbed in and out of the Staging window a couple of times (this forces a title bar refresh). Confirmed we always show the correct protected mode cycles value.

- Exited and restarted a few games and made sure the real / pmode switching is reflected correctly in the title bar.

The change has been manually tested on:

- [x] Windows
- [ ] macOS
- [ ] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [x] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

