### PR TITLE
Dynamically load Slirp library at runtime

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -180,6 +180,11 @@ jobs:
       - name: Dump workspace contents
         run: find $RUNNER_WORKSPACE
 
+      - name: Verify executable RPATH
+        run: |
+          set -x
+          objdump -x build/release-linux/dosbox | grep \$ORIGIN/lib
+
       - name: Package
         run: |
           echo "*** dosbox transitive deps:"

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -80,10 +80,19 @@ jobs:
           cmake --preset release-macos-${{ matrix.conf.arch }}
           cmake --build --preset release-macos-${{ matrix.conf.arch }} 2>&1 | tee build.log
 
+      - name: Dump workspace contents
+        run: find $RUNNER_WORKSPACE
+
       - name: Summarize warnings
         env:
           MAX_WARNINGS: ${{ matrix.conf.max_warnings }}
         run:  python3 ./scripts/count-warnings.py -lf build.log
+
+      - name: Verify executable RPATH
+        run: |
+          set -x
+          otool -l build/release-macos-${{ matrix.conf.arch }}/Release/dosbox \
+            | grep "path @executable_path/lib"
 
       - name: Upload binary
         uses: actions/upload-artifact@v4

--- a/.github/workflows/pvs-studio.yml
+++ b/.github/workflows/pvs-studio.yml
@@ -129,7 +129,7 @@ jobs:
 
       - name: Summarize report
         env:
-          MAX_BUGS: 170
+          MAX_BUGS: 176
         run: |
           echo "Full report is included in build Artifacts"
           echo

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,19 +195,19 @@ configure_file(
 
 ### end of config.h ###
 
-add_executable(dosbox src/main.cpp src/dosbox.cpp)
-target_include_directories(
-  dosbox PUBLIC include ${CMAKE_CURRENT_BINARY_DIR}/include
-)
-
 # Allow dynamically loading externalised vcpkg dependencies at runtime
-# from the $EXE_DIR/lib directory
+# from the $EXE_DIR/lib directory (must be set before 'add_executable')
 if (APPLE)
   set(CMAKE_INSTALL_RPATH "@executable_path/lib")
 else()
   set(CMAKE_INSTALL_RPATH "$ORIGIN/lib")
 endif()
 set(CMAKE_BUILD_WITH_INSTALL_RPATH ON)
+
+add_executable(dosbox src/main.cpp src/dosbox.cpp)
+target_include_directories(
+  dosbox PUBLIC include ${CMAKE_CURRENT_BINARY_DIR}/include
+)
 
 # TODO This happens on every execution, better to have a target with
 # dependencies instead

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,10 +137,6 @@ set(C_FPU ON)
 set(C_MODEM ON)
 set(C_IPX ON)
 
-# More networking (TODO: Option)
-set(C_SLIRP OFF)
-set(C_NE2000 OFF)
-
 set(C_OPENGL ON)
 set(C_MT32EMU ON)       # TODO: Option
 

--- a/include/dynlib.h
+++ b/include/dynlib.h
@@ -34,7 +34,12 @@ enum class DynLibResult {
 #ifdef WIN32
 
 // clang-format off
-// 'windows.h' must be included first, otherwise we'll get compilation errors
+// 'windows.h' must be included first, otherwise we'll get compilation errors.
+// Defining WIN32_LEAN_AND_MEAN ensures that winsock.h is not included, which 
+// conflicts with winsock2.h used by slirp
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
 #include <windows.h>
 #include <libloaderapi.h>
 // clang-format on

--- a/include/ne2000.h
+++ b/include/ne2000.h
@@ -33,8 +33,6 @@
 
 #include "dosbox.h"
 
-#if C_NE2000
-
 #include "inout.h"
 
 #define bx_bool int
@@ -247,7 +245,5 @@ public:
 };
 
 void NE2K_Init(Section* sec);
-
-#endif // C_NE2000
 
 #endif

--- a/meson.build
+++ b/meson.build
@@ -435,8 +435,6 @@ conf_data.set_quoted(
 conf_data.set10(os_family_name, true)
 conf_data.set10('C_MODEM', get_option('use_sdl2_net'))
 conf_data.set10('C_IPX', get_option('use_sdl2_net'))
-conf_data.set10('C_SLIRP', get_option('use_slirp'))
-conf_data.set10('C_NE2000', get_option('use_slirp'))
 conf_data.set10('C_MT32EMU', get_option('use_mt32emu'))
 conf_data.set10('C_TRACY', get_option('tracy'))
 conf_data.set10('C_FPU', true)

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -97,12 +97,6 @@
 // Define to 1 to use opengl display output support
 #mesondefine C_OPENGL
 
-// Define to 1 to enable libslirp Ethernet support
-#mesondefine C_SLIRP
-
-// Define to 1 to enable Novell NE 2000 NIC emulation
-#mesondefine C_NE2000
-
 // Define to 1 to enable the Tracy profiling server
 #mesondefine C_TRACY
 

--- a/src/config.h.in.cmake
+++ b/src/config.h.in.cmake
@@ -96,12 +96,6 @@
 // Define to 1 to use opengl display output support
 #cmakedefine01 C_OPENGL
 
-// Define to 1 to enable libslirp Ethernet support
-#cmakedefine01 C_SLIRP
-
-// Define to 1 to enable Novell NE 2000 NIC emulation
-#cmakedefine01 C_NE2000
-
 // Define to 1 to enable the Tracy profiling server
 #cmakedefine01 C_TRACY
 

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -1267,19 +1267,19 @@ void DOSBOX_Init()
 
 	secprop = control->AddSection_prop("ethernet", &NE2K_Init, changeable_at_runtime);
 
-	pbool = secprop->Add_bool("ne2000", when_idle, true);
+	pbool = secprop->Add_bool("ne2000", when_idle, false);
 	pbool->SetOptionHelp(
 	        "SLIRP",
-	        "Enable emulation of a Novell NE2000 network card on a software-based\n"
-	        "network (using libslirp) with properties as follows ('on' by default):\n"
-	        "  - 255.255.255.0:  Subnet mask of the 10.0.2.0 virtual LAN.\n"
-	        "  - 10.0.2.2:       IP of the gateway and DHCP service.\n"
-	        "  - 10.0.2.3:       IP of the virtual DNS server.\n"
-	        "  - 10.0.2.15:      First IP provided by DHCP, your IP!\n"
-	        "Note: Inside DOS, setting this up requires an NE2000 packet driver, DHCP\n"
-	        "      client, and TCP/IP stack. You might need port-forwarding from the host\n"
-	        "      into the DOS guest, and from your router to your host when acting as the\n"
-	        "      server for multiplayer games.");
+	        "Enable emulation of a Novell NE2000 network card on a software-based network\n"
+	        "with the following properties ('off' by default):\n"
+	        "  - 255.255.255.0   Subnet mask of the 10.0.2.0 virtual LAN.\n"
+	        "  - 10.0.2.2        IP of the gateway and DHCP service.\n"
+	        "  - 10.0.2.3        IP of the virtual DNS server.\n"
+	        "  - 10.0.2.15       First IP provided by DHCP (this is your IP)\n"
+	        "Note: Using this feature requires an NE2000 packet driver, a DHCP client, and a\n"
+	        "      TCP/IP stack set up in DOS. You might need port-forwarding from your host\n"
+	        "      OS into DOSBox, and from your router to your host OS when acting as the\n"
+	        "      server in multiplayer games.");
 
 	pbool->SetEnabledOptions({"SLIRP"});
 

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -1265,11 +1265,7 @@ void DOSBOX_Init()
 	pbool->SetEnabledOptions({"ipx"});
 #endif
 
-#if C_SLIRP
 	secprop = control->AddSection_prop("ethernet", &NE2K_Init, changeable_at_runtime);
-#else
-	secprop = control->AddInactiveSectionProp("ethernet");
-#endif
 
 	pbool = secprop->Add_bool("ne2000", when_idle, true);
 	pbool->SetOptionHelp(
@@ -1284,9 +1280,8 @@ void DOSBOX_Init()
 	        "      client, and TCP/IP stack. You might need port-forwarding from the host\n"
 	        "      into the DOS guest, and from your router to your host when acting as the\n"
 	        "      server for multiplayer games.");
-#if C_SLIRP
+
 	pbool->SetEnabledOptions({"SLIRP"});
-#endif
 
 	phex = secprop->Add_hex("nicbase", when_idle, 0x300);
 	phex->Set_values(
@@ -1295,9 +1290,8 @@ void DOSBOX_Init()
 	                    "Base address of the NE2000 card (300 by default).\n"
 	                    "Note: Addresses 220 and 240 might not be available as they're assigned to the\n"
 	                    "      Sound Blaster and Gravis UltraSound by default.");
-#if C_SLIRP
+
 	phex->SetEnabledOptions({"SLIRP"});
-#endif
 
 	pint = secprop->Add_int("nicirq", when_idle, 3);
 	pint->Set_values({"3", "4", "5", "9", "10", "11", "12", "14", "15"});
@@ -1305,16 +1299,14 @@ void DOSBOX_Init()
 	                    "The interrupt used by the NE2000 card (3 by default).\n"
 	                    "Note: IRQs 3 and 5 might not be available as they're assigned to\n"
 	                    "      'serial2' and the Gravis UltraSound by default.");
-#if C_SLIRP
+
 	pint->SetEnabledOptions({"SLIRP"});
-#endif
 
 	pstring = secprop->Add_string("macaddr", when_idle, "AC:DE:48:88:99:AA");
 	pstring->SetOptionHelp("SLIRP",
 	                       "The MAC address of the NE2000 card ('AC:DE:48:88:99:AA' by default).");
-#if C_SLIRP
+
 	pstring->SetEnabledOptions({"SLIRP"});
-#endif
 
 	pstring = secprop->Add_string("tcp_port_forwards", when_idle, "");
 	pstring->SetOptionHelp(
@@ -1337,18 +1329,16 @@ void DOSBOX_Init()
 	        "  - If mapped ranges differ, the shorter range is extended to fit.\n"
 	        "  - If conflicting host ports are given, only the first one is setup.\n"
 	        "  - If conflicting guest ports are given, the latter rule takes precedent.");
-#if C_SLIRP
+
 	pstring->SetEnabledOptions({"SLIRP"});
-#endif
 
 	pstring = secprop->Add_string("udp_port_forwards", when_idle, "");
 	pstring->SetOptionHelp(
 	        "SLIRP",
 	        "Forward one or more UDP ports from the host into the DOS guest\n"
 	        "(unset by default). The format is the same as for TCP port forwards.");
-#if C_SLIRP
+
 	pstring->SetEnabledOptions({"SLIRP"});
-#endif
 
 	//	secprop->AddInitFunction(&CREDITS_Init);
 

--- a/src/hardware/ne2000.cpp
+++ b/src/hardware/ne2000.cpp
@@ -1459,9 +1459,12 @@ public:
 		}
 
 		ethernet = ETHERNET_OpenConnection("slirp");
-		if(!ethernet)
-		{
-			LOG_MSG("NE2000: Failed to initialise Slirp Ethernet backend");
+		if (!ethernet) {
+			LOG_WARNING(
+			        "NE2000: Failed to initialise Slirp Ethernet backend; "
+			        "setting 'ne2000' to 'off'");
+
+			set_section_property_value("ethernet", "ne2000", "off");
 			load_success = false;
 			return;
 		}

--- a/src/hardware/ne2000.cpp
+++ b/src/hardware/ne2000.cpp
@@ -1461,7 +1461,7 @@ public:
 		ethernet = ETHERNET_OpenConnection("slirp");
 		if(!ethernet)
 		{
-			LOG_MSG("NE2000: Failed to open Ethernet slirp backend");
+			LOG_MSG("NE2000: Failed to initialise Slirp Ethernet backend");
 			load_success = false;
 			return;
 		}

--- a/src/hardware/ne2000.cpp
+++ b/src/hardware/ne2000.cpp
@@ -24,8 +24,6 @@
 
 #include "ne2000.h"
 
-#if C_NE2000
-
 #include <cstdarg>
 #include <cstdio>
 #include <cstring>
@@ -1548,5 +1546,3 @@ void NE2K_Init(Section* sec)
 		instance = nullptr;
 	}
 }
-
-#endif // C_NE2000

--- a/src/libs/include/README.md
+++ b/src/libs/include/README.md
@@ -7,6 +7,7 @@ and headers can be included as they normally would.
 The headers for the following libraries are included:
 
 - Fluidsynth
+- Slirp
 
 Ideally, headers should come from the minimum required version of the library, 
 and only updated when new features of the API are used.
@@ -22,3 +23,10 @@ The original `fluidsynth.cmake` file has been renamed to `fluidsynth.h` and
 the conditional logic for `BUILD_SHARED_LIBS` was removed and replaced with a 
 bare `#define FLUIDSYNTH_API`. Additionally, `#include "fluidsynth/version.h"` 
 has been commented out.
+
+## Slirp
+
+Headers are sourced from the dist archive for the 4.8.0 release. 
+
+The `libslirp.h` file was copied into the the `slirp` directory, and  
+`#include "libslirp-version.h"` was commented out.

--- a/src/libs/include/slirp/libslirp.h
+++ b/src/libs/include/slirp/libslirp.h
@@ -1,0 +1,342 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+#ifndef LIBSLIRP_H
+#define LIBSLIRP_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <sys/types.h>
+
+#ifdef _WIN32
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#include <in6addr.h>
+#include <basetsd.h>
+typedef SSIZE_T slirp_ssize_t;
+#ifdef BUILDING_LIBSLIRP
+# define SLIRP_EXPORT __declspec(dllexport)
+#else
+# define SLIRP_EXPORT __declspec(dllimport)
+#endif
+#else
+#include <sys/types.h>
+typedef ssize_t slirp_ssize_t;
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#define SLIRP_EXPORT
+#endif
+
+//#include "libslirp-version.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Opaque structure containing the slirp state */
+typedef struct Slirp Slirp;
+
+/* Flags passed to SlirpAddPollCb and to be returned by SlirpGetREventsCb. */
+enum {
+    SLIRP_POLL_IN = 1 << 0,
+    SLIRP_POLL_OUT = 1 << 1,
+    SLIRP_POLL_PRI = 1 << 2,
+    SLIRP_POLL_ERR = 1 << 3,
+    SLIRP_POLL_HUP = 1 << 4,
+};
+
+/* Callback for application to get data from the guest */
+typedef slirp_ssize_t (*SlirpReadCb)(void *buf, size_t len, void *opaque);
+/* Callback for application to send data to the guest */
+typedef slirp_ssize_t (*SlirpWriteCb)(const void *buf, size_t len, void *opaque);
+/* Timer callback */
+typedef void (*SlirpTimerCb)(void *opaque);
+/* Callback for libslirp to register polling callbacks */
+typedef int (*SlirpAddPollCb)(int fd, int events, void *opaque);
+/* Callback for libslirp to get polling result */
+typedef int (*SlirpGetREventsCb)(int idx, void *opaque);
+
+/* For now libslirp creates only a timer for the IPv6 RA */
+typedef enum SlirpTimerId {
+    SLIRP_TIMER_RA,
+    SLIRP_TIMER_NUM,
+} SlirpTimerId;
+
+/*
+ * Callbacks from slirp, to be set by the application.
+ *
+ * The opaque parameter is set to the opaque pointer given in the slirp_new /
+ * slirp_init call.
+ */
+typedef struct SlirpCb {
+    /*
+     * Send an ethernet frame to the guest network. The opaque parameter is the
+     * one given to slirp_init(). If the guest is not ready to receive a frame,
+     * the function can just drop the data. TCP will then handle retransmissions
+     * at a lower pace.
+     * <0 reports an IO error.
+     */
+    SlirpWriteCb send_packet;
+    /* Print a message for an error due to guest misbehavior.  */
+    void (*guest_error)(const char *msg, void *opaque);
+    /* Return the virtual clock value in nanoseconds */
+    int64_t (*clock_get_ns)(void *opaque);
+    /* Create a new timer with the given callback and opaque data. Not
+     * needed if timer_new_opaque is provided. */
+    void *(*timer_new)(SlirpTimerCb cb, void *cb_opaque, void *opaque);
+    /* Remove and free a timer */
+    void (*timer_free)(void *timer, void *opaque);
+    /* Modify a timer to expire at @expire_time (ms) */
+    void (*timer_mod)(void *timer, int64_t expire_time, void *opaque);
+    /* Register a fd for future polling */
+    void (*register_poll_fd)(int fd, void *opaque);
+    /* Unregister a fd */
+    void (*unregister_poll_fd)(int fd, void *opaque);
+    /* Kick the io-thread, to signal that new events may be processed because some TCP buffer
+     * can now receive more data, i.e. slirp_socket_can_recv will return 1. */
+    void (*notify)(void *opaque);
+
+    /*
+     * Fields introduced in SlirpConfig version 4 begin
+     */
+
+    /* Initialization has completed and a Slirp* has been created.  */
+    void (*init_completed)(Slirp *slirp, void *opaque);
+    /* Create a new timer.  When the timer fires, the application passes
+     * the SlirpTimerId and cb_opaque to slirp_handle_timer.  */
+    void *(*timer_new_opaque)(SlirpTimerId id, void *cb_opaque, void *opaque);
+} SlirpCb;
+
+#define SLIRP_CONFIG_VERSION_MIN 1
+#define SLIRP_CONFIG_VERSION_MAX 5
+
+typedef struct SlirpConfig {
+    /* Version must be provided */
+    uint32_t version;
+    /*
+     * Fields introduced in SlirpConfig version 1 begin
+     */
+    /* Whether to prevent the guest from accessing the Internet */
+    int restricted;
+    /* Whether IPv4 is enabled */
+    bool in_enabled;
+    /* Virtual network for the guest */
+    struct in_addr vnetwork;
+    /* Mask for the virtual network for the guest */
+    struct in_addr vnetmask;
+    /* Virtual address for the host exposed to the guest */
+    struct in_addr vhost;
+    /* Whether IPv6 is enabled */
+    bool in6_enabled;
+    /* Virtual IPv6 network for the guest */
+    struct in6_addr vprefix_addr6;
+    /* Len of the virtual IPv6 network for the guest */
+    uint8_t vprefix_len;
+    /* Virtual address for the host exposed to the guest */
+    struct in6_addr vhost6;
+    /* Hostname exposed to the guest in DHCP hostname option */
+    const char *vhostname;
+    /* Hostname exposed to the guest in the DHCP TFTP server name option */
+    const char *tftp_server_name;
+    /* Path of the files served by TFTP */
+    const char *tftp_path;
+    /* Boot file name exposed to the guest via DHCP */
+    const char *bootfile;
+    /* Start of the DHCP range */
+    struct in_addr vdhcp_start;
+    /* Virtual address for the DNS server exposed to the guest */
+    struct in_addr vnameserver;
+    /* Virtual IPv6 address for the DNS server exposed to the guest */
+    struct in6_addr vnameserver6;
+    /* DNS search names exposed to the guest via DHCP */
+    const char **vdnssearch;
+    /* Domain name exposed to the guest via DHCP */
+    const char *vdomainname;
+    /* MTU when sending packets to the guest */
+    /* Default: IF_MTU_DEFAULT */
+    size_t if_mtu;
+    /* MRU when receiving packets from the guest */
+    /* Default: IF_MRU_DEFAULT */
+    size_t if_mru;
+    /* Prohibit connecting to 127.0.0.1:* */
+    bool disable_host_loopback;
+    /*
+     * Enable emulation code (*warning*: this code isn't safe, it is not
+     * recommended to enable it)
+     */
+    bool enable_emu;
+
+    /*
+     * Fields introduced in SlirpConfig version 2 begin
+     */
+    /* Address to be used when sending data to the Internet */
+    struct sockaddr_in *outbound_addr;
+    /* IPv6 Address to be used when sending data to the Internet */
+    struct sockaddr_in6 *outbound_addr6;
+
+    /*
+     * Fields introduced in SlirpConfig version 3 begin
+     */
+    /* slirp will not redirect/serve any DNS packet */
+    bool disable_dns;
+
+    /*
+     * Fields introduced in SlirpConfig version 4 begin
+     */
+    /* slirp will not reply to any DHCP requests */
+    bool disable_dhcp;
+
+    /*
+     * Fields introduced in SlirpConfig version 5 begin
+     */
+    /* Manufacturer ID (IANA Private Enterprise number) */
+    uint32_t mfr_id;
+    /*
+     * MAC address allocated for an out-of-band management controller, to be
+     * retrieved through NC-SI.
+     */
+    uint8_t oob_eth_addr[6];
+} SlirpConfig;
+
+/* Create a new instance of a slirp stack */
+SLIRP_EXPORT
+Slirp *slirp_new(const SlirpConfig *cfg, const SlirpCb *callbacks,
+                 void *opaque);
+/* slirp_init is deprecated in favor of slirp_new */
+SLIRP_EXPORT
+Slirp *slirp_init(int restricted, bool in_enabled, struct in_addr vnetwork,
+                  struct in_addr vnetmask, struct in_addr vhost,
+                  bool in6_enabled, struct in6_addr vprefix_addr6,
+                  uint8_t vprefix_len, struct in6_addr vhost6,
+                  const char *vhostname, const char *tftp_server_name,
+                  const char *tftp_path, const char *bootfile,
+                  struct in_addr vdhcp_start, struct in_addr vnameserver,
+                  struct in6_addr vnameserver6, const char **vdnssearch,
+                  const char *vdomainname, const SlirpCb *callbacks,
+                  void *opaque);
+/* Shut down an instance of a slirp stack */
+SLIRP_EXPORT
+void slirp_cleanup(Slirp *slirp);
+
+/* This is called by the application when it is about to sleep through poll().
+ * *timeout is set to the amount of virtual time (in ms) that the application intends to
+ * wait (UINT32_MAX if infinite). slirp_pollfds_fill updates it according to
+ * e.g. TCP timers, so the application knows it should sleep a smaller amount of
+ * time. slirp_pollfds_fill calls add_poll for each file descriptor
+ * that should be monitored along the sleep. The opaque pointer is passed as
+ * such to add_poll, and add_poll returns an index. */
+SLIRP_EXPORT
+void slirp_pollfds_fill(Slirp *slirp, uint32_t *timeout,
+                        SlirpAddPollCb add_poll, void *opaque);
+
+/* This is called by the application after sleeping, to report which file
+ * descriptors are available. slirp_pollfds_poll calls get_revents on each file
+ * descriptor, giving it the index that add_poll returned during the
+ * slirp_pollfds_fill call, to know whether the descriptor is available for
+ * read/write/etc. (SLIRP_POLL_*)
+ * select_error should be passed 1 if poll() returned an error. */
+SLIRP_EXPORT
+void slirp_pollfds_poll(Slirp *slirp, int select_error,
+                        SlirpGetREventsCb get_revents, void *opaque);
+
+/* This is called by the application when the guest emits a packet on the
+ * guest network, to be interpreted by slirp. */
+SLIRP_EXPORT
+void slirp_input(Slirp *slirp, const uint8_t *pkt, int pkt_len);
+
+/* This is called by the application when a timer expires, if it provides
+ * the timer_new_opaque callback.  It is not needed if the application only
+ * uses timer_new. */
+SLIRP_EXPORT
+void slirp_handle_timer(Slirp *slirp, SlirpTimerId id, void *cb_opaque);
+
+/* These set up / remove port forwarding between a host port in the real world
+ * and the guest network.
+ * Note: guest_addr must be in network order, while guest_port must be in host
+ * order.
+ */
+SLIRP_EXPORT
+int slirp_add_hostfwd(Slirp *slirp, int is_udp, struct in_addr host_addr,
+                      int host_port, struct in_addr guest_addr, int guest_port);
+SLIRP_EXPORT
+int slirp_remove_hostfwd(Slirp *slirp, int is_udp, struct in_addr host_addr,
+                         int host_port);
+
+#define SLIRP_HOSTFWD_UDP 1
+#define SLIRP_HOSTFWD_V6ONLY 2
+SLIRP_EXPORT
+int slirp_add_hostxfwd(Slirp *slirp,
+                       const struct sockaddr *haddr, socklen_t haddrlen,
+                       const struct sockaddr *gaddr, socklen_t gaddrlen,
+                       int flags);
+SLIRP_EXPORT
+int slirp_remove_hostxfwd(Slirp *slirp,
+                          const struct sockaddr *haddr, socklen_t haddrlen,
+                          int flags);
+
+/* Set up port forwarding between a port in the guest network and a
+ * command running on the host */
+SLIRP_EXPORT
+int slirp_add_exec(Slirp *slirp, const char *cmdline,
+                   struct in_addr *guest_addr, int guest_port);
+/* Set up port forwarding between a port in the guest network and a
+ * Unix port on the host */
+SLIRP_EXPORT
+int slirp_add_unix(Slirp *slirp, const char *unixsock,
+                   struct in_addr *guest_addr, int guest_port);
+/* Set up port forwarding between a port in the guest network and a
+ * callback that will receive the data coming from the port */
+SLIRP_EXPORT
+int slirp_add_guestfwd(Slirp *slirp, SlirpWriteCb write_cb, void *opaque,
+                       struct in_addr *guest_addr, int guest_port);
+
+/* TODO: rather identify a guestfwd through an opaque pointer instead of through
+ * the guest_addr */
+
+/* This is called by the application for a guestfwd, to determine how much data
+ * can be received by the forwarded port through a call to slirp_socket_recv. */
+SLIRP_EXPORT
+size_t slirp_socket_can_recv(Slirp *slirp, struct in_addr guest_addr,
+                             int guest_port);
+/* This is called by the application for a guestfwd, to provide the data to be
+ * sent on the forwarded port */
+SLIRP_EXPORT
+void slirp_socket_recv(Slirp *slirp, struct in_addr guest_addr, int guest_port,
+                       const uint8_t *buf, int size);
+
+/* Remove entries added by slirp_add_exec, slirp_add_unix or slirp_add_guestfwd */
+SLIRP_EXPORT
+int slirp_remove_guestfwd(Slirp *slirp, struct in_addr guest_addr,
+                          int guest_port);
+
+/* Return a human-readable state of the slirp stack */
+SLIRP_EXPORT
+char *slirp_connection_info(Slirp *slirp);
+
+/* Return a human-readable state of the NDP/ARP tables */
+SLIRP_EXPORT
+char *slirp_neighbor_info(Slirp *slirp);
+
+/* Save the slirp state through the write_cb. The opaque pointer is passed as
+ * such to the write_cb. */
+SLIRP_EXPORT
+int slirp_state_save(Slirp *s, SlirpWriteCb write_cb, void *opaque);
+
+/* Returns the version of the slirp state, to be saved along the state */
+SLIRP_EXPORT
+int slirp_state_version(void);
+
+/* Load the slirp state through the read_cb. The opaque pointer is passed as
+ * such to the read_cb. The version should be given as it was obtained from
+ * slirp_state_version when slirp_state_save was called. */
+SLIRP_EXPORT
+int slirp_state_load(Slirp *s, int version_id, SlirpReadCb read_cb,
+                     void *opaque);
+
+/* Return the version of the slirp implementation */
+SLIRP_EXPORT
+const char *slirp_version_string(void);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* LIBSLIRP_H */

--- a/src/misc/CMakeLists.txt
+++ b/src/misc/CMakeLists.txt
@@ -21,6 +21,8 @@ add_library(libmisc STATIC
   unicode.cpp
 )
 
+target_include_directories(libmisc PRIVATE ../libs/include)
+
 target_link_libraries(libmisc PRIVATE
   libwhereami $<IF:$<TARGET_EXISTS:SDL2::SDL2>,SDL2::SDL2,SDL2::SDL2-static>
 )

--- a/src/misc/ethernet.cpp
+++ b/src/misc/ethernet.cpp
@@ -28,7 +28,6 @@
 EthernetConnection *ETHERNET_OpenConnection([[maybe_unused]] const std::string &backend)
 {
 	EthernetConnection *conn = nullptr;
-#if C_SLIRP
 	// Currently only slirp is supported
 	if (backend == "slirp") {
 		conn = new SlirpEthernetConnection;
@@ -40,7 +39,6 @@ EthernetConnection *ETHERNET_OpenConnection([[maybe_unused]] const std::string &
 			conn = nullptr;
 		}
 	}
-#endif
 
 	return conn;
 }

--- a/src/misc/ethernet.cpp
+++ b/src/misc/ethernet.cpp
@@ -1,7 +1,7 @@
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *
- *  Copyright (C) 2021  The DOSBox Staging Team
+ *  Copyright (C) 2025-2025  The DOSBox Staging Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -25,13 +25,15 @@
 #include "control.h"
 #include "ethernet_slirp.h"
 
-EthernetConnection *ETHERNET_OpenConnection([[maybe_unused]] const std::string &backend)
+EthernetConnection* ETHERNET_OpenConnection([[maybe_unused]] const std::string& backend)
 {
-	EthernetConnection *conn = nullptr;
+	EthernetConnection* conn = nullptr;
+
 	// Currently only slirp is supported
 	if (backend == "slirp") {
 		conn = new SlirpEthernetConnection;
 		assert(control);
+
 		const auto settings = control->GetSection("ethernet");
 		if (!conn->Initialize(settings)) {
 			delete conn;

--- a/src/misc/ethernet.cpp
+++ b/src/misc/ethernet.cpp
@@ -34,7 +34,6 @@ EthernetConnection *ETHERNET_OpenConnection([[maybe_unused]] const std::string &
 		assert(control);
 		const auto settings = control->GetSection("ethernet");
 		if (!conn->Initialize(settings)) {
-			LOG_WARNING("Failed to initialize the slirp Ethernet backend");
 			delete conn;
 			conn = nullptr;
 		}

--- a/src/misc/ethernet_slirp.cpp
+++ b/src/misc/ethernet_slirp.cpp
@@ -225,7 +225,7 @@ bool SlirpEthernetConnection::Initialize(Section *dosbox_config)
 			return false;
 		}
 	}
-	LOG_MSG("SLIRP: Successfully loaded Slirp version: %s", LibSlirp::slirp_version_string());
+	LOG_MSG("SLIRP: Successfully loaded Slirp %s", LibSlirp::slirp_version_string());
 
 	/* Config */
 	config.version = 1;

--- a/src/misc/ethernet_slirp.cpp
+++ b/src/misc/ethernet_slirp.cpp
@@ -193,18 +193,7 @@ static void db_slirp_notify([[maybe_unused]] void *opaque)
 /* End boilerplate */
 
 SlirpEthernetConnection::SlirpEthernetConnection()
-        : EthernetConnection(),
-          config(),
-          timers(),
-          get_packet_callback(),
-          registered_fds(),
-#ifdef WIN32
-          readfds(),
-          writefds(),
-          exceptfds()
-#else /* !WIN32 */
-          polls()
-#endif
+        : EthernetConnection()
 {
 	slirp_callbacks.send_packet = db_slirp_receive_packet;
 	slirp_callbacks.guest_error = db_slirp_guest_error;
@@ -254,8 +243,8 @@ bool SlirpEthernetConnection::Initialize(Section *dosbox_config)
 	config.if_mtu = ethernet_frame_size;
 	config.if_mru = ethernet_frame_size;
 
-	config.enable_emu = 0; // buggy - keep this at 0
-	config.in_enabled = 1;
+	config.enable_emu = false; // buggy - keep this at false
+	config.in_enabled = true;
 
 	// The IPv4 network the guest and host services are on
 	inet_pton(AF_INET, "10.0.2.0", &config.vnetwork);
@@ -268,7 +257,7 @@ bool SlirpEthernetConnection::Initialize(Section *dosbox_config)
 
 	/* IPv6 code is left here as reference but disabled as no DOS-era
 	 * software supports it and might get confused by it */
-	config.in6_enabled = 0;
+	config.in6_enabled = false;
 	inet_pton(AF_INET6, "fec0::", &config.vprefix_addr6);
 	config.vprefix_len = 64;
 	inet_pton(AF_INET6, "fec0::2", &config.vhost6);
@@ -328,7 +317,7 @@ std::map<int, int> SlirpEthernetConnection::SetupPortForwards(const bool is_udp,
 	inet_pton(AF_INET, "0.0.0.0", &bind_addr);
 
 	// Split the rules first by spaces
-	for (auto &forward_rule : split_with_empties(port_forward_rules, ' ')) {
+	for (const auto &forward_rule : split_with_empties(port_forward_rules, ' ')) {
 		if (forward_rule.empty())
 			continue;
 

--- a/src/misc/ethernet_slirp.cpp
+++ b/src/misc/ethernet_slirp.cpp
@@ -41,7 +41,7 @@
 #if defined(WIN32)
 constexpr const char* libslirp_dynlib_file = "slirp-0.dll";
 #elif defined(MACOSX)
-constexpr const char* libslirp_dynlib_file = "libslirp.0.dylib";
+constexpr const char* libslirp_dynlib_file = "libslirp.dylib";
 #else
 constexpr const char* libslirp_dynlib_file = "libslirp.so.0";
 #endif

--- a/src/misc/ethernet_slirp.cpp
+++ b/src/misc/ethernet_slirp.cpp
@@ -20,8 +20,6 @@
 
 #include "config.h"
 
-#if C_SLIRP
-
 #include <algorithm>
 #include <map>
 #include <stdexcept>
@@ -703,7 +701,5 @@ int SlirpEthernetConnection::PollGetSlirpRevents(int idx)
 	}
 	return slirp_revents;
 }
-
-#endif
 
 #endif

--- a/src/misc/ethernet_slirp.h
+++ b/src/misc/ethernet_slirp.h
@@ -29,14 +29,7 @@
 #include <deque>
 #include <vector>
 
-// Specific unreleased slirp to work with MSVC
-#if _MSC_VER >= 1920
 #include <slirp/libslirp.h>
-#define db_ssize_t slirp_ssize_t
-#else
-#include <libslirp.h>
-#define db_ssize_t ssize_t
-#endif
 
 #include "config.h"
 #include "ethernet.h"

--- a/src/misc/ethernet_slirp.h
+++ b/src/misc/ethernet_slirp.h
@@ -23,8 +23,6 @@
 
 #include "dosbox.h"
 
-#if C_SLIRP
-
 #include <map>
 #include <deque>
 #include <vector>
@@ -144,7 +142,5 @@ private:
 	fd_set exceptfds = {}; /*!< Exceptional descriptors for select() */
 #endif
 };
-
-#endif
 
 #endif

--- a/src/platform/visualc/config.h
+++ b/src/platform/visualc/config.h
@@ -15,12 +15,6 @@
 /* Define to 1 to enable IPX networking support, requires SDL_net */
 #define C_IPX 1
 
-/* Define to 1 to enable NE2000 emulation */
-#define C_NE2000 1
-
-/* Define to 1 to enable slirp networking support, requires libslirp */
-#define C_SLIRP 1
-
 /* Define to 1 to enable dual-mouse gaming support using ManyMouse library */
 #define C_MANYMOUSE 1
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -8,7 +8,6 @@
     "iir1",
     "libmt32emu",
     "libpng",
-    "libslirp",
     "opusfile",
     {
       "name": "sdl2",

--- a/vs/dosbox.vcxproj
+++ b/vs/dosbox.vcxproj
@@ -220,7 +220,7 @@
       <OmitFramePointers>false</OmitFramePointers>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>slirp.lib;zlib-ngd.lib;iir.lib;opengl32.lib;SDL2_netd.lib;winmm.lib;libpng16d.lib;SDL2maind.lib;SDL2d.lib;odbc32.lib;odbccp32.lib;ws2_32.lib;mt32emu.lib;opusfile.lib;opus.lib;ogg.lib;speexdsp.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>zlib-ngd.lib;iir.lib;opengl32.lib;SDL2_netd.lib;winmm.lib;libpng16d.lib;SDL2maind.lib;SDL2d.lib;odbc32.lib;odbccp32.lib;ws2_32.lib;mt32emu.lib;opusfile.lib;opus.lib;ogg.lib;speexdsp.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)\dosbox.exe</OutputFile>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
@@ -262,7 +262,7 @@ IF %ERRORLEVEL% LSS 8 SET ERRORLEVEL = 0</Command>
       <ObjectFileName>$(IntDir)\$(ProjectName)\$(ConfigurationName)\%(RelativeDir)</ObjectFileName>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>slirp.lib;zlib-ngd.lib;iir.lib;opengl32.lib;SDL2_netd.lib;winmm.lib;libpng16d.lib;SDL2maind.lib;SDL2d.lib;odbc32.lib;odbccp32.lib;ws2_32.lib;mt32emu.lib;opusfile.lib;opus.lib;ogg.lib;speexdsp.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>zlib-ngd.lib;iir.lib;opengl32.lib;SDL2_netd.lib;winmm.lib;libpng16d.lib;SDL2maind.lib;SDL2d.lib;odbc32.lib;odbccp32.lib;ws2_32.lib;mt32emu.lib;opusfile.lib;opus.lib;ogg.lib;speexdsp.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)\dosbox.exe</OutputFile>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
@@ -303,7 +303,7 @@ IF %ERRORLEVEL% LSS 8 SET ERRORLEVEL = 0</Command>
       <ObjectFileName>$(IntDir)\$(ProjectName)\$(ConfigurationName)\%(RelativeDir)</ObjectFileName>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>slirp.lib;zlib-ngd.lib;iir.lib;opengl32.lib;SDL2_netd.lib;winmm.lib;libpng16d.lib;SDL2maind.lib;SDL2d.lib;odbc32.lib;odbccp32.lib;ws2_32.lib;mt32emu.lib;opusfile.lib;opus.lib;ogg.lib;speexdsp.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>zlib-ngd.lib;iir.lib;opengl32.lib;SDL2_netd.lib;winmm.lib;libpng16d.lib;SDL2maind.lib;SDL2d.lib;odbc32.lib;odbccp32.lib;ws2_32.lib;mt32emu.lib;opusfile.lib;opus.lib;ogg.lib;speexdsp.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)\dosbox.exe</OutputFile>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
@@ -347,7 +347,7 @@ IF %ERRORLEVEL% LSS 8 SET ERRORLEVEL = 0</Command>
       <ObjectFileName>$(IntDir)\$(ProjectName)\$(ConfigurationName)\%(RelativeDir)</ObjectFileName>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>slirp.lib;zlib-ng.lib;iir.lib;opengl32.lib;winmm.lib;libpng16.lib;SDL2_net.lib;SDL2.lib;SDL2main.lib;odbc32.lib;odbccp32.lib;ws2_32.lib;mt32emu.lib;opusfile.lib;opus.lib;ogg.lib;speexdsp.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>zlib-ng.lib;iir.lib;opengl32.lib;winmm.lib;libpng16.lib;SDL2_net.lib;SDL2.lib;SDL2main.lib;odbc32.lib;odbccp32.lib;ws2_32.lib;mt32emu.lib;opusfile.lib;opus.lib;ogg.lib;speexdsp.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)\dosbox.exe</OutputFile>
       <GenerateDebugInformation>false</GenerateDebugInformation>
       <ProgramDatabaseFile />
@@ -455,7 +455,7 @@ IF %ERRORLEVEL% LSS 8 SET ERRORLEVEL = 0</Command>
       <ObjectFileName>$(IntDir)\$(ProjectName)\$(ConfigurationName)\%(RelativeDir)</ObjectFileName>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>slirp.lib;zlib-ng.lib;iir.lib;opengl32.lib;winmm.lib;libpng16.lib;SDL2_net.lib;SDL2.lib;SDL2main.lib;odbc32.lib;odbccp32.lib;ws2_32.lib;mt32emu.lib;opusfile.lib;opus.lib;ogg.lib;speexdsp.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>zlib-ng.lib;iir.lib;opengl32.lib;winmm.lib;libpng16.lib;SDL2_net.lib;SDL2.lib;SDL2main.lib;odbc32.lib;odbccp32.lib;ws2_32.lib;mt32emu.lib;opusfile.lib;opus.lib;ogg.lib;speexdsp.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)\dosbox.exe</OutputFile>
       <GenerateDebugInformation>false</GenerateDebugInformation>
       <ProgramDatabaseFile>
@@ -508,7 +508,7 @@ IF %ERRORLEVEL% LSS 8 SET ERRORLEVEL = 0</Command>
       <ObjectFileName>$(IntDir)\$(ProjectName)\$(ConfigurationName)\%(RelativeDir)</ObjectFileName>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>slirp.lib;zlib-ng.lib;iir.lib;opengl32.lib;winmm.lib;libpng16.lib;SDL2_net.lib;SDL2.lib;SDL2main.lib;odbc32.lib;odbccp32.lib;ws2_32.lib;mt32emu.lib;opusfile.lib;opus.lib;ogg.lib;speexdsp.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>zlib-ng.lib;iir.lib;opengl32.lib;winmm.lib;libpng16.lib;SDL2_net.lib;SDL2.lib;SDL2main.lib;odbc32.lib;odbccp32.lib;ws2_32.lib;mt32emu.lib;opusfile.lib;opus.lib;ogg.lib;speexdsp.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)\dosbox.exe</OutputFile>
       <GenerateDebugInformation>false</GenerateDebugInformation>
       <ProgramDatabaseFile>


### PR DESCRIPTION
# Description

Part 2 in the quest to remove glib as a build dependency.

Since the whole feature is a copy-paste job from #4222 let's just copy the description as well:

> slirp depends on glib. Compiling Glib on windows using VCPKG takes an eternity. This PR switches from linking slirp at compile time to loading the slirp library at runtime, falling back to host MIDI output if the library cannot be loaded.
>
> Our official releases can include pre-compiled slirp binaries for a seamless transition. Exactly how this will work is TBD.
>
> The slirp library is only loaded if slirp is enabled in the config.

Hopefully I've scrubbed the evidence from the code...

# Manual testing

The change has been manually tested on:

- [x] Windows
- [x] macOS
- [x] Linux

Smoke tested on Windows 11 using the following testing pack provided by @kcgen a long time ago.

[ethernet-pack.zip](https://github.com/user-attachments/files/20242415/ethernet-pack.zip)

Simply extract the pack, and start dosbox from the ethernet-pack/ethernet directory. It will run a couple of tests, concluding with a ping to google.

Note, the ping to google currently fails, both in this PR, and `main`. It seems to be a recent regression, as it successfully pings on 0.82.1.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

