### PR TITLE
Fix incorrect check cast in IMFC

### DIFF
--- a/src/hardware/imfc.cpp
+++ b/src/hardware/imfc.cpp
@@ -577,7 +577,8 @@ constexpr bool operator!=(const FractionalNote& a, const FractionalNote& b) noex
 constexpr FractionalNote operator-(const FractionalNote& a,
                                    const FractionalNote& b) noexcept
 {
-	const auto val = check_cast<uint16_t>(a.GetUint16() - b.GetUint16());
+	// 16-bit wrap-around is expected and normal
+	const auto val = static_cast<uint16_t>(a.GetUint16() - b.GetUint16());
 	return to_fractional_note(val);
 }
 


### PR DESCRIPTION
# Description

Tune 1 in the music disk IMFCDISK now doesn't trigger a debug assertion.

See https://github.com/dosbox-staging/dosbox-staging/issues/4200 for details.


## Related issues

Fixes https://github.com/dosbox-staging/dosbox-staging/issues/4200


# Release notes

None as it only affected the debug build.


# Manual testing

Listened to tune 1 for a few minutes, everything sounded perfect. Then also started tunes 2 and 3 to make sure the the emulated IMFC card didn't get into an invalid state or something. Everything sounds fine to me.


The change has been manually tested on:

- [x] Windows
- [ ] macOS
- [ ] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

