### PR TITLE
Replace infinity with max float in prop parser

### DIFF
--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -162,9 +162,9 @@ bool Value::SetInt(const std::string& in)
 bool Value::SetDouble(const std::string& in)
 {
 	std::istringstream input(in);
-	double result = std::numeric_limits<double>::infinity();
+	double result = std::numeric_limits<double>::max();
 	input >> result;
-	if (result == std::numeric_limits<double>::infinity()) {
+	if (result == std::numeric_limits<double>::max()) {
 		return false;
 	}
 	_double = result;


### PR DESCRIPTION
# Description

This replaces the use of `std::numeric_limits<double>::infinity()` as sentinel value in config file parser with `std::numeric_limits<double>::max()`. It seems that MSVC Clang disables the use of infinity and NaN by default as of recently so the check in `Value::SetDouble()` breaks which gets caught by the auto tests (you also get a warning notifying you of this).

```
..\..\src\misc\setup.cpp(165,18): warning : use of infinity is undefined behavior due to the currently enabled floating-point options [-Wnan-infinity-disabled]
..\..\src\misc\setup.cpp(167,16): warning : use of infinity is undefined behavior due to the currently enabled floating-point options [-Wnan-infinity-disabled]
```

# Release notes

None, not a user facing change.


# Manual testing

V_DOUBLE is actually not used anywhere, we have no floating point config parameters whatsoever. Auto tests, however, succeed with this fix.


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

