### PR TITLE
Improve GUS config setting descriptions

### DIFF
--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -1584,11 +1584,17 @@ void init_gus_dosbox_settings(Section_prop& secprop)
 	assert(bool_prop);
 	bool_prop->Set_help(
 	        "Enable Gravis UltraSound emulation ('off' by default).\n"
-	        "The default settings of base address 240, IRQ 5, and DMA 3 have been chosen so\n"
-	        "the GUS can coexist with a Sound Blaster card. This works fine for the majority\n"
-	        "of programs, but some games and demos expect the GUS factory defaults of base\n"
-	        "address 220, IRQ 11, and DMA 1. The default IRQ 11 is also problematic with\n"
-	        "specific versions of the DOS4GW extender that cannot handle IRQs above 7.");
+	        "Many games and all demos upload their own sounds, but some rely on the\n"
+	        "instrument patch files included with the GUS for MIDI playback (see 'ultradir'\n"
+	        "for details). Some games also require ULTRAMID.EXE to be loaded prior to\n"
+	        "starting the game.\n"
+	        "\n"
+	        "Note: The default settings of base address 240, IRQ 5, and DMA 3 have been\n"
+	        "      chosen so the GUS can coexist with a Sound Blaster card. This works fine\n"
+	        "      for the majority of programs, but some games and demos expect the GUS\n"
+	        "      factory defaults of base address 220, IRQ 11, and DMA 1. The default\n"
+	        "      IRQ 11 is also problematic with specific versions of the DOS4GW extender\n"
+	        "      that cannot handle IRQs above 7.");
 
 	auto* hex_prop = secprop.Add_hex("gusbase", when_idle, 0x240);
 	assert(hex_prop);
@@ -1617,9 +1623,11 @@ void init_gus_dosbox_settings(Section_prop& secprop)
 	str_prop = secprop.Add_string("ultradir", when_idle, "C:\\ULTRASND");
 	assert(str_prop);
 	str_prop->Set_help(
-	        "Path to UltraSound directory ('C:\\ULTRASND' by default).\n"
-	        "In this directory, there should be a 'MIDI' directory that contains the patch\n"
-	        "files for GUS playback.");
+	        "Path to the UltraSound directory ('C:\\ULTRASND' by default).\n"
+	        "This should have a 'MIDI' subdirectory containing the patches (instrument\n"
+	        "files) required by some games for MIDI music playback. Not all games need these\n"
+	        "patches; many GUS-native games and all demos upload their own custom sounds\n"
+	        "instead.");
 }
 
 void GUS_AddConfigSection(const ConfigPtr& conf)


### PR DESCRIPTION
# Description

What it says on the tin.


# Release notes

N/A

# Manual testing

![image](https://github.com/user-attachments/assets/df51c6c9-4483-4d45-bf54-99859539d983)

![image](https://github.com/user-attachments/assets/9583efda-e800-4423-88b7-fbf537ad7d30)

The change has been manually tested on:

- [x] Windows
- [ ] macOS
- [ ] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

