### PR TITLE
Allow graceful failure if OpenGL context could not be created

### DIFF
--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1313,11 +1313,10 @@ static SDL_Window* SetWindowMode(const RenderingBackend rendering_backend,
 #if C_OPENGL
 		if (rendering_backend == RenderingBackend::OpenGl) {
 			flags |= SDL_WINDOW_OPENGL;
-		}
-
-		if (SDL_GL_SetAttribute(SDL_GL_FRAMEBUFFER_SRGB_CAPABLE, 1)) {
-			LOG_ERR("OPENGL: Failed requesting an sRGB framebuffer: %s",
-			        SDL_GetError());
+			if (SDL_GL_SetAttribute(SDL_GL_FRAMEBUFFER_SRGB_CAPABLE, 1)) {
+				LOG_ERR("OPENGL: Failed requesting an sRGB framebuffer: %s",
+						SDL_GetError());
+			}
 		}
 #endif
 		if (!sdl.desktop.window.show_decorations) {

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1315,23 +1315,6 @@ static SDL_Window* SetWindowMode(const RenderingBackend rendering_backend,
 			flags |= SDL_WINDOW_OPENGL;
 		}
 
-		// We need a context to query the vendor string.
-		const auto temp_window = SDL_CreateWindow(
-		        "", 0, 0, 200, 200, SDL_WINDOW_OPENGL | SDL_WINDOW_HIDDEN);
-		if (temp_window == nullptr) {
-			LOG_ERR("SDL: Failed to create temporary window: %s",
-			        SDL_GetError());
-			return nullptr;
-		}
-		const auto temp_context = SDL_GL_CreateContext(temp_window);
-		if (temp_context == nullptr) {
-			LOG_ERR("OPENGL: Failed to create temporary context: %s",
-			        SDL_GetError());
-			return nullptr;
-		}
-
-		SDL_GL_DeleteContext(temp_context);
-		SDL_DestroyWindow(temp_window);
 		if (SDL_GL_SetAttribute(SDL_GL_FRAMEBUFFER_SRGB_CAPABLE, 1)) {
 			LOG_ERR("OPENGL: Failed requesting an sRGB framebuffer: %s",
 			        SDL_GetError());

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1330,6 +1330,14 @@ static SDL_Window* SetWindowMode(const RenderingBackend rendering_backend,
 
 		assert(sdl.window == nullptr); // enusre we don't leak
 		sdl.window = SDL_CreateWindow("", pos.x, pos.y, width, height, flags);
+		if (!sdl.window && rendering_backend == RenderingBackend::Texture && (flags & SDL_WINDOW_OPENGL)) {
+			// opengl_driver_crash_workaround() call above conditionally sets SDL_WINDOW_OPENGL.
+			// It sometimes gets this wrong (ex. SDL_VIDEODRIVER=dummy).
+			// This can only be determined reliably by trying SDL_CreateWindow().
+			// If we failed to create the window, try again without it.
+			flags &= ~SDL_WINDOW_OPENGL;
+			sdl.window = SDL_CreateWindow("", pos.x, pos.y, width, height, flags);
+		}
 		if (!sdl.window) {
 			LOG_ERR("SDL: Failed to create window: %s", SDL_GetError());
 			return nullptr;


### PR DESCRIPTION
# Description

These should be pretty safe changes. I removed some code leftover from an old workaround (removed in 3d7852b71e0d2874057162025bd477f8403b4f32) that was lingering around being useless and added a fallback to create a non-OpenGL window if we're using the Texture backend.

See commit messages for more details.

## Related issues

Fixes #4215

# Release notes

Fixes a crash when using "output = texture" with non-functional OpenGL drivers or hardware.
SDL_VIDEODRIVER=dummy now works if you want to use DOSBox heedlessly for some reason.

# Manual testing

- SDL_VIDEODRIVER=dummy works even if `output = opengl`. There was existing code to fallback to `output = texture` that was broken due to the temporary OpenGL context.
- `output = opengl` and `output = texture` continue to work as before with normal drivers.

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [x] Linux

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [x] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

