### PR TITLE
Use CMake to build the Windows release on CI

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -30,7 +30,6 @@ jobs:
     runs-on: ${{ matrix.conf.os }}${{ matrix.arch == 'arm64' && '-arm' || '' }}
     if:      github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     env:
-      VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
       VCPKG_ROOT: ${{ github.workspace }}/vcpkg
 
     strategy:
@@ -75,13 +74,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: false
-
-      - name: Export GitHub Actions cache environment variables
-        uses: actions/github-script@v7
-        with:
-          script: |
-            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
-            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
       - name: Setup CMake
         uses: lukka/get-cmake@ea004816823209b8d1211e47b216185caee12cc5 # v4.0.2
@@ -130,7 +122,6 @@ jobs:
     runs-on: ubuntu-22.04
     if:      github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     env:
-      VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
       VCPKG_ROOT: ${{ github.workspace }}/vcpkg
 
     steps:
@@ -138,13 +129,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: false
-
-      - name: Export GitHub Actions cache environment variables
-        uses: actions/github-script@v7
-        with:
-          script: |
-            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
-            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
       - name: Setup CMake
         uses: lukka/get-cmake@ea004816823209b8d1211e47b216185caee12cc5 # v4.0.2

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -31,7 +31,6 @@ jobs:
     if:      github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     env:
       MACOSX_DEPLOYMENT_TARGET: ${{ matrix.conf.minimum_deployment }}
-      VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
       VCPKG_ROOT: ${{ github.workspace }}/vcpkg
 
     strategy:
@@ -52,13 +51,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: false
-
-      - name: Export GitHub Actions cache environment variables
-        uses: actions/github-script@v7
-        with:
-          script: |
-            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
-            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
       - name: Setup CMake
         uses: lukka/get-cmake@ea004816823209b8d1211e47b216185caee12cc5 # v4.0.2

--- a/.github/workflows/pvs-studio.yml
+++ b/.github/workflows/pvs-studio.yml
@@ -20,7 +20,6 @@ jobs:
     name: PVS-Studio static analyzer
     runs-on: ubuntu-22.04
     env:
-      VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
       VCPKG_ROOT: ${{ github.workspace }}/vcpkg
 
     steps:
@@ -28,13 +27,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: false
-
-      - name: Export GitHub Actions cache environment variables
-        uses: actions/github-script@v7
-        with:
-          script: |
-            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
-            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
       - name: Setup CMake
         uses: lukka/get-cmake@ea004816823209b8d1211e47b216185caee12cc5 # v4.0.2

--- a/.github/workflows/windows-cmake.yml
+++ b/.github/workflows/windows-cmake.yml
@@ -26,7 +26,6 @@ concurrency:
 
 env:
   VCPKG_ROOT: C:\vcpkg
-  VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
 
 jobs:
   build_windows_release:
@@ -64,13 +63,6 @@ jobs:
           rm vcpkg.exe
           git -c advice.detachedHead=false checkout $baseline
           bootstrap-vcpkg.bat -disableMetrics
-
-      - name: Export GitHub Actions cache environment variables
-        uses: actions/github-script@v7
-        with:
-          script: |
-            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
-            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
       - name: Setup CMake
         uses: lukka/get-cmake@v4.0.1

--- a/.github/workflows/windows-cmake.yml
+++ b/.github/workflows/windows-cmake.yml
@@ -1,0 +1,279 @@
+name: Windows CMake builds
+permissions: read-all
+
+on:
+  push:
+    paths-ignore:
+      - '.clang-format'
+      - '.mdl-styles'
+      - '*.md'
+      - 'docs/**'
+      - 'licenses/**'
+      - 'website/**'
+
+  pull_request:
+    paths-ignore:
+      - '.clang-format'
+      - '.mdl-styles'
+      - '*.md'
+      - 'docs/**'
+      - 'licenses/**'
+      - 'website/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  VCPKG_ROOT: C:\vcpkg
+  VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
+
+jobs:
+  build_windows_release:
+    name: Release ${{ matrix.conf.debugger && 'w/ debugger' || '' }} (${{ matrix.conf.arch }})
+    if:   github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+    outputs:
+      dosbox_version: ${{ steps.set_vars.outputs.dosbox_version }}
+
+    runs-on: windows-2022
+    strategy:
+      matrix:
+        conf:
+          # TODO reinstate ARM64 build at some point, but we'll need to build the
+          # external vcpkg dependencies for AMR64 first
+          - arch: x64
+            debugger: false
+            max_warnings: 20
+
+          - arch: x64
+            debugger: true
+            max_warnings: 20
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          submodules: false
+
+      - name:  Checkout vcpkg baseline
+        shell: pwsh
+        run: |
+          $baseline = (Get-Content vcpkg.json | ConvertFrom-Json).'builtin-baseline'
+          cd $env:VCPKG_INSTALLATION_ROOT
+          git fetch
+          rm vcpkg.exe
+          git -c advice.detachedHead=false checkout $baseline
+          bootstrap-vcpkg.bat -disableMetrics
+
+      - name: Export GitHub Actions cache environment variables
+        uses: actions/github-script@v7
+        with:
+          script: |
+            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+
+      - name: Setup CMake
+        uses: lukka/get-cmake@v4.0.1
+
+      - name:  Log environment
+        shell: pwsh
+        run:   .\scripts\log-env.ps1
+
+      - name:  Set variables
+        id:    set_vars
+        shell: bash
+        run: |
+          set -x
+          echo "build_dir=build/release-windows/Release" >> $GITHUB_OUTPUT
+
+          VERSION=$(./scripts/get-version.sh version-and-hash)
+          echo "pkg_dir=dosbox-staging-windows-${{ matrix.conf.arch }}-${VERSION}" >> $GITHUB_OUTPUT
+          echo "dosbox_version=${VERSION}" >> $GITHUB_OUTPUT
+
+      - name:  Set the Git hash in config.h
+        shell: bash
+        run: |
+          set -x
+          GIT_HASH=$(./scripts/get-version.sh hash)
+          sed -i "s|BUILD_GIT_HASH \"git\"|BUILD_GIT_HASH \"$GIT_HASH\"|" src/platform/visualc/config.h
+
+      # TODO run tests
+      #- name:  Build release
+      #  if:    ${{ !matrix.conf.debugger }}
+      #  shell: pwsh
+      #  run: |
+      #    TODO
+
+      - name:  Build release
+        if:    ${{ !matrix.conf.debugger }}
+        shell: pwsh
+        run: |
+          cmake --preset release-windows
+          cmake --build --preset release-windows >> build.log 2>&1
+
+      - name:  Build release with debugger
+        if:    ${{ matrix.conf.debugger }}
+        shell: pwsh
+        run: |
+          cmake --preset release-windows -DOPT_DEBUG=ON -DOPT_HEAVY_DEBUG=ON
+          cmake --build --preset release-windows >> build.log 2>&1
+
+      - name: Summarize warnings
+        env:
+          MAX_WARNINGS: ${{ matrix.conf.max_warnings }}
+        run:  python3 ./scripts/count-warnings.py -lf --msclang build.log
+
+      - name:  Package standard build
+        if:    ${{ !matrix.conf.debugger }}
+        shell: bash
+        run: |
+          set -x
+          # Construct VC_REDIST_DIR
+          readonly VC_REDIST_BASE="C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Redist/MSVC"
+          readonly VC_REDIST_CRT_VERSION="Microsoft.VC143.CRT"
+
+          for ENTRY in "$VC_REDIST_BASE"/*
+          do
+              ENTRY=$ENTRY/${{ matrix.conf.arch }}/$VC_REDIST_CRT_VERSION
+              if [ -d "$ENTRY" ]; then
+                  export VC_REDIST_DIR=$ENTRY
+                  break
+              fi
+          done
+          if [ ! -d "$VC_REDIST_DIR" ]; then
+              echo "Failed to find MSVC Redistributable"
+              exit 1
+          fi
+
+          # Package
+          ./scripts/create-package.sh \
+            -p windows \
+            ${{ steps.set_vars.outputs.build_dir }} \
+            ${{ steps.set_vars.outputs.pkg_dir }}
+
+
+      - name:  Inject external vcpkg dependencies
+        if:    ${{ !matrix.conf.debugger }}
+        shell: bash
+        run: |
+          set -x
+          DEPS_VERSION=v0.83.0
+          ZIP_NAME=dosbox-vcpkg-deps-windows-${{ matrix.conf.arch }}.zip
+
+          curl -L https://github.com/dosbox-staging/dosbox-staging-ext/releases/download/$DEPS_VERSION/$ZIP_NAME -o $ZIP_NAME
+          unzip $ZIP_NAME -d vcpkg-deps
+
+          cp vcpkg-deps/release/* ${{ steps.set_vars.outputs.pkg_dir }}
+
+
+      - name: Upload package
+        if:   ${{ !matrix.conf.debugger }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.set_vars.outputs.pkg_dir }}-without-debugger
+          path: ${{ steps.set_vars.outputs.pkg_dir }}
+          overwrite: true
+
+      - name:  Package debugger build
+        if:    ${{ matrix.conf.debugger }}
+        shell: bash
+        run: |
+          set -x
+          mkdir -p ${{ steps.set_vars.outputs.pkg_dir }}
+          # Move the debugger build into the release area
+          ls ${{ steps.set_vars.outputs.build_dir }}
+          cp ${{ steps.set_vars.outputs.build_dir }}/dosbox.exe ${{ steps.set_vars.outputs.pkg_dir }}/dosbox_with_debugger.exe
+
+      - name: Upload debugger artifact
+        if:   ${{ matrix.conf.debugger }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.set_vars.outputs.pkg_dir }}-with-debugger
+          path: ${{ steps.set_vars.outputs.pkg_dir }}/dosbox_with_debugger.exe
+          overwrite: true
+
+
+  merge_artifacts:
+    name: Merge release & debugger artifacts (${{ matrix.arch }} )
+    needs: build_windows_release
+    outputs:
+      dosbox_version: ${{ needs.build_windows_release.outputs.dosbox_version }}
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # TODO reinstate ARM64 build at some point, but we'll need to build the
+        # external vcpkg dependencies for AMR64 first
+        # arch: [x64, ARM64]
+        arch: [x64]
+
+    steps:
+      - name: Merge artifacts (${{ matrix.arch }} )
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name:    dosbox-staging-windows-${{ matrix.arch }}-${{ needs.build_windows_release.outputs.dosbox_version }}
+          pattern: dosbox-staging-windows-${{ matrix.arch }}-*
+          delete-merged: 'true'
+
+
+  build_installer:
+    name:    Build installer (${{ matrix.arch }} )
+    needs:   merge_artifacts
+    runs-on: windows-2022
+    strategy:
+      matrix:
+        # We only provide x64 installers as ARM64 support is experimental
+        arch: [x64]
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          submodules: false
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+
+      - name:  Set variables
+        id:    set_vars
+        shell: bash
+        run: |
+          set -x
+          VERSION=${{ needs.merge_artifacts.outputs.dosbox_version }}
+          echo "pkg_dir=dosbox-staging-windows-${{ matrix.arch }}-${VERSION}" >> $GITHUB_OUTPUT
+
+
+      - name: Prepare Windows installer
+        shell: bash
+        run: |
+          set -x
+          VERSION=${{ needs.merge_artifacts.outputs.dosbox_version }}
+          PACKAGE_INFO="release ${VERSION}"
+
+          mkdir -p out/program
+
+          sed -e "s|%PACKAGE_INFORMATION%|${PACKAGE_INFO}|;s|%GITHUB_REPO%|${{ github.repository }}|" docs/README.template >out/setup_preamble.txt
+          sed -i "s|DOSBOX-STAGING-VERSION|${VERSION}|" contrib/windows_installer/DOSBox-Staging-setup.iss
+
+          cp contrib/windows_installer/*                   out
+          cp contrib/icons/windows/dosbox-staging.ico      out
+          cp contrib/icons/windows/dosbox-staging.bmp      out
+          cp contrib/icons/windows/dosbox-staging-side.bmp out
+
+          mv ${{ steps.set_vars.outputs.pkg_dir }}/*       out/program
+          mv out/program/dosbox*.exe                       out
+
+
+      - name: Build Windows installer
+        shell: pwsh
+        run: |
+          cd out
+          C:\PROGRA~2\INNOSE~1\ISCC.exe DOSBox-Staging-setup.iss
+          dir
+
+      - name: Upload Windows installer
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.set_vars.outputs.pkg_dir }}-setup
+          path: ${{ github.workspace }}\out\${{ steps.set_vars.outputs.pkg_dir }}-setup.exe
+          overwrite: true

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -37,7 +37,7 @@ jobs:
         conf:
           - name: MS Clang/LLVM (x64)
             arch: x64
-            max_warnings: 30
+            max_warnings: 60
 
     steps:
       - name: Check out repository

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -26,7 +26,6 @@ concurrency:
 
 env:
   VCPKG_ROOT: C:\vcpkg
-  VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
 
 jobs:
   build_windows_vs:
@@ -55,13 +54,6 @@ jobs:
           rm vcpkg.exe
           git -c advice.detachedHead=false checkout $baseline
           bootstrap-vcpkg.bat -disableMetrics
-
-      - name: Export GitHub Actions cache environment variables
-        uses: actions/github-script@v7
-        with:
-          script: |
-            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
-            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
       - name: Setup CMake
         uses: lukka/get-cmake@v4.0.2
@@ -132,13 +124,6 @@ jobs:
           rm vcpkg.exe
           git -c advice.detachedHead=false checkout $baseline
           bootstrap-vcpkg.bat -disableMetrics
-
-      - name: Export GitHub Actions cache environment variables
-        uses: actions/github-script@v7
-        with:
-          script: |
-            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
-            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
       - name: Setup CMake
         uses: lukka/get-cmake@v4.0.2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ else()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-conversion -Wno-narrowing")
 endif()
 
-option(OPT_DEBUG "Enable debugging" $<IF:$<CONFIG:Debug>,ON,OFF>)
+option(OPT_DEBUG "Enable debugging" OFF)
 option(OPT_HEAVY_DEBUG "Enable heavy debugging" OFF)
 
 if(OPT_HEAVY_DEBUG)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -231,6 +231,10 @@ include_directories(
 
 add_subdirectory(src)
 
+if(WIN32)
+  target_sources(dosbox PRIVATE src/winres.rc)
+endif()
+
 target_link_libraries(dosbox PRIVATE
   $<TARGET_NAME_IF_EXISTS:SDL2::SDL2main>
   $<IF:$<TARGET_EXISTS:SDL2::SDL2>,SDL2::SDL2,SDL2::SDL2-static>

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -138,7 +138,7 @@
       "generator": "Visual Studio 17 2022",
       "binaryDir": "${sourceDir}/build/debug-windows",
       "cacheVariables": {
-        "CMAKE_GENERATOR_TOOLSET": "ClangCL",      
+        "CMAKE_GENERATOR_TOOLSET": "ClangCL",
         "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
         "CMAKE_FIND_PACKAGE_PREFER_CONFIG" : "ON",
         "CMAKE_BUILD_TYPE": "Debug",
@@ -156,7 +156,7 @@
       "generator": "Visual Studio 17 2022",
       "binaryDir": "${sourceDir}/build/release-windows",
       "cacheVariables": {
-        "CMAKE_GENERATOR_TOOLSET": "ClangCL",      
+        "CMAKE_GENERATOR_TOOLSET": "ClangCL",
         "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
         "CMAKE_FIND_PACKAGE_PREFER_CONFIG" : "ON",
         "CMAKE_BUILD_TYPE": "Release",

--- a/scripts/count-warnings.py
+++ b/scripts/count-warnings.py
@@ -48,10 +48,10 @@ MSVC_WARN_PATTERN = re.compile(
 # For recognizing warnings in Visual Studio Clang format:
 #
 MSCLANG_WARN_PATTERN = re.compile(
-    r">[^>]*?([^:]+)\((\d+),\d+\): warning : .+? \[-W(.+?)\](.*)")
-#             ~~~~~    ~~~  ~~~              ~~~      ~~~    ~~
-#             ↑        ↑     ↑               ↑        ↑      ↑
-#             file     line column          message  type   extra
+    r"([^:]+)\((\d+),\d+\): warning : .+? \[-W(.+?)\](.*)")
+#      ~~~~~    ~~~  ~~~              ~~~      ~~~    ~~
+#      ↑        ↑     ↑               ↑        ↑      ↑
+#      file     line column          message  type   extra
 
 
 class MessageFormat(enum.Enum):

--- a/src/winres.rc
+++ b/src/winres.rc
@@ -18,12 +18,12 @@ BEGIN
     BEGIN
         BLOCK "040904b0"
         BEGIN
-            VALUE "Comments", "© 2024 The DOSBox Staging Team, published under GNU GPL"
+            VALUE "Comments", "© 2025 The DOSBox Staging Team, published under GNU GPL"
             VALUE "CompanyName", "DOSBox Staging"
             VALUE "FileDescription", "DOSBox Staging DOS Emulator"
             VALUE "FileVersion", "0, 83, 0, 0"
             VALUE "InternalName", "dosbox-staging"
-            VALUE "LegalCopyright", "Copyright © 2024 The DOSBox Staging Team"
+            VALUE "LegalCopyright", "Copyright © 2025 The DOSBox Staging Team"
             VALUE "OriginalFilename", "dosbox.exe"
             VALUE "ProductName", "DOSBox Staging"
             VALUE "ProductVersion", "0, 83, 0, 0"


### PR DESCRIPTION
# Description

Another important step towards total CMake domination 😎 This adds a CMake-based Windows build workflow. After this goes in, we'll have a consistent CMake + vcpkg workflow across the board on all three OSes! 🥳 

I've kept the existing MSBuild-based workflow for now. Maybe let it stay there for a little while until we gain 100% confidence in the CMake build.

Note that the MSBuild job also builds `zmbv.dll` as a separate library in addition to statically linking it to the DOSBox executable. I think they did this so other programs can use `zmbv.dll` as a plugin or something for ZMBV support. I don't think anybody cares about that... Players like VLC have support ZMBV out of the box AFAIK.

Next thing is to remove all the MSVC project files from the repo... but one step at a time 😄

# Manual testing

- Portable package contents are identical to that of the MSBuild package (minus the `zmbv.dll`)
- Both the standard and debugger versions start up
- Debugger works
- Windows installer works
- Application icon and extra metadata is set

![image](https://github.com/user-attachments/assets/57479e47-fbcb-4f3d-bef8-feecb6d1397a)


The change has been manually tested on:

- [x] Windows
- [ ] macOS
- [ ] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

