### PR TITLE
Make Windows CI build errors visible

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -94,14 +94,14 @@ jobs:
         shell: pwsh
         run: |
           cmake --preset release-windows
-          cmake --build --preset release-windows >> build.log 2>&1
+          cmake --build --preset release-windows 2>&1 | Tee-Object -FilePath build.log
 
       - name:  Build release with debugger
         if:    ${{ matrix.conf.debugger }}
         shell: pwsh
         run: |
           cmake --preset release-windows -DOPT_DEBUG=ON -DOPT_HEAVY_DEBUG=ON
-          cmake --build --preset release-windows >> build.log 2>&1
+          cmake --build --preset release-windows 2>&1 | Tee-Object -FilePath build.log
 
       - name: Summarize warnings
         env:


### PR DESCRIPTION
# Description

We were re-directing the build output to build.log so a Python script can use it to check the warning count.

Linux and Mac use tee so we can also see the errors on the console. PowerShell has Tee-Object as a replacement for tee.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

