### PR TITLE
Minor Windows CMake QoL improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,9 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 # `include/checks.h` for details.
 if(MSVC)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4244")
+  
+  # Disable cl/clangcl warnings about insecure C functions
+  add_compile_definitions(_CRT_SECURE_NO_WARNINGS)
 else()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-conversion -Wno-narrowing")
 endif()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -143,6 +143,10 @@
         "CMAKE_FIND_PACKAGE_PREFER_CONFIG" : "ON",
         "CMAKE_BUILD_TYPE": "Debug",
         "RESOURCE_COPY_PATH": "/Resources"
+      },
+      "environment": {
+        "UseMultiToolTask": "true",
+        "EnforceProcessCountAcrossBuilds": "true"
       }
     },
     {
@@ -157,6 +161,10 @@
         "CMAKE_FIND_PACKAGE_PREFER_CONFIG" : "ON",
         "CMAKE_BUILD_TYPE": "Release",
         "RESOURCE_COPY_PATH": "/Resources"
+      },
+      "environment": {
+        "UseMultiToolTask": "true",
+        "EnforceProcessCountAcrossBuilds": "true"
       }
     }
   ],


### PR DESCRIPTION
# Description

Just a couple of minor improvements to make using cmake with the Visual Studio generator nicer on Windows.

1. Add `_CRT_SECURE_NO_WARNINGS` to silence all the warnings about using "insecure" C functions.
2. Enable `UseMultiToolTask` in the Windows cmake presets to use MSBuild Multi Tool Task for much faster build times.

# Manual testing

The change has been manually tested on:

- [x] Windows
- [ ] macOS
- [ ] Linux

1. Configure cmake on the command line (in one of the Visual Studio developer command prompts) or in VS with one of the windows cmake presets
2. Build. Notice the much reduced warnings, and much faster build times

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

