### PR TITLE
Enable bilinear filtering for the 3dfx Voodoo by default

### DIFF
--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -824,14 +824,20 @@ void DOSBOX_Init()
 	secprop = control->AddSection_prop("voodoo", &VOODOO_Init);
 
 	pbool = secprop->Add_bool("voodoo", when_idle, true);
-	pbool->Set_help("Enable 3dfx Voodoo emulation ('on' by default).");
+	pbool->Set_help(
+	        "Enable 3dfx Voodoo emulation ('on' by default). This is authentic low-level\n"
+	        "emulation of the Voodoo card without any OpenGL passthrough, so it requires a\n"
+	        "powerful CPU. Most games need the DOS Glide driver called 'GLIDE2X.OVL' to be\n"
+	        "in the path for 3dfx mode to work. Many games include their own Glide driver\n"
+	        "variants, but for some you need to provide a suitable 'GLIDE2X.OVL' version.\n"
+	        "A small number of games integrate the Glide driver into their code, so they\n"
+	        "don't need 'GLIDE2X.OVL'.");
 
 	pstring = secprop->Add_string("voodoo_memsize", only_at_start, "4");
 	pstring->Set_values({"4", "12"});
 	pstring->Set_help(
-	        "Set the amount of video memory for 3dfx Voodoo graphics, either 4 or 12 MB.\n"
-	        "The memory is used by the Frame Buffer Interface (FBI) and Texture Mapping Unit\n"
-	        "(TMU) as follows:\n"
+	        "Set the amount of video memory for 3dfx Voodoo graphics. The memory is used by\n"
+	        "the Frame Buffer Interface (FBI) and Texture Mapping Unit (TMU) as follows:\n"
 	        "   4: 2 MB for the FBI and one TMU with 2 MB (default).\n"
 	        "  12: 4 MB for the FBI and two TMUs, each with 4 MB.");
 
@@ -853,7 +859,8 @@ void DOSBOX_Init()
 	pbool = secprop->Add_bool("voodoo_bilinear_filtering", only_at_start, true);
 	pbool->Set_help(
 	        "Use bilinear filtering to emulate the 3dfx Voodoo's texture smoothing effect\n"
-	        "('on' by default).");
+	        "('on' by default). Bilinear filtering can impact frame rates on slower systems;\n"
+	        "try turning it off if you're not getting adequate performance.");
 
 	// Configure capture
 	CAPTURE_AddConfigSection(control);

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -39,6 +39,7 @@
 #include "dos/dos_locale.h"
 #include "dos_inc.h"
 #include "hardware.h"
+#include "hardware/voodoo.h"
 #include "inout.h"
 #include "ints/int10.h"
 #include "mapper.h"
@@ -85,7 +86,6 @@ void FPU_Init(Section*);
 void DMA_Init(Section*);
 
 void PCI_Init(Section*);
-void VOODOO_Init(Section*);
 void VIRTUALBOX_Init(Section*);
 void VMWARE_Init(Section*);
 
@@ -821,46 +821,8 @@ void DOSBOX_Init()
 	secprop->AddInitFunction(&KEYBOARD_Init);
 	secprop->AddInitFunction(&PCI_Init); // PCI bus
 
-	secprop = control->AddSection_prop("voodoo", &VOODOO_Init);
-
-	pbool = secprop->Add_bool("voodoo", when_idle, true);
-	pbool->Set_help(
-	        "Enable 3dfx Voodoo emulation ('on' by default). This is authentic low-level\n"
-	        "emulation of the Voodoo card without any OpenGL passthrough, so it requires a\n"
-	        "powerful CPU. Most games need the DOS Glide driver called 'GLIDE2X.OVL' to be\n"
-	        "in the path for 3dfx mode to work. Many games include their own Glide driver\n"
-	        "variants, but for some you need to provide a suitable 'GLIDE2X.OVL' version.\n"
-	        "A small number of games integrate the Glide driver into their code, so they\n"
-	        "don't need 'GLIDE2X.OVL'.");
-
-	pstring = secprop->Add_string("voodoo_memsize", only_at_start, "4");
-	pstring->Set_values({"4", "12"});
-	pstring->Set_help(
-	        "Set the amount of video memory for 3dfx Voodoo graphics. The memory is used by\n"
-	        "the Frame Buffer Interface (FBI) and Texture Mapping Unit (TMU) as follows:\n"
-	        "   4: 2 MB for the FBI and one TMU with 2 MB (default).\n"
-	        "  12: 4 MB for the FBI and two TMUs, each with 4 MB.");
-
-	// Deprecate the boolean Voodoo multithreading setting
-	pbool = secprop->Add_bool("voodoo_multithreading", deprecated, false);
-	pbool->Set_help("Renamed to 'voodoo_threads'");
-
-	pstring = secprop->Add_string("voodoo_threads", only_at_start, "auto");
-	pstring->Set_help(
-	        "Use threads to improve 3dfx Voodoo performance:\n"
-	        "  auto:     Use up to 16 threads based on available CPU cores (default).\n"
-	        "  <value>:  Set a specific number of threads between 1 and 128.\n"
-	        "Note: Setting this to a higher value than the number of logical CPUs your\n"
-	        "      hardware supports is very likely to harm performance. This has been\n"
-	        "      measured to scale well up to 8-16 threads, but it has not been tested\n"
-	        "      on a many-core CPU. If you have a Threadripper or similar CPU, please\n"
-	        "      let us know how it goes.");
-
-	pbool = secprop->Add_bool("voodoo_bilinear_filtering", only_at_start, true);
-	pbool->Set_help(
-	        "Use bilinear filtering to emulate the 3dfx Voodoo's texture smoothing effect\n"
-	        "('on' by default). Bilinear filtering can impact frame rates on slower systems;\n"
-	        "try turning it off if you're not getting adequate performance.");
+	// Configure 3dfx Voodoo settings
+	VOODOO_AddConfigSection(control);
 
 	// Configure capture
 	CAPTURE_AddConfigSection(control);

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -850,11 +850,10 @@ void DOSBOX_Init()
 	        "      on a many-core CPU. If you have a Threadripper or similar CPU, please\n"
 	        "      let us know how it goes.");
 
-	pbool = secprop->Add_bool("voodoo_bilinear_filtering", only_at_start, false);
+	pbool = secprop->Add_bool("voodoo_bilinear_filtering", only_at_start, true);
 	pbool->Set_help(
 	        "Use bilinear filtering to emulate the 3dfx Voodoo's texture smoothing effect\n"
-	        "('off' by default). Only suggested if you have a fast desktop-class CPU, as it\n"
-	        "can impact frame rates on slower systems.");
+	        "('on' by default).");
 
 	// Configure capture
 	CAPTURE_AddConfigSection(control);

--- a/src/hardware/voodoo.cpp
+++ b/src/hardware/voodoo.cpp
@@ -7923,11 +7923,12 @@ PageHandler* VOODOO_PCI_GetLFBPageHandler(Bitu page) {
 	return (page >= (voodoo_current_lfb>>12) && page < (voodoo_current_lfb>>12) + VOODOO_PAGES ? voodoo_pagehandler : nullptr);
 }
 
-void VOODOO_Destroy(Section* /*sec*/) {
+
+static void voodoo_destroy(Section* /*sec*/) {
 	voodoo_shutdown();
 }
 
-void VOODOO_Init(Section* sec)
+static void voodoo_init(Section* sec)
 {
 	auto* section = dynamic_cast<Section_prop*>(sec);
 
@@ -7942,7 +7943,7 @@ void VOODOO_Init(Section* sec)
 
 	voodoo_bilinear_filtering = section->Get_bool("voodoo_bilinear_filtering");
 
-	sec->AddDestroyFunction(&VOODOO_Destroy,false);
+	sec->AddDestroyFunction(&voodoo_destroy, false);
 
 	// Check 64 KB alignment of LFB base
 	static_assert((PciVoodooLfbBase & 0xffff) == 0);
@@ -7961,3 +7962,59 @@ void VOODOO_Init(Section* sec)
 	        num_threads == 1 ? "thread" : "threads",
 	        (voodoo_bilinear_filtering ? "" : "no "));
 }
+
+static void init_voodoo_dosbox_settings(Section_prop& secprop)
+{
+	constexpr auto Deprecated  = Property::Changeable::Deprecated;
+	constexpr auto OnlyAtStart = Property::Changeable::OnlyAtStart;
+	constexpr auto WhenIdle    = Property::Changeable::WhenIdle;
+
+	auto* bool_prop = secprop.Add_bool("voodoo", WhenIdle, true);
+	bool_prop->Set_help(
+	        "Enable 3dfx Voodoo emulation ('on' by default). This is authentic low-level\n"
+	        "emulation of the Voodoo card without any OpenGL passthrough, so it requires a\n"
+	        "powerful CPU. Most games need the DOS Glide driver called 'GLIDE2X.OVL' to be\n"
+	        "in the path for 3dfx mode to work. Many games include their own Glide driver\n"
+	        "variants, but for some you need to provide a suitable 'GLIDE2X.OVL' version.\n"
+	        "A small number of games integrate the Glide driver into their code, so they\n"
+	        "don't need 'GLIDE2X.OVL'.");
+
+	auto* str_prop = secprop.Add_string("voodoo_memsize", OnlyAtStart, "4");
+	str_prop->Set_values({"4", "12"});
+	str_prop->Set_help(
+	        "Set the amount of video memory for 3dfx Voodoo graphics. The memory is used by\n"
+	        "the Frame Buffer Interface (FBI) and Texture Mapping Unit (TMU) as follows:\n"
+	        "   4: 2 MB for the FBI and one TMU with 2 MB (default).\n"
+	        "  12: 4 MB for the FBI and two TMUs, each with 4 MB.");
+
+	// Deprecate the boolean Voodoo multithreading setting
+	bool_prop = secprop.Add_bool("voodoo_multithreading", Deprecated, false);
+	bool_prop->Set_help("Renamed to 'voodoo_threads'");
+
+	str_prop = secprop.Add_string("voodoo_threads", OnlyAtStart, "auto");
+	str_prop->Set_help(
+	        "Use threads to improve 3dfx Voodoo performance:\n"
+	        "  auto:     Use up to 16 threads based on available CPU cores (default).\n"
+	        "  <value>:  Set a specific number of threads between 1 and 128.\n"
+	        "Note: Setting this to a higher value than the number of logical CPUs your\n"
+	        "      hardware supports is very likely to harm performance. This has been\n"
+	        "      measured to scale well up to 8-16 threads, but it has not been tested\n"
+	        "      on a many-core CPU. If you have a Threadripper or similar CPU, please\n"
+	        "      let us know how it goes.");
+
+	bool_prop = secprop.Add_bool("voodoo_bilinear_filtering", OnlyAtStart, true);
+	bool_prop->Set_help(
+	        "Use bilinear filtering to emulate the 3dfx Voodoo's texture smoothing effect\n"
+	        "('on' by default). Bilinear filtering can impact frame rates on slower systems;\n"
+	        "try turning it off if you're not getting adequate performance.");
+}
+
+void VOODOO_AddConfigSection(const ConfigPtr& conf)
+{
+	assert(conf);
+
+	Section_prop* sec = conf->AddSection_prop("voodoo", &voodoo_init);
+	assert(sec);
+	init_voodoo_dosbox_settings(*sec);
+}
+

--- a/src/hardware/voodoo.h
+++ b/src/hardware/voodoo.h
@@ -1,0 +1,26 @@
+/*
+ *  Copyright (C) 2025-2025  The DOSBox Staging Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#ifndef DOSBOX_VOODOO_H
+#define DOSBOX_VOODOO_H
+
+#include "control.h"
+
+void VOODOO_AddConfigSection(const ConfigPtr& conf);
+
+#endif // DOSBOX_VOODOO_H

--- a/vs/dosbox.vcxproj
+++ b/vs/dosbox.vcxproj
@@ -1104,6 +1104,7 @@ IF %ERRORLEVEL% LSS 8 SET ERRORLEVEL = 0</Command>
     <ClInclude Include="..\src\hardware\ston1_dac.h" />
     <ClInclude Include="..\src\hardware\tandy_sound.h" />
     <ClInclude Include="..\src\hardware\virtualbox.h" />
+    <ClInclude Include="..\src\hardware\voodoo.h" />
     <ClInclude Include="..\src\hardware\vmware.h" />
     <ClInclude Include="..\src\hardware\input\intel8042.h" />
     <ClInclude Include="..\src\hardware\input\intel8255.h" />

--- a/vs/dosbox.vcxproj.filters
+++ b/vs/dosbox.vcxproj.filters
@@ -1627,6 +1627,9 @@
     <ClInclude Include="..\src\hardware\tandy_sound.h">
       <Filter>src\hardware</Filter>
     </ClInclude>
+	<ClInclude Include="..\src\hardware\voodoo.h">
+      <Filter>src\hardware</Filter>
+    </ClInclude>
     <ClInclude Include="..\src\gui\render_loops.h">
       <Filter>src\gui</Filter>
     </ClInclude>


### PR DESCRIPTION
# Description

My understanding is we only disabled bilinear filtering for the Voodoo because of performance reasons, but I can't see any significant CPU usage difference between bilinear on and off in my recent tests when using the stock settings. Probably @weirddan455's nice threading improvements brought the "bilinear on" performance on par with the "bilinear off" path! 🎉 

For context, bilinear filtering was a big deal back in the day. It was impossible to do such smoothing via purely CPU-rendered texture mapping, so blocky pixelated rendering was considered yesterday's news--everybody wanted the bilinear-filtered wax figurine look of the Voodoo in 3D games 😆 That was _the shit_ in the late 90s in DOS circles among 3D enthusiasts! 😎 

So yeah, I think we should emulate the Voodoo as accurately as possible by default.

Some sample screenies with bilinear and no bilinear:

![lol2_1-filter](https://github.com/user-attachments/assets/1ffee763-b0d6-438d-b16a-6a82fe684e79)

![lol2_1-no-filter](https://github.com/user-attachments/assets/a32f1645-a0a8-41c3-bd58-0100a1d6af4b)

![lol2_2-filter](https://github.com/user-attachments/assets/4392e375-d740-4682-9b45-0bc921d1717a)

![lol2_2-no-filter](https://github.com/user-attachments/assets/8f57e204-2a68-4449-bff3-180e22a0200c)



# Release notes

- Bilinear filtering is now enabled by default on the 3dfx Voodoo to emulate the Voodoo look more accurately.

# Manual testing

I've also improved the config descriptions a little bit:

![image](https://github.com/user-attachments/assets/f02cbaf1-c14a-4f07-bc41-9f16c5403460)

The change has been manually tested on:

- [x] Windows
- [ ] macOS
- [ ] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [x] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

