### PR TITLE
Add keyboard grabbing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ DOSBox Staging has the following library dependencies:
 | [libpng](http://www.libpng.org/pub/png/libpng.html)      | PNG encoding of screen captures                 | libpng             | 1.6.46#0        | yes :green_circle:  |
 | [Munt](https://github.com/munt/munt)                     | Roland MT-32 and CM-32L emulation               | libmt32emu         | 2.7.1#0         | yes :green_circle:  |
 | [Opus File](https://opus-codec.org/)                     | CD Audio playback for Opus-encoded audio tracks | opusfile           | 0.12+20221121#1 | **no** :red_circle: |
-| [SDL 2.0](https://github.com/libsdl-org/SDL)             | OS-agnostic API for video, audio, and eventing  | sdl2               | 2.32.4#0        | **no** :red_circle: |
+| [SDL 2.0](https://github.com/libsdl-org/SDL)             | OS-agnostic API for video, audio, and eventing  | sdl2               | 2.32.6#0        | **no** :red_circle: |
 | [SDL_net 2.0](https://github.com/libsdl-org/SDL_net)     | Network API for emulated serial and IPX         | sdl2-net           | 2.2.0#3         | yes :green_circle:  |
 | [slirp](https://gitlab.freedesktop.org/slirp)            | TCP/IP library for Ethernet emulation           | libslirp           | 4.9.0#0         | yes :green_circle:  |
 | [SpeexDSP](https://github.com/xiph/speexdsp)             | Audio resampling                                | speexdsp           | 1.2.1#1         | **no** :red_circle: |

--- a/include/sdlmain.h
+++ b/include/sdlmain.h
@@ -1,7 +1,7 @@
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *
- *  Copyright (C) 2022-2024  The DOSBox Staging Team
+ *  Copyright (C) 2022-2025  The DOSBox Staging Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -293,6 +293,8 @@ struct SDL_Block {
 
 	bool mute_when_inactive  = false;
 	bool pause_when_inactive = false;
+
+	bool keyboard_capture = false;
 
 	SDL_Rect draw_rect_px     = {};
 	SDL_Window* window        = nullptr;

--- a/include/sdlmain.h
+++ b/include/sdlmain.h
@@ -294,8 +294,6 @@ struct SDL_Block {
 	bool mute_when_inactive  = false;
 	bool pause_when_inactive = false;
 
-	bool keyboard_capture = false;
-
 	SDL_Rect draw_rect_px     = {};
 	SDL_Window* window        = nullptr;
 	SDL_Renderer* renderer    = nullptr;

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3400,9 +3400,11 @@ static void apply_active_settings()
 	// At least on some platforms grabbing the keyboard has to be repeated
 	// each time we regain focus
 	if (sdl.window) {
+		const auto capture_keyboard = get_sdl_section()->Get_bool(
+		        "keyboard_capture");
+
 		SDL_SetWindowKeyboardGrab(sdl.window,
-	        	                  sdl.keyboard_capture ? SDL_TRUE :
-	        	                                         SDL_FALSE);
+		                          capture_keyboard ? SDL_TRUE : SDL_FALSE);
 	}
 }
 
@@ -3473,8 +3475,6 @@ static void read_gui_config(Section* sec)
 	sdl.pause_when_inactive = section->Get_bool("pause_when_inactive");
 
 	sdl.mute_when_inactive = (!sdl.pause_when_inactive) && section->Get_bool("mute_when_inactive");
-
-	sdl.keyboard_capture = section->Get_bool("keyboard_capture");
 
 	// Assume focus on startup
 	apply_active_settings();
@@ -4504,7 +4504,7 @@ static void config_add_sdl()
 	pbool = sdl_sec->Add_bool("pause_when_inactive", on_start, false);
 	pbool->Set_help("Pause emulation when the window is inactive ('off' by default).");
 
-	pbool = sdl_sec->Add_bool("keyboard_capture", on_start, false);
+	pbool = sdl_sec->Add_bool("keyboard_capture", always, false);
 	pbool->Set_help("Takes over more host OS keyboard shortcuts ('off' by default).");
 
 	pstring = sdl_sec->Add_path("mapperfile", always, MAPPERFILE);

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -4505,7 +4505,11 @@ static void config_add_sdl()
 	pbool->Set_help("Pause emulation when the window is inactive ('off' by default).");
 
 	pbool = sdl_sec->Add_bool("keyboard_capture", always, false);
-	pbool->Set_help("Takes over more host OS keyboard shortcuts ('off' by default).");
+	pbool->Set_help(
+	        "Capture system keyboard shortcuts ('off' by default).\n"
+	        "When enabled, most system shortcuts such as Alt+Tab are captured and sent to\n"
+	        "DOSBox Staging. This is useful for Windows 3.1x and some DOS programs with\n"
+	        "unchangeable keyboard shortcuts that conflict with system shortcuts.");
 
 	pstring = sdl_sec->Add_path("mapperfile", always, MAPPERFILE);
 	pstring->Set_help(

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,0 +1,5 @@
+{
+  "overlay-ports": [
+    "./vcpkg-ports"
+  ]
+}

--- a/vcpkg-ports/sdl2/alsa-dep-fix.patch
+++ b/vcpkg-ports/sdl2/alsa-dep-fix.patch
@@ -1,0 +1,14 @@
+diff --git a/SDL2Config.cmake.in b/SDL2Config.cmake.in
+index cc8bcf26d..ead829767 100644
+--- a/SDL2Config.cmake.in
++++ b/SDL2Config.cmake.in
+@@ -35,7 +35,8 @@ include("${CMAKE_CURRENT_LIST_DIR}/sdlfind.cmake")
+ 
+ set(SDL_ALSA @SDL_ALSA@)
+ set(SDL_ALSA_SHARED @SDL_ALSA_SHARED@)
+-if(SDL_ALSA AND NOT SDL_ALSA_SHARED AND TARGET SDL2::SDL2-static)
++if(SDL_ALSA)
++  set(CMAKE_REQUIRE_FIND_PACKAGE_ALSA 1)
+   sdlFindALSA()
+ endif()
+ unset(SDL_ALSA)

--- a/vcpkg-ports/sdl2/cxx-linkage-pkgconfig.diff
+++ b/vcpkg-ports/sdl2/cxx-linkage-pkgconfig.diff
@@ -1,0 +1,24 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 2a91824..a8e9de4 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -3162,6 +3162,19 @@ set(SDL_STATIC_LIBS ${SDL_LIBS} ${EXTRA_LDFLAGS} ${_EXTRA_LIBS})
+ list(REMOVE_DUPLICATES SDL_STATIC_LIBS)
+ listtostr(SDL_STATIC_LIBS _SDL_STATIC_LIBS)
+ set(SDL_STATIC_LIBS ${_SDL_STATIC_LIBS})
++if("${SOURCE_FILES};" MATCHES "[.]cpp;")
++  set(FAKE_CXX_LINKAGE "")
++  foreach(lib IN LISTS CMAKE_CXX_IMPLICIT_LINK_LIBRARIES)
++      if(lib IN_LIST CMAKE_C_IMPLICIT_LINK_LIBRARIES)
++          continue()
++      elseif(EXISTS "${lib}")
++          string(APPEND FAKE_CXX_LINKAGE " ${CMAKE_LINK_LIBRARY_FILE_FLAG}${lib}")
++      else()
++          string(APPEND FAKE_CXX_LINKAGE " ${CMAKE_LINK_LIBRARY_FLAG}${lib}")
++      endif()
++  endforeach()
++  string(APPEND SDL_STATIC_LIBS "${FAKE_CXX_LINKAGE}")
++endif()
+ listtostr(SDL_LIBS _SDL_LIBS)
+ set(SDL_LIBS ${_SDL_LIBS})
+ listtostr(SDL_CFLAGS _SDL_CFLAGS "")

--- a/vcpkg-ports/sdl2/deps.patch
+++ b/vcpkg-ports/sdl2/deps.patch
@@ -1,0 +1,13 @@
+diff --git a/cmake/sdlchecks.cmake b/cmake/sdlchecks.cmake
+index 65a98efbe..2f99f28f1 100644
+--- a/cmake/sdlchecks.cmake
++++ b/cmake/sdlchecks.cmake
+@@ -352,7 +352,7 @@ endmacro()
+ # - HAVE_SDL_LOADSO opt
+ macro(CheckLibSampleRate)
+   if(SDL_LIBSAMPLERATE)
+-    find_package(SampleRate QUIET)
++    find_package(SampleRate CONFIG REQUIRED)
+     if(SampleRate_FOUND AND TARGET SampleRate::samplerate)
+       set(HAVE_LIBSAMPLERATE TRUE)
+       set(HAVE_LIBSAMPLERATE_H TRUE)

--- a/vcpkg-ports/sdl2/portfile.cmake
+++ b/vcpkg-ports/sdl2/portfile.cmake
@@ -1,0 +1,125 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO libsdl-org/SDL
+    REF "release-${VERSION}"
+    SHA512 c3bbec85835e7f50662c408d220b0706d4247738472cb93fe44341d9cc81093988ac34993b43e2e4178969381d6097a1f401be97476deaec9f0dded01e7e11a1
+    HEAD_REF main
+    PATCHES
+        deps.patch
+        alsa-dep-fix.patch
+        cxx-linkage-pkgconfig.diff
+)
+
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" SDL_STATIC)
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" SDL_SHARED)
+string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "static" FORCE_STATIC_VCRT)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        alsa     SDL_ALSA
+        dbus     SDL_DBUS
+        ibus     SDL_IBUS
+        samplerate SDL_LIBSAMPLERATE
+        vulkan   SDL_VULKAN
+        wayland  SDL_WAYLAND
+        x11      SDL_X11
+)
+
+if ("x11" IN_LIST FEATURES)
+    message(WARNING "You will need to install Xorg dependencies to use feature x11:\nsudo apt install libx11-dev libxft-dev libxext-dev\n")
+endif()
+if ("wayland" IN_LIST FEATURES)
+    message(WARNING "You will need to install Wayland dependencies to use feature wayland:\nsudo apt install libwayland-dev libxkbcommon-dev libegl1-mesa-dev\n")
+endif()
+if ("ibus" IN_LIST FEATURES)
+    message(WARNING "You will need to install ibus dependencies to use feature ibus:\nsudo apt install libibus-1.0-dev\n")
+endif()
+
+if(VCPKG_TARGET_IS_UWP)
+    set(configure_opts WINDOWS_USE_MSBUILD)
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    ${configure_opts}
+    OPTIONS ${FEATURE_OPTIONS}
+        -DSDL_STATIC=${SDL_STATIC}
+        -DSDL_SHARED=${SDL_SHARED}
+        -DSDL_FORCE_STATIC_VCRT=${FORCE_STATIC_VCRT}
+        -DSDL_LIBC=ON
+        -DSDL_TEST=OFF
+        -DSDL_INSTALL_CMAKEDIR=cmake
+        -DCMAKE_DISABLE_FIND_PACKAGE_Git=ON
+        -DSDL_LIBSAMPLERATE_SHARED=OFF
+    MAYBE_UNUSED_VARIABLES
+        SDL_FORCE_STATIC_VCRT
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH cmake)
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+    "${CURRENT_PACKAGES_DIR}/bin/sdl2-config"
+    "${CURRENT_PACKAGES_DIR}/debug/bin/sdl2-config"
+    "${CURRENT_PACKAGES_DIR}/SDL2.framework"
+    "${CURRENT_PACKAGES_DIR}/debug/SDL2.framework"
+    "${CURRENT_PACKAGES_DIR}/share/licenses"
+    "${CURRENT_PACKAGES_DIR}/share/aclocal"
+)
+
+file(GLOB BINS "${CURRENT_PACKAGES_DIR}/debug/bin/*" "${CURRENT_PACKAGES_DIR}/bin/*")
+if(NOT BINS)
+    file(REMOVE_RECURSE
+        "${CURRENT_PACKAGES_DIR}/bin"
+        "${CURRENT_PACKAGES_DIR}/debug/bin"
+    )
+endif()
+
+if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_UWP AND NOT VCPKG_TARGET_IS_MINGW)
+    if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
+        file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/lib/manual-link")
+        file(RENAME "${CURRENT_PACKAGES_DIR}/lib/SDL2main.lib" "${CURRENT_PACKAGES_DIR}/lib/manual-link/SDL2main.lib")
+    endif()
+    if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
+        file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/debug/lib/manual-link")
+        file(RENAME "${CURRENT_PACKAGES_DIR}/debug/lib/SDL2maind.lib" "${CURRENT_PACKAGES_DIR}/debug/lib/manual-link/SDL2maind.lib")
+    endif()
+
+    file(GLOB SHARE_FILES "${CURRENT_PACKAGES_DIR}/share/sdl2/*.cmake")
+    foreach(SHARE_FILE ${SHARE_FILES})
+        vcpkg_replace_string("${SHARE_FILE}" "lib/SDL2main" "lib/manual-link/SDL2main" IGNORE_UNCHANGED)
+    endforeach()
+endif()
+
+vcpkg_copy_pdbs()
+
+set(DYLIB_COMPATIBILITY_VERSION_REGEX "set\\(DYLIB_COMPATIBILITY_VERSION (.+)\\)")
+set(DYLIB_CURRENT_VERSION_REGEX "set\\(DYLIB_CURRENT_VERSION (.+)\\)")
+file(STRINGS "${SOURCE_PATH}/CMakeLists.txt" DYLIB_COMPATIBILITY_VERSION REGEX ${DYLIB_COMPATIBILITY_VERSION_REGEX})
+file(STRINGS "${SOURCE_PATH}/CMakeLists.txt" DYLIB_CURRENT_VERSION REGEX ${DYLIB_CURRENT_VERSION_REGEX})
+string(REGEX REPLACE ${DYLIB_COMPATIBILITY_VERSION_REGEX} "\\1" DYLIB_COMPATIBILITY_VERSION "${DYLIB_COMPATIBILITY_VERSION}")
+string(REGEX REPLACE ${DYLIB_CURRENT_VERSION_REGEX} "\\1" DYLIB_CURRENT_VERSION "${DYLIB_CURRENT_VERSION}")
+
+if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug" AND NOT VCPKG_TARGET_IS_ANDROID)
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/sdl2.pc" "-lSDL2main" "-lSDL2maind" IGNORE_UNCHANGED)
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/sdl2.pc" "-lSDL2 " "-lSDL2d " IGNORE_UNCHANGED)
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/sdl2.pc" "-lSDL2-static " "-lSDL2-staticd " IGNORE_UNCHANGED)
+endif()
+
+if(VCPKG_TARGET_IS_UWP)
+    if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
+        vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/pkgconfig/sdl2.pc" "$<$<CONFIG:Debug>:d>.lib" "")
+        vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/pkgconfig/sdl2.pc" "-l-nodefaultlib:" "-nodefaultlib:")
+    endif()
+    if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
+        vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/sdl2.pc" "$<$<CONFIG:Debug>:d>.lib" "d")
+        vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/sdl2.pc" "-l-nodefaultlib:" "-nodefaultlib:")
+    endif()
+endif()
+
+vcpkg_fixup_pkgconfig()
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/vcpkg-ports/sdl2/portfile.cmake
+++ b/vcpkg-ports/sdl2/portfile.cmake
@@ -14,6 +14,11 @@ string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" SDL_STATIC)
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" SDL_SHARED)
 string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "static" FORCE_STATIC_VCRT)
 
+# SDL_SetWindowKeyboardGrab() only works on macOS if SDL_MAC_NO_SANDBOX
+# is defined
+string(APPEND VCPKG_C_FLAGS   " -DSDL_MAC_NO_SANDBOX")
+string(APPEND VCPKG_CXX_FLAGS " -DSDL_MAC_NO_SANDBOX")
+
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         alsa     SDL_ALSA
@@ -38,6 +43,7 @@ endif()
 if(VCPKG_TARGET_IS_UWP)
     set(configure_opts WINDOWS_USE_MSBUILD)
 endif()
+
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"

--- a/vcpkg-ports/sdl2/usage
+++ b/vcpkg-ports/sdl2/usage
@@ -1,0 +1,8 @@
+sdl2 provides CMake targets:
+
+    find_package(SDL2 CONFIG REQUIRED)
+    target_link_libraries(main
+        PRIVATE
+        $<TARGET_NAME_IF_EXISTS:SDL2::SDL2main>
+        $<IF:$<TARGET_EXISTS:SDL2::SDL2>,SDL2::SDL2,SDL2::SDL2-static>
+    )

--- a/vcpkg-ports/sdl2/vcpkg.json
+++ b/vcpkg-ports/sdl2/vcpkg.json
@@ -1,0 +1,74 @@
+{
+  "name": "sdl2",
+  "version": "2.32.6",
+  "description": "Simple DirectMedia Layer is a cross-platform development library designed to provide low level access to audio, keyboard, mouse, joystick, and graphics hardware via OpenGL and Direct3D.",
+  "homepage": "https://www.libsdl.org/download-2.0.php",
+  "license": "Zlib",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "default-features": [
+    {
+      "name": "dbus",
+      "platform": "linux"
+    },
+    {
+      "name": "ibus",
+      "platform": "linux"
+    },
+    {
+      "name": "wayland",
+      "platform": "linux"
+    },
+    {
+      "name": "x11",
+      "platform": "linux"
+    }
+  ],
+  "features": {
+    "alsa": {
+      "description": "Support for alsa audio",
+      "dependencies": [
+        "alsa"
+      ]
+    },
+    "dbus": {
+      "description": "Build with D-Bus support",
+      "dependencies": [
+        {
+          "name": "dbus",
+          "default-features": false,
+          "platform": "linux"
+        }
+      ]
+    },
+    "ibus": {
+      "description": "Build with ibus IME support",
+      "supports": "linux"
+    },
+    "samplerate": {
+      "description": "Use libsamplerate for audio rate conversion",
+      "dependencies": [
+        "libsamplerate"
+      ]
+    },
+    "vulkan": {
+      "description": "Vulkan functionality for SDL"
+    },
+    "wayland": {
+      "description": "Build with Wayland support",
+      "supports": "linux"
+    },
+    "x11": {
+      "description": "Build with X11 support",
+      "supports": "!windows"
+    }
+  }
+}


### PR DESCRIPTION
# Description

Adds a `keyboard_capture` option to call https://wiki.libsdl.org/SDL2/SDL_SetWindowKeyboardGrab - to grab more keyboard shortcuts, so they trigger DOSBox or game action instead of host OS action.


## Related issues

Fixes https://github.com/dosbox-staging/dosbox-staging/issues/4306
Fixes https://github.com/dosbox-staging/dosbox-staging/issues/4350


# Release notes

If `keyboard_capture` option is set, emulator now takes over more keyboard shortcuts, like ALT+TAB or some platform specific - CTRL+ESC (normally activates the start menu on Windows), CTRL+F4 (normally switches to virtual desktop #4 on KDE), CTRL+LeftArrow (shows the desktop on macOS). They are now passed to the running game or they trigger DOSBox actions.


# Manual testing

Test results with `keyboard_capture` enabled so far:
- _Linux_ (_KDE_, _Wayland_) - without keyboard grab the F12 launches _Yakuake_ (a _Quake_-style console), with keyboard grab it does not and the key is passed to the guest software; also CTRL+F4 does not switch to virtual desktop #4 anymore, but switches the mounted CD image
- _macOS_ - in fullscreen mode CTRL+LeftArrow is not taken over by the _macOS_
- _Windows_ -at least CTRL+ESC keyboard shortcut is grabbed

The change has been manually tested on:

- [x] Windows
- [x] macOS
- [x] Linux


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [x] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

