### PR TITLE
Fix emulator becoming unresponsive if the user exits the app while inside the reboot handler

### DIFF
--- a/.github/workflows/pvs-studio.yml
+++ b/.github/workflows/pvs-studio.yml
@@ -109,7 +109,7 @@ jobs:
 
       - name: Summarize report
         env:
-          MAX_BUGS: 84
+          MAX_BUGS: 137
         run: |
           echo "Full report is included in build Artifacts"
           echo

--- a/src/ints/bios.cpp
+++ b/src/ints/bios.cpp
@@ -1072,6 +1072,11 @@ static Bitu reboot_handler()
 		const auto start = PIC_FullIndex();
 		while ((PIC_FullIndex() - start) < delay_ms) {
 			CALLBACK_Idle();
+			// Bail out if the user closes the window.
+			// Otherwise we get stuck in an infinite loop.
+			if (shutdown_requested) {
+				return CBRET_NONE;
+			}
 		}
 	}
 


### PR DESCRIPTION
# Description

It was getting stuck inside an idle loop that's meant to delay a three second countdown message. We just need to bail out early if shutdown is requested. We've had to add similar logic in other places (grep for "shutdown_requested").

## Related issues

Fixes #4232

# Release notes

Fix emulator becoming unresponsive if the user exits the app while inside the reboot handler

# Manual testing

Tested reboot functionality with the URIDIUM.ZIP from #4232

The game doesn't actually run like this though. It looks like it's a booter disk and the game wants to reboot the computer if it's inside DOS so that it can boot from floppy. You'd have to get a .img of the floppy and do a `boot URIDIUM.img` to play this game with DOSBox.

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [x] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

