### PR TITLE
Fix edge case where CDROM mixer hangs at the end of a track

### DIFF
--- a/src/dos/cdrom.h
+++ b/src/dos/cdrom.h
@@ -331,6 +331,7 @@ public:
 private:
 	static struct imagePlayer {
 		// Objects, pointers, and then scalars; in descending size-order.
+		std::mutex mutex                   = {};
 		std::weak_ptr<TrackFile> trackFile = {};
 		MixerChannelPtr channel            = nullptr;
 		CDROM_Interface_Image* cd          = nullptr;
@@ -340,7 +341,6 @@ private:
 		uint32_t playedTrackFrames  = 0;
 		uint32_t totalTrackFrames   = 0;
 		uint32_t startSector        = 0;
-		uint32_t totalRedbookFrames = 0;
 		bool isPlaying              = false;
 		bool isPaused               = false;
 
@@ -364,6 +364,8 @@ private:
 	                 const bool mode2);
 	std::vector<Track>::iterator GetTrack(const uint32_t sector);
 	void CDAudioCallback(const int desired_track_frames);
+	void PlayNextAudioTrack();
+	bool PlayAudioTrack(const Track& track, const uint32_t sector_offset);
 
 	// Private functions for cue sheet processing
 	bool  LoadCueSheet(const char *cuefile);
@@ -380,6 +382,7 @@ private:
 	std::vector<Track>   tracks;
 	std::vector<uint8_t> readBuffer;
 	std::string          mcn;
+	size_t               currentTrackIndex = 0;
 	static int           refCount;
 };
 


### PR DESCRIPTION
# Description

When the track got to the end, it was doing some back-and-forth logic going between time and sector number to figure out where to seek next.

It can hang if either the conversion is slightly off or the MP3 decoder returns slightly fewer frames that it was expecting.

Even on MP3 files where it didn't hang, it sometimes did 10+ seeks back-to-back each seeking to the last second of the file.

New code skips all that conversion business and just goes to the start of the next track :)

## Related issues

Fixes #4296

# Release notes

Fix audio hanging after about 2 minutes of play in the GOG version of Tomb Raider

# Manual testing

Tested both MP3 and .bin audio of Tomb Raider. Tested both with and without the 2 second pregap.

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [x] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [x] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

