### PR TITLE
Lock the mixer thread inside disknoise_destroy()

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -81,6 +81,7 @@ jobs:
       - name: Install dependencies
         run: |
           export DEBIAN_FRONTEND=noninteractive
+          sudo apt-get update
           sudo apt-get install -y $(cat packages/ubuntu-22.04-apt.txt)
 
       - name: Clone vcpkg
@@ -136,6 +137,7 @@ jobs:
       - name: Install all dependencies
         run: |
           export DEBIAN_FRONTEND=noninteractive
+          sudo apt-get update
           sudo apt-get install -y $(cat packages/ubuntu-22.04-apt.txt)
 
       - name: Clone vcpkg

--- a/.github/workflows/pvs-studio.yml
+++ b/.github/workflows/pvs-studio.yml
@@ -121,7 +121,7 @@ jobs:
 
       - name: Summarize report
         env:
-          MAX_BUGS: 164
+          MAX_BUGS: 172
         run: |
           echo "Full report is included in build Artifacts"
           echo

--- a/src/hardware/disk_noise.cpp
+++ b/src/hardware/disk_noise.cpp
@@ -504,9 +504,9 @@ void DiskNoises::SetLastIoPath(const std::string& path,
 
 static void disknoise_destroy([[maybe_unused]] Section* sec)
 {
-	if (disk_noises) {
-		disk_noises = nullptr;
-	}
+	MIXER_LockMixerThread();
+	disk_noises.reset();
+	MIXER_UnlockMixerThread();
 }
 
 static void disknoise_init(Section* section)


### PR DESCRIPTION
# Description

There is a difficult to reproduce segfault on exit here.

We're taking a lock inside the DiskNoises destructor but there is a race condition where the disk_noises global is set to nullptr before the destructor has been run and AudioCallback can de-reference the nullptr and crash.

# Manual testing

I was only able to trigger the crash once by accident. I was stepping through with a debugger working on something else and it caught a segfault when DOSBox was in the process of exiting.

I have run into this same crash with other audio devices though so I believe this is the correct fix.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

