### PR TITLE
Replace non-ASCII copyright symbol in winres.rc

### DIFF
--- a/src/winres.rc
+++ b/src/winres.rc
@@ -18,12 +18,12 @@ BEGIN
     BEGIN
         BLOCK "040904b0"
         BEGIN
-            VALUE "Comments", "© 2025 The DOSBox Staging Team, published under GNU GPL"
+            VALUE "Comments", "(C) 2025 The DOSBox Staging Team, published under GNU GPL"
             VALUE "CompanyName", "DOSBox Staging"
             VALUE "FileDescription", "DOSBox Staging DOS Emulator"
             VALUE "FileVersion", "0, 83, 0, 0"
             VALUE "InternalName", "dosbox-staging"
-            VALUE "LegalCopyright", "Copyright © 2025 The DOSBox Staging Team"
+            VALUE "LegalCopyright", "Copyright (C) 2025 The DOSBox Staging Team"
             VALUE "OriginalFilename", "dosbox.exe"
             VALUE "ProductName", "DOSBox Staging"
             VALUE "ProductVersion", "0, 83, 0, 0"


### PR DESCRIPTION
# Description

My Clang + Ninja build on WIndows started to fail after 3b20fb811024a090ee1ec84df1e8d9f148c14208 now that we're compiling `winres.rc`. It gives the following error: 

```
llvm-rc: Error in VERSIONINFO statement (ID 1):
Non-ASCII 8-bit codepoint can't be interpreted in the current codepage
```

I researched the problem and found that libcurl ran into this same issue and this was their solution. I tried the prefix with "L" thing but it didn't work.

https://github.com/curl/curl/issues/7765

# Manual testing

Only affects Windows. It builds for me now.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

