### PR TITLE
Change 'ux' keyboard layout autodetection priority to low

### DIFF
--- a/src/dos/dos_locale_data.cpp
+++ b/src/dos/dos_locale_data.cpp
@@ -334,8 +334,9 @@ const std::vector<KeyboardLayoutInfoEntry> LocaleData::KeyboardLayoutInfo = {
 	},
 	{
 		{ "ux" }, "US (international, QWERTY)",
-		// The QWERTY layer is almost identical to the US layout
-		AutodetectionPriority::High,
+		// The QWERTY layer is almost very similar to the US layout,
+		// but uses dead keys, which might be confusing
+		AutodetectionPriority::Low,
 		850,
 		KeyboardScript::LatinQwerty,
 	},


### PR DESCRIPTION
# Description

Change the `ux` keyboard layout autodetection priority to low (which means the standard US layout is going to be preferred). The `ux`is s a variant of the QWERTY `us` layout, but uses dead keys, which might be confusing (see the related issue), and is only needed by a few exotic languages.


## Related issues

Fixes https://github.com/dosbox-staging/dosbox-staging/issues/4076


# Release notes

(not needed; this is just a small tweak to the improved autodetection algorithm, which wasn't released yet)


# Manual testing

Set `keyboard_layout = auto` (this is the default value), configure the host OS (macOS, Windows, or Linux with GNOME) to have exactly two keyboard layouts:
- US English (normal one)
- English International (with dead keys)
Launch DOSBox and check (execute the `KEYB` command) that the `us` layout (not the `ux`) has been set.

Notes:
- Linux with KDE is not suitable for the bringup due to different processing tailored for this particular environment - contrary to macOS or Windows it allows the user to order keyboard layouts by priority, and contrary to GNOME it always starts with the highest priority keyboard layout, therefore we (well, mostly) respect the keyboard layouts priority from the KDE configuration tool
- it might be hard to configure Windows the required way

The change has been manually tested on:

- [ ] Windows (hard to test, but the change is trivial)
- [x] macOS
- [x] Linux


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

