### PR TITLE
Fix reporting of failed CI builds on Linux and macOS

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -102,7 +102,7 @@ jobs:
 
       - name: Setup and build
         run: |
-          set -x
+          set -xo pipefail
           export CC=${{ matrix.conf.cc }}
           export CXX=${{ matrix.conf.cxx }}
           cmake ${{ matrix.conf.cmake_flags }} --preset ${{ matrix.conf.cmake_preset }}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Setup and build release
         run: |
-          set -x
+          set -xo pipefail
           cmake --preset release-macos-${{ matrix.conf.arch }}
           cmake --build --preset release-macos-${{ matrix.conf.arch }} 2>&1 | tee build.log
 


### PR DESCRIPTION
# Description

In the Linux and macOS CI build jobs, the CMake output is piped to a `build.log` file via `tee`, then we run our analyzer warnings script on the log file. But I forgot to specify `set -o pipefail`, so if the build fails, the CMake error code gets overwritten by that of `tee` which is always a success.

This caused later stages of the pipeline to fail with unexpected errors (e.g., because the build artifacts were missing). Pretty trivial but still took me a while to realise what's going on 😅 

# Manual testing

Tested in my WIP PR https://github.com/dosbox-staging/dosbox-staging/pull/4351; the build errors now fail the "Setup and build" step.


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

