### PR TITLE
Only register disk noise callback if required

### DIFF
--- a/src/hardware/disk_noise.cpp
+++ b/src/hardware/disk_noise.cpp
@@ -50,14 +50,18 @@ DiskNoises::DiskNoises(const bool enable_floppy_disk_noise,
                        const std::string& floppy_spin,
                        const std::vector<std::string>& floppy_seek_samples)
 {
+	if (!enable_floppy_disk_noise && !enable_hard_disk_noise) {
+		return;
+	}
+
 	MIXER_LockMixerThread();
 	const auto mixer_callback = std::bind(&DiskNoises::AudioCallback,
 	                                      this,
 	                                      std::placeholders::_1);
-	mix_channel               = MIXER_AddChannel(mixer_callback,
-                                       DiskNoiseSampleRateInHz,
-                                       ChannelName::DiskNoise,
-	                                             {ChannelFeature::Stereo});
+	mix_channel = MIXER_AddChannel(mixer_callback,
+	                               DiskNoiseSampleRateInHz,
+	                               ChannelName::DiskNoise,
+	                               {ChannelFeature::Stereo});
 	mix_channel->Enable(true);
 	float vol_gain = percentage_to_gain(100);
 	mix_channel->SetAppVolume({vol_gain, vol_gain});
@@ -111,13 +115,8 @@ DiskNoises::~DiskNoises()
 {
 	MIXER_LockMixerThread();
 
-	if (floppy_noise) {
-		floppy_noise.reset();
-	}
-
-	if (hdd_noise) {
-		hdd_noise.reset();
-	}
+	floppy_noise.reset();
+	hdd_noise.reset();
 	active_devices.clear();
 
 	if (active_devices.empty() && mix_channel) {


### PR DESCRIPTION
# Description

This PR prevents registering the audio callback when no disk noise is enabled in the configuration

## Related issues

#4374 

# Manual testing

Tested locally. Added log output inside the callback, disabled both FDD and HDD noise in config. Also tested with only HDD and only FDD, as well as both enabled, to verify no errors on shutdown.

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [X] Linux


# Checklist

I have:

- [X] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [X] performed a self-review of my code.
- [X] commented on the particularly hard-to-understand areas of my code.
- [X] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [X] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [X] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [X] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

