### PR TITLE
Cleanup AUTOEXEC.BAT regeneration

### DIFF
--- a/include/autoexec.h
+++ b/include/autoexec.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023  The DOSBox Staging Team
+ *  Copyright (C) 2020-2025  The DOSBox Staging Team
  *  Copyright (C) 2002-2021  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -24,18 +24,8 @@
 
 #include <string>
 
-// Registers the AUTOEXEC.BAT file on the emulated Z: drive.
-// From now on, the only changes to the file content which became visible on the
-// guest side, are DOS code page changes.
-// TODO: change this, every environment variable modification or [autoexec]
-// modification by CONFIG.COM command should be reflected; this will require
-// careful checking of our COMMAND.COM iomplementattion in order not break
-// anything when the change happens during AUTOEXEC.BAT execution.
-void AUTOEXEC_RegisterFile();
-
-// Notify, that DOS display code page has changed, and the AUTOEXEC.BAT content
-// might need to be refreshed from the original (internal) UTF-8 version.
-void AUTOEXEC_NotifyNewCodePage();
+// Creates or refreshes the AUTOEXEC.BAT file on the emulated Z: drive.
+void AUTOEXEC_RefreshFile();
 
 // Adds/updates environment variable to the AUTOEXEC.BAT file. Empty value
 // removes the variable. If a shell is already running, it the environment is

--- a/src/dos/dos_code_page.cpp
+++ b/src/dos/dos_code_page.cpp
@@ -53,7 +53,7 @@ static void notify_code_page_changed()
 	MSG_NotifyNewCodePage();
 	DOS_UpdateCurrentProgramName();
 	DOS_RepopulateCountryInfo();
-	AUTOEXEC_NotifyNewCodePage();
+	AUTOEXEC_RefreshFile();
 }
 
 // ***************************************************************************

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -1,7 +1,7 @@
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *
- *  Copyright (C) 2020-2024  The DOSBox Staging Team
+ *  Copyright (C) 2020-2025  The DOSBox Staging Team
  *  Copyright (C) 2002-2021  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -63,7 +63,7 @@ void REELMAGIC_MaybeCreateFmpdrvExecutable();
 void VFILE_GetPathZDrive(std::string& path, const std::string& dirname);
 void VFILE_RegisterZDrive(const std_fs::path& z_drive_path);
 
-void Add_VFiles(const bool add_autoexec)
+void Add_VFiles()
 {
 	const std::string dirname = "drivez";
 
@@ -106,9 +106,7 @@ void Add_VFiles(const bool add_autoexec)
 
 	REELMAGIC_MaybeCreateFmpdrvExecutable();
 
-	if (add_autoexec) {
-		AUTOEXEC_RegisterFile();
-	}
+	AUTOEXEC_RefreshFile();
 }
 
 void DOS_SetupPrograms(void)
@@ -117,6 +115,5 @@ void DOS_SetupPrograms(void)
 	MSG_Add("WIKI_ADD_UTILITIES_ARTICLE", WIKI_ADD_UTILITIES_ARTICLE);
 	MSG_Add("WIKI_URL", WIKI_URL);
 
-	const auto add_autoexec = false;
-	Add_VFiles(add_autoexec);
+	Add_VFiles();
 }

--- a/src/dos/drive_virtual.cpp
+++ b/src/dos/drive_virtual.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2021-2024  The DOSBox Staging Team
+ *  Copyright (C) 2021-2025  The DOSBox Staging Team
  *  Copyright (C) 2002-2021  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -44,7 +44,7 @@ unsigned int vfile_pos = 1;
 uint16_t fztime = 0;
 uint16_t fzdate = 0;
 char sfn[DOS_NAMELENGTH_ASCII];
-void Add_VFiles(const bool add_autoexec);
+void Add_VFiles();
 extern DOS_Shell *first_shell;
 
 class VFILE_Block;
@@ -677,5 +677,5 @@ void Virtual_Drive::EmptyCache()
 	vfile_pos = 1;
 	PROGRAMS_Destroy(nullptr);
 	vfilenames = {Filename{"", ""}};
-	Add_VFiles(first_shell != nullptr);
+	Add_VFiles();
 }


### PR DESCRIPTION
# Description

Cleanup the `Z:\AUTOEXEC.BAT` regeneration to make the code slighly smaller and safer - `AUTOEXEC_RegisterFile` and `AUTOEXEC_NotifyNewCodePage` were replaced with one function, `AUTOEXEC_RefreshFile`, which is always safe to call.


# Manual testing

- start DOSBox, ideally switch the language to non-English, for example using command `dosbox --set language=pl`
- display the `Z:\AUTOEXEC.BAT` file content, for example type `more Z:\AUTOEXEC.BAT` (you can terminate the command by pressing Q)
- press CTRL+F4, check that `Z:\AUTOEXEC.BAT` still exists
- change the code page a few times, for example use commands `keyb us 667`, `keyb us 668`, `keyb us 437` - after each command check that the file still exists
- change the DOSBox language, for example `config -set language=de` - afterwards check that the `Z:\AUTOEXEC.BAT` file still exists and the comments in the file are in the same language as when the emulator was started

The change has been manually tested on:

- [x] Windows
- [x] macOS
- [x] Linux


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

