### PR TITLE
Fix GUS Mix Control Register not getting reset to the correct value

### DIFF
--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -1119,7 +1119,7 @@ void Gus::Reset() noexcept
 	PIC_RemoveEvents(GUS_TimerEvent);
 
 	reset_register.data = {};
-	mix_control_register.data = {};
+	mix_control_register.data = MixControlRegisterDefaultState;
 }
 
 static void GUS_TimerEvent(uint32_t t)

--- a/src/hardware/gus.h
+++ b/src/hardware/gus.h
@@ -217,11 +217,13 @@ union ResetRegister {
 	bit_view<2, 1> are_irqs_enabled;
 };
 
+// Default state: lines disabled, latches enabled
+constexpr uint8_t MixControlRegisterDefaultState = 0b0000'1011;
+
 // Mix Control Register (2X0), section 2.13, page 28, of the UltraSound Software
 // Development Kit (SDK) Version 2.22
 union MixControlRegister {
-	// Default state: lines disabled, latches enabled
-	uint8_t data = 0b0000'1011;
+	uint8_t data = MixControlRegisterDefaultState;
 
 	bit_view<0, 1> line_in_disabled;
 	bit_view<1, 1> line_out_disabled;


### PR DESCRIPTION
# Description
Regression from bdba6032523b363a4bd207f5229e860b783a1e09

After the above refactor, the register was getting reset to 0 which is not its default value.
Added a constant and make sure we reset to that.

## Related issues

Fixes Astral Blur demo https://github.com/dosbox-staging/dosbox-staging/issues/4269

# Release notes

Fix GUS regression that caused Astral Blur demo to infinitely loop the first scene

# Manual testing

Astral Blur demo works now.

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [x] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

