### PR TITLE
Make restart_dosbox() go through the normal shutdown routine

### DIFF
--- a/include/control.h
+++ b/include/control.h
@@ -64,6 +64,7 @@ struct CommandLineArguments {
 	std::vector<std::string> set;
 	std::optional<std::vector<std::string>> editconf;
 	std::optional<int> socket;
+	std::optional<int> wait_pid;
 };
 
 class Config {

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -4769,12 +4769,12 @@ int sdl_main(int argc, char* argv[])
 	// Ensure we perform SDL cleanup and restore console settings
 	atexit(QuitSDL);
 
-	switch_console_to_utf8();
-
 	CommandLine command_line(argc, argv);
 	control = std::make_unique<Config>(&command_line);
 
 	const auto arguments = &control->arguments;
+
+	switch_console_to_utf8();
 
 	// Set up logging after command line was parsed and trivial arguments have
 	// been handled

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -1945,6 +1945,7 @@ void Config::ParseArguments()
 	arguments.machine = cmdline->FindRemoveStringArgument("machine");
 
 	arguments.socket = cmdline->FindRemoveIntArgument("socket");
+	arguments.wait_pid = cmdline->FindRemoveIntArgument("waitpid");
 
 	arguments.conf = cmdline->FindRemoveVectorArgument("conf");
 	arguments.set  = cmdline->FindRemoveVectorArgument("set");


### PR DESCRIPTION
# Description

Restarting either by `config -r` or by Ctrl+Alt+Home hotkey now goes through the normal shutdown procedure. A child process gets created that waits for the parent process to terminate before continuing.

What caused me to look into this was the command line history not being saved on restart but I was concerned about other clean-up routines not being run (ex. some of the file system meta-data doesn't get written until close).

This ensures that restart is the same as a normal shutdown. It also delays init of the new process until the old process is fully terminated.

## Related issues

Fixes #4318


# Release notes

Restarting DOSBox now correctly saves the command line history.

# Manual testing

Command line history is now saved after restart on Windows and Linux. Log output confirms the parent process gets fully shutdown before the child process starts init.

The change has been manually tested on:

- [x] Windows
- [x] macOS
- [x] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [x] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

