### PR TITLE
Disable narrowing & conversion warnings in the CMake build and reinstate macOS CI build warning checks

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -26,17 +26,17 @@ concurrency:
 
 jobs:
   build_macos_release:
-    name: Release build (${{ matrix.runner.arch }})
-    runs-on: ${{ matrix.runner.host }}
+    name: Release build (${{ matrix.conf.arch }})
+    runs-on: ${{ matrix.conf.host }}
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     env:
-      MACOSX_DEPLOYMENT_TARGET: ${{ matrix.runner.minimum_deployment }}
+      MACOSX_DEPLOYMENT_TARGET: ${{ matrix.conf.minimum_deployment }}
       VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
       VCPKG_ROOT: ${{ github.workspace }}/vcpkg
 
     strategy:
       matrix:
-        runner:
+        conf:
           - host: macos-15
             arch: x86_64
             minimum_deployment: '11.0'
@@ -70,7 +70,7 @@ jobs:
           ./bootstrap-vcpkg.sh
 
       - name: Log environment
-        run: arch -arch=${{ matrix.runner.arch }} ./scripts/log-env.sh
+        run: arch -arch=${{ matrix.conf.arch }} ./scripts/log-env.sh
 
       - name: Inject version string
         run: |
@@ -81,21 +81,21 @@ jobs:
       - name: Setup and build release
         run: |
           set -x
-          cmake --preset release-macos-${{ matrix.runner.arch }}
-          cmake --build --preset release-macos-${{ matrix.runner.arch }}
+          cmake --preset release-macos-${{ matrix.conf.arch }}
+          cmake --build --preset release-macos-${{ matrix.conf.arch }}
 
       - name: Upload binary
         uses: actions/upload-artifact@v4
         with:
-          name: dosbox-${{ matrix.runner.arch }}
-          path: build/release-macos-${{ matrix.runner.arch }}/Release/dosbox
+          name: dosbox-${{ matrix.conf.arch }}
+          path: build/release-macos-${{ matrix.conf.arch }}/Release/dosbox
           overwrite: true
 
       - name: Upload resources
         uses: actions/upload-artifact@v4
         with:
           name: Resources
-          path: build/release-macos-${{ matrix.runner.arch }}/Resources
+          path: build/release-macos-${{ matrix.conf.arch }}/Resources
           overwrite: true
 
   publish_universal_build:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -40,10 +40,12 @@ jobs:
           - host: macos-15
             arch: x86_64
             minimum_deployment: '11.0'
+            max_warnings: 64
 
           - host: macos-15
             arch: arm64
             minimum_deployment: '11.0'
+            max_warnings: 64
 
     steps:
       - name: Checkout repository
@@ -82,7 +84,12 @@ jobs:
         run: |
           set -x
           cmake --preset release-macos-${{ matrix.conf.arch }}
-          cmake --build --preset release-macos-${{ matrix.conf.arch }}
+          cmake --build --preset release-macos-${{ matrix.conf.arch }} 2>&1 | tee build.log
+
+      - name: Summarize warnings
+        env:
+          MAX_WARNINGS: ${{ matrix.conf.max_warnings }}
+        run:  python3 ./scripts/count-warnings.py -lf build.log
 
       - name: Upload binary
         uses: actions/upload-artifact@v4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,15 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 # TODO: Enable certain warnings-as-errors for at least MSVC, Clang & GCC
 
+# Disable the noisy narrowing and conversion warnings by default.
+# Use the CHECK_NARROWING() macro to opt-in these checks on a per-file basis.
+# See `include/checks.h` for details.
+if (MSVC)
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4244")
+else()
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-conversion -Wno-narrowing")
+endif()
+
 option(OPT_DEBUG "Enable debugging" $<IF:$<CONFIG:Debug>,ON,OFF>)
 option(OPT_HEAVY_DEBUG "Enable heavy debugging" OFF)
 

--- a/include/checks.h
+++ b/include/checks.h
@@ -1,7 +1,7 @@
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *
- *  Copyright (C) 2022-2024  The DOSBox Staging Team
+ *  Copyright (C) 2022-2025  The DOSBox Staging Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -24,18 +24,19 @@
 // This file contains macros that enable extra code checks at the file-level.
 //
 // Checks can include any compiler-toggleable features that the project team
-// feels can improve code-quality. This might include:
+// feels can improve code quality. This might include:
 //   - warnings
 //   - warnings-as-errors
 //   - diagnostics
 //   - formatting / structure / design / etc..
 //
 // These checks are those that (currently) can't be enabled project-wide
-// because they would be fatal (ie, -Werror) or too verbose (ie, -Wnarrowing
-// generating 3,400+ warnings!)
+// because they would be fatal (i.e., -Werror) or too verbose (i.e.,
+// -Wnarrowing generating too many warnings to make the warnings actually
+// useful).
 //
-// So this per file approach lets us focus down one file at a time and then
-// declare that it's free from the issue(s) we're checking.
+// This per file approach lets us focus on one file at a time and then declare
+// that it's free from the issue(s) we're checking.
 //
 // Usage:
 //     #include "checks.h"
@@ -43,8 +44,8 @@
 //
 // How to add new checks:
 //
-//   1. Assess how much work it would be to enable it at the project level. If
-//      the check is too burdensome, then carry on.
+//   1. Assess how much work it would be to enable it at the project level.
+//      If the check is too burdensome, then carry on.
 //
 //   2. The C98 and C++11 standards supports the _Pragma() function to add
 //      #pragma strings. We can use it to add compiler-specific features.


### PR DESCRIPTION
# Description

As per title. This is to achieve parity with the Meson workflow with regards to our default handling of narrowing & conversion checks, and to reinstate the warning checks for the macOS CI workflow.

Number of warnings in the macOS CI workflow:

- without disabling narrowing and conversion checks: 485 (see [this test run](https://github.com/dosbox-staging/dosbox-staging/actions/runs/14611134814/job/40989244076))
- with the checks disabled: 64 (see [this test run](https://github.com/dosbox-staging/dosbox-staging/actions/runs/14611726642/job/40990900950))

The warning checks are already in place for the MSVC CMake workflow.

We don't have a Linux CMake workflow yet. That will come in my next PR with the warning checks enabled.

## Related issues

- https://github.com/dosbox-staging/dosbox-staging/issues/4196

# Manual testing

CI is green.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

