### PR TITLE
Establish clear boundaries on what Staging releases we support

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -72,6 +72,15 @@ body:
         - label: I am running Staging on a native OS
           required: true
 
+  - type: checkboxes
+    id: official-linux-release
+    attributes:
+      label: Are you able to trigger the issue with our official DOSBox Staging release?
+      description: We only support our official releases downloaded from our [website](https://www.dosbox-staging.org/releases/). We do not support repackaged versions of our software; see [this note](https://www.dosbox-staging.org/releases/linux/#non-official-repackaged-releases) for further info.
+      options:
+        - label: I am running an official Staging release, not a release installed by my operating system's package manager, or a version repackaged by an external team.
+          required: true
+
   - type: input
     id: hardware
     attributes:

--- a/website/docs/releases/linux.md
+++ b/website/docs/releases/linux.md
@@ -19,8 +19,9 @@ sha256: 0b7ca2e0f1fbc10fe51c05011f6cad72<wbr>d10608658de0a58e22a5a936d5e7d075
 </section>
 
 
-Our pre-compiled builds run on most desktop Linux distributions (x86\_64 only for
-now). They only depend on the C/C++, ALSA, and OpenGL system libraries.
+Our official build runs on most desktop Linux distributions (x86\_64 only for
+now). It only depends on the C/C++, ALSA, and OpenGL system libraries; all
+other libraries are statically linked.
 
 Please run the `install-icons.sh` script included with the release to install
 the application icons.
@@ -38,95 +39,35 @@ From the x86 family of processors, a processor with SSSE3 (Supplemental
 Streaming SIMD Extensions 3) is required.
 
 
-## External repository packages
+## Non-official repackaged releases
 
-DOSBox Staging is also packaged by external teams, as listed below.
-These packages may have variations in configuration file locations,
-filesystem or network restrictions, feature exclusions, and other
-differences compared to the project-released tarball.
+DOSBox Staging is also repackaged by external teams as distribution-specific
+repository packages, containerised images, etc. These repackaged releases may
+have variations in configuration file locations, filesystem or network
+restrictions, feature exclusions, and other differences compared to our
+official tarball releases. They might also have bugs introduced by using
+different library versions than what we have tested out official releases
+with.
 
-To understand these potential differences, we recommend referring to the
-repository's documentation and, if uncertain, comparing against the
-project-released tarball.
-
-The DOSBox Staging team does not track or document these differences.
-For issues specific to these packages, please contact the respective
+The DOSBox Staging team does _not_ track or document these differences.
+For issues specific to these non-official packages, we recommend referring to the
+repository's documentation, and when in doubt, please contact the respective
 repository owners.
 
+!!! warning "Non-official releases and support"
 
-### Containerised packages
+    We only provide support for our official releases. Any number of weird
+    issues can happen if you start using different library versions, different
+    compilers, different compiler flags or revisions, etc. Many of these
+    issues are hard to notice without being intimately familiar with
+    our software and doing hundreds of hours of testing---the amount of
+    testing we typically put into each release.
 
-[![Download from Flathub](https://flathub.org/assets/badges/flathub-badge-en.png){ class=linux-badge width=35% align=left }][flathub]
-
-[flathub]:https://flathub.org/apps/details/io.github.dosbox-staging
-
-
-### Fedora repository package
-
-    sudo dnf install dosbox-staging
-
-### Gentoo repository package
-
-    emerge games-emulation/dosbox-staging
-
-### Ubuntu and Mint repository package
-
-Available via [Personal Package Archive](https://launchpad.net/~feignint/+archive/ubuntu/dosbox-staging):
-
-    sudo add-apt-repository ppa:feignint/dosbox-staging
-    sudo apt-get update
-    sudo apt install dosbox-staging
-
-### Arch and Manjaro repository package
-
-Available via [Arch User Repository](https://aur.archlinux.org/packages/dosbox-staging).
-
-### NixOS repository package
-
-Available via NixOS or Home Manager. Add the following to your `configuration.nix` file:
-
-For NixOS:
-
-    environment.systemPackages = with pkgs; [
-      dosbox-staging
-    ];
-
-For Home Manager:
-
-    home.packages = with pkgs; [
-      dosbox-staging
-    ];
-
-Then rebuild your system with: `nixos-rebuild switch`
-
-### Other repository packages
-
-[![Packaging status](https://repology.org/badge/vertical-allrepos/dosbox-staging.svg){ width=230 }][other-repos]
-
-[other-repos]:https://repology.org/project/dosbox-staging/versions
-
-## Steam
-
-You can easily configure your DOS games on Steam to use DOSBox Staging via
-[Boxtron](https://github.com/dreamer/boxtron) (a community-developed
-Steam Play compatibility tool for DOS games).
-
-Boxtron will automatically use `dosbox` if found in your path, or can be
-configured to use a specific binary by editing the file
-`~/.config/boxtron.conf` and overriding [dosbox.cmd][boxtron-conf]:
-
-    cmd = ~/path-to-dosbox-staging/dosbox
-
-[boxtron-conf]:https://github.com/dreamer/boxtron/wiki/Configuration#dosboxcmd
-
-
-## RetroPie package
-
-You can easily configure your DOS games on
-[Retropie](https://retropie.org.uk/) to use DOSBox Staging via
-[RetroPie-Setup](https://github.com/RetroPie/RetroPie-Setup) (select
-**Optional Packages** --> **DOSBox Staging**).
-
+    Therefore, if you believe you've found a bug, and you're not using our
+    official Linux release, the first thing to do is to re-test with that.
+    **Please only report issues that are reproducible using our official
+    release!** If the problem is only present in the non-official package, you
+    should ask the person or team who did the repackaging for help.
 
 ## Development snapshot builds
 

--- a/website/docs/releases/macos.md
+++ b/website/docs/releases/macos.md
@@ -33,30 +33,6 @@ The latest release is compatible with macOS 10.15 (Catalina) or newer and
 supports both 64-bit Intel and Apple silicon Macs.
 
 
-## Homebrew
-
-The [Homebrew package](https://formulae.brew.sh/formula/dosbox-staging) is
-compatible with macOS 10.14 (Mojave) or newer. Learn how to set up Homebrew
-[here](https://mac.install.guide/homebrew/).
-
-    brew update
-    brew install dosbox-staging
-
-
-## MacPorts
-
-The [MacPorts package](https://ports.macports.org/port/dosbox-staging/)
-should build on systems as old as macOS 10.6 (Snow Leopard, circa 2009) or newer.
-Learn how to set up MacPorts [here](https://guide.macports.org/).
-
-    sudo port selfupdate
-    sudo port install dosbox-staging
-
-If you're running an OS not longer maintained by Apple, then support is on a
-best-effort basis (as the team runs supported configurations and may not be able
-to reproduce some issues).
-
-
 ## Development snapshot builds
 
 You can always see what's cooking on the main branch! :sunglasses: :beer:


### PR DESCRIPTION
# Description

As per title—it's just a healthy thing to do for our sanity 😎

One recent issue where a distro-packager induced bug resulted in a 5+ page issue ticket:
https://github.com/dosbox-staging/dosbox-staging/issues/4173#issuecomment-2817249807

Relevant comment:
 > Okay, so I tried the binaries from the website, and the keyboard configuration works. It seems this is a problem with the packaging of specific distros, then. Idk what could be wrong with the [PKGBUILD](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=dosbox-staging) in the AUR, though.

I can remember a few more SDL and Pi-related ones just from this month on Linux...

So, this PR removes the list of distro-provided packages from our Linux downloads section and replaces it with a warning and explanation for using our official Linux builds.

If you go to "established" big Linux projects' websites, such as Blender and Inkscape, they don't even advertise repo-provided packages, neither do they provide build instructions. Which is perfectly understandable—there are millions of ways to screw up complex software like that if it's repackaged/rebuilt by a different team not intimately familiar with it. They wouldn't even notice something is wrong, unless they put in tens of hours of testing, which I doubt many of them do.

Similar deal with putting "build instruction" type of information into our releases pages. That doesn't belong there. Build instructions should be in Markdown files inside the repo, and we should not "encourage" people to use alternative build methods we are intending to remove soon (e.g. Homebrew, MacPorts).

I've deployed the changes to our preview website:

https://www.dosbox-staging.org/preview/dev/releases/linux/

Lastly, I've added a checkbox to the bug report template to confirm the reporter is using our official release:

- Are you able to trigger the issue with our official DOSBox Staging release?

## Related issues

Many, unfortunately 😅 

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [x] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

