### PR TITLE
PVS Studio warning fixes

### DIFF
--- a/.github/workflows/pvs-studio.yml
+++ b/.github/workflows/pvs-studio.yml
@@ -121,7 +121,7 @@ jobs:
 
       - name: Summarize report
         env:
-          MAX_BUGS: 177
+          MAX_BUGS: 164
         run: |
           echo "Full report is included in build Artifacts"
           echo

--- a/src/dos/dos_locale.cpp
+++ b/src/dos/dos_locale.cpp
@@ -1743,7 +1743,7 @@ void DOS_Locale_AddMessages()
 
 	// Add strings with keyboard layout names
 	for (const auto& entry : LocaleData::KeyboardLayoutInfo) {
-		MSG_Add(entry.GetMsgName().c_str(), entry.layout_name.c_str());
+		MSG_Add(entry.GetMsgName(), entry.layout_name);
 	}
 
 	MSG_Add("KEYBOARD_MOD_ADJECTIVE_LEFT",  "Left");

--- a/src/dos/program_keyb.cpp
+++ b/src/dos/program_keyb.cpp
@@ -1,7 +1,7 @@
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *
- *  Copyright (C) 2002-2024  The DOSBox Team
+ *  Copyright (C) 2002-2025  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -303,16 +303,16 @@ void KEYB::WriteOutSuccess()
 	std::vector<std::pair<std::string, std::string>> table = {};
 
 	if (script1) {
-		table.push_back({DOS_GetKeyboardScriptName(*script1),
-		                 DOS_GetShortcutKeyboardScript1()});
+		table.emplace_back(DOS_GetKeyboardScriptName(*script1),
+		                   DOS_GetShortcutKeyboardScript1());
 	}
 	if (script2) {
-		table.push_back({DOS_GetKeyboardScriptName(*script2),
-		                 DOS_GetShortcutKeyboardScript2()});
+		table.emplace_back(DOS_GetKeyboardScriptName(*script2),
+		                   DOS_GetShortcutKeyboardScript2());
 	}
 	if (script3) {
-		table.push_back({DOS_GetKeyboardScriptName(*script3),
-		                 DOS_GetShortcutKeyboardScript3()});
+		table.emplace_back(DOS_GetKeyboardScriptName(*script3),
+		                   DOS_GetShortcutKeyboardScript3());
 	}
 
 	const bool show_shortcuts = (table.size() > 1);

--- a/src/dos/program_ls.cpp
+++ b/src/dos/program_ls.cpp
@@ -88,7 +88,7 @@ void LS::Run()
 	}
 
 	if (patterns.empty()) {
-		patterns.push_back({});
+		patterns.emplace_back();
 	}
 	for (auto& pattern : patterns) {
 		pattern = to_search_pattern(pattern.c_str());

--- a/src/hardware/disk_noise.cpp
+++ b/src/hardware/disk_noise.cpp
@@ -432,7 +432,7 @@ DiskNoiseDevice::DiskNoiseDevice(const DiskType disk_type,
 	        disk_type);
 }
 
-DiskNoiseDevice::~DiskNoiseDevice() {}
+DiskNoiseDevice::~DiskNoiseDevice() = default;
 
 void DiskNoiseDevice::ActivateSpin()
 {

--- a/src/hardware/input/mouse_common.cpp
+++ b/src/hardware/input/mouse_common.cpp
@@ -92,16 +92,18 @@ uint8_t MOUSE_GetDelayFromRateHz(const uint16_t rate_hz)
 float MOUSE_ClampRelativeMovement(const float rel)
 {
 	constexpr float Max = 2048.0f;
+	constexpr float Min = -Max;
 	// Enforce sane upper limit of relative mouse movement
-	return std::clamp(rel, -Max, Max);
+	return std::clamp(rel, Min, Max);
 }
 
 float MOUSE_ClampWheelMovement(const float rel)
 {
 	// Chosen so that the result always fits into int8_t
 	constexpr float Max = 127.0f;
+	constexpr float Min = -Max;
 	// Enforce sane upper limit of relative mouse wheel
-	return std::clamp(rel, -Max, Max);
+	return std::clamp(rel, Min, Max);
 }
 
 uint16_t MOUSE_ClampRateHz(const uint16_t rate_hz)

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -1229,7 +1229,7 @@ void MixerChannel::AddSilence()
 	if (audio_frames.size() < frames_needed) {
 		if (prev_frame.left == 0.0f && prev_frame.right == 0.0f) {
 			while (audio_frames.size() < frames_needed) {
-				audio_frames.push_back({0.0f, 0.0f});
+				audio_frames.emplace_back(0.0f, 0.0f);
 			}
 
 			// Make sure the next samples are zero when they get

--- a/src/misc/cross.cpp
+++ b/src/misc/cross.cpp
@@ -1,7 +1,7 @@
 /*
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *
- *  Copyright (C) 2021-2024  The DOSBox Staging Team
+ *  Copyright (C) 2021-2025  The DOSBox Staging Team
  *  Copyright (C) 2002-2021  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -596,7 +596,7 @@ bool get_expanded_files(const std::string &path,
 		if (WildFileCmp(filename.string().c_str(),
 		                p.filename().string().c_str(),
 		                long_compare)) {
-			files.push_back((dir / filename).string());
+			files.emplace_back((dir / filename).string());
 		}
 	}
 

--- a/src/misc/host_locale_posix.cpp
+++ b/src/misc/host_locale_posix.cpp
@@ -1368,7 +1368,6 @@ static HostKeyboardLayouts get_host_keyboard_layouts_tty()
 	}
 
 	// Map the detected keyboard layouts to the matching FreeDOS layouts
-	std::vector<KeyboardLayoutMaybeCodepage> results = {};
 	for (const auto& entry : results_tty) {
 		if (!result.log_info.empty()) {
 			result.log_info += ";";

--- a/src/misc/messages.cpp
+++ b/src/misc/messages.cpp
@@ -210,7 +210,7 @@ void Message::VerifyFormatString(const std::string& name)
 
 		// Found a new specifier - parse it according to:
 		// - https://cplusplus.com/reference/cstdio/printf/
-		format_specifiers.push_back({});
+		format_specifiers.emplace_back();
 		auto& specifier = format_specifiers.back();
 
 		// First check for POSIX format string extensions


### PR DESCRIPTION
# Description

We used to have much less PVS Studio warnings in our code, below 100 actually - now we have 177 on the `main`. This PR handles some of them - all modifications are trivial changes, low hanging fruits.


# Manual testing

- executed command `keyb`
- started DOOM game, played for a while
- started Windows 3.11, started few apps


The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [x] Linux (changes are trivial)


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

