### PR TITLE
Improve DOS builtin mouse driver configurability

### DIFF
--- a/include/programs.h
+++ b/include/programs.h
@@ -55,16 +55,16 @@ public:
 
 	bool FindCommand(unsigned int which, std::string& value) const;
 
-	bool FindStringBegin(const char* const begin, std::string& value,
+	bool FindStringBegin(const std::string& begin, std::string& value,
 	                     bool remove = false);
 
-	bool FindStringCaseInsensitiveBegin(const char* const begin,
+	bool FindStringCaseInsensitiveBegin(const std::string& begin,
 	                                    std::string& value,
 	                                    bool remove = false);
 
-	bool FindStringRemain(const char* const name, std::string& value);
+	bool FindStringRemain(const std::string& name, std::string& value);
 
-	bool FindStringRemainBegin(const char* const name, std::string& value);
+	bool FindStringRemainBegin(const std::string& name, std::string& value);
 
 	bool GetStringRemain(std::string& value);
 
@@ -101,7 +101,7 @@ private:
 	std::list<std::string> cmds = {};
 	std::string file_name       = "";
 
-	bool FindEntry(const char* const name, cmd_it& it, bool neednext = false);
+	bool FindEntry(const std::string& name, cmd_it& it, bool neednext = false);
 
 	std::string FindRemoveSingleString(const char* name);
 

--- a/include/programs.h
+++ b/include/programs.h
@@ -47,10 +47,10 @@ public:
 		return file_name.c_str();
 	}
 
-	bool FindExist(const char* const name, bool remove = false);
-	bool FindInt(const char* const name, int& value, bool remove = false);
+	bool FindExist(const std::string& name, bool remove = false);
+	bool FindInt(const std::string& name, int& value, bool remove = false);
 
-	bool FindString(const char* const name, std::string& value,
+	bool FindString(const std::string& name, std::string& value,
 	                bool remove = false);
 
 	bool FindCommand(unsigned int which, std::string& value) const;

--- a/include/programs.h
+++ b/include/programs.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2024  The DOSBox Staging Team
+ *  Copyright (C) 2020-2025  The DOSBox Staging Team
  *  Copyright (C) 2002-2021  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -57,6 +57,10 @@ public:
 
 	bool FindStringBegin(const char* const begin, std::string& value,
 	                     bool remove = false);
+
+	bool FindStringCaseInsensitiveBegin(const char* const begin,
+	                                    std::string& value,
+	                                    bool remove = false);
 
 	bool FindStringRemain(const char* const name, std::string& value);
 

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -59,8 +59,8 @@ static bool windows_multiplex()
 	// 0x4002 - switch task to foreground
 	case 0x1605: // Windows startup
 	{
-		const uint8_t major = static_cast<uint8_t>(reg_di >> 8);
-		const uint8_t minor = static_cast<uint8_t>(reg_di & 0xff);
+		const auto major = static_cast<uint8_t>(reg_di >> 8);
+		const auto minor = static_cast<uint8_t>(reg_di & 0xff);
 		LOG_INFO("DOS: Starting Microsoft Windows %d.%d", major, minor);
 		return false;
 	}

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2024  The DOSBox Staging Team
+ *  Copyright (C) 2020-2025  The DOSBox Staging Team
  *  Copyright (C) 2002-2021  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -50,6 +50,26 @@ unsigned int result_errorcode = 0;
 static bool is_guest_booted = false;
 
 extern void DOS_ClearLaunchedProgramNames();
+
+static bool windows_multiplex()
+{
+	switch (reg_ax) {
+	// 0x1607 - Windows device callout
+	// 0x4001 - switch task to background
+	// 0x4002 - switch task to foreground
+	case 0x1605: // Windows startup
+	{
+		const uint8_t major = static_cast<uint8_t>(reg_di >> 8);
+		const uint8_t minor = static_cast<uint8_t>(reg_di & 0xff);
+		LOG_INFO("DOS: Starting Microsoft Windows %d.%d", major, minor);
+		return false;
+	}
+	case 0x1606: // Windows shutdown
+		LOG_INFO("DOS: Shutting down Microsoft Windows");
+		return false;
+	default: return false;
+	}
+}
 
 void DOS_NotifyBooting()
 {
@@ -1531,6 +1551,8 @@ public:
 			dos.version.major = new_version.major;
 			dos.version.minor = new_version.minor;
 		}
+
+		DOS_AddMultiplexHandler(windows_multiplex);
 	}
 
 	// Shutdown the DOS OS constructs leaving only the BIOS and hardware

--- a/src/dos/program_serial.cpp
+++ b/src/dos/program_serial.cpp
@@ -1,7 +1,7 @@
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *
- *  Copyright (C) 2021-2024  The DOSBox Staging Team
+ *  Copyright (C) 2021-2025  The DOSBox Staging Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -205,8 +205,8 @@ void SERIAL::AddMessages() {
 	        "  For [color=light-cyan]MODEM[reset]     : IRQ, LISTENPORT, SOCK\n"
 	        "  For [color=light-cyan]NULLMODEM[reset] : IRQ, SERVER, RXDELAY, TXDELAY, TELNET, USEDTR, TRANSPARENT,\n"
 	        "                  PORT, INHSOCKET, SOCK\n"
-	        "  For [color=light-cyan]MOUSE[reset]     : IRQ, RATE (NORMAL or SMOOTH), TYPE (2BTN, 3BTN, WHEEL, MSM,\n"
-	        "                  2BTN+MSM, 3BTN+MSM, or WHEEL+MSM)\n"
+	        "  For [color=light-cyan]MOUSE[reset]     : IRQ, MODEL (2BUTTON, 3BUTTON, WHEEL, MSM, 2BUTTON+MSM,\n"
+	        "                  3BUTTON+MSM, or WHEEL+MSM)\n"
 	        "  For [color=light-cyan]DIRECT[reset]    : IRQ, REALPORT (required), RXDELAY\n"
 	        "  For [color=light-cyan]DUMMY[reset]     : IRQ\n"
 	        "\n"
@@ -215,7 +215,7 @@ void SERIAL::AddMessages() {
 	        "  [color=light-green]SERIAL[reset] [color=white]2[reset] [color=light-cyan]NULLMODEM[reset] SERVER:10.0.0.6 PORT:1250 : Connect to TCP:1250 as client\n"
 	        "  [color=light-green]SERIAL[reset] [color=white]3[reset] [color=light-cyan]MODEM[reset] LISTENPORT:5000 SOCK:1        : Listen on UDP:5000 as server\n"
 	        "  [color=light-green]SERIAL[reset] [color=white]4[reset] [color=light-cyan]DIRECT[reset] REALPORT:ttyUSB0             : Use a physical port on Linux\n"
-	        "  [color=light-green]SERIAL[reset] [color=white]1[reset] [color=light-cyan]MOUSE[reset] TYPE:MSM                      : Mouse Systems mouse\n");
+	        "  [color=light-green]SERIAL[reset] [color=white]1[reset] [color=light-cyan]MOUSE[reset] MODEL:MSM                     : Mouse Systems mouse\n");
 	MSG_Add("PROGRAM_SERIAL_SHOW_PORT", "COM%d: %s %s\n");
 	MSG_Add("PROGRAM_SERIAL_BAD_PORT",
 	        "Must specify a numeric port value between 1 and %d, inclusive.\n");

--- a/src/dos/program_serial.cpp
+++ b/src/dos/program_serial.cpp
@@ -119,7 +119,7 @@ void SERIAL::Run()
 		// They entered something, but do we have a matching type?
 		auto desired_type = SERIAL_PORT_TYPE::INVALID;
 		for (const auto& [type, name] : serial_type_names) {
-			if (temp_line == name) {
+			if (iequals(temp_line, name)) {
 				desired_type = type;
 				break;
 			}

--- a/src/hardware/input/mouse_common.cpp
+++ b/src/hardware/input/mouse_common.cpp
@@ -1,7 +1,7 @@
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *
- *  Copyright (C) 2022-2024  The DOSBox Staging Team
+ *  Copyright (C) 2022-2025  The DOSBox Staging Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -226,4 +226,9 @@ MouseButtons12S &MouseButtons12S::operator=(const MouseButtons12S &other)
 {
 	_data = other._data;
 	return *this;
+}
+
+bool MouseButtons12S::operator==(const MouseButtons12S other) const
+{
+	return _data == other._data;
 }

--- a/src/hardware/input/mouse_common.h
+++ b/src/hardware/input/mouse_common.h
@@ -1,7 +1,7 @@
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *
- *  Copyright (C) 2022-2024  The DOSBox Staging Team
+ *  Copyright (C) 2022-2025  The DOSBox Staging Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -168,6 +168,8 @@ union MouseButtons12S {
 	MouseButtons12S(const uint8_t data) : _data(data) {}
 	MouseButtons12S(const MouseButtons12S &other) : _data(other._data) {}
 	MouseButtons12S &operator=(const MouseButtons12S &other);
+
+	bool operator==(const MouseButtons12S other) const;
 };
 
 #endif // DOSBOX_MOUSE_COMMON_H

--- a/src/hardware/input/mouse_config.cpp
+++ b/src/hardware/input/mouse_config.cpp
@@ -94,25 +94,25 @@ const std::vector<uint16_t>& MouseConfig::GetValidMinRateList()
 bool MouseConfig::ParseComModel(const std::string_view model_str,
                                 MouseModelCOM& model, bool& auto_msm)
 {
-	if (model_str == ModelCom2Button) {
+	if (iequals(model_str, ModelCom2Button)) {
 		model    = MouseModelCOM::Microsoft;
 		auto_msm = false;
-	} else if (model_str == ModelCom3Button) {
+	} else if (iequals(model_str, ModelCom3Button)) {
 		model    = MouseModelCOM::Logitech;
 		auto_msm = false;
-	} else if (model_str == ModelComWheel) {
+	} else if (iequals(model_str, ModelComWheel)) {
 		model    = MouseModelCOM::Wheel;
 		auto_msm = false;
-	} else if (model_str == ModelComMsm) {
+	} else if (iequals(model_str, ModelComMsm)) {
 		model    = MouseModelCOM::MouseSystems;
 		auto_msm = false;
-	} else if (model_str == ModelCom2ButtonMsm) {
+	} else if (iequals(model_str, ModelCom2ButtonMsm)) {
 		model    = MouseModelCOM::Microsoft;
 		auto_msm = true;
-	} else if (model_str == ModelCom3ButtonMsm) {
+	} else if (iequals(model_str, ModelCom3ButtonMsm)) {
 		model    = MouseModelCOM::Logitech;
 		auto_msm = true;
-	} else if (model_str == ModelComWheelMsm) {
+	} else if (iequals(model_str, ModelComWheelMsm)) {
 		model    = MouseModelCOM::Wheel;
 		auto_msm = true;
 	} else {
@@ -124,13 +124,13 @@ bool MouseConfig::ParseComModel(const std::string_view model_str,
 
 static void set_capture_type(const std::string_view capture_str)
 {
-	if (capture_str == CaptureTypeSeamless) {
+	if (iequals(capture_str, CaptureTypeSeamless)) {
 		mouse_config.capture = MouseCapture::Seamless;
-	} else if (capture_str == CaptureTypeOnClick) {
+	} else if (iequals(capture_str, CaptureTypeOnClick)) {
 		mouse_config.capture = MouseCapture::OnClick;
-	} else if (capture_str == CaptureTypeOnStart) {
+	} else if (iequals(capture_str, CaptureTypeOnStart)) {
 		mouse_config.capture = MouseCapture::OnStart;
-	} else if (capture_str == CaptureTypeNoMouse) {
+	} else if (iequals(capture_str, CaptureTypeNoMouse)) {
 		mouse_config.capture = MouseCapture::NoMouse;
 	} else {
 		assertm(false, "Invalid mouse capture value");
@@ -141,11 +141,11 @@ static void set_dos_driver_model(const std::string_view model_str)
 {
 	auto new_model = mouse_config.model_dos;
 
-	if (model_str == ModelDos2Button) {
+	if (iequals(model_str, ModelDos2Button)) {
 		new_model = MouseModelDos::TwoButton;
-	} else if (model_str == ModelDos3Button) {
+	} else if (iequals(model_str, ModelDos3Button)) {
 		new_model = MouseModelDos::ThreeButton;
-	} else if (model_str == ModelDosWheel) {
+	} else if (iequals(model_str, ModelDosWheel)) {
 		new_model = MouseModelDos::Wheel;
 	} else {
 		assertm(false, "Invalid DOS driver mouse model value");
@@ -159,13 +159,13 @@ static void set_dos_driver_model(const std::string_view model_str)
 
 static void set_ps2_mouse_model(const std::string_view model_str)
 {
-	if (model_str == ModelPs2Standard) {
+	if (iequals(model_str, ModelPs2Standard)) {
 		mouse_config.model_ps2 = MouseModelPS2::Standard;
-	} else if (model_str == ModelPs2Intellimouse) {
+	} else if (iequals(model_str, ModelPs2Intellimouse)) {
 		mouse_config.model_ps2 = MouseModelPS2::IntelliMouse;
-	} else if (model_str == ModelPs2Explorer) {
+	} else if (iequals(model_str, ModelPs2Explorer)) {
 		mouse_config.model_ps2 = MouseModelPS2::Explorer;
-	} else if (model_str == ModelPs2NoMouse) {
+	} else if (iequals(model_str, ModelPs2NoMouse)) {
 		mouse_config.model_ps2 = MouseModelPS2::NoMouse;
 	} else {
 		assertm(false, "Invalid PS/2 mouse model value");

--- a/src/hardware/input/mouse_config.cpp
+++ b/src/hardware/input/mouse_config.cpp
@@ -94,26 +94,28 @@ const std::vector<uint16_t>& MouseConfig::GetValidMinRateList()
 bool MouseConfig::ParseComModel(const std::string_view model_str,
                                 MouseModelCOM& model, bool& auto_msm)
 {
+	using enum MouseModelCOM;
+
 	if (iequals(model_str, ModelCom2Button)) {
-		model    = MouseModelCOM::Microsoft;
+		model    = Microsoft;
 		auto_msm = false;
 	} else if (iequals(model_str, ModelCom3Button)) {
-		model    = MouseModelCOM::Logitech;
+		model    = Logitech;
 		auto_msm = false;
 	} else if (iequals(model_str, ModelComWheel)) {
-		model    = MouseModelCOM::Wheel;
+		model    = Wheel;
 		auto_msm = false;
 	} else if (iequals(model_str, ModelComMsm)) {
-		model    = MouseModelCOM::MouseSystems;
+		model    = MouseSystems;
 		auto_msm = false;
 	} else if (iequals(model_str, ModelCom2ButtonMsm)) {
-		model    = MouseModelCOM::Microsoft;
+		model    = Microsoft;
 		auto_msm = true;
 	} else if (iequals(model_str, ModelCom3ButtonMsm)) {
-		model    = MouseModelCOM::Logitech;
+		model    = Logitech;
 		auto_msm = true;
 	} else if (iequals(model_str, ModelComWheelMsm)) {
-		model    = MouseModelCOM::Wheel;
+		model    = Wheel;
 		auto_msm = true;
 	} else {
 		return false;
@@ -124,14 +126,16 @@ bool MouseConfig::ParseComModel(const std::string_view model_str,
 
 static void set_capture_type(const std::string_view capture_str)
 {
+	using enum MouseCapture;
+
 	if (iequals(capture_str, CaptureTypeSeamless)) {
-		mouse_config.capture = MouseCapture::Seamless;
+		mouse_config.capture = Seamless;
 	} else if (iequals(capture_str, CaptureTypeOnClick)) {
-		mouse_config.capture = MouseCapture::OnClick;
+		mouse_config.capture = OnClick;
 	} else if (iequals(capture_str, CaptureTypeOnStart)) {
-		mouse_config.capture = MouseCapture::OnStart;
+		mouse_config.capture = OnStart;
 	} else if (iequals(capture_str, CaptureTypeNoMouse)) {
-		mouse_config.capture = MouseCapture::NoMouse;
+		mouse_config.capture = NoMouse;
 	} else {
 		assertm(false, "Invalid mouse capture value");
 	}
@@ -139,14 +143,16 @@ static void set_capture_type(const std::string_view capture_str)
 
 static void set_dos_driver_model(const std::string_view model_str)
 {
+	using enum MouseModelDos;
+
 	auto new_model = mouse_config.model_dos;
 
 	if (iequals(model_str, ModelDos2Button)) {
-		new_model = MouseModelDos::TwoButton;
+		new_model = TwoButton;
 	} else if (iequals(model_str, ModelDos3Button)) {
-		new_model = MouseModelDos::ThreeButton;
+		new_model = ThreeButton;
 	} else if (iequals(model_str, ModelDosWheel)) {
-		new_model = MouseModelDos::Wheel;
+		new_model = Wheel;
 	} else {
 		assertm(false, "Invalid DOS driver mouse model value");
 	}
@@ -159,14 +165,16 @@ static void set_dos_driver_model(const std::string_view model_str)
 
 static void set_ps2_mouse_model(const std::string_view model_str)
 {
+	using enum MouseModelPS2;
+
 	if (iequals(model_str, ModelPs2Standard)) {
-		mouse_config.model_ps2 = MouseModelPS2::Standard;
+		mouse_config.model_ps2 = Standard;
 	} else if (iequals(model_str, ModelPs2Intellimouse)) {
-		mouse_config.model_ps2 = MouseModelPS2::IntelliMouse;
+		mouse_config.model_ps2 = IntelliMouse;
 	} else if (iequals(model_str, ModelPs2Explorer)) {
-		mouse_config.model_ps2 = MouseModelPS2::Explorer;
+		mouse_config.model_ps2 = Explorer;
 	} else if (iequals(model_str, ModelPs2NoMouse)) {
-		mouse_config.model_ps2 = MouseModelPS2::NoMouse;
+		mouse_config.model_ps2 = NoMouse;
 	} else {
 		assertm(false, "Invalid PS/2 mouse model value");
 	}

--- a/src/hardware/input/mouse_config.h
+++ b/src/hardware/input/mouse_config.h
@@ -1,7 +1,7 @@
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *
- *  Copyright (C) 2022-2024  The DOSBox Staging Team
+ *  Copyright (C) 2022-2025  The DOSBox Staging Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -59,7 +59,13 @@ extern MousePredefined mouse_predefined;
 // Configuration file content
 // ***************************************************************************
 
-enum class MouseCapture : uint8_t { Seamless, OnClick, OnStart, NoMouse };
+enum class MouseCapture { Seamless, OnClick, OnStart, NoMouse };
+
+enum class MouseModelDos {
+	TwoButton,
+	ThreeButton,
+	Wheel,
+};
 
 enum class MouseModelPS2 : uint8_t {
 	NoMouse      = 0xff,
@@ -69,7 +75,7 @@ enum class MouseModelPS2 : uint8_t {
 	Explorer     = 0x04,
 };
 
-enum class MouseModelCOM : uint8_t {
+enum class MouseModelCOM {
 	NoMouse, // dummy value or no mouse
 	Microsoft,
 	Logitech,
@@ -87,8 +93,13 @@ struct MouseConfig {
 	bool raw_input           = false; // true = relative input is raw data
 	bool multi_display_aware = false;
 
-	bool dos_driver    = false; // whether DOS virtual mouse driver should be enabled
-	bool dos_immediate = false;
+	bool dos_driver_enabled   = false;
+	bool dos_driver_modern    = false;
+	bool dos_driver_immediate = false;
+
+	std::string dos_driver_last_options_str = {};
+
+	MouseModelDos model_dos = MouseModelDos::TwoButton;
 
 	MouseModelPS2 model_ps2 = MouseModelPS2::Standard;
 

--- a/src/hardware/input/mouse_interfaces.cpp
+++ b/src/hardware/input/mouse_interfaces.cpp
@@ -1,7 +1,7 @@
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *
- *  Copyright (C) 2022-2024  The DOSBox Staging Team
+ *  Copyright (C) 2022-2025  The DOSBox Staging Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -639,7 +639,7 @@ InterfaceDos::InterfaceDos()
 void InterfaceDos::Init()
 {
 	MouseInterface::Init();
-	if (mouse_config.dos_driver) {
+	if (mouse_config.dos_driver_enabled) {
 		emulated = true;
 		MOUSEDOS_Init();
 	}

--- a/src/hardware/input/mouse_interfaces.h
+++ b/src/hardware/input/mouse_interfaces.h
@@ -59,6 +59,8 @@ void MOUSEDOS_NotifyMoved(const float x_rel, const float y_rel,
 void MOUSEDOS_NotifyButton(const MouseButtons12S buttons_12S);
 void MOUSEDOS_NotifyWheel(const float w_rel);
 
+void MOUSEDOS_NotifyModelChanged();
+
 // ***************************************************************************
 // PS/2 mouse
 // ***************************************************************************

--- a/src/hardware/input/mouseif_dos_driver.cpp
+++ b/src/hardware/input/mouseif_dos_driver.cpp
@@ -241,11 +241,13 @@ static RealPt user_callback;
 
 static uint8_t get_num_buttons()
 {
+	using enum MouseModelDos;
+
 	switch (mouse_config.model_dos) {
-	case MouseModelDos::TwoButton:
+	case TwoButton:
 		return 2;
-	case MouseModelDos::ThreeButton:
-	case MouseModelDos::Wheel:
+	case ThreeButton:
+	case Wheel:
 		return 3;
 	default:
 		assertm(false, "unknown mouse model (DOS)");
@@ -704,6 +706,8 @@ static void draw_cursor()
 
 static void maybe_log_mouse_model()
 {
+	using enum MouseModelDos;
+
 	if (!mouse_config.dos_driver_enabled) {
 		return;
 	}
@@ -717,13 +721,13 @@ static void maybe_log_mouse_model()
 
 	std::string model_name = {};
 	switch (mouse_config.model_dos) {
-	case MouseModelDos::TwoButton:
+	case TwoButton:
 		model_name = "2 buttons";
 		break;
-	case MouseModelDos::ThreeButton:
+	case ThreeButton:
 		model_name = "3 buttons";
 		break;
-	case MouseModelDos::Wheel:
+	case Wheel:
 		model_name = "3 buttons + wheel";
 		break;
 	default:

--- a/src/hardware/input/mouseif_dos_driver.cpp
+++ b/src/hardware/input/mouseif_dos_driver.cpp
@@ -244,8 +244,12 @@ static uint8_t get_num_buttons()
 	switch (mouse_config.model_dos) {
 	case MouseModelDos::TwoButton:
 		return 2;
-	default:
+	case MouseModelDos::ThreeButton:
+	case MouseModelDos::Wheel:
 		return 3;
+	default:
+		assertm(false, "unknown mouse model (DOS)");
+		return 2;
 	}
 }
 
@@ -253,14 +257,10 @@ static uint8_t get_button_mask()
 {
 	MouseButtonsAll button_mask = {};
 
-	switch (get_num_buttons()) {
-	case 2:
-		button_mask.left  = 1;
-		button_mask.right = 1;
-		break;
-	default:
-		button_mask.left   = 1;
-		button_mask.right  = 1;
+	button_mask.left  = 1;
+	button_mask.right = 1;
+
+	if (get_num_buttons() >= 3) {
 		button_mask.middle = 1;
 	}
 

--- a/src/hardware/input/mouseif_ps2_bios.cpp
+++ b/src/hardware/input/mouseif_ps2_bios.cpp
@@ -174,6 +174,8 @@ static void terminate_unlock_sequence()
 
 static void maybe_log_mouse_protocol()
 {
+	using enum MouseModelPS2;
+
 	static bool first_time = true;
 	static MouseModelPS2 last_logged = {};
 
@@ -183,16 +185,16 @@ static void maybe_log_mouse_protocol()
 
 	std::string protocol_name = {};
 	switch (protocol) {
-	case MouseModelPS2::Standard:
+	case Standard:
 		protocol_name = "3 buttons";
 		break;
-	case MouseModelPS2::IntelliMouse:
+	case IntelliMouse:
 		protocol_name = "3 buttons + wheel (IntelliMouse)";
 		break;
-	case MouseModelPS2::Explorer:
+	case Explorer:
 		protocol_name = "5 buttons + wheel (IntelliMouse Explorer)";
 		break;
-	case MouseModelPS2::NoMouse:
+	case NoMouse:
 		break;
 	default:
 		assertm(false, "unknown mouse model (PS/2)");
@@ -493,15 +495,13 @@ static void cmd_set_sample_rate(const uint8_t new_rate_hz)
 	static const std::vector<uint8_t> unlock_sequence_im = {200, 100, 80};
 	static const std::vector<uint8_t> unlock_sequence_xp = {200, 200, 80};
 
-	if (mouse_config.model_ps2 == MouseModelPS2::IntelliMouse) {
-		process_unlock(unlock_sequence_im,
-		               unlock_idx_im,
-		               MouseModelPS2::IntelliMouse);
-	} else if (mouse_config.model_ps2 == MouseModelPS2::Explorer) {
-		process_unlock(unlock_sequence_im,
-		               unlock_idx_im,
-		               MouseModelPS2::IntelliMouse);
-		process_unlock(unlock_sequence_xp, unlock_idx_xp, MouseModelPS2::Explorer);
+	using enum MouseModelPS2;
+
+	if (mouse_config.model_ps2 == IntelliMouse) {
+		process_unlock(unlock_sequence_im, unlock_idx_im, IntelliMouse);
+	} else if (mouse_config.model_ps2 == Explorer) {
+		process_unlock(unlock_sequence_im, unlock_idx_im, IntelliMouse);
+		process_unlock(unlock_sequence_xp, unlock_idx_xp, Explorer);
 	}
 }
 

--- a/src/hardware/serialport/directserial.cpp
+++ b/src/hardware/serialport/directserial.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2021  The DOSBox Team
+ *  Copyright (C) 2002-2025  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -40,7 +40,7 @@ CDirectSerial::CDirectSerial(const uint8_t port_idx, CommandLine *cmd)
     rx_retry_max = 0;
 
 	std::string tmpstring;
-	if(!cmd->FindStringBegin("realport:",tmpstring,false)) return;
+	if(!cmd->FindStringCaseInsensitiveBegin("realport:",tmpstring,false)) return;
 
 	LOG_MSG("SERIAL: Port %" PRIu8 " opening %s.", GetPortNumber(), tmpstring.c_str());
 	if(!SERIAL_open(tmpstring.c_str(), &comport)) {

--- a/src/hardware/serialport/serialmouse.cpp
+++ b/src/hardware/serialport/serialmouse.cpp
@@ -1,7 +1,7 @@
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *
- *  Copyright (C) 2022-2024  The DOSBox Staging Team
+ *  Copyright (C) 2022-2025  The DOSBox Staging Team
  *  Copyright (C) 2002-2021  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -63,7 +63,7 @@ CSerialMouse::CSerialMouse(const uint8_t id, CommandLine *cmd)
 	// Override with parameters from command line or [serial] section
 
 	std::string model_string;
-	if (cmd->FindStringBegin("model:", model_string, false) &&
+	if (cmd->FindStringCaseInsensitiveBegin("model:", model_string, false) &&
 	    !MouseConfig::ParseComModel(model_string, param_model, param_auto_msm)) {
 		LOG_ERR("MOUSE (COM%d): Invalid model '%s'",
 		        port_num,

--- a/src/hardware/serialport/serialmouse.cpp
+++ b/src/hardware/serialport/serialmouse.cpp
@@ -89,7 +89,7 @@ CSerialMouse::~CSerialMouse()
 	}
 
 	removeEvent(SERIAL_TX_EVENT); // clear events
-	SetModel(MouseModelCOM::NoMouse);
+	LOG_MSG("MOUSE (COM%d): Disconnected", port_num);
 }
 
 void CSerialMouse::HandleDeprecatedOptions(CommandLine *cmd)

--- a/src/hardware/serialport/serialmouse.cpp
+++ b/src/hardware/serialport/serialmouse.cpp
@@ -167,43 +167,50 @@ void CSerialMouse::BoostRate(const uint16_t rate_hz)
 	rate_coeff = estimate(1200) / rate_hz;
 }
 
+void CSerialMouse::LogMouseModel()
+{
+	std::string model_name = {};
+	switch (model) {
+	case MouseModelCOM::Microsoft:
+		model_name     = "2 buttons (Microsoft)";
+		has_3rd_button = false;
+		has_wheel      = false;
+		break;
+	case MouseModelCOM::Logitech:
+		model_name     = "3 buttons (Logitech)";
+		has_3rd_button = true;
+		has_wheel      = false;
+		break;
+	case MouseModelCOM::Wheel:
+		model_name     = "3 buttons + wheel";
+		has_3rd_button = true;
+		has_wheel      = true;
+		break;
+	case MouseModelCOM::MouseSystems:
+		model_name     = "3 buttons (Mouse Systems)";
+		has_3rd_button = true;
+		has_wheel      = false;
+		break;
+	case MouseModelCOM::NoMouse:
+		LOG_MSG("MOUSE (COM%d): Disabled", port_num);
+		break;
+	default:
+		assertm(false, "unknown mouse model (COM)");
+		break;
+	}
+
+	if (!model_name.empty()) {
+		LOG_MSG("MOUSE (COM%d): Using a %s model protocol", port_num,
+		        model_name.c_str());
+	}
+}
+
 void CSerialMouse::SetModel(const MouseModelCOM new_model)
 {
 	if (model != new_model) {
-		model            = new_model;
-		const char *name = nullptr;
-		switch (model) {
-		case MouseModelCOM::NoMouse: // just to print out log in the
-		                             // destructor
-			name = "(none)";
-			break;
-		case MouseModelCOM::Microsoft:
-			name           = "Microsoft, 2 buttons";
-			has_3rd_button = false;
-			has_wheel      = false;
-			break;
-		case MouseModelCOM::Logitech:
-			name           = "Logitech, 3 buttons";
-			has_3rd_button = true;
-			has_wheel      = false;
-			break;
-		case MouseModelCOM::Wheel:
-			name           = "wheel, 3 buttons";
-			has_3rd_button = true;
-			has_wheel      = true;
-			break;
-		case MouseModelCOM::MouseSystems:
-			name           = "Mouse Systems, 3 buttons";
-			has_3rd_button = true;
-			has_wheel      = false;
-			break;
-		default:
-			assert(false); // unimplemented
-			break;
-		}
-
-		if (name)
-			LOG_MSG("MOUSE (COM%d): %s", port_num, name);
+		model = new_model;
+		
+		LogMouseModel();
 	}
 
 	// So far all emulated mice are 1200 bauds, but report anyway

--- a/src/hardware/serialport/serialmouse.h
+++ b/src/hardware/serialport/serialmouse.h
@@ -1,7 +1,7 @@
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *
- *  Copyright (C) 2022-2024  The DOSBox Staging Team
+ *  Copyright (C) 2022-2025  The DOSBox Staging Team
  *  Copyright (C) 2002-2021  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -49,7 +49,9 @@ public:
 	void handleUpperEvent(const uint16_t event_type) override;
 
 private:
-	void HandleDeprecatedOptions(CommandLine *cmd);
+	void LogMouseModel();
+
+	void HandleDeprecatedOptions(CommandLine* cmd);
 	void SetModel(const MouseModelCOM new_type);
 	void AbortPacket();
 	void ClearCounters();

--- a/src/hardware/serialport/serialport.cpp
+++ b/src/hardware/serialport/serialport.cpp
@@ -1184,7 +1184,7 @@ bool CSerial::getUintFromString(const char *name, uint32_t &data, CommandLine *c
 {
 	bool result = false;
 	std::string tmpstring;
-	if (cmd->FindStringBegin(name, tmpstring, false))
+	if (cmd->FindStringCaseInsensitiveBegin(name, tmpstring, false))
 		result = (sscanf(tmpstring.c_str(), "%" PRIu32, &data) == 1);
 	return result;
 }

--- a/src/shell/command_line.cpp
+++ b/src/shell/command_line.cpp
@@ -1,7 +1,7 @@
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *
- *  Copyright (C) 2023-2023  The DOSBox Staging Team
+ *  Copyright (C) 2023-2025  The DOSBox Staging Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -151,6 +151,23 @@ bool CommandLine::FindStringBegin(const char* const begin, std::string& value,
 	size_t len = strlen(begin);
 	for (cmd_it it = cmds.begin(); it != cmds.end(); ++it) {
 		if (strncmp(begin, (*it).c_str(), len) == 0) {
+			value = ((*it).c_str() + len);
+			if (remove) {
+				cmds.erase(it);
+			}
+			return true;
+		}
+	}
+	return false;
+}
+
+bool CommandLine::FindStringCaseInsensitiveBegin(const char* const begin,
+                                                 std::string& value,
+                                                 bool remove)
+{
+	size_t len = strlen(begin);
+	for (cmd_it it = cmds.begin(); it != cmds.end(); ++it) {
+		if (iequals(begin, std::string_view(*it).substr(0, len))) {
 			value = ((*it).c_str() + len);
 			if (remove) {
 				cmds.erase(it);

--- a/src/shell/command_line.cpp
+++ b/src/shell/command_line.cpp
@@ -130,10 +130,10 @@ bool CommandLine::HasExecutableName() const
 	return false;
 }
 
-bool CommandLine::FindEntry(const char* name, cmd_it& it, bool neednext)
+bool CommandLine::FindEntry(const std::string& name, cmd_it& it, bool neednext)
 {
 	for (it = cmds.begin(); it != cmds.end(); ++it) {
-		if (!strcasecmp((*it).c_str(), name)) {
+		if (iequals((*it).c_str(), name)) {
 			cmd_it itnext = it;
 			++itnext;
 			if (neednext && (itnext == cmds.end())) {
@@ -145,12 +145,12 @@ bool CommandLine::FindEntry(const char* name, cmd_it& it, bool neednext)
 	return false;
 }
 
-bool CommandLine::FindStringBegin(const char* const begin, std::string& value,
+bool CommandLine::FindStringBegin(const std::string& begin, std::string& value,
                                   bool remove)
 {
-	size_t len = strlen(begin);
+	const auto len = begin.length();
 	for (cmd_it it = cmds.begin(); it != cmds.end(); ++it) {
-		if (strncmp(begin, (*it).c_str(), len) == 0) {
+		if (begin.substr(0, len) == (*it).substr(0, len)) {
 			value = ((*it).c_str() + len);
 			if (remove) {
 				cmds.erase(it);
@@ -161,11 +161,11 @@ bool CommandLine::FindStringBegin(const char* const begin, std::string& value,
 	return false;
 }
 
-bool CommandLine::FindStringCaseInsensitiveBegin(const char* const begin,
+bool CommandLine::FindStringCaseInsensitiveBegin(const std::string& begin,
                                                  std::string& value,
                                                  bool remove)
 {
-	size_t len = strlen(begin);
+	const auto len = begin.length();
 	for (cmd_it it = cmds.begin(); it != cmds.end(); ++it) {
 		if (iequals(begin, std::string_view(*it).substr(0, len))) {
 			value = ((*it).c_str() + len);
@@ -178,7 +178,7 @@ bool CommandLine::FindStringCaseInsensitiveBegin(const char* const begin,
 	return false;
 }
 
-bool CommandLine::FindStringRemain(const char* name, std::string& value)
+bool CommandLine::FindStringRemain(const std::string& name, std::string& value)
 {
 	cmd_it it;
 	value.clear();
@@ -197,16 +197,16 @@ bool CommandLine::FindStringRemain(const char* name, std::string& value)
 // Allowing /C dir and /Cdir
 // Restoring quotes back into the commands so command /C mount d "/tmp/a b"
 // works as intended
-bool CommandLine::FindStringRemainBegin(const char* name, std::string& value)
+bool CommandLine::FindStringRemainBegin(const std::string& name, std::string& value)
 {
 	cmd_it it;
 	value.clear();
 
 	if (!FindEntry(name, it)) {
-		size_t len = strlen(name);
+		size_t len = name.length();
 
 		for (it = cmds.begin(); it != cmds.end(); ++it) {
-			if (strncasecmp(name, (*it).c_str(), len) == 0) {
+			if (iequals(name.substr(0, len), (*it).substr(0, len))) {
 				std::string temp = ((*it).c_str() + len);
 				// Restore quotes for correct parsing in later
 				// stages

--- a/src/shell/command_line.cpp
+++ b/src/shell/command_line.cpp
@@ -22,7 +22,7 @@
 #include "programs.h"
 #include "string_utils.h"
 
-bool CommandLine::FindExist(const char* name, bool remove)
+bool CommandLine::FindExist(const std::string& name, bool remove)
 {
 	cmd_it it;
 	if (!(FindEntry(name, it, false))) {
@@ -61,7 +61,7 @@ bool CommandLine::ExistsPriorTo(const std::list<std::string_view>& pre_args,
 	return false;
 }
 
-bool CommandLine::FindInt(const char* name, int& value, bool remove)
+bool CommandLine::FindInt(const std::string& name, int& value, bool remove)
 {
 	cmd_it it, it_next;
 
@@ -79,7 +79,7 @@ bool CommandLine::FindInt(const char* name, int& value, bool remove)
 	return true;
 }
 
-bool CommandLine::FindString(const char* name, std::string& value, bool remove)
+bool CommandLine::FindString(const std::string& name, std::string& value, bool remove)
 {
 	cmd_it it, it_next;
 
@@ -402,8 +402,8 @@ bool CommandLine::FindBoolArgument(const std::string& name, bool remove,
 	char short_name[3]            = {};
 	short_name[0]                 = '-';
 	short_name[1]                 = short_letter;
-	return FindExist(double_dash.c_str(), remove) ||
-	       FindExist(dash.c_str(), remove) ||
+	return FindExist(double_dash, remove) ||
+	       FindExist(dash, remove) ||
 	       (short_letter && FindExist(short_name, remove));
 }
 

--- a/src/shell/command_line.cpp
+++ b/src/shell/command_line.cpp
@@ -149,7 +149,7 @@ bool CommandLine::FindStringBegin(const std::string& begin, std::string& value,
                                   bool remove)
 {
 	const auto len = begin.length();
-	for (cmd_it it = cmds.begin(); it != cmds.end(); ++it) {
+	for (auto it = cmds.begin(); it != cmds.end(); ++it) {
 		if (begin.substr(0, len) == (*it).substr(0, len)) {
 			value = ((*it).c_str() + len);
 			if (remove) {
@@ -166,7 +166,7 @@ bool CommandLine::FindStringCaseInsensitiveBegin(const std::string& begin,
                                                  bool remove)
 {
 	const auto len = begin.length();
-	for (cmd_it it = cmds.begin(); it != cmds.end(); ++it) {
+	for (auto it = cmds.begin(); it != cmds.end(); ++it) {
 		if (iequals(begin, std::string_view(*it).substr(0, len))) {
 			value = ((*it).c_str() + len);
 			if (remove) {
@@ -244,8 +244,8 @@ bool CommandLine::GetStringRemain(std::string& value)
 		return false;
 	}
 
-	cmd_it it = cmds.begin();
-	value     = (*it++);
+	auto it = cmds.begin();
+	value   = (*it++);
 
 	for (; it != cmds.end(); ++it) {
 		value += " ";
@@ -286,7 +286,7 @@ int CommandLine::GetParameterFromList(const char* const params[],
 
 	enum { P_START, P_FIRSTNOMATCH, P_FIRSTMATCH } parsestate = P_START;
 
-	cmd_it it = cmds.begin();
+	auto it = cmds.begin();
 
 	while (it != cmds.end()) {
 		bool found = false;


### PR DESCRIPTION
# Description

Fixed/improved builtin DOS mouse driver configurability.

Rationale behind making serial port options case-insensitive:

1. Help in case of `SERIAL.COM` syntax error:

![1](https://github.com/user-attachments/assets/cd5a9ac1-67cd-4573-b23e-9583bd1d53f3)

2. `SERIAL.COM` command help:

![2](https://github.com/user-attachments/assets/c27ee863-78fd-4302-8cc0-04b1b7240d07)



## Related issues

Fixes https://github.com/dosbox-staging/dosbox-staging/issues/4207
Fixes https://github.com/dosbox-staging/dosbox-staging/issues/3891


# Release notes

Naming scheme of the built-in DOS mouse driver options got changed to be less confusing:
- `dos_mouse_driver` has been renamed to `builtin_dos_mouse_driver`
- `dos_mouse_immediate` became an `immediate` parameter of `builtin_dos_mouse_driver_options`
It is now possible to select the mouse model simulated by the built-in mouse driver - can be useful for games which misinterpret the middle mouse button presses, like _Eye of the Beholder_.
It is now possible to fine-tune mouse driver behavior, for the _Descent II_ official 3dfx patch.
Serial port config options are now case-insensitive; examples from `SERIAL.COM` help now work correctly.
Fixed `SERIAL.COM` help description of serial mouse config options.


# Manual testing

1. Check that _Descent II Vertigo_ with the official 3dfx patch can now be played with a mouse if `builtin_dos_mouse_driver_options = modern` is set (see https://github.com/dosbox-staging/dosbox-staging/issues/3891)
2. Check that `GTEST.COM` utility from the _Genius DOS mouse driver_ 9.20 package shows 2-button mouse if `builtin_dos_mouse_driver_model = 2button` (it should show 3 button mouse otherwise).
3. Check that if `builtin_dos_mouse_driver_model = 2button`, the _Eye of the Beholder_ game does not react to middle mouse button (see https://github.com/dosbox-staging/dosbox-staging/issues/4207).
4. Using _MPXPlay v1.66_ check that mouse wheel is supported (can be used to scroll directory tree) if `builtin_dos_mouse_driver_model = wheel` (`2button` or `3button` options should result in mouse wheel being ignored)
5. Execute command `SERIAL.COM 1 MOUSE MODEL:MSM` (try different case variants) - _CuteMouse v2.1_ driver can't be started with `ctmouse /S1` command (complains about hardware not found), but can be started with `ctmouse /S1 /M` (detects Mouse Systems mouse)
6. Execute command `SERIAL.COM 1 MOUSE MODEL:MSM` (try different case variants) - _CuteMouse v2.1_ driver can be started with _ctmouse /S1_ command, detects a wheel mouse

The change has been manually tested on:

- [x] Windows
- [x] macOS
- [x] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [x] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

