### PR TITLE
Improve default crossfeed setting behaviour

### DIFF
--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -3063,7 +3063,11 @@ static void init_mixer_dosbox_settings(Section_prop& sec_prop)
 	        "           features lots of white noise).\n"
 	        "  normal:  Normal chorus that works well with a wide variety of games.\n"
 	        "  strong:  An obvious and upfront chorus effect.\n"
-	        "Note: You can fine-tune each channel's chorus level using the MIXER.");
+	        "\n"
+	        "Notes:\n"
+	        "  - The presets apply the chorus effect to the synth channels only (except\n"
+	        "    for synths with built-in chorus; e.g. the Roland MT-32).\n"
+	        "  - Use the MIXER command to fine-tune the chorus levels per channel.");
 	string_prop->Set_values({"off", "on", "light", "normal", "strong"});
 
 	MAPPER_AddHandler(handle_toggle_mute, SDL_SCANCODE_F8, PRIMARY_MOD, "mute", "Mute");

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -347,7 +347,11 @@ static void set_global_crossfeed(const MixerChannelPtr& channel)
 {
 	assert(channel);
 
-	if (!mixer.do_crossfeed || !channel->HasFeature(ChannelFeature::Stereo)) {
+	const auto apply_crossfeed = (channel->GetName() == ChannelName::Opl &&
+	                              channel->HasFeature(ChannelFeature::Stereo)) ||
+	                             (channel->GetName() == ChannelName::Cms);
+
+	if (!mixer.do_crossfeed || !apply_crossfeed) {
 		channel->SetCrossfeedStrength(0.0f);
 	} else {
 		channel->SetCrossfeedStrength(mixer.crossfeed.global_strength);
@@ -3010,13 +3014,20 @@ static void init_mixer_dosbox_settings(Section_prop& sec_prop)
 
 	auto string_prop = sec_prop.Add_string("crossfeed", WhenIdle, "off");
 	string_prop->Set_help(
-	        "Enable crossfeed globally on all stereo channels for headphone listening:\n"
+	        "Enable crossfeed on the OPL and CMS (Gameblaster) mixer channels. Many games\n"
+	        "pan the instruments 100%% left and 100%% right in the stereo field on these audio\n"
+	        "devices which is unpleasant to listen to in headphones. With crossfeed enabled,\n"
+	        "a portion of the left channel signal is mixed into the right channel and vice\n"
+	        "versa, creating a more natural listening experience.\n"
 	        "  off:     No crossfeed (default).\n"
 	        "  on:      Enable crossfeed (normal preset).\n"
 	        "  light:   Light crossfeed (strength 15).\n"
 	        "  normal:  Normal crossfeed (strength 40).\n"
 	        "  strong:  Strong crossfeed (strength 65).\n"
-	        "Note: You can fine-tune each channel's crossfeed strength using the MIXER.");
+	        "\n"
+	        "Notes:\n"
+	        "  - Use the MIXER command to apply crossfeed to other audio channels as well\n"
+	        "    and to fine-tune the crossfeed strength per channel.");
 	string_prop->Set_values({"off", "on", "light", "normal", "strong"});
 
 	string_prop = sec_prop.Add_string("reverb", WhenIdle, "off");

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -3045,7 +3045,12 @@ static void init_mixer_dosbox_settings(Section_prop& sec_prop)
 	        "           channels for music and digital audio.\n"
 	        "  huge:    A stronger variant of the large hall preset; works really well\n"
 	        "           in some games with more atmospheric soundtracks.\n"
-	        "Note: You can fine-tune each channel's reverb level using the MIXER.");
+	        "\n"
+	        "Notes:\n"
+	        "  - The presets apply a noticeable amount of reverb to the synth mixer channels\n"
+	        "    (except for synths with built-in reverb; e.g., the Roland MT-32), and a\n"
+	        "    subtle amount to the digital audio channels.\n"
+	        "  - Use the MIXER command to fine-tune the reverb levels per channel.");
 	string_prop->Set_values(
 	        {"off", "on", "tiny", "small", "medium", "large", "huge"});
 


### PR DESCRIPTION
# Description

Setting `crossfeed = on` previously enabled crossfeed on all active stereo channels with the default strength of 40. In retrospect, this wasn't such a great behaviour as it also enabled crossfeed for the `SB`, `GUS`, `MT32`, etc. channels which is rarely wanted.

This bit me in the ass when I was testing audio stuff in the last few days and haven't even realised for a while...

I only wanted to enable crossfeed on the OPL channel. Okay, so let's do this then in the global config:

```ini
[mixer]
crossfeed = on

[autoexec]
mixer x0 OPL x40
```

So `crossfeed = on` enabled crossfeed on all stereo channels with the default strength of 40, then `mixer x0` sets it to 0 on all active channels, then `OPL x40` sets it 40 on the OPL channel only. Well, this is already pretty convoluted and not very user friendly, but wait, it get worse...

If I launch a game with a local config that mounts a CD with `IMGMOUNT`, the CD mixer channel will became active _after_ my `mixer x0` command in the global config (remember, all global mixer commands only set stuff for the currently active channels, which is reasonable). So what happens is that when my `CD` channel pops into existence, it gets a crossfeed of 40 😐

IMO, this is all rather confusing and not that great, so I'm simplifying the crossfeed presets a bit.

In practice, 9 times out of 10 you only wanna set crossfeed for the OPL and CMS channels which typically feature hard-panned sounds. So I'm changing the behaviour of the `crossfeed` setting to do only apply to those two channels. Then people can add crossfeed to other mixer channels manually to their liking, but they should need that very rarely 
(e.g., a few GUS games that use hard-panned sounds, such as Pinball Dreams).

I've also enhanced the `chorus` and `reverb` setting descriptions a bit.

# Release notes

Enabling crossfeed (e.g., by setting `crossfeed = on` in the config) now only applies the crossfeed effect to the **OPL** and **CMS** channels. These are the two devices that typically feature hard-panned sounds. Previously, crossfeed presets applied to all stereo channels, but this was rarely wanted.  You can apply crossfeed to other channels as well with the `MIXER` command if you want (e.g., `MIXER GUS x50`).


# Manual testing

With `crossfeed = on` in the global config and mounting some ISOs in the local config, only the OPL channel has crossfeed enabled:

![image](https://github.com/user-attachments/assets/54f0829f-0086-440b-898e-ea3a58b0808a)

Crossfeed is only applied to Dual OPL2 and OPL3, but not to OPL2:

![image](https://github.com/user-attachments/assets/6cfe0c14-c718-4680-be74-4d3da17902bf)


The **CMS** channel has crossfeed applied to it too when enabled:

![image](https://github.com/user-attachments/assets/2bdbeccf-5a28-481c-b667-6e004e47999a)


### Setting descriptions

![image](https://github.com/user-attachments/assets/21c9c85d-f252-4268-8af3-4bc198d6172e)

![image](https://github.com/user-attachments/assets/844e807d-c7db-4de3-8df9-09087ba221b3)

![image](https://github.com/user-attachments/assets/a85d1166-7ca3-4514-b825-e1b2f88595f9)

The change has been manually tested on:

- [x] Windows
- [ ] macOS
- [ ] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [x] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

