### PR TITLE
Unit tests compilation fix

### DIFF
--- a/src/misc/messages.cpp
+++ b/src/misc/messages.cpp
@@ -798,7 +798,7 @@ void MSG_NotifyNewCodePage()
 	check_code_page();
 }
 
-// MSG_Init loads the requested language provided on the command line or
+// MSG_LoadMessages loads the requested language provided on the command line or
 // from the language = conf setting.
 
 // 1. The provided language can be an exact filename and path to the lng

--- a/src/misc/messages_stubs.cpp
+++ b/src/misc/messages_stubs.cpp
@@ -1,7 +1,7 @@
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *
- *  Copyright (C) 2022-2024  The DOSBox Staging Team
+ *  Copyright (C) 2022-2025  The DOSBox Staging Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -50,5 +50,4 @@ bool MSG_WriteToFile(const std::string&)
 	return true;
 }
 
-class Section_prop;
-void MSG_Init(Section_prop *) {}
+void MSG_LoadMessages() {}


### PR DESCRIPTION
# Description

- fix for unit tests compilation
- updated one comment in the source code


# Manual testing

Compiled and executed unit tests

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [x] Linux


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

