### PR TITLE
Change display names of bool conf settings to 'on' and 'off'

### DIFF
--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -3383,7 +3383,7 @@ void init_cpu_dosbox_settings(Section_prop& secprop)
 	        "cannot keep up (%s by default).\n"
 	        "Only affects fixed cycles settings. When enabled, the number of cycles per\n"
 	        "millisecond can vary; this might cause issues in some DOS programs.",
-	        (CpuThrottleDefault ? "enabled" : "disabled")));
+	        (CpuThrottleDefault ? "'on'" : "'off'")));
 
 	auto pint = secprop.Add_int("cycleup", Always, DefaultCpuCycleUp);
 	pint->SetMinMax(CpuCycleStepMin, CpuCycleStepMax);

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -736,17 +736,17 @@ void DOSBOX_Init()
 	        "               demoscene productions.");
 
 	pbool = secprop->Add_bool("vga_8dot_font", only_at_start, false);
-	pbool->Set_help("Use 8-pixel-wide fonts on VGA adapters (disabled by default).");
+	pbool->Set_help("Use 8-pixel-wide fonts on VGA adapters ('off' by default).");
 
 	pbool = secprop->Add_bool("vga_render_per_scanline", only_at_start, true);
 	pbool->Set_help(
-	        "Emulate accurate per-scanline VGA rendering (enabled by default).\n"
+	        "Emulate accurate per-scanline VGA rendering ('on' by default).\n"
 	        "Currently, you need to disable this for a few games, otherwise they will crash\n"
 	        "at startup (e.g., Deus, Ishar 3, Robinson's Requiem, Time Warriors).");
 
 	pbool = secprop->Add_bool("speed_mods", only_at_start, true);
 	pbool->Set_help(
-	        "Permit changes known to improve performance (enabled by default).\n"
+	        "Permit changes known to improve performance ('on' by default).\n"
 	        "Currently, no games are known to be negatively affected by this.\n"
 	        "Please file a bug with the project if you find a game that fails\n"
 	        "when this is enabled so we will list them here.");
@@ -767,7 +767,7 @@ void DOSBOX_Init()
 	pbool = secprop->Add_bool("automount", only_at_start, true);
 	pbool->Set_help(
 	        "Mount 'drives/[c]' directories as drives on startup, where [c] is a lower-case\n"
-	        "drive letter from 'a' to 'y' (enabled by default). The 'drives' folder can be\n"
+	        "drive letter from 'a' to 'y' ('on' by default). The 'drives' folder can be\n"
 	        "provided relative to the current directory or via built-in resources.\n"
 	        "Mount settings can be optionally provided using a [c].conf file along-side\n"
 	        "the drive's directory, with content as follows:\n"
@@ -793,13 +793,13 @@ void DOSBOX_Init()
 	pbool->Set_help(
 	        "Many games open all their files with writable permissions; even files that they\n"
 	        "never modify. This setting lets you write-protect those files while still\n"
-	        "allowing the game to read them (enabled by default). A second use-case: if\n"
-	        "you're using a copy-on-write or network-based filesystem, this setting avoids\n"
+	        "allowing the game to read them ('on' by default). A second use-case: if you're\n"
+	        "using a copy-on-write or network-based filesystem, this setting avoids\n"
 	        "triggering write operations for these write-protected files.");
 
 	pbool = secprop->Add_bool("shell_config_shortcuts", when_idle, true);
 	pbool->Set_help(
-	        "Allow shortcuts for simpler configuration management (enabled by default).\n"
+	        "Allow shortcuts for simpler configuration management ('on' by default).\n"
 	        "E.g., instead of 'config -set sbtype sb16', it is enough to execute\n"
 	        "'sbtype sb16', and instead of 'config -get sbtype', you can just execute\n"
 	        "the 'sbtype' command.");
@@ -824,7 +824,7 @@ void DOSBOX_Init()
 	secprop = control->AddSection_prop("voodoo", &VOODOO_Init);
 
 	pbool = secprop->Add_bool("voodoo", when_idle, true);
-	pbool->Set_help("Enable 3dfx Voodoo emulation (enabled by default).");
+	pbool->Set_help("Enable 3dfx Voodoo emulation ('on' by default).");
 
 	pstring = secprop->Add_string("voodoo_memsize", only_at_start, "4");
 	pstring->Set_values({"4", "12"});
@@ -853,8 +853,8 @@ void DOSBOX_Init()
 	pbool = secprop->Add_bool("voodoo_bilinear_filtering", only_at_start, false);
 	pbool->Set_help(
 	        "Use bilinear filtering to emulate the 3dfx Voodoo's texture smoothing effect\n"
-	        "(disabled by default). Only suggested if you have a fast desktop-class CPU, as\n"
-	        "it can impact frame rates on slower systems.");
+	        "('off' by default). Only suggested if you have a fast desktop-class CPU, as it\n"
+	        "can impact frame rates on slower systems.");
 
 	// Configure capture
 	CAPTURE_AddConfigSection(control);
@@ -991,7 +991,7 @@ void DOSBOX_Init()
 	secprop->AddInitFunction(&PS1AUDIO_Init, changeable_at_runtime);
 
 	pbool = secprop->Add_bool("ps1audio", when_idle, false);
-	pbool->Set_help("Enable IBM PS/1 Audio emulation (disabled by default).");
+	pbool->Set_help("Enable IBM PS/1 Audio emulation ('off' by default).");
 
 	pstring = secprop->Add_string("ps1audio_filter", when_idle, "on");
 	pstring->Set_help(
@@ -1063,25 +1063,23 @@ void DOSBOX_Init()
 
 	pbool = secprop->Add_bool("timed", when_idle, true);
 	pbool->Set_help(
-	        "Enable timed intervals for axis (enabled by default).\n"
+	        "Enable timed intervals for axis ('on' by default).\n"
 	        "Experiment with this option, if your joystick drifts away.");
 
 	pbool = secprop->Add_bool("autofire", when_idle, false);
-	pbool->Set_help(
-	        "Fire continuously as long as the button is pressed\n"
-	        "(disabled by default).");
+	pbool->Set_help("Fire continuously as long as the button is pressed ('off' by default)");
 
 	pbool = secprop->Add_bool("swap34", when_idle, false);
 	pbool->Set_help(
-	        "Swap the 3rd and the 4th axis (disabled by default).\n"
-	        "Can be useful for certain joysticks.");
+	        "Swap the 3rd and the 4th axis ('off' by default). Can be useful for certain\n"
+	        "joysticks.");
 
 	pbool = secprop->Add_bool("buttonwrap", when_idle, false);
-	pbool->Set_help("Enable button wrapping at the number of emulated buttons (disabled by default).");
+	pbool->Set_help("Enable button wrapping at the number of emulated buttons ('off' by default).");
 
 	pbool = secprop->Add_bool("circularinput", when_idle, false);
 	pbool->Set_help(
-	        "Enable translation of circular input to square output (disabled by default).\n"
+	        "Enable translation of circular input to square output ('off' by default).\n"
 	        "Try enabling this if your left analog stick can only move in a circle.");
 
 	pint = secprop->Add_int("deadzone", when_idle, 10);
@@ -1093,8 +1091,8 @@ void DOSBOX_Init()
 	pbool = secprop->Add_bool("use_joy_calibration_hotkeys", when_idle, false);
 	pbool->Set_help(
 	        "Enable hotkeys to allow realtime calibration of the joystick's X and Y axes\n"
-	        "(disabled by default). Only consider this if in-game calibration fails and\n"
-	        "other settings have been tried.\n"
+	        "('off' by default). Only consider this as a last resort if in-game calibration\n"
+	        "doesn't work correctly.\n"
 	        "  - Ctrl/Cmd+Arrow-keys adjust the axis' scalar value:\n"
 	        "      - Left and Right diminish or magnify the x-axis scalar, respectively.\n"
 	        "      - Down and Up diminish or magnify the y-axis scalar, respectively.\n"
@@ -1171,18 +1169,18 @@ void DOSBOX_Init()
 	secprop = control->AddSection_prop("dos", &DOS_Init);
 	secprop->AddInitFunction(&XMS_Init, changeable_at_runtime);
 	pbool = secprop->Add_bool("xms", when_idle, true);
-	pbool->Set_help("Enable XMS support (enabled by default).");
+	pbool->Set_help("Enable XMS support ('on' by default).");
 
 	secprop->AddInitFunction(&EMS_Init, changeable_at_runtime);
 	pstring = secprop->Add_string("ems", when_idle, "true");
 	pstring->Set_values({"true", "emsboard", "emm386", "off"});
 	pstring->Set_help(
-	        "Enable EMS support (enabled by default). Enabled provides the best\n"
-	        "compatibility but certain applications may run better with other choices,\n"
-	        "or require EMS support to be disabled to work at all.");
+	        "Enable EMS support ('on' by default). Enabled provides the best compatibility\n"
+	        "but certain applications may run better with other choices, or require EMS\n"
+	        "support to be disabled to work at all.");
 
 	pbool = secprop->Add_bool("umb", when_idle, true);
-	pbool->Set_help("Enable UMB support (enabled by default).");
+	pbool->Set_help("Enable UMB support ('on' by default).");
 
 	pstring = secprop->Add_string("pcjr_memory_config", only_at_start, "expanded");
 	pstring->Set_values({"expanded", "standard"});
@@ -1266,7 +1264,7 @@ void DOSBOX_Init()
 	secprop->AddInitFunction(&DOS_InitFileLocking, changeable_at_runtime);
 	pbool = secprop->Add_bool("file_locking", when_idle, true);
 	pbool->Set_help(
-	        "Enable file locking (SHARE.EXE emulation; enabled by default).\n"
+	        "Enable file locking (SHARE.EXE emulation; 'on' by default).\n"
 	        "This is required for some Windows 3.1x applications to work properly.\n"
 	        "It generally does not cause problems for DOS games except in rare cases\n"
 	        "(e.g., Astral Blur demo). If you experience crashes related to file\n"
@@ -1283,7 +1281,7 @@ void DOSBOX_Init()
 	secprop = control->AddInactiveSectionProp("ipx");
 #endif
 	pbool = secprop->Add_bool("ipx", when_idle, false);
-	pbool->SetOptionHelp("Enable IPX over UDP/IP emulation (disabled by default).");
+	pbool->SetOptionHelp("Enable IPX over UDP/IP emulation ('off' by default).");
 #if C_IPX
 	pbool->SetEnabledOptions({"ipx"});
 #endif
@@ -1298,7 +1296,7 @@ void DOSBOX_Init()
 	pbool->SetOptionHelp(
 	        "SLIRP",
 	        "Enable emulation of a Novell NE2000 network card on a software-based\n"
-	        "network (using libslirp) with properties as follows (enabled by default):\n"
+	        "network (using libslirp) with properties as follows ('on' by default):\n"
 	        "  - 255.255.255.0:  Subnet mask of the 10.0.2.0 virtual LAN.\n"
 	        "  - 10.0.2.2:       IP of the gateway and DHCP service.\n"
 	        "  - 10.0.2.3:       IP of the virtual DNS server.\n"

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -772,12 +772,12 @@ void DOSBOX_Init()
 	        "Mount settings can be optionally provided using a [c].conf file along-side\n"
 	        "the drive's directory, with content as follows:\n"
 	        "  [drive]\n"
-	        "  type    = dir, overlay, floppy, or cdrom\n"
-	        "  label   = custom_label\n"
-	        "  path    = path-specification, ie: path = %%path%%;c:\\tools\n"
+	        "  type     = dir, overlay, floppy, or cdrom\n"
+	        "  label    = custom_label\n"
+	        "  path     = path-specification (e.g., path = %%path%%;c:\\tools)\n"
 	        "  override_drive = mount the directory to this drive instead (default empty)\n"
-	        "  verbose = true or false\n"
-	        "  readonly = true or false");
+	        "  verbose  = on or off\n"
+	        "  readonly = on or off");
 
 	pstring = secprop->Add_string("startup_verbosity", only_at_start, "auto");
 	pstring->Set_values({"auto", "high", "low", "quiet"});
@@ -1175,7 +1175,7 @@ void DOSBOX_Init()
 
 	secprop->AddInitFunction(&EMS_Init, changeable_at_runtime);
 	pstring = secprop->Add_string("ems", when_idle, "true");
-	pstring->Set_values({"true", "emsboard", "emm386", "false"});
+	pstring->Set_values({"true", "emsboard", "emm386", "off"});
 	pstring->Set_help(
 	        "Enable EMS support (enabled by default). Enabled provides the best\n"
 	        "compatibility but certain applications may run better with other choices,\n"
@@ -1241,7 +1241,7 @@ void DOSBOX_Init()
 	// COMMAND.COM settings
 
 	pstring = secprop->Add_string("expand_shell_variable", when_idle, "auto");
-	pstring->Set_values({"auto", "true", "false"});
+	pstring->Set_values({"auto", "on", "off"});
 	pstring->Set_help(
 	        "Enable expanding environment variables such as %%PATH%% in the DOS command shell\n"
 	        "(auto by default, enabled if DOS version >= 7.0).\n"

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -4375,7 +4375,7 @@ static void config_add_sdl()
 
 	auto pbool = sdl_sec->Add_bool("fullscreen", always, false);
 	pbool->Set_help(
-	        "Start directly in fullscreen (disabled by default).\n"
+	        "Start directly in fullscreen ('off' by default).\n"
 	        "Run INTRO and see Special Keys for window control hotkeys.");
 
 	pstring = sdl_sec->Add_string("fullresolution", always, "desktop");
@@ -4402,7 +4402,7 @@ static void config_add_sdl()
 	        "             0,0 is the top-left corner of the screen.");
 
 	pbool = sdl_sec->Add_bool("window_decorations", always, true);
-	pbool->Set_help("Enable window decorations in windowed mode (enabled by default).");
+	pbool->Set_help("Enable window decorations in windowed mode ('on' by default).");
 
 	TITLEBAR_AddConfig(*sdl_sec);
 
@@ -4473,7 +4473,7 @@ static void config_add_sdl()
 	pbool->Set_help("Moved to [mouse] section and renamed to 'mouse_raw_input'.");
 
 	pbool = sdl_sec->Add_bool("waitonerror", always, true);
-	pbool->Set_help("Keep the console open if an error has occurred (enabled by default).");
+	pbool->Set_help("Keep the console open if an error has occurred ('on' by default).");
 
 	pmulti = sdl_sec->AddMultiVal("priority", always, " ");
 	pmulti->SetValue("auto auto");
@@ -4489,10 +4489,10 @@ static void config_add_sdl()
 	        ->Set_values({"auto", "lowest", "lower", "normal", "higher", "highest"});
 
 	pbool = sdl_sec->Add_bool("mute_when_inactive", on_start, false);
-	pbool->Set_help("Mute the sound when the window is inactive (disabled by default).");
+	pbool->Set_help("Mute the sound when the window is inactive ('off' by default).");
 
 	pbool = sdl_sec->Add_bool("pause_when_inactive", on_start, false);
-	pbool->Set_help("Pause emulation when the window is inactive (disabled by default).");
+	pbool->Set_help("Pause emulation when the window is inactive ('off' by default).");
 
 	pstring = sdl_sec->Add_path("mapperfile", always, MAPPERFILE);
 	pstring->Set_help(

--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -1583,7 +1583,7 @@ void init_gus_dosbox_settings(Section_prop& secprop)
 	auto* bool_prop = secprop.Add_bool("gus", when_idle, false);
 	assert(bool_prop);
 	bool_prop->Set_help(
-	        "Enable Gravis UltraSound emulation (disabled by default).\n"
+	        "Enable Gravis UltraSound emulation ('off' by default).\n"
 	        "The default settings of base address 240, IRQ 5, and DMA 3 have been chosen so\n"
 	        "the GUS can coexist with a Sound Blaster card. This works fine for the majority\n"
 	        "of programs, but some games and demos expect the GUS factory defaults of base\n"

--- a/src/hardware/imfc.cpp
+++ b/src/hardware/imfc.cpp
@@ -13453,13 +13453,13 @@ void init_imfc_dosbox_settings(Section_prop& secprop)
 
 	const auto bool_prop = secprop.Add_bool("imfc", when_idle, false);
 	assert(bool_prop);
-	bool_prop->Set_help("Enable the IBM Music Feature Card (disabled by default).");
+	bool_prop->Set_help("Enable the IBM Music Feature Card ('off' by default).");
 
 	const auto hex_prop = secprop.Add_hex("imfc_base", when_idle, 0x2A20);
 	assert(hex_prop);
 	hex_prop->Set_values({"2A20", "2A30"});
 	hex_prop->Set_help(
-	        "The IO base address of the IBM Music Feature Card (2A20 by default).");
+	        "The IO base address of the IBM Music Feature Card ('2A20' by default).");
 
 	const auto int_prop = secprop.Add_int("imfc_irq", when_idle, 3);
 	assert(int_prop);

--- a/src/hardware/input/mouse_config.cpp
+++ b/src/hardware/input/mouse_config.cpp
@@ -352,12 +352,12 @@ static void config_init(Section_prop& secprop)
 	prop_bool = secprop.Add_bool("mouse_middle_release", always, true);
 	prop_bool->Set_help(
 	        "Release the captured mouse by middle-clicking, and also capture it in\n"
-	        "seamless mode (enabled by default).");
+	        "seamless mode ('on' by default).");
 
 	prop_bool = secprop.Add_bool("mouse_multi_display_aware", always, true);
 	prop_bool->Set_help(
 	        "Allow seamless mouse behavior and mouse pointer release to work in fullscreen\n"
-	        "mode on systems with more than one display (enabled by default).\n"
+	        "mode on systems with more than one display ('on' by default).\n"
 	        "Note: You should disable this if it incorrectly detects multiple displays\n"
 	        "      when only one should actually be used. This might happen if you are\n"
 	        "      using mirrored display mode or using an AV receiver's HDMI input for\n"
@@ -375,18 +375,18 @@ static void config_init(Section_prop& secprop)
 	prop_bool = secprop.Add_bool("mouse_raw_input", always, true);
 	prop_bool->Set_help(
 	        "Enable to bypass your operating system's mouse acceleration and sensitivity\n"
-	        "settings (enabled by default). Works in fullscreen or when the mouse is\n"
-	        "captured in windowed mode.");
+	        "settings ('on' by default). Works in fullscreen or when the mouse is captured\n"
+	        "in windowed mode.");
 
 	// DOS driver configuration
 
 	prop_bool = secprop.Add_bool("dos_mouse_driver", only_at_start, true);
 	assert(prop_bool);
 	prop_bool->Set_help(
-	        "Enable the built-in mouse driver (enabled by default). This results in the\n"
-	        "lowest possible latency and the smoothest mouse movement, so only disable it\n"
-	        "and load a real DOS mouse driver if it's really necessary (e.g., if a game is\n"
-	        "not compatible with the built-in driver).\n"
+	        "Enable the built-in mouse driver ('on' by default). This results in the lowest\n"
+	        "possible latency and the smoothest mouse movement, so only disable it and load\n"
+	        "a real DOS mouse driver if it's really necessary (e.g., if a game is not\n"
+	        "compatible with the built-in driver).\n"
 	        "  on:   Enable the built-in mouse driver. `ps2_mouse_model` and\n"
 	        "        `com_mouse_model` have no effect on the built-in driver.\n"
 	        "  off:  Disable the built-in mouse driver (if you don't want mouse support or\n"
@@ -403,7 +403,7 @@ static void config_init(Section_prop& secprop)
 	assert(prop_bool);
 	prop_bool->Set_help(
 	        "Update mouse movement counters immediately, without waiting for interrupt\n"
-	        "(disabled by default). May improve gameplay, especially in fast-paced games\n"
+	        "('off' by default). May improve gameplay, especially in fast-paced games\n"
 	        "(arcade, FPS, etc.), as for some games it effectively boosts the mouse\n"
 	        "sampling rate to 1000 Hz, without increasing interrupt overhead.\n"
 	        "Might cause compatibility issues. List of known incompatible games:\n"
@@ -463,13 +463,13 @@ static void config_init(Section_prop& secprop)
 
 	prop_bool = secprop.Add_bool("vmware_mouse", only_at_start, true);
 	prop_bool->Set_help(
-	        "VMware mouse interface (enabled by default).\n"
-	        "Fully compatible only with experimental 3rd party Windows 3.1x driver.\n"
+	        "VMware mouse interface ('on' by default).\n"
+	        "with experimental 3rd party Windows 3.1x driver.\n"
 	        "Note: Requires PS/2 mouse to be enabled.");
 
 	prop_bool = secprop.Add_bool("virtualbox_mouse", only_at_start, true);
 	prop_bool->Set_help(
-	        "VirtualBox mouse interface (enabled by default).\n"
+	        "VirtualBox mouse interface ('on' by default).\n"
 	        "Fully compatible only with 3rd party Windows 3.1x driver.\n"
 	        "Note: Requires PS/2 mouse to be enabled.");
 }

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -2969,7 +2969,7 @@ static void init_mixer_dosbox_settings(Section_prop& sec_prop)
 	auto bool_prop = sec_prop.Add_bool("nosound", OnlyAtStart, false);
 	assert(bool_prop);
 	bool_prop->Set_help(
-	        "Enable silent mode (disabled by default).\n"
+	        "Enable silent mode ('off' by default).\n"
 	        "Sound is still emulated in silent mode, but DOSBox outputs no sound to the host.\n"
 	        "Capturing the emulated audio output to a WAV file works in silent mode.");
 

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -3723,7 +3723,7 @@ void init_sblaster_dosbox_settings(Section_prop& secprop)
 
 	auto pbool = secprop.Add_bool("sbmixer", when_idle, true);
 	pbool->Set_help(
-	        "Allow the Sound Blaster mixer to modify volume levels (enabled by default).\n"
+	        "Allow the Sound Blaster mixer to modify volume levels ('on' by default).\n"
 	        "Sound Blaster Pro 1 and later cards allow programs to set the volume of the\n"
 	        "digital audio (DAC), FM synth, and CD Audio output. These correspond to the\n"
 	        "SB, OPL, and CDAUDIO DOSBox mixer channels, respectively.\n"
@@ -3761,7 +3761,7 @@ void init_sblaster_dosbox_settings(Section_prop& secprop)
 
 	pbool = secprop.Add_bool("sb_filter_always_on", when_idle, false);
 	pbool->Set_help(
-	        "Force the Sound Blaster Pro 2 filter to be always on (disabled by default).\n"
+	        "Force the Sound Blaster Pro 2 filter to be always on ('off' by default).\n"
 	        "Other Sound Blaster models don't allow toggling the filter in software.");
 }
 

--- a/src/midi/midi.cpp
+++ b/src/midi/midi.cpp
@@ -932,7 +932,7 @@ void init_midi_dosbox_settings(Section_prop& secprop)
 
 	auto bool_prop = secprop.Add_bool("raw_midi_output", WhenIdle, false);
 	bool_prop->Set_help(
-	        "Enable raw, unaltered MIDI output (disabled by default).\n"
+	        "Enable raw, unaltered MIDI output ('off' by default).\n"
 	        "The MIDI drivers of many games don't fully conform to the MIDI standard,\n"
 	        "which makes editing the MIDI recordings of these games very error-prone and\n"
 	        "cumbersome in MIDI sequencers, often resulting in hanging or missing notes.\n"

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -479,9 +479,7 @@ void CONFIG::HandleHelpCommand(const std::vector<std::string>& pvars_in)
 				std::vector<Value> pv = p->GetValues();
 
 				if (p->Get_type() == Value::V_BOOL) {
-					// Possible values for boolean are true
-					// & false
-					possible_values += "true, false";
+					possible_values += "on, off";
 
 				} else if (p->Get_type() == Value::V_INT) {
 					// Print min & max for integer values if

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -196,7 +196,7 @@ std::string Value::ToString() const
 		oss << _hex;
 		break;
 	case V_INT: oss << _int; break;
-	case V_BOOL: oss << std::boolalpha << _bool; break;
+	case V_BOOL: oss << (_bool ? "on" : "off"); break;
 	case V_STRING: oss << _string; break;
 	case V_DOUBLE:
 		oss.precision(2);
@@ -1170,8 +1170,8 @@ bool Config::WriteConfig(const std_fs::path& path) const
 				// Percentage signs are encoded as '%%' in the
 				// config descriptions because they are sent
 				// through printf-like functions (e.g.,
-				// WriteOut()). So we need to de-escape them before
-				// writing them into the config.
+				// WriteOut()). So we need to de-escape them
+				// before writing them into the config.
 				auto s = format_str(help);
 
 				fprintf(outfile,
@@ -1213,7 +1213,8 @@ bool Config::WriteConfig(const std_fs::path& path) const
 				};
 
 				print_values("CONFIG_VALID_VALUES", p->GetValues());
-				print_values("CONFIG_DEPRECATED_VALUES", p->GetDeprecatedValues());
+				print_values("CONFIG_DEPRECATED_VALUES",
+				             p->GetDeprecatedValues());
 
 				fprintf(outfile, "\n");
 				fprintf(outfile, "#\n");

--- a/tests/setup_tests.cpp
+++ b/tests/setup_tests.cpp
@@ -113,14 +113,14 @@ TEST(Value, Hex)
 TEST(Value, Bool)
 {
 	Value test_value{true};
-	Value check_value("true", Value::V_BOOL);
+	Value check_value("on", Value::V_BOOL);
 	EXPECT_EQ(test_value.type, check_value.type);
 	EXPECT_EQ(test_value.type, Value::V_BOOL);
 	EXPECT_TRUE(test_value == check_value);
 	EXPECT_FALSE(test_value < check_value);
 	EXPECT_FALSE(check_value < test_value);
 	EXPECT_EQ(test_value.ToString(), check_value.ToString());
-	EXPECT_EQ(test_value.ToString(), "true");
+	EXPECT_EQ(test_value.ToString(), "on");
 	EXPECT_TRUE(test_value);
 }
 


### PR DESCRIPTION
# Description

The primary audience for DOSBox is gamers, not programmers, so we should avoid using terms that only a programmer would understand.

This change completely eradicates the use of `true` and `false` for toggle config settings (that we like to call "booleans" that nobody understands who isn't a mathematician or a programmer 😄). Now the displayable names for those settings are `on` and `off`.

From now on, if you write a new config with the `config -wc blah.conf` command, the config file will contain `on` and `off` for the toggle setting types.

Note we have already been accepting `false`, `off`, `disabled`, `0` and `none` for negative values, and `true`, `on`, `enabled`, and `1` for positive values, so this is a display-only change.

# Release notes

Probably it's not worth mentioning.


# Manual testing

![image](https://github.com/user-attachments/assets/14a7b8fd-05fd-416c-8859-93344f730ab8)

![image](https://github.com/user-attachments/assets/68fdac55-d313-4c4b-9920-91c66831ab52)

![image](https://github.com/user-attachments/assets/77381b98-d66e-4991-a3c7-53799edfd3ce)


The change has been manually tested on:

- [x] Windows
- [ ] macOS
- [ ] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

