### PR TITLE
On Windows, clear the read-only attribute before removing a directory.

### DIFF
--- a/include/fs_utils.h
+++ b/include/fs_utils.h
@@ -195,6 +195,7 @@ std::deque<std_fs::path> get_xdg_data_dirs() noexcept;
 union FatAttributeFlags; // forward declaration
 
 uint16_t local_drive_create_dir(const std_fs::path& path);
+bool local_drive_remove_dir(const std_fs::path& path);
 uint16_t local_drive_get_attributes(const std_fs::path& path,
                                     FatAttributeFlags& attributes);
 uint16_t local_drive_set_attributes(const std_fs::path& path,

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -468,9 +468,12 @@ bool localDrive::RemoveDir(const char* dir)
 	safe_strcpy(newdir, basedir);
 	safe_strcat(newdir, dir);
 	CROSS_FILENAME(newdir);
-	int temp = rmdir(dirCache.GetExpandNameAndNormaliseCase(newdir));
-	if (temp==0) dirCache.DeleteEntry(newdir,true);
-	return (temp==0);
+
+	const auto success = local_drive_remove_dir(dirCache.GetExpandNameAndNormaliseCase(newdir));
+	if (success) {
+		dirCache.DeleteEntry(newdir, true);
+	}
+	return success;
 }
 
 bool localDrive::TestDir(const char* dir)

--- a/src/misc/fs_utils_posix.cpp
+++ b/src/misc/fs_utils_posix.cpp
@@ -508,4 +508,9 @@ bool delete_native_file(const std_fs::path& path)
 	return unlink(path.c_str()) == 0;
 }
 
+bool local_drive_remove_dir(const std_fs::path& path)
+{
+	return rmdir(path.c_str()) == 0;
+}
+
 #endif


### PR DESCRIPTION
# Description

MS-DOS allows removal of read-only directories. Windows does not.
Implement a hack to remove the read-only bit if directory removal fails.

## Related issues

Fixes #4282

# Release notes

Allow read-only directories to be removed on Windows.

# Manual testing

```
mkdir blah
attrib +r blah
rmdir blah
```

Above has always worked on real MS-DOS and on Linux. This PR makes it work on Windows.

The change has been manually tested on:

- [x] Windows
- [ ] macOS
- [x] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [x] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

