### PR TITLE
C++ library locale autodetection fixes

### DIFF
--- a/src/misc/host_locale.cpp
+++ b/src/misc/host_locale.cpp
@@ -417,8 +417,14 @@ void StdLibLocale::GetDateFormat(const std::locale& locale)
 	}
 }
 
+#if !defined(WIN32)
 void StdLibLocale::DetectCurrencyFormat(const std::locale& locale)
 {
+	// We can only get a suitable data if monetary locale format is UTF-8
+	if (!IsMonetaryUtf8(locale)) {
+		return;
+	}
+
 	// Retrieve currency code
 	constexpr bool International = true;
 	const auto& format_code =
@@ -479,6 +485,7 @@ void StdLibLocale::DetectCurrencyFormat(const std::locale& locale)
 	currency_code_format = detect_format(money_code_example, currency_code);
 	currency_utf8_format = detect_format(money_code_example, currency_utf8);
 }
+#endif
 
 void StdLibLocale::DetectTimeDateFormat(const std::locale& locale)
 {

--- a/src/misc/host_locale.cpp
+++ b/src/misc/host_locale.cpp
@@ -387,6 +387,10 @@ StdLibLocale::StdLibLocale()
 	DetectTimeDateFormat(locale);
 }
 
+// On macOS the C++ standard library returns generic values. To get the real
+// values, we need to refer to the CoreFoundation API.
+#if !C_COREFOUNDATION
+
 void StdLibLocale::GetNumericFormat(const std::locale& locale)
 {
 	const auto& format = std::use_facet<std::numpunct<char>>(locale);
@@ -564,3 +568,5 @@ void StdLibLocale::DetectTimeDateFormat(const std::locale& locale)
 		}
 	}
 }
+
+#endif

--- a/src/misc/host_locale.h
+++ b/src/misc/host_locale.h
@@ -156,6 +156,8 @@ struct HostLanguages {
 	std::string log_info = {};
 };
 
+bool IsMonetaryUtf8(const std::locale& locale);
+
 const HostLocale&          GetHostLocale();
 const HostKeyboardLayouts& GetHostKeyboardLayouts();
 const HostLanguages&       GetHostLanguages();

--- a/src/misc/host_locale.h
+++ b/src/misc/host_locale.h
@@ -1,7 +1,7 @@
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *
- *  Copyright (C) 2024-2024  The DOSBox Staging Team
+ *  Copyright (C) 2024-2025  The DOSBox Staging Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -89,6 +89,13 @@ struct StdLibLocale {
 
 	char date_separator = {};
 	char time_separator = {};
+
+private:
+	void GetNumericFormat(const std::locale& locale);
+	void GetDateFormat(const std::locale& locale);
+
+	void DetectCurrencyFormat(const std::locale& locale);
+	void DetectTimeDateFormat(const std::locale& locale);
 };
 
 struct HostLocaleElement {

--- a/src/misc/host_locale_macos.cpp
+++ b/src/misc/host_locale_macos.cpp
@@ -667,6 +667,11 @@ static HostKeyboardLayouts get_host_keyboard_layouts()
 	return get_host_keyboard_layouts(apple_layouts);
 }
 
+bool IsMonetaryUtf8([[maybe_unused]] const std::locale& locale)
+{
+	return false;
+}
+
 const HostLocale& GetHostLocale()
 {
 	static std::optional<HostLocale> locale = {};

--- a/src/misc/host_locale_posix.cpp
+++ b/src/misc/host_locale_posix.cpp
@@ -1409,6 +1409,36 @@ static HostKeyboardLayouts get_host_keyboard_layouts()
 	return {};
 }
 
+bool IsMonetaryUtf8(const std::locale& locale)
+{
+	auto check_utf8 = [](const std::locale& locale,
+	                     const std::string& variable) -> std::optional<bool> {
+		for (auto entry : split(locale.name(), ";\n\r")) {
+			trim(entry);
+			if (!entry.starts_with(variable)) {
+				continue;
+			}
+
+			upcase(entry);
+			return (entry.find("UTF8")  != std::string::npos) ||
+			       (entry.find("UTF-8") != std::string::npos);
+		}
+
+		return {};
+	};
+
+	bool found_utf8 = false;
+	for (const auto& variable : { "LC_ALL", "LC_MONETARY", "LANG" }) {
+		const auto result = check_utf8(locale, variable);
+		if (result) {
+			found_utf8 = *result;
+			break;
+		}
+	}
+
+	return found_utf8;
+}
+
 const HostLocale& GetHostLocale()
 {
 	static std::optional<HostLocale> locale = {};

--- a/src/misc/host_locale_win32.cpp
+++ b/src/misc/host_locale_win32.cpp
@@ -1,7 +1,7 @@
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *
- *  Copyright (C) 2024-2024  The DOSBox Staging Team
+ *  Copyright (C) 2024-2025  The DOSBox Staging Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -592,6 +592,11 @@ static HostLanguages get_host_languages()
 	return result;
 }
 
+bool IsMonetaryUtf8([[maybe_unused]] const std::locale& locale)
+{
+	return false;
+}
+
 const HostLocale& GetHostLocale()
 {
 	static std::optional<HostLocale> locale = {};
@@ -625,6 +630,15 @@ const HostLanguages& GetHostLanguages()
 	}
 
 	return *locale;
+}
+
+// ***************************************************************************
+// Overridden generic locale fetch routines
+// ***************************************************************************
+
+void StdLibLocale::DetectCurrencyFormat([[maybe_unused]] const std::locale& locale)
+{
+	// Not implemented for Windows
 }
 
 #endif


### PR DESCRIPTION
# Description

This PR fixes some problems related to locale autodetection using the C++ standard library:
- **Windows**: disabled currency format detection due to test string returned by the C++ standard library not being UTF-8
- **Linux**: only perform currency format detection if the monetary locale is UTF-8
- **macOS**: do not use the C++ standard library for locale detection, as it returns dummy values; use _CoreFoundation_ functions instead


## Related issues

Fixes https://github.com/dosbox-staging/dosbox-staging/issues/4094


# Release notes

(not needed - bugfix for a feature which wasn't released yet)


# Manual testing

- make sure `locale_period = native` in the config file
- start DOSBox, check that no `UNICODE: Problem decoding UTF8 string` is printed out
- execute DOSBox  `dir` command, check that time/date format and file size format follows the host OS settings
- repeat with different locale settings (on some OSes or desktop environments you might need to re-login for the new settings to be detected by DOSBox)

The change has been manually tested on:

- [x] Windows
- [x] macOS
- [x] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

