### PR TITLE
Simplify 'for' help message handling

### DIFF
--- a/contrib/resources/translations/br.lng
+++ b/contrib/resources/translations/br.lng
@@ -4416,18 +4416,18 @@ Executa um comando especificado para cada string em um conjunto.
 .
 :SHELL_CMD_FOR_HELP_LONG
 Uso:
-  [color=light-green]for[reset] [color=white]%VAR[reset] [color=light-cyan]in[reset] [color=white](CONJUNTO)[reset] [color=light-cyan]do[reset] [color=white]COMANDO[reset]
+  [color=light-green]for[reset] [color=white]%%VAR[reset] [color=light-cyan]in[reset] [color=white](CONJUNTO)[reset] [color=light-cyan]do[reset] [color=white]COMANDO[reset]
 
 Parâmetros:
-  [color=white]%VAR[reset]          caractere único representando uma variável, prefixado por um '%'
+  [color=white]%%VAR[reset]          caractere único representando uma variável, prefixado por um '%%'
   [color=light-cyan]in[reset]            palavra-chave insensível a maiúsculas e minúsculas
-  [color=white](CONJUNTO)[reset]    conjunto de strings para substituir instâncias de [color=white]%VAR[reset]
+  [color=white](CONJUNTO)[reset]    conjunto de strings para substituir instâncias de [color=white]%%VAR[reset]
                 em [color=white]COMANDO[reset]
   [color=light-cyan]do[reset]            palavra-chave insensível a maiúsculas e minúsculas
   [color=white]COMANDO[reset]       comando a repetir para cada string em [color=white](CONJUNTO)[reset]
 
 Notas:
-  - Em arquivos em lote, [color=white]%VAR[reset] deve ser escrito como [color=white]%%VAR[reset] (dois sinais de
+  - Em arquivos em lote, [color=white]%%VAR[reset] deve ser escrito como [color=white]%%%%VAR[reset] (dois sinais de
     percentagem) em vez disso.
   - As strings em [color=white](CONJUNTO)[reset] podem ser separadas por qualquer separador
     DOS válido.
@@ -4436,8 +4436,8 @@ Notas:
   - Usar outro [color=light-green]for[reset] como [color=white]COMANDO[reset] não é permitido.
 
 Exemplos:
-  [color=light-green]for[reset] [color=white]%C[reset] [color=light-cyan]in[reset] [color=white](UM DOIS)[reset] [color=light-cyan]do[reset] [color=white]MKDIR[reset] [color=white]%C[reset]
-  [color=light-green]for[reset] [color=white]%D[reset] [color=light-cyan]in[reset] [color=white](*.TXT)[reset] [color=light-cyan]do[reset] [color=white]ECHO[reset] [color=white]%D[reset]
+  [color=light-green]for[reset] [color=white]%%C[reset] [color=light-cyan]in[reset] [color=white](UM DOIS)[reset] [color=light-cyan]do[reset] [color=white]MKDIR[reset] [color=white]%%C[reset]
+  [color=light-green]for[reset] [color=white]%%D[reset] [color=light-cyan]in[reset] [color=white](*.TXT)[reset] [color=light-cyan]do[reset] [color=white]ECHO[reset] [color=white]%%D[reset]
 
 .
 :HELP_UTIL_CATEGORY_DOSBOX

--- a/contrib/resources/translations/de.lng
+++ b/contrib/resources/translations/de.lng
@@ -4471,21 +4471,21 @@ Führt angegebenen Befehl für jede Zeichenkette in einer Gruppe aus.
 .
 :SHELL_CMD_FOR_HELP_LONG
 Verwendung:
-  [color=light-green]for[reset] [color=white]%VAR[reset] [color=light-cyan]in[reset] [color=white](GRUPPE)[reset] [color=light-cyan]do[reset] [color=white]BEFEHL[reset]
+  [color=light-green]for[reset] [color=white]%%VAR[reset] [color=light-cyan]in[reset] [color=white](GRUPPE)[reset] [color=light-cyan]do[reset] [color=white]BEFEHL[reset]
 
 Wobei:
-  [color=white]%VAR[reset]     Ein einzelnes Zeichen, das eine Variable darstellt und dem ein '%'
+  [color=white]%%VAR[reset]     Ein einzelnes Zeichen, das eine Variable darstellt und dem ein '%%'
            vorangestellt ist.
   [color=light-cyan]in[reset]       Ein Schlüsselwort, bei dem Groß- und Kleinschreibung nicht
            unterschieden wird.
-  [color=white](GRUPPE)[reset] Die Menge der Zeichenketten, die die [color=white]%VAR[reset]-Instanzen in [color=white]BEFEHL[reset]
+  [color=white](GRUPPE)[reset] Die Menge der Zeichenketten, die die [color=white]%%VAR[reset]-Instanzen in [color=white]BEFEHL[reset]
            ersetzen.
   [color=light-cyan]do[reset]       Ein Schlüsselwort, bei dem Groß- und Kleinschreibung nicht
            unterschieden wird.
   [color=white]BEFEHL[reset]   Der Befehl, der für jeden String in [color=white](GRUPPE)[reset] wiederholt werden soll.
 
 Hinweise:
-  - In Batch-Dateien muss [color=white]%VAR[reset] als [color=white]%%VAR[reset] (zwei Prozentzeichen) geschrieben
+  - In Batch-Dateien muss [color=white]%%VAR[reset] als [color=white]%%%%VAR[reset] (zwei Prozentzeichen) geschrieben
     werden.
   - Zeichenketten in [color=white](GRUPPE)[reset] können durch jedes gültige DOS-Trennzeichen
     getrennt werden.
@@ -4494,8 +4494,8 @@ Hinweise:
   - Die Verwendung eines anderen [color=light-green]for[reset]-Befehls als [color=white]BEFEHL[reset] ist nicht erlaubt.
 
 Beispiele:
-  [color=light-green]for[reset] [color=white]%C[reset] [color=light-cyan]in[reset] [color=white](EINS WEI)[reset] [color=light-cyan]do[reset] [color=white]MKDIR[reset] [color=white]%C[reset]
-  [color=light-green]for[reset] [color=white]%D[reset] [color=light-cyan]in[reset] [color=white](*.TXT)[reset] [color=light-cyan]do[reset] [color=white]ECHO[reset] [color=white]%D[reset]
+  [color=light-green]for[reset] [color=white]%%C[reset] [color=light-cyan]in[reset] [color=white](EINS WEI)[reset] [color=light-cyan]do[reset] [color=white]MKDIR[reset] [color=white]%%C[reset]
+  [color=light-green]for[reset] [color=white]%%D[reset] [color=light-cyan]in[reset] [color=white](*.TXT)[reset] [color=light-cyan]do[reset] [color=white]ECHO[reset] [color=white]%%D[reset]
 .
 :HELP_UTIL_CATEGORY_DOSBOX
 DOSBox-Befehle

--- a/contrib/resources/translations/es.lng
+++ b/contrib/resources/translations/es.lng
@@ -4488,18 +4488,18 @@ Ejecutar un comando por cada cadena especificada en el conjunto.
 .
 :SHELL_CMD_FOR_HELP_LONG
 Uso:
-  [color=light-green]for[reset] [color=white]%VAR[reset] [color=light-cyan]in[reset] [color=white](CONJUNTO)[reset] [color=light-cyan]do[reset] [color=white]COMANDO[reset]
+  [color=light-green]for[reset] [color=white]%%VAR[reset] [color=light-cyan]in[reset] [color=white](CONJUNTO)[reset] [color=light-cyan]do[reset] [color=white]COMANDO[reset]
 
 Parámetros:
-  [color=white]%VAR[reset]        un solo carácter representando una variable, prefijado por '%'
+  [color=white]%%VAR[reset]        un solo carácter representando una variable, prefijado por '%%'
   [color=light-cyan]in[reset]          palabra clave no sensible a las mayúsculas
   [color=white](CONJUNTO)[reset]  conjunto de cadenas por el cual se reemplazarán las instancias
-              de [color=white]%VAR[reset] en [color=white]COMANDO[reset]
+              de [color=white]%%VAR[reset] en [color=white]COMANDO[reset]
   [color=light-cyan]do[reset]          palabra clave no sensible a las mayúsculas
   [color=white]COMANDO[reset]     comando a repetir para cada cadena en [color=white](CONJUNTO)[reset]
 
 Notas:
-  - En los programas por lotes, [color=white]%VAR[reset] debe escribirse como [color=white]%%VAR[reset] (con dos signos
+  - En los programas por lotes, [color=white]%%VAR[reset] debe escribirse como [color=white]%%%%VAR[reset] (con dos signos
     de porcentaje).
   - Las cadenas en [color=white](CONJUNTO)[reset] deben separarse por un separador de DOS válido.
   - Cualquier cadena en [color=white](CONJUNTO)[reset] que contenga comodines (* o ?) será expandida
@@ -4507,8 +4507,8 @@ Notas:
   - Usar otro comando [color=light-green]for[reset] como [color=white]COMANDO[reset] no está permitido.
 
 Ejemplos:
-  [color=light-green]for[reset] [color=white]%C[reset] [color=light-cyan]in[reset] [color=white](UNO DOS)[reset] [color=light-cyan]do[reset] [color=white]MKDIR[reset] [color=white]%C[reset]
-  [color=light-green]for[reset] [color=white]%D[reset] [color=light-cyan]in[reset] [color=white](*.TXT)[reset] [color=light-cyan]do[reset] [color=white]ECHO[reset] [color=white]%D[reset]
+  [color=light-green]for[reset] [color=white]%%C[reset] [color=light-cyan]in[reset] [color=white](UNO DOS)[reset] [color=light-cyan]do[reset] [color=white]MKDIR[reset] [color=white]%%C[reset]
+  [color=light-green]for[reset] [color=white]%%D[reset] [color=light-cyan]in[reset] [color=white](*.TXT)[reset] [color=light-cyan]do[reset] [color=white]ECHO[reset] [color=white]%%D[reset]
 
 .
 :HELP_UTIL_CATEGORY_DOSBOX

--- a/contrib/resources/translations/it.lng
+++ b/contrib/resources/translations/it.lng
@@ -5854,18 +5854,18 @@ Esegue il comando specificato per ogni file o stringa di un gruppo.
 .
 :SHELL_CMD_FOR_HELP_LONG
 Utilizzo:
-  [color=light-green]for[reset] [color=white]%VAR[reset] [color=light-cyan]in[reset] [color=white](GRUPPO)[reset] [color=light-cyan]do[reset] [color=white]COMANDO[reset]
+  [color=light-green]for[reset] [color=white]%%VAR[reset] [color=light-cyan]in[reset] [color=white](GRUPPO)[reset] [color=light-cyan]do[reset] [color=white]COMANDO[reset]
 
 Parametri:
-  [color=white]%VAR[reset]      singolo carattere che rappresenta una variabile, con prefisso '%'
+  [color=white]%%VAR[reset]      singolo carattere che rappresenta una variabile, con prefisso '%%'
   [color=light-cyan]in[reset]        parte del comando [color=light-green]for[reset], senza distinzione tra maiuscole e minuscole
-  [color=white](GRUPPO)[reset]  gruppo di file o stringhe con cui sostituire le istanze [color=white]%VAR[reset]
+  [color=white](GRUPPO)[reset]  gruppo di file o stringhe con cui sostituire le istanze [color=white]%%VAR[reset]
             nel [color=white]COMANDO[reset]
   [color=light-cyan]do[reset]        parte del comando [color=light-green]for[reset], senza distinzione tra maiuscole e minuscole
   [color=white]COMANDO[reset]   comando da eseguire per ciascun file o stringa presente in [color=white](GRUPPO)[reset]
 
 Note:
-  - In un programma batch, utilizzare la sintassi [color=white]%%VAR[reset] anziché [color=white]%VAR[reset].
+  - In un programma batch, utilizzare la sintassi [color=white]%%%%VAR[reset] anziché [color=white]%%VAR[reset].
   - I file o le stringhe presenti in [color=white](GRUPPO)[reset] possono essere separati da
     qualsiasi separatore DOS valido.
   - Qualsiasi file presente in [color=white](GRUPPO)[reset] contenente caratteri jolly (* o ?) si
@@ -5873,8 +5873,8 @@ Note:
   - Non è consentito l'utilizzo di un altro comando [color=light-green]for[reset] come [color=white]COMANDO[reset].
 
 Esempi:
-  [color=light-green]for[reset] [color=white]%C[reset] [color=light-cyan]in[reset] [color=white](UNO DUE)[reset] [color=light-cyan]do[reset] [color=white]MKDIR[reset] [color=white]%C[reset]
-  [color=light-green]for[reset] [color=white]%D[reset] [color=light-cyan]in[reset] [color=white](*.TXT)[reset] [color=light-cyan]do[reset] [color=white]ECHO[reset] [color=white]%D[reset]
+  [color=light-green]for[reset] [color=white]%%C[reset] [color=light-cyan]in[reset] [color=white](UNO DUE)[reset] [color=light-cyan]do[reset] [color=white]MKDIR[reset] [color=white]%%C[reset]
+  [color=light-green]for[reset] [color=white]%%D[reset] [color=light-cyan]in[reset] [color=white](*.TXT)[reset] [color=light-cyan]do[reset] [color=white]ECHO[reset] [color=white]%%D[reset]
 
 .
 :HELP_UTIL_CATEGORY_DOSBOX

--- a/contrib/resources/translations/nl.lng
+++ b/contrib/resources/translations/nl.lng
@@ -5605,17 +5605,17 @@ Voert een opgegeven opdracht uit voor elke string in een set.
 .
 :SHELL_CMD_FOR_HELP_LONG
 Gebruik:
-  [color=light-green]for[reset] [color=white]%VAR[reset] [color=light-cyan]in[reset] [color=white](SET)[reset] [color=light-cyan]do[reset] [color=white]COMMANDO[reset]
+  [color=light-green]for[reset] [color=white]%%VAR[reset] [color=light-cyan]in[reset] [color=white](SET)[reset] [color=light-cyan]do[reset] [color=white]COMMANDO[reset]
 
 Parameters:
-  [color=white]%VAR[reset]    enkel teken dat een variabele vertegenwoordigt, voorafgegaan door '%'
+  [color=white]%%VAR[reset]    enkel teken dat een variabele vertegenwoordigt, voorafgegaan door '%%'
   [color=light-cyan]in[reset]      hoofdletterongevoelig trefwoord.
-  [color=white](SET)[reset]   set strings die [color=white]%VAR[reset] instanties in [color=white]COMMANDO[reset] moeten vervangen.
+  [color=white](SET)[reset]   set strings die [color=white]%%VAR[reset] instanties in [color=white]COMMANDO[reset] moeten vervangen.
   [color=light-cyan]do[reset]      hoofdletterongevoelig trefwoord.
   [color=white]COMMAND[reset] commando dat moet worden herhaald voor elke string in [color=white](SET)[reset].
 
 Opmerkingen:
-  - In batchbestanden moet [color=white]%VAR[reset] worden geschreven als [color=white]%%VAR[reset]
+  - In batchbestanden moet [color=white]%%VAR[reset] worden geschreven als [color=white]%%%%VAR[reset]
     (twee procenttekens).
   - Strings in [color=white](SET)[reset] mogen worden gescheiden door elk geldig
     DOS-scheidingsteken.
@@ -5624,8 +5624,8 @@ Opmerkingen:
   - Het gebruik van een ander [color=light-green]for[reset] commando als [color=white]COMMANDO[reset] is niet toegestaan.
 
 Voorbeelden:
-  [color=light-green]for[reset] [color=white]%C[reset] [color=light-cyan]in[reset] [color=white](EEN TWEE)[reset] [color=light-cyan]do[reset] [color=white]MKDIR[reset] [color=white]%C[reset]
-  [color=light-green]for[reset] [color=white]%D[reset] [color=light-cyan]in[reset] [color=white](*.TXT)[reset] [color=light-cyan]do[reset] [color=white]ECHO[reset] [color=white]%D[reset]
+  [color=light-green]for[reset] [color=white]%%C[reset] [color=light-cyan]in[reset] [color=white](EEN TWEE)[reset] [color=light-cyan]do[reset] [color=white]MKDIR[reset] [color=white]%%C[reset]
+  [color=light-green]for[reset] [color=white]%%D[reset] [color=light-cyan]in[reset] [color=white](*.TXT)[reset] [color=light-cyan]do[reset] [color=white]ECHO[reset] [color=white]%%D[reset]
 
 .
 :HELP_UTIL_CATEGORY_DOSBOX

--- a/contrib/resources/translations/pl.lng
+++ b/contrib/resources/translations/pl.lng
@@ -5448,17 +5448,17 @@ Wykonaj polecenie dla każdego z podanych łańcuchów.
 .
 :SHELL_CMD_FOR_HELP_LONG
 Składnia:
-  [color=light-green]for[reset] [color=white]%ZMIENNA[reset] [color=light-cyan]in[reset] [color=white](ŁAŃCUCHY)[reset] [color=light-cyan]do[reset] [color=white]POLECENIE[reset]
+  [color=light-green]for[reset] [color=white]%%ZMIENNA[reset] [color=light-cyan]in[reset] [color=white](ŁAŃCUCHY)[reset] [color=light-cyan]do[reset] [color=white]POLECENIE[reset]
 
 Gdzie:
-  [color=white]%ZMIENNA[reset]    pojedynczy znak będący nazwą zmiennej, poprzedzony '%'
+  [color=white]%%ZMIENNA[reset]    pojedynczy znak będący nazwą zmiennej, poprzedzony '%%'
   [color=light-cyan]in[reset]          słowo kluczowe, wielkość liter nie ma znaczenia
-  [color=white](ŁAŃCUCHY)[reset]  łańcuchy, które zostaną podstawione pod [color=white]%ZMIENNĄ[reset] w [color=white]POLECENIU[reset]
+  [color=white](ŁAŃCUCHY)[reset]  łańcuchy, które zostaną podstawione pod [color=white]%%ZMIENNĄ[reset] w [color=white]POLECENIU[reset]
   [color=light-cyan]do[reset]          słowo kluczowe, wielkość liter nie ma znaczenia
   [color=white]POLECENIE[reset]   polecenie, które zostanie wykonane dla każdego z łańcuchów
 
 Uwagi:
-  W plikach wsadowych [color=white]%ZMIENNA[reset] musi zostać zapisana jako [color=white]%%ZMIENNA[reset] (musi być
+  W plikach wsadowych [color=white]%%ZMIENNA[reset] musi zostać zapisana jako [color=white]%%%%ZMIENNA[reset] (musi być
   poprzedzona dwoma znakami procentu).
   [color=white](ŁAŃCUCHY)[reset] można rozdzielić dowolnym separatorem.
   [color=white](ŁAŃCUCHY)[reset] zawierające symbole wieloznaczności (* lub ?) zostaną zastąpione
@@ -5466,8 +5466,8 @@ Uwagi:
   Użycie kolejnego [color=light-green]for[reset] jako [color=white]POLECENIA[reset] jest niedozwolone.
 
 Przykłady:
-  [color=light-green]for[reset] [color=white]%C[reset] [color=light-cyan]in[reset] [color=white](RAZ DWA)[reset] [color=light-cyan]do[reset] [color=white]MKDIR[reset] [color=white]%C[reset]
-  [color=light-green]for[reset] [color=white]%D[reset] [color=light-cyan]in[reset] [color=white](*.TXT)[reset] [color=light-cyan]do[reset] [color=white]ECHO[reset] [color=white]%D[reset]
+  [color=light-green]for[reset] [color=white]%%C[reset] [color=light-cyan]in[reset] [color=white](RAZ DWA)[reset] [color=light-cyan]do[reset] [color=white]MKDIR[reset] [color=white]%%C[reset]
+  [color=light-green]for[reset] [color=white]%%D[reset] [color=light-cyan]in[reset] [color=white](*.TXT)[reset] [color=light-cyan]do[reset] [color=white]ECHO[reset] [color=white]%%D[reset]
 
 .
 :HELP_UTIL_CATEGORY_DOSBOX

--- a/include/messages.h
+++ b/include/messages.h
@@ -29,7 +29,6 @@ void MSG_LoadMessages();
 
 // Add message (in UTF-8 encoding) to the translation system
 void MSG_Add(const std::string& name, const std::string& message);
-void MSG_AddNoFormatString(const std::string& name, const std::string& message);
 
 // Get message text, adapted to the current code page,
 // with markup tags converted to ANSI escape codes

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2021-2024  The DOSBox Staging Team
+ *  Copyright (C) 2021-2025  The DOSBox Staging Team
  *  Copyright (C) 2002-2021  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -1304,27 +1304,27 @@ void SHELL_Init() {
 	        "Cannot move multiple files to a single file.\n");
 	MSG_Add("SHELL_CMD_FOR_HELP",
 	        "Run a specified command for each string in a set.\n");
-	MSG_AddNoFormatString("SHELL_CMD_FOR_HELP_LONG",
+	MSG_Add("SHELL_CMD_FOR_HELP_LONG",
 	        "Usage:\n"
-	        "  [color=light-green]for[reset] [color=white]%VAR[reset] [color=light-cyan]in[reset] [color=white](SET)[reset] [color=light-cyan]do[reset] [color=white]COMMAND[reset]\n"
+	        "  [color=light-green]for[reset] [color=white]%%VAR[reset] [color=light-cyan]in[reset] [color=white](SET)[reset] [color=light-cyan]do[reset] [color=white]COMMAND[reset]\n"
 	        "\n"
 	        "Parameters:\n"
-	        "  [color=white]%VAR[reset]     single character representing a variable, prefixed by a '%'\n"
+	        "  [color=white]%%VAR[reset]     single character representing a variable, prefixed by a '%%'\n"
 	        "  [color=light-cyan]in[reset]       case-insensitive keyword\n"
-	        "  [color=white](SET)[reset]    set of strings to replace [color=white]%VAR[reset] instances in [color=white]COMMAND[reset]\n"
+	        "  [color=white](SET)[reset]    set of strings to replace [color=white]%%VAR[reset] instances in [color=white]COMMAND[reset]\n"
 	        "  [color=light-cyan]do[reset]       case-insensitive keyword\n"
 	        "  [color=white]COMMAND[reset]  command to repeat for each string in [color=white](SET)[reset]\n"
 	        "\n"
 	        "Notes:\n"
-	        "  - In batch files, [color=white]%VAR[reset] must be written as [color=white]%%VAR[reset] (two percent signs) instead.\n"
+	        "  - In batch files, [color=white]%%VAR[reset] must be written as [color=white]%%VAR[reset] (two percent signs) instead.\n"
 	        "  - Strings in [color=white](SET)[reset] may be separated by any valid DOS separator.\n"
 	        "  - Any string in [color=white](SET)[reset] containing wildcards (* or ?) will expand to\n"
 	        "    the set of matching files in the current directory.\n"
 	        "  - Using another [color=light-green]for[reset] command as [color=white]COMMAND[reset] is not permitted.\n"
 	        "\n"
 	        "Examples:\n"
-	        "  [color=light-green]for[reset] [color=white]%C[reset] [color=light-cyan]in[reset] [color=white](ONE TWO)[reset] [color=light-cyan]do[reset] [color=white]MKDIR[reset] [color=white]%C[reset]\n"
-	        "  [color=light-green]for[reset] [color=white]%D[reset] [color=light-cyan]in[reset] [color=white](*.TXT)[reset] [color=light-cyan]do[reset] [color=white]ECHO[reset] [color=white]%D[reset]\n");
+	        "  [color=light-green]for[reset] [color=white]%%C[reset] [color=light-cyan]in[reset] [color=white](ONE TWO)[reset] [color=light-cyan]do[reset] [color=white]MKDIR[reset] [color=white]%%C[reset]\n"
+	        "  [color=light-green]for[reset] [color=white]%%D[reset] [color=light-cyan]in[reset] [color=white](*.TXT)[reset] [color=light-cyan]do[reset] [color=white]ECHO[reset] [color=white]%%D[reset]\n");
 
 	/* Ensure help categories are loaded into the message vector */
 	HELP_AddMessages();

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -1,7 +1,7 @@
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *
- *  Copyright (C) 2020-2024  The DOSBox Staging Team
+ *  Copyright (C) 2020-2025  The DOSBox Staging Team
  *  Copyright (C) 2002-2021  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -241,12 +241,14 @@ bool DOS_Shell::WriteHelp(const std::string &command, char *args) {
 
 	MoreOutputStrings output(*this);
 	std::string short_key("SHELL_CMD_" + command + "_HELP");
-	output.AddString("%s\n", MSG_Get(short_key));
+	output.AddString(MSG_Get(short_key));
+	output.AddString("\n");
 	std::string long_key("SHELL_CMD_" + command + "_HELP_LONG");
-	if (MSG_Exists(long_key))
-		output.AddString("%s", MSG_Get(long_key));
-	else
+	if (MSG_Exists(long_key)) {
+		output.AddString(MSG_Get(long_key));
+	} else {
 		output.AddString("%s\n", command.c_str());
+	}
 	output.Display();
 
 	return true;


### PR DESCRIPTION
# Description

The `for` command help needs to display a percent (`%`) sign several time in it's output and the current help string contains the percent sign verbatim (no `%%` to print just one character by the prinf-like functions).

This is the only command needing this character, and handling the string without proper percent escaping needs quite some extra code - this PR adds the escaping and simplifies the implementation.


# Manual testing

For every language containing the `SHELL_CMD_FOR_HELP_LONG` string (en, br, de, es, it, nl, pl) check the `for` command help, for example:

```
config -set language=pl
help for
```

There should be no `SHELL_CMD_FOR_HELP_LONG` related warnings in the log, the `help for` command should print out the localized help message - each of them should contain a single `%%` (two percent signs) sequence.


The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [x] Linux (the change is trivial)


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

