### PR TITLE
Only delete the build dir for the selected CMake preset in `compile-commits.sh`

### DIFF
--- a/scripts/tools/compile-commits.sh
+++ b/scripts/tools/compile-commits.sh
@@ -34,7 +34,7 @@ compile_commit() {
 
 	# Configure if the build directory does not exist (this happens when
 	# compiling the first commit)
-	if ! test -d "$BUILD_DIR"; then
+	if ! test -d "${BUILD_DIR:?}/$CMAKE_PRESET"; then
 		DO_CONFIGURE=1
 	fi
 
@@ -92,7 +92,7 @@ BUILD_DIR=build
 echo
 
 # Ensure CMake configure is triggered before compiling the first commit
-rm -rf $BUILD_DIR
+rm -rf "${BUILD_DIR:?}/$CMAKE_PRESET"
 
 PARENT_BRANCH=main
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)


### PR DESCRIPTION
# Description

As per title. Previously, it did an `rm -rf` on the whole `build` dir which is not that great if you have a bunch of different build configs set up (e.g., build, release, sanitizer, etc.)


# Manual testing

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [ ] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [ ] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [ ] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [ ] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

