### PR TITLE
Add ManyMouse support to CMake scripts

### DIFF
--- a/.github/workflows/pvs-studio.yml
+++ b/.github/workflows/pvs-studio.yml
@@ -121,7 +121,7 @@ jobs:
 
       - name: Summarize report
         env:
-          MAX_BUGS: 176
+          MAX_BUGS: 177
         run: |
           echo "Full report is included in build Artifacts"
           echo

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,15 @@ if(NOT HAS_UNISTD)
   )
 endif()
 
+# File-descriptor manipulation routines, such as FD_ZERO, are used
+# by Enet, slirp, and ManyMouse's X11 interface. Unfortunately these
+# routines aren't universally available.
+if(DOSBOX_PLATFORM_WINDOWS)
+  check_symbol_exists(FD_ZERO  "winsock2.h"    HAVE_FD_ZERO)
+else()
+  check_symbol_exists(FD_ZERO  "sys/select.h"  HAVE_FD_ZERO)
+endif()
+
 ### config.h shenanigans
 
 set(TEST_CODE_BUILTIN_AVAILABLE "
@@ -151,9 +160,43 @@ if(OPT_DEBUG)
   endif()
 endif()
 
+# ManyMouse - optional XInput support
+option(OPT_MANYMOUSE
+       "Use ManyMouse library for single-computer multiplayer gaming in The Settlers I/II"
+       ON
+)
+
+# ManyMouse - optional XInput support
+option(OPT_XINPUT
+       "Let ManyMouse use the X Input protocol"
+       OFF
+)
+
 # ManyMouse
-set(C_MANYMOUSE OFF)    # TODO
-set(SUPPORT_XINPUT2 OFF)    # TODO
+if (OPT_MANYMOUSE)
+  if (NOT HAVE_FD_ZERO)
+    message(WARNING "ManyMouse requires FD_ZERO support")
+  elseif(DOSBOX_PLATFORM_MACOS)
+    include (${CMAKE_CURRENT_SOURCE_DIR}/src/libs/manymouse/cmake/FindIOKit.cmake)
+    if (NOT ${IOKit_FOUND})
+      message(WARNING "ManyMouse requires IOKit")
+    else()
+      set(C_MANYMOUSE ON)
+    endif()
+  else()
+    set(C_MANYMOUSE ON)
+  endif()
+
+  if (C_MANYMOUSE AND OPT_XINPUT)
+    check_include_file("X11/extensions/XInput2.h" HAVE_XINPUT)
+    include (${CMAKE_ROOT}/Modules/FindX11.cmake)
+    if ((NOT ${X11_Xinput_FOUND}) OR (NOT HAVE_XINPUT))
+      message(WARNING "XInput not found.")
+    else()
+      set(SUPPORT_XINPUT2 ON)
+    endif()
+  endif()
+endif()
 
 # macOS
 set(C_COREAUDIO      "${DOSBOX_PLATFORM_MACOS}")

--- a/src/hardware/CMakeLists.txt
+++ b/src/hardware/CMakeLists.txt
@@ -99,6 +99,7 @@ target_link_libraries(libhardware PRIVATE
   libresidfp
   libym7128bemu
   libtalchorus
+  $<IF:$<BOOL:${C_MANYMOUSE}>,libmanymouse,>
   libnuked
   libints
   libgui

--- a/src/libs/CMakeLists.txt
+++ b/src/libs/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_subdirectory(decoders)
 add_subdirectory(ESFMu)
 add_subdirectory(loguru)
+add_subdirectory(manymouse)
 add_subdirectory(nuked)
 add_subdirectory(PDCurses)
 add_subdirectory(residfp)

--- a/src/libs/manymouse/CMakeLists.txt
+++ b/src/libs/manymouse/CMakeLists.txt
@@ -1,0 +1,17 @@
+
+if(C_MANYMOUSE)
+
+  add_library(libmanymouse STATIC
+    linux_evdev.c
+    macosx_hidmanager.c
+    macosx_hidutilities.c
+    manymouse.c
+    windows_wminput.c
+    x11_xinput2.c
+  )
+
+  target_link_libraries(dosbox PRIVATE
+    $<IF:$<BOOL:${SUPPORT_XINPUT2}>,${X11_Xinput_LIB},>
+  )
+
+endif()

--- a/src/libs/manymouse/cmake/FindIOKit.cmake
+++ b/src/libs/manymouse/cmake/FindIOKit.cmake
@@ -1,0 +1,45 @@
+#-------------------------------------------------------------------
+# This file is part of the CMake build system for OGRE
+#     (Object-oriented Graphics Rendering Engine)
+# For the latest info, see http://www.ogre3d.org/
+#
+# The contents of this file are placed in the public domain. Feel
+# free to make use of it in any way you like.
+#-------------------------------------------------------------------
+
+# - Try to find IOKit
+# Once done, this will define
+#
+#  IOKit_FOUND - system has IOKit
+#  IOKit_INCLUDE_DIRS - the IOKit include directories 
+#  IOKit_LIBRARIES - link these to use IOKit
+
+include(FindPkgMacros)
+findpkg_begin(IOKit)
+
+# construct search paths
+set(IOKit_PREFIX_PATH ${IOKit_HOME} $ENV{IOKit_HOME}
+  ${OGRE_HOME} $ENV{OGRE_HOME})
+create_search_paths(IOKit)
+# redo search if prefix path changed
+clear_if_changed(IOKit_PREFIX_PATH
+  IOKit_LIBRARY_FWK
+  IOKit_LIBRARY_REL
+  IOKit_LIBRARY_DBG
+  IOKit_INCLUDE_DIR
+)
+
+set(IOKit_LIBRARY_NAMES IOKit)
+get_debug_names(IOKit_LIBRARY_NAMES)
+
+use_pkgconfig(IOKit_PKGC IOKit)
+
+findpkg_framework(IOKit)
+
+find_path(IOKit_INCLUDE_DIR NAMES IOKitLib.h HINTS ${IOKit_INC_SEARCH_PATH} ${IOKit_PKGC_INCLUDE_DIRS} PATH_SUFFIXES IOKit)
+find_library(IOKit_LIBRARY_REL NAMES ${IOKit_LIBRARY_NAMES} HINTS ${IOKit_LIB_SEARCH_PATH} ${IOKit_PKGC_LIBRARY_DIRS})
+find_library(IOKit_LIBRARY_DBG NAMES ${IOKit_LIBRARY_NAMES_DBG} HINTS ${IOKit_LIB_SEARCH_PATH} ${IOKit_PKGC_LIBRARY_DIRS})
+make_library_set(IOKit_LIBRARY)
+findpkg_finish(IOKit)
+add_parent_dir(IOKit_INCLUDE_DIRS IOKit_INCLUDE_DIR)
+

--- a/src/libs/manymouse/cmake/FindIOKit.cmake
+++ b/src/libs/manymouse/cmake/FindIOKit.cmake
@@ -14,7 +14,7 @@
 #  IOKit_INCLUDE_DIRS - the IOKit include directories 
 #  IOKit_LIBRARIES - link these to use IOKit
 
-include(FindPkgMacros)
+include(${CMAKE_CURRENT_SOURCE_DIR}/src/libs/manymouse/cmake/FindPkgMacros.cmake)
 findpkg_begin(IOKit)
 
 # construct search paths

--- a/src/libs/manymouse/cmake/FindPkgMacros.cmake
+++ b/src/libs/manymouse/cmake/FindPkgMacros.cmake
@@ -1,0 +1,161 @@
+#-------------------------------------------------------------------
+# This file is part of the CMake build system for OGRE
+#     (Object-oriented Graphics Rendering Engine)
+# For the latest info, see http://www.ogre3d.org/
+#
+# The contents of this file are placed in the public domain. Feel
+# free to make use of it in any way you like.
+#-------------------------------------------------------------------
+
+##################################################################
+# Provides some common functionality for the FindPackage modules
+##################################################################
+
+# Begin processing of package
+macro(findpkg_begin PREFIX)
+  if (NOT ${PREFIX}_FIND_QUIETLY)
+    message(STATUS "Looking for ${PREFIX}...")
+  endif ()
+endmacro(findpkg_begin)
+
+# Display a status message unless FIND_QUIETLY is set
+macro(pkg_message PREFIX)
+  if (NOT ${PREFIX}_FIND_QUIETLY)
+    message(STATUS ${ARGN})
+  endif ()
+endmacro(pkg_message)
+
+# Get environment variable, define it as ENV_$var and make sure backslashes are converted to forward slashes
+macro(getenv_path VAR)
+   set(ENV_${VAR} $ENV{${VAR}})
+   # replace won't work if var is blank
+   if (ENV_${VAR})
+     string( REGEX REPLACE "\\\\" "/" ENV_${VAR} ${ENV_${VAR}} )
+   endif ()
+endmacro(getenv_path)
+
+# Construct search paths for includes and libraries from a PREFIX_PATH
+macro(create_search_paths PREFIX)
+  foreach(dir ${${PREFIX}_PREFIX_PATH})
+    set(${PREFIX}_INC_SEARCH_PATH ${${PREFIX}_INC_SEARCH_PATH}
+      ${dir}/include ${dir}/Include ${dir}/include/${PREFIX} ${dir}/Headers)
+    set(${PREFIX}_LIB_SEARCH_PATH ${${PREFIX}_LIB_SEARCH_PATH}
+      ${dir}/lib ${dir}/Lib ${dir}/lib/${PREFIX} ${dir}/Libs)
+    set(${PREFIX}_BIN_SEARCH_PATH ${${PREFIX}_BIN_SEARCH_PATH}
+      ${dir}/bin)
+  endforeach(dir)
+  set(${PREFIX}_FRAMEWORK_SEARCH_PATH ${${PREFIX}_PREFIX_PATH})
+endmacro(create_search_paths)
+
+# clear cache variables if a certain variable changed
+macro(clear_if_changed TESTVAR)
+  # test against internal check variable
+  # HACK: Apparently, adding a variable to the cache cleans up the list
+  # a bit. We need to also remove any empty strings from the list, but
+  # at the same time ensure that we are actually dealing with a list.
+  list(APPEND ${TESTVAR} "")
+  list(REMOVE_ITEM ${TESTVAR} "")
+  if (NOT "${${TESTVAR}}" STREQUAL "${${TESTVAR}_INT_CHECK}")
+    message(STATUS "${TESTVAR} changed.")
+    foreach(var ${ARGN})
+      set(${var} "NOTFOUND" CACHE STRING "x" FORCE)
+    endforeach(var)
+  endif ()
+  set(${TESTVAR}_INT_CHECK ${${TESTVAR}} CACHE INTERNAL "x" FORCE)
+endmacro(clear_if_changed)
+
+# Try to get some hints from pkg-config, if available
+macro(use_pkgconfig PREFIX PKGNAME)
+  find_package(PkgConfig)
+  if (PKG_CONFIG_FOUND)
+    pkg_check_modules(${PREFIX} ${PKGNAME})
+  endif ()
+endmacro (use_pkgconfig)
+
+# Couple a set of release AND debug libraries (or frameworks)
+macro(make_library_set PREFIX)
+  if (${PREFIX}_FWK)
+    set(${PREFIX} ${${PREFIX}_FWK})
+  elseif (${PREFIX}_REL AND ${PREFIX}_DBG)
+    set(${PREFIX} optimized ${${PREFIX}_REL} debug ${${PREFIX}_DBG})
+  elseif (${PREFIX}_REL)
+    set(${PREFIX} ${${PREFIX}_REL})
+  elseif (${PREFIX}_DBG)
+    set(${PREFIX} ${${PREFIX}_DBG})
+  endif ()
+endmacro(make_library_set)
+
+# Generate debug names from given release names
+macro(get_debug_names PREFIX)
+  foreach(i ${${PREFIX}})
+    set(${PREFIX}_DBG ${${PREFIX}_DBG} ${i}d ${i}D ${i}_d ${i}_D ${i}_debug ${i})
+  endforeach(i)
+endmacro(get_debug_names)
+
+# Add the parent dir from DIR to VAR 
+macro(add_parent_dir VAR DIR)
+  get_filename_component(${DIR}_TEMP "${${DIR}}/.." ABSOLUTE)
+  set(${VAR} ${${VAR}} ${${DIR}_TEMP})
+endmacro(add_parent_dir)
+
+# Do the final processing for the package find.
+macro(findpkg_finish PREFIX)
+  # skip if already processed during this run
+  if (NOT ${PREFIX}_FOUND)
+    if (${PREFIX}_INCLUDE_DIR AND ${PREFIX}_LIBRARY)
+      set(${PREFIX}_FOUND TRUE)
+      set(${PREFIX}_INCLUDE_DIRS ${${PREFIX}_INCLUDE_DIR})
+      set(${PREFIX}_LIBRARIES ${${PREFIX}_LIBRARY})
+      if (NOT ${PREFIX}_FIND_QUIETLY)
+        message(STATUS "Found ${PREFIX}: ${${PREFIX}_LIBRARIES}")
+      endif ()
+    else ()
+      if (NOT ${PREFIX}_FIND_QUIETLY)
+        message(STATUS "Could not locate ${PREFIX}")
+      endif ()
+      if (${PREFIX}_FIND_REQUIRED)
+        message(FATAL_ERROR "Required library ${PREFIX} not found! Install the library (including dev packages) and try again. If the library is already installed, set the missing variables manually in cmake.")
+      endif ()
+    endif ()
+
+    mark_as_advanced(${PREFIX}_INCLUDE_DIR ${PREFIX}_LIBRARY ${PREFIX}_LIBRARY_REL ${PREFIX}_LIBRARY_DBG ${PREFIX}_LIBRARY_FWK)
+  endif ()
+endmacro(findpkg_finish)
+
+
+# Slightly customised framework finder
+MACRO(findpkg_framework fwk)
+  IF(APPLE)
+    SET(${fwk}_FRAMEWORK_PATH
+      ${${fwk}_FRAMEWORK_SEARCH_PATH}
+      ${CMAKE_FRAMEWORK_PATH}
+      ~/Library/Frameworks
+      /Library/Frameworks
+      /System/Library/Frameworks
+      /Network/Library/Frameworks
+      /Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS3.0.sdk/System/Library/Frameworks/
+      ${CMAKE_CURRENT_SOURCE_DIR}/lib/Release
+      ${CMAKE_CURRENT_SOURCE_DIR}/lib/Debug
+    )
+    # These could be arrays of paths, add each individually to the search paths
+    foreach(i ${OGRE_PREFIX_PATH})
+      set(${fwk}_FRAMEWORK_PATH ${${fwk}_FRAMEWORK_PATH} ${i}/lib/Release ${i}/lib/Debug)
+    endforeach(i)
+
+    foreach(i ${OGRE_PREFIX_BUILD})
+      set(${fwk}_FRAMEWORK_PATH ${${fwk}_FRAMEWORK_PATH} ${i}/lib/Release ${i}/lib/Debug)
+    endforeach(i)
+
+    FOREACH(dir ${${fwk}_FRAMEWORK_PATH})
+      SET(fwkpath ${dir}/${fwk}.framework)
+      IF(EXISTS ${fwkpath})
+        SET(${fwk}_FRAMEWORK_INCLUDES ${${fwk}_FRAMEWORK_INCLUDES}
+          ${fwkpath}/Headers ${fwkpath}/PrivateHeaders)
+        SET(${fwk}_FRAMEWORK_PATH ${dir})
+        if (NOT ${fwk}_LIBRARY_FWK)
+          SET(${fwk}_LIBRARY_FWK "-framework ${fwk}")
+        endif ()
+      ENDIF(EXISTS ${fwkpath})
+    ENDFOREACH(dir)
+  ENDIF(APPLE)
+ENDMACRO(findpkg_framework)


### PR DESCRIPTION
# Description

Updated _CMake_ scripts for _ManyMouse_ support. Should not interfere with the work-in-progress spring cleanup.

_macOS_ remark: Imported some _CMake_ support scripts from the _OGRE_ project - to check whether the OS provides appropriate interfaces (carryover behavior from from old _Meson_ scripts).

_Linux_ remark: The _XInput_ interface is disabled by default:
- distros use _evdev_ since a long time
- _ManyMouse_ driver for _evdev_ works better, thus it is already the default one with 0.82
- more and more distros are now dropping the _X11_ 


## Related issues

https://github.com/dosbox-staging/dosbox-staging/issues/4196


# Manual testing

- grab the tarball from CI or compile the project using CMake scripts (like `cmake --preset=release-linux`, then `cmake --build --preset=release-linux`)
- if on Windows, set `mouse_raw_input = false`
- start DOSBox, type `mousectl -all` - it should print out all the USB mice found
- execute `mousectl dos -map` command, press mouse button, check with any software that the mapped mouse works; it should not react on non-mapped mice

The change has been manually tested on:

- [x] Windows
- [x] macOS
- [x] Linux


# Checklist


I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

