### PR TITLE
Remove wrong assertion in the keyboard autodetection code

### DIFF
--- a/src/dos/dos_locale.cpp
+++ b/src/dos/dos_locale.cpp
@@ -1312,7 +1312,6 @@ static void sort_detected_keyboard_layouts(
 		for (const auto& entry : LocaleData::KeyboardLayoutInfo) {
 			for (const auto& layout_code : entry.layout_codes) {
 				if (layout_code == detected_deduplicated) {
-					assert(!info_map.contains(layout_code));
 					info_map[layout_code] = entry;
 					break;
 				}


### PR DESCRIPTION
# Description

Current GIT main crashes with failed assertion during the startup if the following conditions are met:
- we are running a debug build
- `keyboard_layout = auto`
- host OS has at least two keyboard layouts configured, which both map to the same bundled FreeDOS keyboard layout, for example:

![Screenshot](https://github.com/user-attachments/assets/de7f6b9f-4483-47b8-bece-7c991cca78b5)

The PR just removes the assertion in the code collecting the keyboard layout information matching the configured host layouts - I was overcautious, the condition is actually legal.

## Related issues

Fixes https://github.com/dosbox-staging/dosbox-staging/issues/4289 (thanks to @shermp for noticing this)
 


# Release notes

(n/a - debug build only fix, buggy code wasn't released yet)


# Manual testing

Recreate conditions, as described in the PR description, after starting DOSBox check with `KEYB` command that a sane keyboard layout and code page is selected (in the example from the screenshot - `pl` keyboard layout should be set). 


The change has been manually tested on:

- [x] Windows
- [ ] macOS (not tested, the change is trivial)
- [x] Linux


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

