### PR TITLE
Add custom vcpkg overlay port for FluidSynth

### DIFF
--- a/src/midi/CMakeLists.txt
+++ b/src/midi/CMakeLists.txt
@@ -21,6 +21,11 @@ if (C_ALSA)
 	target_link_libraries(libmidi PRIVATE ALSA::ALSA)
 endif()
 
+if (C_COREMIDI)
+	target_link_libraries(libmidi PRIVATE "-framework CoreFoundation")
+	target_link_libraries(libmidi PRIVATE "-framework CoreMIDI")
+endif()
+
 target_link_libraries(libmidi PRIVATE
 		$<IF:$<TARGET_EXISTS:SDL2::SDL2>,SDL2::SDL2,SDL2::SDL2-static>
 		libaudio

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,0 +1,5 @@
+{
+  "overlay-ports": [
+    "./vcpkg-ports"
+  ]
+}

--- a/vcpkg-ports/fluidsynth/gentables.patch
+++ b/vcpkg-ports/fluidsynth/gentables.patch
@@ -1,0 +1,51 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index e86a6429..9240e091 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -538,6 +538,9 @@ install(EXPORT FluidSynthTargets
+ 
+ # ******* Auto Generated Lookup Tables ******
+ 
++if(VCPKG_BUILD_MAKE_TABLES)
++    add_subdirectory(gentables)
++elseif(0)
+ include(ExternalProject)
+ 
+ set (GENTAB_SDIR ${CMAKE_CURRENT_SOURCE_DIR}/gentables)
+@@ -557,4 +560,11 @@ ExternalProject_Add(gentables
+         "${CMAKE_COMMAND}" --build "${GENTAB_BDIR}"
+     INSTALL_COMMAND ${GENTAB_BDIR}/make_tables.exe "${FluidSynth_BINARY_DIR}/"
+ )
++endif()
++if(TARGET make_tables AND NOT CMAKE_CROSSCOMPILING)
++    set(GENTABLES make_tables)
++else()
++    find_program(GENTABLES make_tables REQUIRED)
++endif()
++add_custom_target(gentables COMMAND "${GENTABLES}" "${CMAKE_BINARY_DIR}/")
+ add_dependencies(libfluidsynth-OBJ gentables)
+diff --git a/src/gentables/CMakeLists.txt b/src/gentables/CMakeLists.txt
+index 9cb69f2b..c393a670 100644
+--- a/src/gentables/CMakeLists.txt
++++ b/src/gentables/CMakeLists.txt
+@@ -12,6 +12,7 @@ unset(ENV{LDFLAGS})
+ 
+ project (gentables C)
+ 
++if (0)
+ set ( CMAKE_BUILD_TYPE Debug )
+ 
+ # hardcode ".exe" as suffix to the binary, else in case of cross-platform cross-compiling the calling cmake will not know the suffix used here and fail to find the binary
+@@ -20,6 +21,7 @@ set ( CMAKE_EXECUTABLE_SUFFIX ".exe" )
+ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG ${CMAKE_BINARY_DIR})
+ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR})
++endif()
+ 
+ # Add the executable that generates the table
+ add_executable( make_tables
+@@ -34,3 +36,4 @@ if ( WIN32 )
+ else ( WIN32 )
+     target_link_libraries (make_tables "m")
+ endif ()
++install(TARGETS make_tables DESTINATION bin)

--- a/vcpkg-ports/fluidsynth/portfile.cmake
+++ b/vcpkg-ports/fluidsynth/portfile.cmake
@@ -1,0 +1,80 @@
+if("pulseaudio" IN_LIST FEATURES)
+    message(
+    "${PORT} with pulseaudio feature currently requires the following from the system package manager:
+        libpulse-dev pulseaudio
+    These can be installed on Ubuntu systems via sudo apt install libpulse-dev pulseaudio"
+    )
+endif()
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO FluidSynth/fluidsynth
+    REF "v${VERSION}"
+    SHA512 35eaea8c1709ebbd5dee8f3946ab59c39afe31d92b972a44013fa23987aa48936f7d1326d5bda81c6e66f02bf988e48601367d49276a4dd78dbca7a2571f5e57
+    HEAD_REF master
+    PATCHES
+        gentables.patch
+)
+
+vcpkg_check_features(
+    OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        buildtools  VCPKG_BUILD_MAKE_TABLES
+        sndfile     enable-libsndfile
+        pulseaudio  enable-pulseaudio
+)
+
+set(OPTIONS_TO_ENABLE enable-floats)
+
+set(OPTIONS_TO_DISABLE enable-coverage enable-dbus enable-fpe-check enable-framework enable-jack
+    enable-libinstpatch enable-midishare enable-oboe enable-openmp enable-oss enable-pipewire enable-portaudio
+    enable-profiling enable-readline enable-sdl2 enable-sdl3 enable-systemd enable-trap-on-fpe enable-ubsan
+    enable-dsound enable-wasapi enable-waveout enable-winmidi enable-coreaudio enable-coremidi enable-alsa enable-opensles)
+
+foreach(_option IN LISTS OPTIONS_TO_ENABLE)
+    list(APPEND ENABLED_OPTIONS "-D${_option}:BOOL=ON")
+endforeach()
+    
+foreach(_option IN LISTS OPTIONS_TO_DISABLE)
+    list(APPEND DISABLED_OPTIONS "-D${_option}:BOOL=OFF")
+endforeach()
+
+vcpkg_find_acquire_program(PKGCONFIG)
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        "-DVCPKG_HOST_TRIPLET=${HOST_TRIPLET}"
+        ${FEATURE_OPTIONS}
+        ${ENABLED_OPTIONS}
+        ${DISABLED_OPTIONS}
+        "-DPKG_CONFIG_EXECUTABLE=${PKGCONFIG}"
+    MAYBE_UNUSED_VARIABLES
+        ${OPTIONS_TO_DISABLE}
+        VCPKG_BUILD_MAKE_TABLES
+        enable-coverage
+        enable-framework
+        enable-ubsan
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/fluidsynth)
+
+vcpkg_fixup_pkgconfig()
+
+set(tools fluidsynth)
+if("buildtools" IN_LIST FEATURES)
+    list(APPEND tools make_tables)
+endif()
+vcpkg_copy_tools(TOOL_NAMES ${tools} AUTO_CLEAN)
+
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+    "${CURRENT_PACKAGES_DIR}/share/man")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/vcpkg-ports/fluidsynth/usage
+++ b/vcpkg-ports/fluidsynth/usage
@@ -1,0 +1,5 @@
+The package fluidsynth provides CMake targets:
+
+    find_package(FluidSynth CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE FluidSynth::libfluidsynth)
+    add_custom_command(OUTPUT result COMMAND FluidSynth::fluidsynth ARGS ...)

--- a/vcpkg-ports/fluidsynth/vcpkg.json
+++ b/vcpkg-ports/fluidsynth/vcpkg.json
@@ -1,0 +1,48 @@
+{
+  "name": "fluidsynth",
+  "version": "2.3.5",
+  "description": "FluidSynth reads and handles MIDI events from the MIDI input device. It is the software analogue of a MIDI synthesizer. FluidSynth can also play midifiles using a Soundfont.",
+  "homepage": "https://github.com/FluidSynth/fluidsynth",
+  "license": "LGPL-2.1-or-later",
+  "supports": "!xbox",
+  "dependencies": [
+    {
+      "name": "fluidsynth",
+      "host": true,
+      "default-features": false,
+      "features": [
+        "buildtools"
+      ]
+    },
+    "glib",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "buildtools": {
+      "description": "Build tools gentables"
+    },
+    "pulseaudio": {
+      "description": "Build with PulseAudio support",
+      "supports": "linux"
+    },
+    "sndfile": {
+      "description": "Enable rendering to file and SF3 support",
+      "dependencies": [
+        {
+          "name": "libsndfile",
+          "default-features": false,
+          "features": [
+            "external-libs"
+          ]
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
# Description

Fixes regression in https://github.com/dosbox-staging/dosbox-staging/issues/4264

Changes made from upstream:
* Downgrade to 2.3.5
* Compile with enable-floats=on
* Disable system audio libraries (not needed to solve the regression but should give faster compile times and smaller binary)

## Related issues

#4264
https://github.com/dosbox-staging/dosbox-staging-ext/pull/1

# Release notes

Fix a FluidSynth regression on Windows that made SC-55 soundfonts sound incorrect.

# Manual testing

Tested the vcpkg + CMake build on Linux and the vcpkg + MSVC build on Windows.

The change has been manually tested on:

- [x] Windows
- [ ] macOS
- [x] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

