### PR TITLE
Fix translation for keyb cmd

### DIFF
--- a/contrib/resources/translations/nl.lng
+++ b/contrib/resources/translations/nl.lng
@@ -3654,28 +3654,28 @@ Configureert een toetsenbord voor een specifieke taal.
 Gebruik:
   [color=light-green]keyb[reset]
   [color=light-green]keyb[reset] /list
-  [color=light-green]keyb[reset] [color=light-cyan]INDELING[reset] [[color=white]CODETABEL[reset]] /rom
-  [color=light-green]keyb[reset] [color=light-cyan]INDELING[reset] [[color=white]CODETABEL[reset] [[color=white]CPI-BESTAND[reset]]]
+  [color=light-green]keyb[reset] [color=light-cyan]INDELING[reset] [[color=white]CODEPAGINA[reset]] /rom
+  [color=light-green]keyb[reset] [color=light-cyan]INDELING[reset] [[color=white]CODEPAGINA[reset] [[color=white]CPI-BESTAND[reset]]]
 
 Parameters:
   [color=light-cyan]INDELING[reset]    Toetsenbordindelingscode
-  [color=white]CODETABEL[reset]  codepaginanummber, bijv. [color=white]437[reset] of [color=white]850[reset]
-  [color=white]CPI-BESTAND[reset]   schermlettertypebestand, in CPI-formaat
-  /list     geeft beschikbare toetsenbordindelingscodes weer
-  /rom      Gebruik indien mogelijk het schermlettertype uit de ROM van de
-            beeldschermadapter
+  [color=white]CODEPAGINA[reset]  codepaginanummber, bijv. [color=white]437[reset] of [color=white]850[reset]
+  [color=white]CPI-BESTAND[reset] schermlettertypebestand, in CPI-formaat
+  /list       geeft beschikbare toetsenbordindelingscodes weer
+  /rom        Gebruik indien mogelijk het schermlettertype uit de ROM van de
+              beeldschermadapter
 
 Opmerkingen:
   - Als u [color=light-green]keyb[reset] uitvoert zonder argument, worden de momenteel geladen
     toetsenbordindeling en codepagina weergegeven.
   - Het [color=white]CPI-BESTAND[reset] moet, indien opgegeven, het schermlettertype bevatten voor
-    de gegeven [color=white]CODETABEL[reset].
+    de gegeven [color=white]CODEPAGINA[reset].
   - MS-DOS, DR-DOS en Windows NT formaten van de CPI bestanden worden direct
     ondersteund. De FreeDOS CPX bestanden moeten eerst worden uitgepakt met de
     3rd party [color=light-green]upx[reset] tool.
   - Als er geen aangepast [color=white]CPI-BESTAND[reset] is opgegeven, zoekt de opdracht naar een
     geschikt schermlettertype in de gebundelde CPI-bestanden.
-  - Als [color=white]CODETABEL[reset] niet is opgegeven en het schermlettertype van de ROM van de
+  - Als [color=white]CODEPAGINA[reset] niet is opgegeven en het schermlettertype van de ROM van de
     beeldschermadapter geschikt is, wordt het schermlettertype van de ROM
     gebruikt.
   - Alleen EGA of betere beeldschermadapters maken het mogelijk om het


### PR DESCRIPTION
# Description

Fix the help text for the keyb command.

## Related issues

none

# Release notes

none

# Manual testing

ran and verified the output

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [ x] Linux


# Checklist

I have:

- [ x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [ x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [ x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

