### PR TITLE
Fix AUTOEXEC.BAT being deleted on disk swap

### DIFF
--- a/include/dos_system.h
+++ b/include/dos_system.h
@@ -417,9 +417,9 @@ void VFILE_Register(const char *name,
                     const uint8_t *data,
                     const uint32_t size,
                     const char *dir = "");
-void VFILE_Register(const char* name, const std::vector<uint8_t>& blob,
+void VFILE_Register(const char* name, const std::vector<uint8_t>& data,
                     const char* dir = "");
-void VFILE_Update(const char* name, std::vector<uint8_t> blob, const char* dir = "");
+bool VFILE_Update(const char* name, const std::vector<uint8_t> &data, const char* dir = "");
 void VFILE_Remove(const char* name, const char* dir = "");
 
 #endif

--- a/src/dos/drive_virtual.cpp
+++ b/src/dos/drive_virtual.cpp
@@ -206,18 +206,21 @@ void VFILE_Register(const char *name,
 	first_file = new_file;
 }
 
-void VFILE_Register(const char *name, const std::vector<uint8_t> &blob, const char *dir)
+void VFILE_Register(const char *name, const std::vector<uint8_t> &data, const char *dir)
 {
-	VFILE_Register(name, blob.data(), check_cast<uint32_t>(blob.size()), dir);
+	VFILE_Register(name, data.data(), check_cast<uint32_t>(data.size()), dir);
 }
 
-void VFILE_Update(const char* name, std::vector<uint8_t> blob, const char* dir)
+bool VFILE_Update(const char* name, const std::vector<uint8_t> &data, const char* dir)
 {
 	auto vfile = find_vfile_by_name_and_dir(name, dir);
 
 	if (vfile) {
-		vfile->data = std::make_shared<std::vector<uint8_t>>(std::move(blob));
+		vfile->data = std::make_shared<std::vector<uint8_t>>(data);
+		return true;
 	}
+
+	return false;
 }
 
 void VFILE_Remove(const char* name, const char* dir)

--- a/src/shell/autoexec.cpp
+++ b/src/shell/autoexec.cpp
@@ -229,13 +229,11 @@ static void create_autoexec_bat_dos(const std::string& input_utf8,
 	                                             autoexec_bat_dos.end());
 
 	// Register/refresh Z:\AUTOEXEC.BAT file
-	if (is_vfile_registered) {
-		VFILE_Update(AutoexecFileName.c_str(), std::move(autoexec_bat_bin));
-	} else {
-		VFILE_Register(AutoexecFileName.c_str(),
-		               std::move(autoexec_bat_bin));
-		is_vfile_registered = true;
+	if (!VFILE_Update(AutoexecFileName.c_str(), autoexec_bat_bin)) {
+		VFILE_Register(AutoexecFileName.c_str(), autoexec_bat_bin);
 	}
+
+	is_vfile_registered = true;
 
 	// Store current code page for caching purposes
 	vfile_code_page = code_page;


### PR DESCRIPTION
# Description

Root cause regression from f466410f49e7c7cae31c743878258723b35859a7
Further regression in 09722228235850c56c0e36b8f90c47dbfdd4dae5 - This caused the [autoexec] section to stop execution on disk swap

Virtual_Drive::EmptyCache() deletes and re-creates all files in Z:\ autoexec.cpp relied on an internal boolean to decide whether to update or re-create AUTOEXEC.bat This boolean is invalided by clearing the cache

Fix by attemping the update first and if the file does not exist, create a new one

Also removed some std::move shenaigans that weren't implemented properly to begin with. I'm pretty sure the receiving function needs to take a && for std::move to do any good.

## Related issues

Fixes #4358

# Release notes

Swapping disks with Ctrl+F4 no longer breaks AUTOEXEC.BAT

# Manual testing

Reproduction steps in #4358

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [x] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [x] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

