### PR TITLE
Fix meson setup warning

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -7,7 +7,7 @@ project(
     ).stdout().strip(),
 
     license: 'GPL-2.0-or-later',
-    meson_version: '>= 0.59.0',
+    meson_version: '>= 1.7.0',
     default_options: [
         'cpp_std=c++20',
         'buildtype=release',


### PR DESCRIPTION
# Description

Fix the following warning in the meson setup phase:

```
WARNING: Project specifies a minimum meson_version '>= 0.59.0' but uses features which were added in newer versions:
 * 1.7.0: {'dep 'atomic' custom lookup'}
```

# Manual testing

Checked that `meson` can still compile DOSBox and the warning is no longer printed.

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [x] Linux


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

