### PR TITLE
Website - mention minimum Windows version on last older release files

### DIFF
--- a/website/docs/releases/windows.md
+++ b/website/docs/releases/windows.md
@@ -175,13 +175,13 @@ command-line install parameters, please see [Inno's documentation page](https://
 
 ## Older releases
 
-- [Download DOSBox Staging 0.82.0 (x86_64, Installer)][0_82_0_INSTALLER]
+- [Download DOSBox Staging 0.82.0 (x86_64, Installer)][0_82_0_INSTALLER] (Windows 8 or newer)
   <br>
   <small>
   sha256: fa041173e55fba9873be0a85734a09a3<wbr>f54b466c95ff8f1b8aa1a84cd3347729
   </small>
 
-- [Download DOSBox Staging 0.82.0 (x86_64, Portable ZIP)][0_82_0_ZIP]
+- [Download DOSBox Staging 0.82.0 (x86_64, Portable ZIP)][0_82_0_ZIP] (Windows 8 or newer)
   <br>
   <small>
   sha256: b558efff258a7bd5f05cf61f1fddffcd<wbr>e8385e04c9b27bb29854bd13a708fbe1


### PR DESCRIPTION
# Description

Add "(Windows 8 or newer)" after the 0.82.0 links - same as for the other files in the older releases list.

# Manual testing

No testing, only adding two strings.

# Checklist

I have:

- [ ] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [ ] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [ ] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

