### PR TITLE
Update macOS build instructions

### DIFF
--- a/docs/build-macos.md
+++ b/docs/build-macos.md
@@ -7,8 +7,7 @@ MacPorts package managers.
 We recommend using Homebrew and Clang because Apple's Core SDKs can be used
 only with Apple's fork of the Clang compiler.
 
-> **Note**
->
+> [!NOTE]
 > CMake support is currently an experimental internal-only, work-in-progress
 > feature; it's not ready for public consumption yet. Please ignore the
 > `CMakeLists.txt` files in the source tree.
@@ -32,33 +31,35 @@ Tools need to be installed and the license agreed to.
 3. Install build dependencies using either Homebrew or MacPorts.
 
 
-### Installing dependencies – Homebrew
+## Installing dependencies
+
+### Homebrew
 
 1. Install Homebrew: <https://brew.sh>.
 
 2. Install the minimum set of dependencies and related tools:
 
-    ``` shell
+    ```shell
     brew install cmake ccache meson sdl2 sdl2_net opusfile \
-         pkg-config python3
+                 pkg-config python3
     ```
 
 3. Add `brew` to your shell path:
 
-    ``` shell
+    ```shell
     echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> "$HOME"/.zprofile
     eval "$(/opt/homebrew/bin/brew shellenv)"
     ```
 
-### Installing dependencies – MacPorts
+### MacPorts
 
 1. Install MacPorts: <https://www.macports.org/install.php>
 
 2. Install the minimum set of dependencies and related tools:
 
     ```shell
-    sudo port -q install cmake ccache meson libsdl2 libsdl2_net opusfile \
-              glib2 pkgconfig python311
+    sudo port install cmake ccache meson libsdl2 libsdl2_net opusfile \
+                      glib2 pkgconfig python311
     ```
 
 ## Building
@@ -67,9 +68,6 @@ Once you have dependencies installed using either environment, clone the
 repository and enter its directory:
 
 ```shell
-cd
-mkdir -p src
-cd src
 git clone https://github.com/dosbox-staging/dosbox-staging.git
 cd dosbox-staging
 meson setup build
@@ -79,18 +77,150 @@ meson compile -C build
 
 ## Permissions and running
 
-1. Allow the Terminal app to get keyboard events, which will let you
-   launch DOSBox Staging from the command line.
+When running DOSBox Staging for the first time, you'll get lots of pop-up
+dialogs asking for granting DOSBox Staging access to various folders. Just
+allow access to all these folders.
 
-   In **System Settings** &gt; **Privacy** &gt; **Input Monitoring** &gt; **Terminal** (enable)
 
-2. Launch DOSBox Staging:
+## Installing clang-format
 
-    ```shell
-    cd src/dosbox-staging/
-    ./build/dosbox
-    ```
+We use [clang-format](https://clang.llvm.org/docs/ClangFormat.html) to ensure
+the consistent formatting of our code. See the
+[Code formatting](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#code-formatting)
+section of our contributor guidelines for more info.
 
+
+### Homebrew
+
+```shell
+brew install clang-format
+```
+
+### MacPorts
+
+Unfortunately, it's not possible to install only clang-format with MacPorts.
+The cleanest way is to install the entire [clang-20](https://ports.macports.org/port/clang-20/) package (this will take a while):
+
+```shell
+sudo port install clang-20
+```
+
+Once installed, clang-format will be available as `clang-format-mp-20`. But
+it's usually more convenient to have it available under the standard
+`clang-format` name, so we'll need to do a few more extra steps.
+
+DOSBox Staging uses Apple clang, so we don't want to switch over to MacPorts
+clang with [clang-select](https://ports.macports.org/port/clang_select/).
+The best way is to create a symlink (aliases only work in interactive shells,
+not in scripts):
+
+Assuming `~/bin` is in your path (e.g., by having `export
+PATH="$HOME/bin:$PATH"` in your `.zshrc`), run the following:
+
+```shell
+ln -s /opt/local/bin/clang-format-mp-20 ~/bin/clang-format
+```
+
+## Installing extra tools
+
+You'll need a few extra tools installed if you want to generate the website
+and documentation locally and run our various scripts used for linting,
+packaging, etc.
+
+
+### Homebrew
+
+TODO
+
+
+### MacPorts
+
+The instructions are up to date for macOS Sequioa 15.5.
+
+#### mkdocs
+
+Tools used for building our website and documentation (see
+[DOCUMENTATION.md](DOCUMENTATION.md)).
+
+
+> [!NOTE]
+> These commands will also set MacPorts Python and Pip as the system default.
+> If you don't want that, you'll probably need to do some symlinking (figuring
+> that out is an exercise for the reader :sunglasses:).
+
+```shell
+sudo port install python313 python_select-313
+sudo port select --set python  python313
+sudo port select --set python3 python313
+
+sudo port install py-pip
+sudo port select --set pip  pip313
+sudo port select --set pip3 pip313
+
+pip install -r contrib/documentation/mkdocs-package-requirements.txt
+```
+
+You'll also need to add the Python programs installed by pip to the path (so
+you can just execute `mkdocs` from the shell). Append the following to your
+`.zshrc`:
+
+```shell
+export PATH="$PATH:$HOME/Library/Python/3.13/bin/"
+```
+
+#### sass
+
+Only necessary if you want to make changes to our customised MkDocs Material
+theme.
+
+```shell
+sudo port install npm11
+sudo npm install -g sass
+```
+
+#### markdownlint
+
+Used by `scripts/linting/verify-markdown.sh`.
+
+> [!NOTE]
+> These commands will also set MacPorts Ruby as the system default.
+> If you don't want that, you'll probably need to do some symlinking (figuring
+> that out is an exercise for the reader :sunglasses:).
+
+```shell
+sudo port install ruby34
+sudo port select --set ruby ruby34
+sudo gem update --system 3.6.9
+sudo gem install mdl
+```
+
+#### shellcheck
+
+Used by `scripts/linting/verify-bash.sh`.
+
+```shell
+sudo port install shellcheck
+```
+
+#### pylint
+
+Used by `scripts/linting/verify-python.sh`. Make sure to set up MacPorts
+Python as described in the **mkdocs** section first.
+
+```shell
+sudo port install py313-pylint
+sudo port select --set pylint pylint313
+```
+
+#### GNU sed
+
+Assuming `~/bin` is in your `PATH` (e.g., by having `export
+PATH="$HOME/bin:$PATH"` in your `.zshrc`):
+
+```shell
+sudo port install gsed
+ln -s /opt/local/bin/gsed ~/bin/sed
+```
 
 ## Using FluidSynth and Slirp during local development
 


### PR DESCRIPTION
# Description

Just getting the macOS instructions for local dev (including running all the linters locally) in a better shape.

You can view the rendered Markdown [here](https://github.com/dosbox-staging/dosbox-staging/blob/57a85654eb4eb1de941341a0551cca25340be995/docs/build-macos.md).

I can't be bothered to do the same for Windows, but we'll accept PRs if someone really wants to install all those tools natively on Windows somehow and then documents their trials and tribulations 😅 

The Linux instructions should be updated as well, though. Should be a somewhat simplified version of the macOS steps (less hoops to jump through). @FeralChild64 @weirddan455 (or @shermp ?), feel free to raise a PR.

I haven't done the extra tools section for Homebrew as I'm a MacPorts guy. Maybe @kklobe you can flesh that out one day if you're so inclined.

# Manual testing

N/A

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [ ] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

