### PR TITLE
Use untranslated keyboard layout name for logging

### DIFF
--- a/src/dos/dos_code_page.cpp
+++ b/src/dos/dos_code_page.cpp
@@ -2115,7 +2115,7 @@ static KeyboardLayoutResult load_bundled_screen_font(const uint16_t code_page)
 
 	LOG_MSG("LOCALE: Loaded code page %d - '%s'",
 	        code_page,
-	        DOS_GetCodePageDescriptionForLog(code_page).c_str());
+	        DOS_GetEnglishCodePageDescription(code_page).c_str());
 
 	notify_code_page_changed();
 	return KeyboardLayoutResult::OK;

--- a/src/dos/dos_keyboard_layout.cpp
+++ b/src/dos/dos_keyboard_layout.cpp
@@ -929,7 +929,7 @@ KeyboardLayoutResult DOS_LoadKeyboardLayout(const std::string& keyboard_layout,
 		assert(!new_keyboard_layout.empty());
 		LOG_MSG("LOCALE: Loaded keyboard layout '%s' - '%s'",
 		        new_keyboard_layout.c_str(),
-		        DOS_GetKeyboardLayoutName(new_keyboard_layout).c_str());
+		        DOS_GetEnglishKeyboardLayoutName(new_keyboard_layout).c_str());
 	}
 
 	return result;

--- a/src/dos/dos_locale.cpp
+++ b/src/dos/dos_locale.cpp
@@ -546,7 +546,7 @@ uint16_t DOS_GetCountry()
 }
 
 // ***************************************************************************
-// Helper functions for 'dosbox --list-*' commands
+// Helper functions for commands and logging output
 // ***************************************************************************
 
 static std::string get_output_header(const char* header_msg_id,
@@ -719,18 +719,32 @@ std::string DOS_GenerateListCodePagesMessage()
 // Helper functions for KEYB.COM command
 // ***************************************************************************
 
-std::string DOS_GetKeyboardLayoutName(const std::string& layout)
+static std::string get_keyboard_layout_name(const std::string& layout,
+                                            const bool translated)
 {
 	const auto layout_deduplicated = deduplicate_layout(layout);
 
 	for (const auto& entry : LocaleData::KeyboardLayoutInfo) {
 		assert(!entry.layout_codes.empty());
 		if (entry.layout_codes[0] == layout_deduplicated) {
-			return MSG_Get(entry.GetMsgName().c_str());
+			return translated ? MSG_Get(entry.GetMsgName())
+			                  : entry.layout_name;
 		}
 	}
 
 	return {};
+}
+
+std::string DOS_GetKeyboardLayoutName(const std::string& layout)
+{
+	constexpr bool Translated = true;
+	return get_keyboard_layout_name(layout, Translated);
+}
+
+std::string DOS_GetEnglishKeyboardLayoutName(const std::string& layout)
+{
+	constexpr bool Translated = false;
+	return get_keyboard_layout_name(layout, Translated);
 }
 
 static Script to_script(const KeyboardScript keyboard_script)
@@ -911,7 +925,7 @@ std::string DOS_GetCodePageDescription(const uint16_t code_page)
 	return {};
 }
 
-std::string DOS_GetCodePageDescriptionForLog(const uint16_t code_page)
+std::string DOS_GetEnglishCodePageDescription(const uint16_t code_page)
 {
 	const auto entry = get_code_page_info_entry(code_page);
 	if (entry) {

--- a/src/dos/dos_locale.h
+++ b/src/dos/dos_locale.h
@@ -528,7 +528,11 @@ std::optional<KeyboardScript> DOS_GetKeyboardLayoutScript3(const std::string& la
                                                            const uint16_t code_page);
 
 std::string DOS_GetCodePageDescription(const uint16_t code_page);
-std::string DOS_GetCodePageDescriptionForLog(const uint16_t code_page);
+
+// Functions for logging purposes
+
+std::string DOS_GetEnglishKeyboardLayoutName(const std::string& layout);
+std::string DOS_GetEnglishCodePageDescription(const uint16_t code_page);
 
 // DOS API support
 


### PR DESCRIPTION
# Description

This fixes a small logging problem, where the keyboard layout description in the log is translated, for example:

```
LOCALE: Loaded code page 437 - 'United States'
LOCALE: Loaded keyboard layout 'us' - 'amerykanski (standardowy, QWERTY/narodowy)'
LOCALE: Loaded code page 667 - 'Polish, Mazovia encoding'
LOCALE: Loaded keyboard layout 'pl' - 'polski (programisty, QWERTY/fonetyczny)'
```

This is wrong - logs should be kept in English, so that everyone can analyze them, regardless of the locale.


# Release notes

(not needed, just a minor fix to the log output - regression after post-0.82.0 locale rework)


# Manual testing

- Set `language = pl` in the config file
- Execute commands `keyb us 437` and `keyb pl 667`

Command output inside the DOSBox window should be fully translated, while the log output should stay untranslated, like:

```
LOCALE: Loaded code page 437 - 'United States'
LOCALE: Loaded keyboard layout 'us' - 'US (standard, QWERTY/national)'
LOCALE: Loaded code page 667 - 'Polish, Mazovia encoding'
LOCALE: Loaded keyboard layout 'pl' - 'Polish (programmers, QWERTY/phonetic)'
```

Note, that only values which are actually changed are being logged

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [x] Linux (the change is trivial)


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

