### PR TITLE
Bump vcpkg baseline

### DIFF
--- a/scripts/vcpkg-baseline-diff.sh
+++ b/scripts/vcpkg-baseline-diff.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+if [ "$#" -ne 2 ]; then
+  echo "Usage: $0 <old-baseline> <new-baseline>"
+  exit 1
+fi
+old="$1"
+new="$2"
+patterns=$(jq -r '.dependencies[] | if type=="string" then . else .name end' vcpkg.json | sed 's/.*/^[[:space:]]*-[[:space:]]*&([[:space:]]|$)/')
+vcpkg portsdiff "$old" "$new" | grep -Ef <(echo "$patterns")

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -24,5 +24,5 @@
       "host": true
     }
   ],
-  "builtin-baseline": "117512d870c0f260f4914b6b4bb006b9054b06eb"
+  "builtin-baseline": "9b75e789ece3f942159b8500584e35aafe3979ff"
 }


### PR DESCRIPTION
# Description

libffi was not building with CMake 4.0 on macOS, so I bumped the vcpkg baseline to the latest. Might as well get everything updated.

# Manual testing

Ran the usual test cases:

- Sunflower
- QTD
- Blood (Voodoo mode)
- moralhardcandy
- Unreal (Future Crew)

The change has been manually tested on:

- [ ] Windows
- [x] macOS
- [ ] Linux


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [ ] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

