### PR TITLE
SDL main cleanup, part 1

### DIFF
--- a/include/control.h
+++ b/include/control.h
@@ -167,6 +167,6 @@ public:
 using ConfigPtr = std::unique_ptr<Config>;
 extern ConfigPtr control;
 
-void restart_dosbox(std::vector<std::string> &parameters = control->startup_params);
+void DOSBOX_Restart(std::vector<std::string> &parameters = control->startup_params);
 
 #endif

--- a/include/dosbox.h
+++ b/include/dosbox.h
@@ -72,7 +72,7 @@ void DOSBOX_RunMachine();
 void DOSBOX_SetLoop(LoopHandler * handler);
 void DOSBOX_SetNormalLoop();
 
-void DOSBOX_Init(void);
+void DOSBOX_InitAllModuleConfigsAndMessages(void);
 
 void DOSBOX_SetMachineTypeFromConfig(Section_prop* section);
 

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -604,8 +604,10 @@ double DOSBOX_GetUptime()
 	return GetTicksSince(start_ms) / MillisInSecond;
 }
 
-void DOSBOX_Init()
+void DOSBOX_InitAllModuleConfigsAndMessages()
 {
+	// Note the [sdl] section is initialised in sdlmain.cpp
+	
 	Section_prop* secprop             = nullptr;
 	Prop_bool* pbool                  = nullptr;
 	Prop_int* pint                    = nullptr;

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -2748,7 +2748,7 @@ void GFX_Start() {
 	sdl.active=true;
 }
 
-void GFX_ObtainDisplayDimensions() {
+static void get_display_dimensions() {
 	SDL_Rect displayDimensions;
 	SDL_GetDisplayBounds(sdl.display_number, &displayDimensions);
 	sdl.desktop.full.width = displayDimensions.w;
@@ -2764,7 +2764,7 @@ void GFX_ObtainDisplayDimensions() {
 void GFX_UpdateDisplayDimensions(int width, int height)
 {
 	if (sdl.desktop.full.display_res && sdl.desktop.fullscreen) {
-		/* Note: We should not use GFX_ObtainDisplayDimensions
+		/* Note: We should not use get_display_dimensions()
 		(SDL_GetDisplayBounds) on Android after a screen rotation:
 		The older values from application startup are returned. */
 		sdl.desktop.full.width = width;
@@ -3531,7 +3531,7 @@ static void read_gui_config(Section* sec)
 
 	sdl.desktop.full.display_res = sdl.desktop.full.fixed && (!sdl.desktop.full.width || !sdl.desktop.full.height);
 	if (sdl.desktop.full.display_res) {
-		GFX_ObtainDisplayDimensions();
+		get_display_dimensions();
 	}
 
 	set_output(section, is_aspect_ratio_correction_enabled());
@@ -3654,7 +3654,7 @@ static void handle_video_resize(int width, int height)
 	/* Maybe a screen rotation has just occurred, so we simply resize.
 	There may be a different cause for a forced resized, though.    */
 	if (sdl.desktop.full.display_res && sdl.desktop.fullscreen) {
-		/* Note: We should not use GFX_ObtainDisplayDimensions
+		/* Note: We should not use get_display_dimensions()
 		(SDL_GetDisplayBounds) on Android after a screen rotation:
 		The older values from application startup are returned. */
 		sdl.desktop.full.width  = width;

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -266,7 +266,7 @@ static const char* safe_gl_get_string(const GLenum requested_name,
 	// the result points to a static string but can be null
 	const auto result = glGetString(requested_name);
 
-	// the default, howeever, needs to be valid
+	// the default, however, needs to be valid
 	assert(default_result);
 
 	return result ? reinterpret_cast<const char*>(result) : default_result;
@@ -3874,6 +3874,7 @@ void GFX_RegenerateWindow(Section* sec)
 	GFX_ResetScreen();
 }
 
+// TODO check if this workaround is still needed
 #if defined(MACOSX)
 #define DB_POLLSKIP 3
 #else
@@ -4018,6 +4019,8 @@ static void handle_user_event(const SDL_Event& event)
 bool GFX_Events()
 {
 #if defined(MACOSX)
+	// TODO check if this workaround is still needed
+	//
 	// Don't poll too often. This can be heavy on the OS, especially Macs.
 	// In idle mode 3000-4000 polls are done per second without this check.
 	// Macs, with this code,  max 250 polls per second. (non-macs unused
@@ -4084,6 +4087,8 @@ bool GFX_Events()
 				GFX_ResetScreen();
 
 #if C_OPENGL && defined(MACOSX)
+				// TODO check if this workaround is still needed
+	
 				// LOG_DEBUG("SDL: Reset macOS's GL viewport
 				// after window-restore");
 				if (sdl.rendering_backend == RenderingBackend::OpenGl) {
@@ -4192,6 +4197,7 @@ bool GFX_Events()
 				continue;
 
 #if C_OPENGL && defined(MACOSX)
+			// TODO check if this workaround is still needed
 			case SDL_WINDOWEVENT_MOVED:
 				// LOG_DEBUG("SDL: Window has been moved to %d,
 				// %d",
@@ -5552,6 +5558,8 @@ int sdl_main(int argc, char* argv[])
 	} catch (char* error) {
 		return_code = 1;
 
+		// TODO Show warning popup dialog with the error (use the tiny
+		// osdialog lib) with console log fallback
 		GFX_ShowMsg("Exit to error: %s", error);
 
 		fflush(nullptr);
@@ -5565,6 +5573,7 @@ int sdl_main(int argc, char* argv[])
 			fgetc(stdin);
 
 #elif defined(WIN32)
+			// TODO not needed once we should the popup dialog
 			Sleep(5000);
 #endif
 		}
@@ -5580,6 +5589,7 @@ int sdl_main(int argc, char* argv[])
 #if defined(WIN32)
 	// Might not be needed if the shutdown function switches to windowed
 	// mode, but it doesn't hurt
+	// TODO is this still needed on current SDL?
 	sticky_keys(true);
 #endif
 

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -4802,6 +4802,26 @@ static void set_wm_class()
 #endif
 }
 
+static void init_logger(const CommandLineArguments* args, int argc, char* argv[])
+{
+	loguru::g_preamble_date    = true;
+	loguru::g_preamble_time    = true;
+	loguru::g_preamble_uptime  = false;
+	loguru::g_preamble_thread  = false;
+	loguru::g_preamble_file    = false;
+	loguru::g_preamble_verbose = false;
+	loguru::g_preamble_pipe    = true;
+
+	if (args->version || args->help || args->printconf || args->editconf ||
+	    args->eraseconf || args->list_countries || args->list_layouts ||
+	    args->list_code_pages || args->list_glshaders || args->erasemapper) {
+
+		loguru::g_stderr_verbosity = loguru::Verbosity_WARNING;
+	}
+
+	loguru::init(argc, argv);
+}
+
 int sdl_main(int argc, char* argv[])
 {
 	// Ensure we perform SDL cleanup and restore console settings
@@ -4844,24 +4864,9 @@ int sdl_main(int argc, char* argv[])
 
 	switch_console_to_utf8();
 
-	// Set up logging after command line was parsed and trivial arguments have
-	// been handled
-	loguru::g_preamble_date    = true;
-	loguru::g_preamble_time    = true;
-	loguru::g_preamble_uptime  = false;
-	loguru::g_preamble_thread  = false;
-	loguru::g_preamble_file    = false;
-	loguru::g_preamble_verbose = false;
-	loguru::g_preamble_pipe    = true;
-
-	if (arguments->version || arguments->help || arguments->printconf ||
-	    arguments->editconf || arguments->eraseconf || arguments->list_countries ||
-	    arguments->list_layouts || arguments->list_code_pages ||
-	    arguments->list_glshaders || arguments->erasemapper) {
-		loguru::g_stderr_verbosity = loguru::Verbosity_WARNING;
-	}
-
-	loguru::init(argc, argv);
+	// Set up logging after command line was parsed and trivial arguments
+	// have been handled
+	init_logger(arguments, argc, argv);
 
 	LOG_MSG("%s version %s", DOSBOX_PROJECT_NAME, DOSBOX_GetDetailedVersion());
 	LOG_MSG("---");

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -2773,7 +2773,7 @@ static void clean_up_sdl_resources()
 	}
 }
 
-static void GUI_ShutDown(Section *)
+static void shutdown_gui(Section *)
 {
 	GFX_Stop();
 
@@ -3437,7 +3437,7 @@ static void restart_hotkey_handler([[maybe_unused]] bool pressed)
 
 static void read_gui_config(Section* sec)
 {
-	sec->AddDestroyFunction(&GUI_ShutDown);
+	sec->AddDestroyFunction(&shutdown_gui);
 	Section_prop* section = static_cast<Section_prop*>(sec);
 
 	sdl.active          = false;

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -275,7 +275,7 @@ constexpr uint8_t MAX_BYTES_PER_PIXEL = 4;
 
 
 #ifdef DB_OPENGL_ERROR
-void OPENGL_ERROR(const char* message)
+static void maybe_log_opengl_error(const char* message)
 {
 	GLenum r = glGetError();
 	if (r == GL_NO_ERROR) {
@@ -287,7 +287,7 @@ void OPENGL_ERROR(const char* message)
 	} while ((r = glGetError()) != GL_NO_ERROR);
 }
 #else
-void OPENGL_ERROR(const char*) {
+static void maybe_log_opengl_error(const char*) {
 	return;
 }
 #endif
@@ -2391,7 +2391,7 @@ uint8_t GFX_SetSize(const int render_width_px, const int render_height_px,
 			glEndList();
 		}
 
-		OPENGL_ERROR("End of setsize");
+		maybe_log_opengl_error("End of setsize");
 
 		retFlags          = GFX_CAN_32 | GFX_CAN_RANDOM;
 		sdl.frame.update  = update_frame_gl;
@@ -2635,7 +2635,7 @@ bool GFX_StartUpdate(uint8_t * &pixels, int &pitch)
 	case RenderingBackend::OpenGl:
 #if C_OPENGL
 		pixels = static_cast<uint8_t*>(sdl.opengl.framebuf);
-		OPENGL_ERROR("end of start update");
+		maybe_log_opengl_error("end of start update");
 		if (pixels == nullptr) {
 			return false;
 		}

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -5135,15 +5135,13 @@ static void maybe_write_primary_config(const CommandLineArguments& args)
 }
 
 static std::optional<int> maybe_handle_command_line_output_only_actions(
-        const CommandLineArguments& args, char* argv[])
+        const CommandLineArguments& args, const char* program_name)
 {
 	if (args.version) {
 		printf(version_msg, DOSBOX_PROJECT_NAME, DOSBOX_GetDetailedVersion());
 		return 0;
 	}
 	if (args.help) {
-		assert(argv && argv[0]);
-		const auto program_name = argv[0];
 		const auto help = format_str(MSG_GetForHost("DOSBOX_HELP"),
 		                             program_name);
 		printf("%s", help.c_str());
@@ -5473,8 +5471,11 @@ int sdl_main(int argc, char* argv[])
 
 		// Handle command line options that don't start the emulator but
 		// only perform some actions and print the results to the console.
+		assert(argv && argv[0]);
+		const auto program_name = argv[0];
+
 		if (const auto return_code = maybe_handle_command_line_output_only_actions(
-		            *arguments, argv);
+		            *arguments, program_name);
 		    return_code) {
 			return *return_code;
 		}

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -272,8 +272,8 @@ static const char* safe_gl_get_string(const GLenum requested_name,
 	return result ? reinterpret_cast<const char*>(result) : default_result;
 }
 
-/* Create a GLSL shader object, load the shader source, and compile the shader. */
-static GLuint BuildShader(GLenum type, const std::string& source)
+// Create a GLSL shader object, load the shader source, and compile the shader.
+static GLuint build_shader_gl(GLenum type, const std::string& source)
 {
 	GLuint shader            = 0;
 	GLint is_shader_compiled = 0;
@@ -349,10 +349,12 @@ static bool LoadGLShaders(const std::string& source, GLuint* vertex, GLuint* fra
 	assert(vertex);
 	assert(fragment);
 
-	GLuint s = BuildShader(GL_VERTEX_SHADER, source);
+	GLuint s = build_shader_gl(GL_VERTEX_SHADER, source);
 	if (s) {
 		*vertex = s;
-		s       = BuildShader(GL_FRAGMENT_SHADER, source);
+
+		s = build_shader_gl(GL_FRAGMENT_SHADER, source);
+
 		if (s) {
 			*fragment = s;
 			return true;

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -364,7 +364,7 @@ static bool load_shader_gl(const std::string& source, GLuint* vertex, GLuint* fr
 	return false;
 }
 
-static bool init_opengl_shader()
+static bool init_shader_gl()
 {
 	GLuint prog = 0;
 
@@ -2368,7 +2368,7 @@ uint8_t GFX_SetSize(const int render_width_px, const int render_height_px,
 		}
 
 		if (sdl.opengl.use_shader) {
-			if (!init_opengl_shader()) {
+			if (!init_shader_gl()) {
 				goto fallback_texture;
 			}
 		}

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -5083,7 +5083,7 @@ static void set_wm_class()
 #endif
 }
 
-static void init_logger(const CommandLineArguments* args, int argc, char* argv[])
+static void init_logger(const CommandLineArguments& args, int argc, char* argv[])
 {
 	loguru::g_preamble_date    = true;
 	loguru::g_preamble_time    = true;
@@ -5093,9 +5093,9 @@ static void init_logger(const CommandLineArguments* args, int argc, char* argv[]
 	loguru::g_preamble_verbose = false;
 	loguru::g_preamble_pipe    = true;
 
-	if (args->version || args->help || args->printconf || args->editconf ||
-	    args->eraseconf || args->list_countries || args->list_layouts ||
-	    args->list_code_pages || args->list_glshaders || args->erasemapper) {
+	if (args.version || args.help || args.printconf || args.editconf ||
+	    args.eraseconf || args.list_countries || args.list_layouts ||
+	    args.list_code_pages || args.list_glshaders || args.erasemapper) {
 
 		loguru::g_stderr_verbosity = loguru::Verbosity_WARNING;
 	}
@@ -5103,7 +5103,7 @@ static void init_logger(const CommandLineArguments* args, int argc, char* argv[]
 	loguru::init(argc, argv);
 }
 
-static void maybe_write_primary_config(const CommandLineArguments* args)
+static void maybe_write_primary_config(const CommandLineArguments& args)
 {
 	// Before loading any configs, write the default primary config if it
 	// doesn't exist when:
@@ -5116,7 +5116,7 @@ static void maybe_write_primary_config(const CommandLineArguments* args)
 	// - AND the primary config is NOT disabled with the
 	//   '--noprimaryconf' option.
 	//
-	if (!args->securemode && !args->noprimaryconf) {
+	if (!args.securemode && !args.noprimaryconf) {
 		const auto primary_config_path = GetPrimaryConfigPath();
 
 		if (!config_file_is_valid(primary_config_path)) {
@@ -5135,13 +5135,13 @@ static void maybe_write_primary_config(const CommandLineArguments* args)
 }
 
 static std::optional<int> maybe_handle_command_line_output_only_actions(
-        const CommandLineArguments* args, char* argv[])
+        const CommandLineArguments& args, char* argv[])
 {
-	if (args->version) {
+	if (args.version) {
 		printf(version_msg, DOSBOX_PROJECT_NAME, DOSBOX_GetDetailedVersion());
 		return 0;
 	}
-	if (args->help) {
+	if (args.help) {
 		assert(argv && argv[0]);
 		const auto program_name = argv[0];
 		const auto help = format_str(MSG_GetForHost("DOSBOX_HELP"),
@@ -5149,31 +5149,31 @@ static std::optional<int> maybe_handle_command_line_output_only_actions(
 		printf("%s", help.c_str());
 		return 0;
 	}
-	if (args->editconf) {
+	if (args.editconf) {
 		return edit_primary_config();
 	}
-	if (args->eraseconf) {
+	if (args.eraseconf) {
 		return erase_primary_config_file();
 	}
-	if (args->erasemapper) {
+	if (args.erasemapper) {
 		return erase_mapper_file();
 	}
-	if (args->printconf) {
+	if (args.printconf) {
 		return print_primary_config_location();
 	}
-	if (args->list_countries) {
+	if (args.list_countries) {
 		list_countries();
 		return 0;
 	}
-	if (args->list_layouts) {
+	if (args.list_layouts) {
 		list_keyboard_layouts();
 		return 0;
 	}
-	if (args->list_code_pages) {
+	if (args.list_code_pages) {
 		list_code_pages();
 		return 0;
 	}
-	if (args->list_glshaders) {
+	if (args.list_glshaders) {
 		list_glshaders();
 		return 0;
 	}
@@ -5414,7 +5414,7 @@ int sdl_main(int argc, char* argv[])
 
 	// Set up logging after command line was parsed and trivial arguments
 	// have been handled
-	init_logger(arguments, argc, argv);
+	init_logger(*arguments, argc, argv);
 
 	LOG_MSG("%s version %s", DOSBOX_PROJECT_NAME, DOSBOX_GetDetailedVersion());
 	LOG_MSG("---");
@@ -5463,7 +5463,7 @@ int sdl_main(int argc, char* argv[])
 		// modules
 		DOSBOX_InitAllModuleConfigsAndMessages();
 
-		maybe_write_primary_config(arguments);
+		maybe_write_primary_config(*arguments);
 
 		// After DOSBOX_InitAllModuleConfigsAndMessages() is done, all
 		// the config sections have been registered, so we're ready to
@@ -5474,7 +5474,7 @@ int sdl_main(int argc, char* argv[])
 		// Handle command line options that don't start the emulator but
 		// only perform some actions and print the results to the console.
 		if (const auto return_code = maybe_handle_command_line_output_only_actions(
-		            arguments, argv);
+		            *arguments, argv);
 		    return_code) {
 			return *return_code;
 		}

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -229,7 +229,6 @@ static SDL_Rect to_sdl_rect(const DosBox::Rect& r)
 	return {iroundf(r.x), iroundf(r.y), iroundf(r.w), iroundf(r.h)};
 }
 
-static void clean_up_sdl_resources();
 static void handle_video_resize(int width, int height);
 
 static void update_frame_texture([[maybe_unused]] const uint16_t* changedLines);
@@ -1293,6 +1292,22 @@ static void check_and_handle_dpi_change(SDL_Window* sdl_window,
 	//         new_dpi_scale);
 
 	apply_new_dpi_scale(new_dpi_scale);
+}
+
+static void clean_up_sdl_resources()
+{
+	if (sdl.texture.pixelFormat) {
+		SDL_FreeFormat(sdl.texture.pixelFormat);
+		sdl.texture.pixelFormat = nullptr;
+	}
+	if (sdl.texture.texture) {
+		SDL_DestroyTexture(sdl.texture.texture);
+		sdl.texture.texture = nullptr;
+	}
+	if (sdl.texture.input_surface) {
+		SDL_FreeSurface(sdl.texture.input_surface);
+		sdl.texture.input_surface = nullptr;
+	}
 }
 
 static SDL_Window* SetWindowMode(const RenderingBackend rendering_backend,
@@ -2754,22 +2769,6 @@ void GFX_UpdateDisplayDimensions(int width, int height)
 		The older values from application startup are returned. */
 		sdl.desktop.full.width = width;
 		sdl.desktop.full.height = height;
-	}
-}
-
-static void clean_up_sdl_resources()
-{
-	if (sdl.texture.pixelFormat) {
-		SDL_FreeFormat(sdl.texture.pixelFormat);
-		sdl.texture.pixelFormat = nullptr;
-	}
-	if (sdl.texture.texture) {
-		SDL_DestroyTexture(sdl.texture.texture);
-		sdl.texture.texture = nullptr;
-	}
-	if (sdl.texture.input_surface) {
-		SDL_FreeSurface(sdl.texture.input_surface);
-		sdl.texture.input_surface = nullptr;
 	}
 }
 

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -2740,9 +2740,11 @@ static void focus_input()
 
 #if defined(WIN32)
 STICKYKEYS stick_keys = {sizeof(STICKYKEYS), 0};
-void sticky_keys(bool restore)
+
+static void sticky_keys(bool restore)
 {
 	static bool inited = false;
+
 	if (!inited) {
 		inited = true;
 		SystemParametersInfo(SPI_GETSTICKYKEYS,

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -947,7 +947,7 @@ void GFX_ResetScreen()
 	VGA_SetupDrawing(0);
 }
 
-void GFX_ForceFullscreenExit()
+static void exit_fullscreen()
 {
 	sdl.desktop.fullscreen = false;
 	GFX_ResetScreen();
@@ -4184,7 +4184,7 @@ static bool handle_sdl_windowevent(const SDL_Event& event)
 #ifdef WIN32
 		if (sdl.desktop.fullscreen) {
 			VGA_KillDrawing();
-			GFX_ForceFullscreenExit();
+			exit_fullscreen();
 		}
 #endif
 		apply_inactive_settings();

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -208,6 +208,57 @@ PFNGLVERTEXATTRIBPOINTERPROC glVertexAttribPointer         = nullptr;
 #define glUseProgram              gl2::glUseProgram
 #define glVertexAttribPointer     gl2::glVertexAttribPointer
 
+static void get_opengl_proc_addresses()
+{
+	glAttachShader = (PFNGLATTACHSHADERPROC)SDL_GL_GetProcAddress("glAttachShader");
+
+	glCompileShader = (PFNGLCOMPILESHADERPROC)SDL_GL_GetProcAddress(
+	        "glCompileShader");
+
+	glCreateProgram = (PFNGLCREATEPROGRAMPROC)SDL_GL_GetProcAddress(
+	        "glCreateProgram");
+
+	glCreateShader = (PFNGLCREATESHADERPROC)SDL_GL_GetProcAddress("glCreateShader");
+
+	glDeleteProgram = (PFNGLDELETEPROGRAMPROC)SDL_GL_GetProcAddress(
+	        "glDeleteProgram");
+
+	glDeleteShader = (PFNGLDELETESHADERPROC)SDL_GL_GetProcAddress("glDeleteShader");
+
+	glEnableVertexAttribArray = (PFNGLENABLEVERTEXATTRIBARRAYPROC)
+	        SDL_GL_GetProcAddress("glEnableVertexAttribArray");
+
+	glGetAttribLocation = (PFNGLGETATTRIBLOCATIONPROC)SDL_GL_GetProcAddress(
+	        "glGetAttribLocation");
+
+	glGetProgramiv = (PFNGLGETPROGRAMIVPROC)SDL_GL_GetProcAddress("glGetProgramiv");
+
+	glGetProgramInfoLog = (PFNGLGETPROGRAMINFOLOGPROC)SDL_GL_GetProcAddress(
+	        "glGetProgramInfoLog");
+
+	glGetShaderiv = (PFNGLGETSHADERIVPROC)SDL_GL_GetProcAddress("glGetShaderiv");
+
+	glGetShaderInfoLog = (PFNGLGETSHADERINFOLOGPROC)SDL_GL_GetProcAddress(
+	        "glGetShaderInfoLog");
+
+	glGetUniformLocation = (PFNGLGETUNIFORMLOCATIONPROC)SDL_GL_GetProcAddress(
+	        "glGetUniformLocation");
+
+	glLinkProgram = (PFNGLLINKPROGRAMPROC)SDL_GL_GetProcAddress("glLinkProgram");
+
+	glShaderSource = (PFNGLSHADERSOURCEPROC_NP)SDL_GL_GetProcAddress(
+	        "glShaderSource");
+
+	glUniform2f = (PFNGLUNIFORM2FPROC)SDL_GL_GetProcAddress("glUniform2f");
+
+	glUniform1i = (PFNGLUNIFORM1IPROC)SDL_GL_GetProcAddress("glUniform1i");
+
+	glUseProgram = (PFNGLUSEPROGRAMPROC)SDL_GL_GetProcAddress("glUseProgram");
+
+	glVertexAttribPointer = (PFNGLVERTEXATTRIBPOINTERPROC)SDL_GL_GetProcAddress(
+	        "glVertexAttribPointer");
+}
+
 #endif // C_OPENGL
 
 #ifdef WIN32
@@ -3469,62 +3520,8 @@ static void set_output(Section* sec, const bool wants_aspect_ratio_correction)
 
 		if (sdl.want_rendering_backend == RenderingBackend::OpenGl) {
 			sdl.opengl.program_object = 0;
-			glAttachShader = (PFNGLATTACHSHADERPROC)SDL_GL_GetProcAddress(
-			        "glAttachShader");
 
-			glCompileShader = (PFNGLCOMPILESHADERPROC)SDL_GL_GetProcAddress(
-			        "glCompileShader");
-
-			glCreateProgram = (PFNGLCREATEPROGRAMPROC)SDL_GL_GetProcAddress(
-			        "glCreateProgram");
-
-			glCreateShader = (PFNGLCREATESHADERPROC)SDL_GL_GetProcAddress(
-			        "glCreateShader");
-
-			glDeleteProgram = (PFNGLDELETEPROGRAMPROC)SDL_GL_GetProcAddress(
-			        "glDeleteProgram");
-
-			glDeleteShader = (PFNGLDELETESHADERPROC)SDL_GL_GetProcAddress(
-			        "glDeleteShader");
-
-			glEnableVertexAttribArray = (PFNGLENABLEVERTEXATTRIBARRAYPROC)
-			        SDL_GL_GetProcAddress("glEnableVertexAttribArray");
-
-			glGetAttribLocation = (PFNGLGETATTRIBLOCATIONPROC)
-			        SDL_GL_GetProcAddress("glGetAttribLocation");
-
-			glGetProgramiv = (PFNGLGETPROGRAMIVPROC)SDL_GL_GetProcAddress(
-			        "glGetProgramiv");
-
-			glGetProgramInfoLog = (PFNGLGETPROGRAMINFOLOGPROC)
-			        SDL_GL_GetProcAddress("glGetProgramInfoLog");
-
-			glGetShaderiv = (PFNGLGETSHADERIVPROC)SDL_GL_GetProcAddress(
-			        "glGetShaderiv");
-
-			glGetShaderInfoLog = (PFNGLGETSHADERINFOLOGPROC)
-			        SDL_GL_GetProcAddress("glGetShaderInfoLog");
-
-			glGetUniformLocation = (PFNGLGETUNIFORMLOCATIONPROC)
-			        SDL_GL_GetProcAddress("glGetUniformLocation");
-
-			glLinkProgram = (PFNGLLINKPROGRAMPROC)SDL_GL_GetProcAddress(
-			        "glLinkProgram");
-
-			glShaderSource = (PFNGLSHADERSOURCEPROC_NP)SDL_GL_GetProcAddress(
-			        "glShaderSource");
-
-			glUniform2f = (PFNGLUNIFORM2FPROC)SDL_GL_GetProcAddress(
-			        "glUniform2f");
-
-			glUniform1i = (PFNGLUNIFORM1IPROC)SDL_GL_GetProcAddress(
-			        "glUniform1i");
-
-			glUseProgram = (PFNGLUSEPROGRAMPROC)SDL_GL_GetProcAddress(
-			        "glUseProgram");
-
-			glVertexAttribPointer = (PFNGLVERTEXATTRIBPOINTERPROC)
-			        SDL_GL_GetProcAddress("glVertexAttribPointer");
+			get_opengl_proc_addresses();
 
 			sdl.opengl.use_shader =
 			        (glAttachShader && glCompileShader &&

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -4920,6 +4920,45 @@ static void handle_cli_set_commands(const std::vector<std::string>& set_args)
 	}
 }
 
+static void maybe_create_resource_directories()
+{
+	const auto plugins_dir = GetConfigDir() / PluginsDir;
+
+	if (create_dir(plugins_dir, 0700, OK_IF_EXISTS) != 0) {
+		LOG_WARNING("CONFIG: Can't create directory '%s': %s",
+		            plugins_dir.string().c_str(),
+		            safe_strerror(errno).c_str());
+	}
+
+#if C_OPENGL
+	const auto glshaders_dir = GetConfigDir() / GlShadersDir;
+
+	if (create_dir(glshaders_dir, 0700, OK_IF_EXISTS) != 0) {
+		LOG_WARNING("CONFIG: Can't create directory '%s': %s",
+		            glshaders_dir.string().c_str(),
+		            safe_strerror(errno).c_str());
+	}
+#endif
+
+	const auto soundfonts_dir = GetConfigDir() / DefaultSoundfontsDir;
+
+	if (create_dir(soundfonts_dir, 0700, OK_IF_EXISTS) != 0) {
+		LOG_WARNING("CONFIG: Can't create directory '%s': %s",
+		            soundfonts_dir.string().c_str(),
+		            safe_strerror(errno).c_str());
+	}
+
+#if C_MT32EMU
+	const auto mt32_rom_dir = GetConfigDir() / DefaultMt32RomsDir;
+
+	if (create_dir(mt32_rom_dir, 0700, OK_IF_EXISTS) != 0) {
+		LOG_WARNING("CONFIG: Can't create directory '%s': %s",
+		            mt32_rom_dir.string().c_str(),
+		            safe_strerror(errno).c_str());
+	}
+#endif
+}
+
 int sdl_main(int argc, char* argv[])
 {
 	// Ensure we perform SDL cleanup and restore console settings
@@ -5131,42 +5170,7 @@ int sdl_main(int argc, char* argv[])
 		// CLI.
 		handle_cli_set_commands(arguments->set);
 
-		// Plugins
-		const auto plugins_dir = GetConfigDir() / PluginsDir;
-
-		if (create_dir(plugins_dir, 0700, OK_IF_EXISTS) != 0) {
-			LOG_WARNING("CONFIG: Can't create directory '%s': %s",
-			            plugins_dir.string().c_str(),
-			            safe_strerror(errno).c_str());
-		}
-
-#if C_OPENGL
-		const auto glshaders_dir = GetConfigDir() / GlShadersDir;
-
-		if (create_dir(glshaders_dir, 0700, OK_IF_EXISTS) != 0) {
-			LOG_WARNING("CONFIG: Can't create directory '%s': %s",
-			            glshaders_dir.string().c_str(),
-			            safe_strerror(errno).c_str());
-		}
-#endif
-
-		const auto soundfonts_dir = GetConfigDir() / DefaultSoundfontsDir;
-
-		if (create_dir(soundfonts_dir, 0700, OK_IF_EXISTS) != 0) {
-			LOG_WARNING("CONFIG: Can't create directory '%s': %s",
-			            soundfonts_dir.string().c_str(),
-			            safe_strerror(errno).c_str());
-		}
-
-#if C_MT32EMU
-		const auto mt32_rom_dir = GetConfigDir() / DefaultMt32RomsDir;
-
-		if (create_dir(mt32_rom_dir, 0700, OK_IF_EXISTS) != 0) {
-			LOG_WARNING("CONFIG: Can't create directory '%s': %s",
-			            mt32_rom_dir.string().c_str(),
-			            safe_strerror(errno).c_str());
-		}
-#endif
+		maybe_create_resource_directories();
 
 		control->ParseEnv();
 

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -5177,13 +5177,10 @@ int sdl_main(int argc, char* argv[])
 		// Execute all registered section init functions
 		control->Init();
 
-		// Some extra SDL Functions
-		Section_prop* sdl_sec = get_sdl_section();
-
 		// All subsystems' hotkeys need to be registered at this point
 		// to ensure their hotkeys appear in the graphical mapper.
-		MAPPER_BindKeys(sdl_sec);
-		GFX_RegenerateWindow(sdl_sec);
+		MAPPER_BindKeys(get_sdl_section());
+		GFX_RegenerateWindow(get_sdl_section());
 
 		if (arguments->startmapper) {
 			MAPPER_DisplayUI();

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -101,40 +101,52 @@ static void restore_console_encoding()
 }
 
 #if C_OPENGL
-//Define to report opengl errors
-//#define DB_OPENGL_ERROR
+// Define to report opengl errors
+// #define DB_OPENGL_ERROR
 
 #ifndef APIENTRY
 #define APIENTRY
 #endif
 
 #ifndef APIENTRYP
-#define APIENTRYP APIENTRY *
+#define APIENTRYP APIENTRY*
 #endif
 
-/* Don't guard these with GL_VERSION_2_0 - Apple defines it but not these typedefs.
- * If they're already defined they should match these definitions, so no conflicts.
+/* Don't guard these with GL_VERSION_2_0 - Apple defines it but not these
+ * typedefs. If they're already defined they should match these definitions, so
+ * no conflicts.
  */
-typedef void (APIENTRYP PFNGLATTACHSHADERPROC) (GLuint program, GLuint shader);
-typedef void (APIENTRYP PFNGLCOMPILESHADERPROC) (GLuint shader);
-typedef GLuint (APIENTRYP PFNGLCREATEPROGRAMPROC) ();
-typedef GLuint (APIENTRYP PFNGLCREATESHADERPROC) (GLenum type);
-typedef void (APIENTRYP PFNGLDELETEPROGRAMPROC) (GLuint program);
-typedef void (APIENTRYP PFNGLDELETESHADERPROC) (GLuint shader);
-typedef void (APIENTRYP PFNGLENABLEVERTEXATTRIBARRAYPROC) (GLuint index);
-typedef GLint (APIENTRYP PFNGLGETATTRIBLOCATIONPROC) (GLuint program, const GLchar *name);
-typedef void (APIENTRYP PFNGLGETPROGRAMIVPROC) (GLuint program, GLenum pname, GLint *params);
-typedef void (APIENTRYP PFNGLGETPROGRAMINFOLOGPROC) (GLuint program, GLsizei bufSize, GLsizei *length, GLchar *infoLog);
-typedef void (APIENTRYP PFNGLGETSHADERIVPROC) (GLuint shader, GLenum pname, GLint *params);
-typedef void (APIENTRYP PFNGLGETSHADERINFOLOGPROC) (GLuint shader, GLsizei bufSize, GLsizei *length, GLchar *infoLog);
-typedef GLint (APIENTRYP PFNGLGETUNIFORMLOCATIONPROC) (GLuint program, const GLchar *name);
-typedef void (APIENTRYP PFNGLLINKPROGRAMPROC) (GLuint program);
-//Change to NP, as Khronos changes include guard :(
-typedef void (APIENTRYP PFNGLSHADERSOURCEPROC_NP) (GLuint shader, GLsizei count, const GLchar **string, const GLint *length);
-typedef void (APIENTRYP PFNGLUNIFORM2FPROC) (GLint location, GLfloat v0, GLfloat v1);
-typedef void (APIENTRYP PFNGLUNIFORM1IPROC) (GLint location, GLint v0);
-typedef void (APIENTRYP PFNGLUSEPROGRAMPROC) (GLuint program);
-typedef void (APIENTRYP PFNGLVERTEXATTRIBPOINTERPROC) (GLuint index, GLint size, GLenum type, GLboolean normalized, GLsizei stride, const GLvoid *pointer);
+typedef void(APIENTRYP PFNGLATTACHSHADERPROC)(GLuint program, GLuint shader);
+typedef void(APIENTRYP PFNGLCOMPILESHADERPROC)(GLuint shader);
+typedef GLuint(APIENTRYP PFNGLCREATEPROGRAMPROC)();
+typedef GLuint(APIENTRYP PFNGLCREATESHADERPROC)(GLenum type);
+typedef void(APIENTRYP PFNGLDELETEPROGRAMPROC)(GLuint program);
+typedef void(APIENTRYP PFNGLDELETESHADERPROC)(GLuint shader);
+typedef void(APIENTRYP PFNGLENABLEVERTEXATTRIBARRAYPROC)(GLuint index);
+typedef GLint(APIENTRYP PFNGLGETATTRIBLOCATIONPROC)(GLuint program,
+                                                    const GLchar* name);
+typedef void(APIENTRYP PFNGLGETPROGRAMIVPROC)(GLuint program, GLenum pname,
+                                              GLint* params);
+typedef void(APIENTRYP PFNGLGETPROGRAMINFOLOGPROC)(GLuint program, GLsizei bufSize,
+                                                   GLsizei* length, GLchar* infoLog);
+typedef void(APIENTRYP PFNGLGETSHADERIVPROC)(GLuint shader, GLenum pname,
+                                             GLint* params);
+typedef void(APIENTRYP PFNGLGETSHADERINFOLOGPROC)(GLuint shader, GLsizei bufSize,
+                                                  GLsizei* length, GLchar* infoLog);
+typedef GLint(APIENTRYP PFNGLGETUNIFORMLOCATIONPROC)(GLuint program,
+                                                     const GLchar* name);
+typedef void(APIENTRYP PFNGLLINKPROGRAMPROC)(GLuint program);
+// Change to NP, as Khronos changes include guard :(
+typedef void(APIENTRYP PFNGLSHADERSOURCEPROC_NP)(GLuint shader, GLsizei count,
+                                                 const GLchar** string,
+                                                 const GLint* length);
+typedef void(APIENTRYP PFNGLUNIFORM2FPROC)(GLint location, GLfloat v0, GLfloat v1);
+typedef void(APIENTRYP PFNGLUNIFORM1IPROC)(GLint location, GLint v0);
+typedef void(APIENTRYP PFNGLUSEPROGRAMPROC)(GLuint program);
+typedef void(APIENTRYP PFNGLVERTEXATTRIBPOINTERPROC)(GLuint index, GLint size,
+                                                     GLenum type, GLboolean normalized,
+                                                     GLsizei stride,
+                                                     const GLvoid* pointer);
 
 /* Apple defines these functions in their GL header (as core functions)
  * so we can't use their names as function pointers. We can't link
@@ -142,26 +154,26 @@ typedef void (APIENTRYP PFNGLVERTEXATTRIBPOINTERPROC) (GLuint index, GLint size,
  * namespace here to keep the official names but avoid collisions.
  */
 namespace gl2 {
-PFNGLATTACHSHADERPROC glAttachShader = nullptr;
-PFNGLCOMPILESHADERPROC glCompileShader = nullptr;
-PFNGLCREATEPROGRAMPROC glCreateProgram = nullptr;
-PFNGLCREATESHADERPROC glCreateShader = nullptr;
-PFNGLDELETEPROGRAMPROC glDeleteProgram = nullptr;
-PFNGLDELETESHADERPROC glDeleteShader = nullptr;
+PFNGLATTACHSHADERPROC glAttachShader                       = nullptr;
+PFNGLCOMPILESHADERPROC glCompileShader                     = nullptr;
+PFNGLCREATEPROGRAMPROC glCreateProgram                     = nullptr;
+PFNGLCREATESHADERPROC glCreateShader                       = nullptr;
+PFNGLDELETEPROGRAMPROC glDeleteProgram                     = nullptr;
+PFNGLDELETESHADERPROC glDeleteShader                       = nullptr;
 PFNGLENABLEVERTEXATTRIBARRAYPROC glEnableVertexAttribArray = nullptr;
-PFNGLGETATTRIBLOCATIONPROC glGetAttribLocation = nullptr;
-PFNGLGETPROGRAMIVPROC glGetProgramiv = nullptr;
-PFNGLGETPROGRAMINFOLOGPROC glGetProgramInfoLog = nullptr;
-PFNGLGETSHADERIVPROC glGetShaderiv = nullptr;
-PFNGLGETSHADERINFOLOGPROC glGetShaderInfoLog = nullptr;
-PFNGLGETUNIFORMLOCATIONPROC glGetUniformLocation = nullptr;
-PFNGLLINKPROGRAMPROC glLinkProgram = nullptr;
-PFNGLSHADERSOURCEPROC_NP glShaderSource = nullptr;
-PFNGLUNIFORM2FPROC glUniform2f = nullptr;
-PFNGLUNIFORM1IPROC glUniform1i = nullptr;
-PFNGLUSEPROGRAMPROC glUseProgram = nullptr;
-PFNGLVERTEXATTRIBPOINTERPROC glVertexAttribPointer = nullptr;
-}
+PFNGLGETATTRIBLOCATIONPROC glGetAttribLocation             = nullptr;
+PFNGLGETPROGRAMIVPROC glGetProgramiv                       = nullptr;
+PFNGLGETPROGRAMINFOLOGPROC glGetProgramInfoLog             = nullptr;
+PFNGLGETSHADERIVPROC glGetShaderiv                         = nullptr;
+PFNGLGETSHADERINFOLOGPROC glGetShaderInfoLog               = nullptr;
+PFNGLGETUNIFORMLOCATIONPROC glGetUniformLocation           = nullptr;
+PFNGLLINKPROGRAMPROC glLinkProgram                         = nullptr;
+PFNGLSHADERSOURCEPROC_NP glShaderSource                    = nullptr;
+PFNGLUNIFORM2FPROC glUniform2f                             = nullptr;
+PFNGLUNIFORM1IPROC glUniform1i                             = nullptr;
+PFNGLUSEPROGRAMPROC glUseProgram                           = nullptr;
+PFNGLVERTEXATTRIBPOINTERPROC glVertexAttribPointer         = nullptr;
+} // namespace gl2
 
 /* "using" is meant to hide identical names declared in outer scope
  * but is unreliable, so just redefine instead.
@@ -241,10 +253,10 @@ static const char* to_string(const VsyncMode mode)
 }
 
 #if C_DEBUG
-extern SDL_Window *pdc_window;
+extern SDL_Window* pdc_window;
 extern std::queue<SDL_Event> pdc_event_queue;
 
-static bool is_debugger_event(const SDL_Event &event)
+static bool is_debugger_event(const SDL_Event& event)
 {
 	switch (event.type) {
 	case SDL_KEYDOWN:
@@ -262,7 +274,7 @@ static bool is_debugger_event(const SDL_Event &event)
 	return false;
 }
 
-SDL_Window *GFX_GetSDLWindow()
+SDL_Window* GFX_GetSDLWindow()
 {
 	return sdl.window;
 }
@@ -272,7 +284,6 @@ SDL_Window *GFX_GetSDLWindow()
 
 // SDL allows pixels sizes (colour-depth) from 1 to 4 bytes
 constexpr uint8_t MAX_BYTES_PER_PIXEL = 4;
-
 
 #ifdef DB_OPENGL_ERROR
 static void maybe_log_opengl_error(const char* message)
@@ -287,7 +298,8 @@ static void maybe_log_opengl_error(const char* message)
 	} while ((r = glGetError()) != GL_NO_ERROR);
 }
 #else
-static void maybe_log_opengl_error(const char*) {
+static void maybe_log_opengl_error(const char*)
+{
 	return;
 }
 #endif
@@ -337,7 +349,7 @@ bool GFX_HaveDesktopEnvironment()
 		have_desktop_environment = std::any_of(std::begin(vars),
 		                                       std::end(vars),
 		                                       std::getenv);
-		already_checked = true;
+		already_checked          = true;
 	}
 
 	return have_desktop_environment;
@@ -472,8 +484,8 @@ static void initialize_vsync_settings()
 
 		// With 'vsync = auto' in windowed mode, we try to disable vsync
 		// because the OS-level compositor usually enforces it anyway,
-		// so we get no tearing. Enabling vsync on our side would usually
-		// have either no effect, or it would add extra latency
+		// so we get no tearing. Enabling vsync on our side would
+		// usually have either no effect, or it would add extra latency
 		// without any benefits in the worst case.
 		//
 		sdl.vsync.when_windowed.requested = VsyncMode::Off;
@@ -543,8 +555,9 @@ static bool is_command_pressed(const SDL_Event event)
 	}
 
 	// Prevent the mixer from running while in our pause loop
-	// Muting is not ideal for some sound devices such as GUS that loop samples
-	// This also saves CPU time by not rendering samples we're not going to play anyway
+	// Muting is not ideal for some sound devices such as GUS that loop
+	// samples This also saves CPU time by not rendering samples we're not
+	// going to play anyway
 	MIXER_LockMixerThread();
 
 	// NOTE: This is one of the few places where we use SDL key codes with
@@ -592,8 +605,8 @@ static bool is_command_pressed(const SDL_Event event)
 #if defined(MACOSX)
 			if (is_command_pressed(event) &&
 			    event.key.keysym.sym == SDLK_q) {
-				// On macOS, Command+Q is the default key to close an
-				// application
+				// On macOS, Command+Q is the default key to
+				// close an application
 				GFX_RequestExit(true);
 				break;
 			}
@@ -637,8 +650,9 @@ void GFX_ForceFullscreenExit()
 [[maybe_unused]] static int int_log2(int val)
 {
 	int log = 0;
-	while ((val >>= 1) != 0)
+	while ((val >>= 1) != 0) {
 		log++;
+	}
 	return log;
 }
 
@@ -656,20 +670,23 @@ static uint32_t opengl_driver_crash_workaround(const RenderingBackend rendering_
 		return SDL_WINDOW_OPENGL;
 	}
 
-	if (sdl.render_driver != "auto")
+	if (sdl.render_driver != "auto") {
 		return 0;
+	}
 
 	static int default_driver_is_opengl = -1;
-	if (default_driver_is_opengl >= 0)
+	if (default_driver_is_opengl >= 0) {
 		return (default_driver_is_opengl ? SDL_WINDOW_OPENGL : 0);
+	}
 
 	// According to SDL2 documentation, the first driver
 	// in the list is the default one.
 	int i = 0;
 	SDL_RendererInfo info;
 	while (SDL_GetRenderDriverInfo(i++, &info) == 0) {
-		if (info.flags & SDL_RENDERER_TARGETTEXTURE)
+		if (info.flags & SDL_RENDERER_TARGETTEXTURE) {
 			break;
+		}
 	}
 	default_driver_is_opengl = std::string_view(info.name).starts_with("opengl");
 	return (default_driver_is_opengl ? SDL_WINDOW_OPENGL : 0);
@@ -831,9 +848,9 @@ static std::optional<int> get_benchmarked_vsync_rate()
 {
 	const auto bench_rate = get_vsync_settings().benchmarked_rate;
 
-	if (bench_rate != 0)
+	if (bench_rate != 0) {
 		return bench_rate;
-	else {
+	} else {
 		return {};
 	}
 }
@@ -927,7 +944,7 @@ static VsyncMode measure_vsynced_rate(int& bench_rate)
 		        "SDL: You will experience rendering lag and stuttering. "
 		        "Consider updating your video drivers and try disabling "
 		        "any frame limiters and vsync in your driver settings, "
-				"or try setting 'vsync = off'");
+		        "or try setting 'vsync = off'");
 	}
 
 	// TODO what are these magic multipliers?
@@ -1033,7 +1050,7 @@ static void remove_window()
 //
 static void maybe_present_throttled(const bool frame_is_new)
 {
-	static int64_t last_present_time = 0;
+	static int64_t last_present_time  = 0;
 	static auto was_new_and_throttled = false;
 
 	const auto now     = GetTicksUs();
@@ -1043,7 +1060,7 @@ static void maybe_present_throttled(const bool frame_is_new)
 		// If we waited beyond this frame's refresh period, then credit
 		// this extra wait back by deducting it from the recorded time.
 		const auto wait_overage = elapsed % sdl.frame.period_us;
-		last_present_time = now - (9 * wait_overage / 10);
+		last_present_time       = now - (9 * wait_overage / 10);
 
 		if (frame_is_new || was_new_and_throttled) {
 			sdl.frame.present();
@@ -1077,7 +1094,7 @@ static void maybe_present_synced(const bool present_if_last_skipped)
 	last_sync_time = should_present ? GetTicksUs() : now;
 }
 
-static void setup_presentation_mode(FrameMode &previous_mode)
+static void setup_presentation_mode(FrameMode& previous_mode)
 {
 	// Always get the reported refresh rate and hint the emulated VGA side
 	// with it. This ensures the VGA side always has the host's rate
@@ -1089,7 +1106,7 @@ static void setup_presentation_mode(FrameMode &previous_mode)
 
 	// Calculate the maximum number of duplicate frames before presenting.
 	constexpr uint16_t MinRateHz = 10;
-	sdl.frame.max_dupe_frames   = static_cast<float>(dos_rate) / MinRateHz;
+	sdl.frame.max_dupe_frames    = static_cast<float>(dos_rate) / MinRateHz;
 
 	// Consider any vsync mode that isn't explicitly 'Off' as having some
 	// level of vsync enforcement as 'On'.
@@ -1216,8 +1233,9 @@ static bool is_aspect_ratio_correction_enabled()
 static void update_fallback_dimensions(const double dpi_scale)
 {
 	// TODO This only works for 320x200 games. We cannot make hardcoded
-	// assumptions about aspect ratios in general, e.g. the pixel aspect ratio
-	// is 1:1 for 640x480 games both with 'aspect = on` and 'aspect = off'.
+	// assumptions about aspect ratios in general, e.g. the pixel aspect
+	// ratio is 1:1 for 640x480 games both with 'aspect = on` and 'aspect =
+	// off'.
 	const auto fallback_height = (is_aspect_ratio_correction_enabled() ? 480
 	                                                                   : 400) /
 	                             dpi_scale;
@@ -1319,7 +1337,7 @@ static SDL_Window* SetWindowMode(const RenderingBackend rendering_backend,
 			flags |= SDL_WINDOW_OPENGL;
 			if (SDL_GL_SetAttribute(SDL_GL_FRAMEBUFFER_SRGB_CAPABLE, 1)) {
 				LOG_ERR("OPENGL: Failed requesting an sRGB framebuffer: %s",
-						SDL_GetError());
+				        SDL_GetError());
 			}
 		}
 #endif
@@ -1329,16 +1347,20 @@ static SDL_Window* SetWindowMode(const RenderingBackend rendering_backend,
 
 		// Using undefined position will take care of placing and
 		// restoring the window by WM.
-		const auto default_val = SDL_WINDOWPOS_UNDEFINED_DISPLAY(sdl.display_number);
+		const auto default_val = SDL_WINDOWPOS_UNDEFINED_DISPLAY(
+		        sdl.display_number);
 		const auto pos = get_initial_window_position_or_default(default_val);
 
 		assert(sdl.window == nullptr); // enusre we don't leak
 		sdl.window = SDL_CreateWindow("", pos.x, pos.y, width, height, flags);
-		if (!sdl.window && rendering_backend == RenderingBackend::Texture && (flags & SDL_WINDOW_OPENGL)) {
-			// opengl_driver_crash_workaround() call above conditionally sets SDL_WINDOW_OPENGL.
-			// It sometimes gets this wrong (ex. SDL_VIDEODRIVER=dummy).
-			// This can only be determined reliably by trying SDL_CreateWindow().
-			// If we failed to create the window, try again without it.
+		if (!sdl.window && rendering_backend == RenderingBackend::Texture &&
+		    (flags & SDL_WINDOW_OPENGL)) {
+			// opengl_driver_crash_workaround() call above
+			// conditionally sets SDL_WINDOW_OPENGL. It sometimes
+			// gets this wrong (ex. SDL_VIDEODRIVER=dummy). This can
+			// only be determined reliably by trying
+			// SDL_CreateWindow(). If we failed to create the
+			// window, try again without it.
 			flags &= ~SDL_WINDOW_OPENGL;
 			sdl.window = SDL_CreateWindow("", pos.x, pos.y, width, height, flags);
 		}
@@ -1347,8 +1369,8 @@ static SDL_Window* SetWindowMode(const RenderingBackend rendering_backend,
 			return nullptr;
 		}
 
-		// Certain functionality (like setting viewport) doesn't work properly
-		// before initial window events are received.
+		// Certain functionality (like setting viewport) doesn't work
+		// properly before initial window events are received.
 		SDL_PumpEvents();
 
 		if (rendering_backend == RenderingBackend::Texture) {
@@ -1428,12 +1450,14 @@ static SDL_Window* SetWindowMode(const RenderingBackend rendering_backend,
 	// Maybe some requested fullscreen resolution is unsupported?
 finish:
 
-	if (sdl.draw.has_changed)
+	if (sdl.draw.has_changed) {
 		setup_presentation_mode(sdl.frame.mode);
+	}
 
 	// Force redraw after changing the window
-	if (sdl.draw.callback)
+	if (sdl.draw.callback) {
 		sdl.draw.callback(GFX_CallbackRedraw);
+	}
 
 	// Ensure the time to change window modes isn't counted against
 	// our paced timing. This is a rare event that depends on host
@@ -1508,17 +1532,17 @@ float GFX_GetDpiScaleFactor()
 static std::pair<double, double> get_scale_factors_from_pixel_aspect_ratio(
         const Fraction& pixel_aspect_ratio)
 {
-       const auto one_per_pixel_aspect = pixel_aspect_ratio.Inverse().ToDouble();
+	const auto one_per_pixel_aspect = pixel_aspect_ratio.Inverse().ToDouble();
 
-       if (one_per_pixel_aspect > 1.0) {
-               const auto scale_x = 1;
-               const auto scale_y = one_per_pixel_aspect;
-               return {scale_x, scale_y};
-       } else {
-               const auto scale_x = pixel_aspect_ratio.ToDouble();
-               const auto scale_y = 1;
-               return {scale_x, scale_y};
-       }
+	if (one_per_pixel_aspect > 1.0) {
+		const auto scale_x = 1;
+		const auto scale_y = one_per_pixel_aspect;
+		return {scale_x, scale_y};
+	} else {
+		const auto scale_x = pixel_aspect_ratio.ToDouble();
+		const auto scale_y = 1;
+		return {scale_x, scale_y};
+	}
 }
 
 static SDL_Window* SetupWindowScaled(const RenderingBackend rendering_backend)
@@ -1537,7 +1561,7 @@ static SDL_Window* SetupWindowScaled(const RenderingBackend rendering_backend)
 	        sdl.draw.render_pixel_aspect_ratio);
 
 	if (window_width == 0 && window_height == 0) {
-		window_width  = iround(sdl.draw.render_width_px * draw_scale_x);
+		window_width = iround(sdl.draw.render_width_px * draw_scale_x);
 		window_height = iround(sdl.draw.render_height_px * draw_scale_y);
 	}
 
@@ -1552,8 +1576,8 @@ static SDL_Window* SetupWindowScaled(const RenderingBackend rendering_backend)
 #if C_OPENGL
 
 // A safe wrapper around that returns the default result on failure
-static const char *safe_gl_get_string(const GLenum requested_name,
-                                      const char *default_result = "")
+static const char* safe_gl_get_string(const GLenum requested_name,
+                                      const char* default_result = "")
 {
 	// the result points to a static string but can be null
 	const auto result = glGetString(requested_name);
@@ -1561,38 +1585,41 @@ static const char *safe_gl_get_string(const GLenum requested_name,
 	// the default, howeever, needs to be valid
 	assert(default_result);
 
-	return result ? reinterpret_cast<const char *>(result) : default_result;
+	return result ? reinterpret_cast<const char*>(result) : default_result;
 }
 
 /* Create a GLSL shader object, load the shader source, and compile the shader. */
 static GLuint BuildShader(GLenum type, const std::string& source)
 {
-	GLuint shader = 0;
+	GLuint shader            = 0;
 	GLint is_shader_compiled = 0;
 
 	assert(source.length());
-	const char *shaderSrc = source.c_str();
-	const char *src_strings[2] = {nullptr, nullptr};
+	const char* shaderSrc      = source.c_str();
+	const char* src_strings[2] = {nullptr, nullptr};
 	std::string top;
 
 	// look for "#version" because it has to occur first
-	const char *ver = strstr(shaderSrc, "#version ");
+	const char* ver = strstr(shaderSrc, "#version ");
 	if (ver) {
-		const char *endline = strchr(ver+9, '\n');
+		const char* endline = strchr(ver + 9, '\n');
 		if (endline) {
-			top.assign(shaderSrc, endline-shaderSrc+1);
-			shaderSrc = endline+1;
+			top.assign(shaderSrc, endline - shaderSrc + 1);
+			shaderSrc = endline + 1;
 		}
 	}
 
-	top += (type==GL_VERTEX_SHADER) ? "#define VERTEX 1\n":"#define FRAGMENT 1\n";
+	top += (type == GL_VERTEX_SHADER) ? "#define VERTEX 1\n"
+	                                  : "#define FRAGMENT 1\n";
 
 	src_strings[0] = top.c_str();
 	src_strings[1] = shaderSrc;
 
 	// Create the shader object
 	shader = glCreateShader(type);
-	if (shader == 0) return 0;
+	if (shader == 0) {
+		return 0;
+	}
 
 	// Load the shader source
 	glShaderSource(shader, 2, src_strings, nullptr);
@@ -1628,11 +1655,11 @@ static GLuint BuildShader(GLenum type, const std::string& source)
 	}
 }
 
-static bool LoadGLShaders(const std::string& source, GLuint *vertex,
-                          GLuint *fragment)
+static bool LoadGLShaders(const std::string& source, GLuint* vertex, GLuint* fragment)
 {
-	if (source.empty())
+	if (source.empty()) {
 		return false;
+	}
 
 	assert(vertex);
 	assert(fragment);
@@ -1640,7 +1667,7 @@ static bool LoadGLShaders(const std::string& source, GLuint *vertex,
 	GLuint s = BuildShader(GL_VERTEX_SHADER, source);
 	if (s) {
 		*vertex = s;
-		s = BuildShader(GL_FRAGMENT_SHADER, source);
+		s       = BuildShader(GL_FRAGMENT_SHADER, source);
 		if (s) {
 			*fragment = s;
 			return true;
@@ -1654,10 +1681,11 @@ static bool LoadGLShaders(const std::string& source, GLuint *vertex,
 static bool is_using_kmsdrm_driver()
 {
 	const bool is_initialized = SDL_WasInit(SDL_INIT_VIDEO);
-	const auto driver = is_initialized ? SDL_GetCurrentVideoDriver()
-	                                   : getenv("SDL_VIDEODRIVER");
-	if (!driver)
+	const auto driver         = is_initialized ? SDL_GetCurrentVideoDriver()
+	                                           : getenv("SDL_VIDEODRIVER");
+	if (!driver) {
 		return false;
+	}
 
 	std::string driver_str = driver;
 	lowcase(driver_str);
@@ -1692,7 +1720,7 @@ static void initialize_sdl_window_size(SDL_Window* sdl_window,
 // Texture update and presentation
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-static void update_frame_texture([[maybe_unused]] const uint16_t *changedLines)
+static void update_frame_texture([[maybe_unused]] const uint16_t* changedLines)
 {
 	SDL_UpdateTexture(sdl.texture.texture,
 	                  nullptr, // update entire texture
@@ -1705,24 +1733,25 @@ static std::optional<RenderedImage> get_rendered_output_from_backbuffer()
 	// This should be impossible, but maybe the user is hitting the screen
 	// capture hotkey on startup even before DOS comes alive.
 	if (!sdl.maybe_video_mode) {
-		LOG_WARNING("SDL: The DOS video mode needs to be set "
-		            "before we can get the rendered image");
+		LOG_WARNING(
+		        "SDL: The DOS video mode needs to be set "
+		        "before we can get the rendered image");
 		return {};
 	}
 
 	RenderedImage image = {};
 
-	// The draw rect can extends beyond the bounds of the window or the screen
-	// in fullscreen when we're "zooming into" the DOS content in `relative`
-	// viewport mode. But rendered captures should always capture what we see
-	// on the screen, so only the visible part of the enlarged image.
-	// Therefore, we need to clip the draw rect to the bounds of the canvas
-	// (the total visible area of the window or screen), and only capture the
-	// resulting output rectangle.
-	
+	// The draw rect can extends beyond the bounds of the window or the
+	// screen in fullscreen when we're "zooming into" the DOS content in
+	// `relative` viewport mode. But rendered captures should always capture
+	// what we see on the screen, so only the visible part of the enlarged
+	// image. Therefore, we need to clip the draw rect to the bounds of the
+	// canvas (the total visible area of the window or screen), and only
+	// capture the resulting output rectangle.
+
 	auto canvas_rect_px = get_canvas_size_in_pixels(sdl.rendering_backend);
-	canvas_rect_px.x = 0.0f;
-	canvas_rect_px.y = 0.0f;
+	canvas_rect_px.x    = 0.0f;
+	canvas_rect_px.y    = 0.0f;
 
 	const auto output_rect_px = canvas_rect_px.Copy().Intersect(
 	        to_rect(sdl.draw_rect_px));
@@ -1828,10 +1857,10 @@ static bool present_frame_texture()
 		SDL_RenderCopy(sdl.renderer, sdl.texture.texture, nullptr, nullptr);
 
 		if (CAPTURE_IsCapturingPostRenderImage()) {
-			// glReadPixels() implicitly blocks until all pipelined rendering
-			// commands have finished, so we're guaranteed to read the
-			// contents of the up-to-date backbuffer here right before the
-			// buffer swap.
+			// glReadPixels() implicitly blocks until all pipelined
+			// rendering commands have finished, so we're guaranteed
+			// to read the contents of the up-to-date backbuffer
+			// here right before the buffer swap.
 			const auto image = get_rendered_output_from_backbuffer();
 			if (image) {
 				CAPTURE_AddPostRenderImage(*image);
@@ -1851,19 +1880,25 @@ static bool present_frame_texture()
 static void update_frame_gl(const uint16_t* changedLines)
 {
 	if (changedLines) {
-		const auto framebuf = static_cast<uint8_t *>(sdl.opengl.framebuf);
+		const auto framebuf = static_cast<uint8_t*>(sdl.opengl.framebuf);
 		const auto pitch = sdl.opengl.pitch;
-		int y = 0;
-		size_t index = 0;
+		int y            = 0;
+		size_t index     = 0;
 		while (y < sdl.draw.render_height_px) {
 			if (!(index & 1)) {
 				y += changedLines[index];
 			} else {
-				const uint8_t *pixels = framebuf + y * pitch;
-				const int height_px = changedLines[index];
-				glTexSubImage2D(GL_TEXTURE_2D, 0, 0, y,
-				                sdl.draw.render_width_px, height_px, GL_BGRA_EXT,
-				                GL_UNSIGNED_INT_8_8_8_8_REV, pixels);
+				const uint8_t* pixels = framebuf + y * pitch;
+				const int height_px   = changedLines[index];
+				glTexSubImage2D(GL_TEXTURE_2D,
+				                0,
+				                0,
+				                y,
+				                sdl.draw.render_width_px,
+				                height_px,
+				                GL_BGRA_EXT,
+				                GL_UNSIGNED_INT_8_8_8_8_REV,
+				                pixels);
 				y += height_px;
 			}
 			index++;
@@ -1887,10 +1922,10 @@ static bool present_frame_gl()
 		}
 
 		if (CAPTURE_IsCapturingPostRenderImage()) {
-			// glReadPixels() implicitly blocks until all pipelined rendering
-			// commands have finished, so we're guaranateed to read the
-			// contents of the up-to-date backbuffer here right before the
-			// buffer swap.
+			// glReadPixels() implicitly blocks until all pipelined
+			// rendering commands have finished, so we're
+			// guaranateed to read the contents of the up-to-date
+			// backbuffer here right before the buffer swap.
 			const auto image = get_rendered_output_from_backbuffer();
 			if (image) {
 				CAPTURE_AddPostRenderImage(*image);
@@ -1904,15 +1939,14 @@ static bool present_frame_gl()
 }
 #endif
 
-
-
 uint8_t GFX_SetSize(const int render_width_px, const int render_height_px,
                     const Fraction& render_pixel_aspect_ratio, const uint8_t flags,
                     const VideoMode& video_mode, GFX_Callback_t callback)
 {
 	uint8_t retFlags = 0;
-	if (sdl.updating)
+	if (sdl.updating) {
 		GFX_EndUpdate(nullptr);
+	}
 
 	GFX_DisengageRendering();
 	// The rendering objects are recreated below with new sizes, after which
@@ -1940,14 +1974,14 @@ uint8_t GFX_SetSize(const int render_width_px, const int render_height_px,
 	sdl.draw.callback = callback;
 
 	// If we're changing the SDL output type (i.e., going from 'output =
-	// texture' to 'output = opengl'), then re-initialise our vsync settings.
-	// The host OS might handles this backend differently, therefore we
-	// need a new measurement.
-	if (sdl.want_rendering_backend  != sdl.rendering_backend) {
+	// texture' to 'output = opengl'), then re-initialise our vsync
+	// settings. The host OS might handles this backend differently,
+	// therefore we need a new measurement.
+	if (sdl.want_rendering_backend != sdl.rendering_backend) {
 		initialize_vsync_settings();
 	}
 
-	switch (sdl.want_rendering_backend ) {
+	switch (sdl.want_rendering_backend) {
 	case RenderingBackend::Texture: {
 	fallback_texture: // FIXME: Must be replaced with a proper fallback system.
 
@@ -1974,7 +2008,7 @@ uint8_t GFX_SetSize(const int render_width_px, const int render_height_px,
 		}
 
 		// release the existing surface if needed
-		auto &texture_input_surface = sdl.texture.input_surface;
+		auto& texture_input_surface = sdl.texture.input_surface;
 		if (texture_input_surface) {
 			SDL_FreeSurface(texture_input_surface);
 			texture_input_surface = nullptr;
@@ -1994,12 +2028,12 @@ uint8_t GFX_SetSize(const int render_width_px, const int render_height_px,
 		assert(sdl.texture.pixelFormat == nullptr); // ensure we don't leak
 		sdl.texture.pixelFormat = SDL_AllocFormat(pixel_format);
 		switch (SDL_BITSPERPIXEL(pixel_format)) {
-			case 8:  retFlags = GFX_CAN_8;  break;
-			case 15: retFlags = GFX_CAN_15; break;
-			case 16: retFlags = GFX_CAN_16; break;
-			case 24: /* SDL_BYTESPERPIXEL is probably 4, though. */
-			case 32: retFlags = GFX_CAN_32; break;
-		        }
+		case 8: retFlags = GFX_CAN_8; break;
+		case 15: retFlags = GFX_CAN_15; break;
+		case 16: retFlags = GFX_CAN_16; break;
+		case 24: /* SDL_BYTESPERPIXEL is probably 4, though. */
+		case 32: retFlags = GFX_CAN_32; break;
+		}
 
 		// Log changes to the rendering driver
 		static std::string render_driver = {};
@@ -2044,7 +2078,7 @@ uint8_t GFX_SetSize(const int render_width_px, const int render_height_px,
 			LOG_ERR("SDL: Failed to set viewport: %s", SDL_GetError());
 		}
 
-		sdl.frame.update = update_frame_texture;
+		sdl.frame.update  = update_frame_texture;
 		sdl.frame.present = present_frame_texture;
 
 		break; // RenderingBackend::Texture
@@ -2079,10 +2113,11 @@ uint8_t GFX_SetSize(const int render_width_px, const int render_height_px,
 
 		if (texsize_w_px > sdl.opengl.max_texsize ||
 		    texsize_h_px > sdl.opengl.max_texsize) {
-			LOG_WARNING("OPENGL: No support for texture size of %dx%d pixels, "
-			            "falling back to texture",
-			            texsize_w_px,
-			            texsize_h_px);
+			LOG_WARNING(
+			        "OPENGL: No support for texture size of %dx%d pixels, "
+			        "falling back to texture",
+			        texsize_w_px,
+			        texsize_h_px);
 			goto fallback_texture;
 		}
 
@@ -2104,17 +2139,21 @@ uint8_t GFX_SetSize(const int render_width_px, const int render_height_px,
 		}
 
 		if (sdl.opengl.use_shader) {
-			GLuint prog=0;
+			GLuint prog = 0;
 			// reset error
 			glGetError();
 			glGetIntegerv(GL_CURRENT_PROGRAM, (GLint*)&prog);
-			// if there was an error this context doesn't support shaders
-			if (glGetError()==GL_NO_ERROR && (sdl.opengl.program_object==0 || prog!=sdl.opengl.program_object)) {
+			// if there was an error this context doesn't support
+			// shaders
+			if (glGetError() == GL_NO_ERROR &&
+			    (sdl.opengl.program_object == 0 ||
+			     prog != sdl.opengl.program_object)) {
 				// check if existing program is valid
 				if (sdl.opengl.program_object) {
 					glUseProgram(sdl.opengl.program_object);
 					if (glGetError() != GL_NO_ERROR) {
-						// program is not usable (probably new context), purge it
+						// program is not usable (probably
+						// new context), purge it
 						glDeleteProgram(sdl.opengl.program_object);
 						sdl.opengl.program_object = 0;
 					}
@@ -2136,26 +2175,33 @@ uint8_t GFX_SetSize(const int render_width_px, const int render_height_px,
 						glDeleteShader(vertexShader);
 						glDeleteShader(fragmentShader);
 
-						LOG_WARNING("OPENGL: Can't create program object, "
-						            "falling back to texture");
+						LOG_WARNING(
+						        "OPENGL: Can't create program object, "
+						        "falling back to texture");
 						goto fallback_texture;
 					}
-					glAttachShader(sdl.opengl.program_object, vertexShader);
-					glAttachShader(sdl.opengl.program_object, fragmentShader);
+					glAttachShader(sdl.opengl.program_object,
+					               vertexShader);
+					glAttachShader(sdl.opengl.program_object,
+					               fragmentShader);
 
 					// Link the program
 					glLinkProgram(sdl.opengl.program_object);
 
-					// Even if we *are* successful, we may delete the shader objects
+					// Even if we *are* successful, we may
+					// delete the shader objects
 					glDeleteShader(vertexShader);
 					glDeleteShader(fragmentShader);
 
 					// Check the link status
 					GLint is_program_linked = 0;
-					glGetProgramiv(sdl.opengl.program_object, GL_LINK_STATUS, &is_program_linked);
+					glGetProgramiv(sdl.opengl.program_object,
+					               GL_LINK_STATUS,
+					               &is_program_linked);
 
-					// The info log might contain warnings and info messages
-					// even if the linking was successful, so we'll always log
+					// The info log might contain warnings
+					// and info messages even if the linking
+					// was successful, so we'll always log
 					// it if it's non-empty.
 					GLint info_len = 0;
 
@@ -2188,7 +2234,8 @@ uint8_t GFX_SetSize(const int render_width_px, const int render_height_px,
 
 					glUseProgram(sdl.opengl.program_object);
 
-					GLint u = glGetAttribLocation(sdl.opengl.program_object, "a_position");
+					GLint u = glGetAttribLocation(sdl.opengl.program_object,
+					                              "a_position");
 					// upper left
 					sdl.opengl.vertex_data[0] = -1.0f;
 					sdl.opengl.vertex_data[1] = 1.0f;
@@ -2199,16 +2246,30 @@ uint8_t GFX_SetSize(const int render_width_px, const int render_height_px,
 					sdl.opengl.vertex_data[4] = 3.0f;
 					sdl.opengl.vertex_data[5] = 1.0f;
 					// Load the vertex positions
-					glVertexAttribPointer(u, 2, GL_FLOAT, GL_FALSE, 0, sdl.opengl.vertex_data);
+					glVertexAttribPointer(u,
+					                      2,
+					                      GL_FLOAT,
+					                      GL_FALSE,
+					                      0,
+					                      sdl.opengl.vertex_data);
 					glEnableVertexAttribArray(u);
 
-					u = glGetUniformLocation(sdl.opengl.program_object, "rubyTexture");
+					u = glGetUniformLocation(sdl.opengl.program_object,
+					                         "rubyTexture");
 					glUniform1i(u, 0);
 
-					sdl.opengl.ruby.texture_size = glGetUniformLocation(sdl.opengl.program_object, "rubyTextureSize");
-					sdl.opengl.ruby.input_size = glGetUniformLocation(sdl.opengl.program_object, "rubyInputSize");
-					sdl.opengl.ruby.output_size = glGetUniformLocation(sdl.opengl.program_object, "rubyOutputSize");
-					sdl.opengl.ruby.frame_count = glGetUniformLocation(sdl.opengl.program_object, "rubyFrameCount");
+					sdl.opengl.ruby.texture_size = glGetUniformLocation(
+					        sdl.opengl.program_object,
+					        "rubyTextureSize");
+					sdl.opengl.ruby.input_size = glGetUniformLocation(
+					        sdl.opengl.program_object,
+					        "rubyInputSize");
+					sdl.opengl.ruby.output_size = glGetUniformLocation(
+					        sdl.opengl.program_object,
+					        "rubyOutputSize");
+					sdl.opengl.ruby.frame_count = glGetUniformLocation(
+					        sdl.opengl.program_object,
+					        "rubyFrameCount");
 				}
 			}
 		}
@@ -2237,7 +2298,7 @@ uint8_t GFX_SetSize(const int render_width_px, const int render_height_px,
 		//         (canvas_size_px.h - sdl.clip.h) / 2,
 		//         sdl.clip.w,
 		//         sdl.clip.h);
-	
+
 		sdl.draw_rect_px = to_sdl_rect(
 		        calc_draw_rect_in_pixels(canvas_size_px));
 
@@ -2247,10 +2308,10 @@ uint8_t GFX_SetSize(const int render_width_px, const int render_height_px,
 		           sdl.draw_rect_px.h);
 
 		if (sdl.opengl.texture > 0) {
-			glDeleteTextures(1,&sdl.opengl.texture);
+			glDeleteTextures(1, &sdl.opengl.texture);
 		}
 		glGenTextures(1, &sdl.opengl.texture);
-		glBindTexture(GL_TEXTURE_2D,sdl.opengl.texture);
+		glBindTexture(GL_TEXTURE_2D, sdl.opengl.texture);
 
 		// No borders
 		const auto wrap_parameter = use_npot_texture ? GL_CLAMP_TO_EDGE
@@ -2274,7 +2335,7 @@ uint8_t GFX_SetSize(const int render_width_px, const int render_height_px,
 
 		const auto texture_area_bytes = static_cast<size_t>(texsize_w_px) *
 		                                texsize_h_px * MAX_BYTES_PER_PIXEL;
-		uint8_t *emptytex = new uint8_t[texture_area_bytes];
+		uint8_t* emptytex = new uint8_t[texture_area_bytes];
 		assert(emptytex);
 
 		memset(emptytex, 0, texture_area_bytes);
@@ -2353,7 +2414,8 @@ uint8_t GFX_SetSize(const int render_width_px, const int render_height_px,
 		if (sdl.opengl.program_object) {
 			// Set shader variables
 			glUniform2f(sdl.opengl.ruby.texture_size,
-			            (GLfloat)texsize_w_px, (GLfloat)texsize_h_px);
+			            (GLfloat)texsize_w_px,
+			            (GLfloat)texsize_h_px);
 
 			glUniform2f(sdl.opengl.ruby.input_size,
 			            (GLfloat)render_width_px,
@@ -2366,26 +2428,34 @@ uint8_t GFX_SetSize(const int render_width_px, const int render_height_px,
 			// The following uniform is *not* set right now
 			sdl.opengl.actual_frame_count = 0;
 		} else {
-			GLfloat tex_width = ((GLfloat)render_width_px / (GLfloat)texsize_w_px);
-			GLfloat tex_height = ((GLfloat)render_height_px / (GLfloat)texsize_h_px);
+			GLfloat tex_width  = ((GLfloat)render_width_px /
+                                             (GLfloat)texsize_w_px);
+			GLfloat tex_height = ((GLfloat)render_height_px /
+			                      (GLfloat)texsize_h_px);
 
 			glShadeModel(GL_FLAT);
 			glMatrixMode(GL_MODELVIEW);
 			glLoadIdentity();
 
-			if (glIsList(sdl.opengl.displaylist)) glDeleteLists(sdl.opengl.displaylist, 1);
+			if (glIsList(sdl.opengl.displaylist)) {
+				glDeleteLists(sdl.opengl.displaylist, 1);
+			}
 			sdl.opengl.displaylist = glGenLists(1);
 			glNewList(sdl.opengl.displaylist, GL_COMPILE);
 
-			//Create one huge triangle and only display a portion.
-			//When using a quad, there was scaling bug (certain resolutions on Nvidia chipsets) in the seam
+			// Create one huge triangle and only display a portion.
+			// When using a quad, there was scaling bug (certain
+			// resolutions on Nvidia chipsets) in the seam
 			glBegin(GL_TRIANGLES);
 			// upper left
-			glTexCoord2f(0,0); glVertex2f(-1.0f, 1.0f);
+			glTexCoord2f(0, 0);
+			glVertex2f(-1.0f, 1.0f);
 			// lower left
-			glTexCoord2f(0,tex_height*2); glVertex2f(-1.0f,-3.0f);
+			glTexCoord2f(0, tex_height * 2);
+			glVertex2f(-1.0f, -3.0f);
 			// upper right
-			glTexCoord2f(tex_width*2,0); glVertex2f(3.0f, 1.0f);
+			glTexCoord2f(tex_width * 2, 0);
+			glVertex2f(3.0f, 1.0f);
 			glEnd();
 
 			glEndList();
@@ -2403,7 +2473,7 @@ uint8_t GFX_SetSize(const int render_width_px, const int render_height_px,
 		        "falling back to texture output");
 		goto fallback_texture;
 
-#endif // C_OPENGL
+#endif                 // C_OPENGL
 		break; // RenderingBackend::OpenGl
 	}
 	}
@@ -2424,17 +2494,12 @@ uint8_t GFX_SetSize(const int render_width_px, const int render_height_px,
 
 		auto vsync_mode = VsyncMode::Unset;
 		switch (SDL_GL_GetSwapInterval()) {
-		case -1:
-			vsync_mode = VsyncMode::Adaptive;
-			break;
-		case 0:
-			vsync_mode = VsyncMode::Off;
-			break;
-		case 1:
-			vsync_mode = VsyncMode::On;
-			break;
+		case -1: vsync_mode = VsyncMode::Adaptive; break;
+		case 0: vsync_mode = VsyncMode::Off; break;
+		case 1: vsync_mode = VsyncMode::On; break;
 		default:
-			assertm(false, "SDL_GL_GetSwapInterval() returned invalid result");
+			assertm(false,
+			        "SDL_GL_GetSwapInterval() returned invalid result");
 		}
 
 		if (last_vsync_mode != vsync_mode) {
@@ -2513,9 +2578,10 @@ void GFX_SetMouseRawInput(const bool requested_raw_input)
 {
 	if (SDL_SetHintWithPriority(SDL_HINT_MOUSE_RELATIVE_MODE_WARP,
 	                            requested_raw_input ? "0" : "1",
-	                            SDL_HINT_OVERRIDE) != SDL_TRUE)
+	                            SDL_HINT_OVERRIDE) != SDL_TRUE) {
 		LOG_WARNING("SDL: Failed to %s raw mouse input",
 		            requested_raw_input ? "enable" : "disable");
+	}
 }
 
 void GFX_SetMouseCapture(const bool requested_capture)
@@ -2524,17 +2590,18 @@ void GFX_SetMouseCapture(const bool requested_capture)
 	if (SDL_SetRelativeMouseMode(param) != 0) {
 		SDL_ShowCursor(SDL_ENABLE);
 		E_Exit("SDL: Failed to %s relative-mode [SDL Bug]",
-		       requested_capture ? "put the mouse in" :
-		                           "take the mouse out of");
+		       requested_capture ? "put the mouse in"
+		                         : "take the mouse out of");
 	}
 }
 
 void GFX_SetMouseVisibility(const bool requested_visible)
 {
 	const auto param = requested_visible ? SDL_ENABLE : SDL_DISABLE;
-	if (SDL_ShowCursor(param) < 0)
+	if (SDL_ShowCursor(param) < 0) {
 		E_Exit("SDL: Failed to make mouse cursor %s [SDL Bug]",
 		       requested_visible ? "visible" : "invisible");
+	}
 }
 
 static void focus_input()
@@ -2544,34 +2611,43 @@ static void focus_input()
 #endif
 
 	// Ensure we have input focus when in fullscreen
-	if (!sdl.desktop.fullscreen)
+	if (!sdl.desktop.fullscreen) {
 		return;
+	}
 
 	// Do we already have focus?
-	if (SDL_GetWindowFlags(sdl.window) & SDL_WINDOW_INPUT_FOCUS)
+	if (SDL_GetWindowFlags(sdl.window) & SDL_WINDOW_INPUT_FOCUS) {
 		return;
+	}
 
 	// If not, raise-and-focus to prevent stranding the window
 	SDL_RaiseWindow(sdl.window);
 	SDL_SetWindowInputFocus(sdl.window);
 }
 
-#if defined (WIN32)
+#if defined(WIN32)
 STICKYKEYS stick_keys = {sizeof(STICKYKEYS), 0};
-void sticky_keys(bool restore){
+void sticky_keys(bool restore)
+{
 	static bool inited = false;
-	if (!inited){
+	if (!inited) {
 		inited = true;
-		SystemParametersInfo(SPI_GETSTICKYKEYS, sizeof(STICKYKEYS), &stick_keys, 0);
+		SystemParametersInfo(SPI_GETSTICKYKEYS,
+		                     sizeof(STICKYKEYS),
+		                     &stick_keys,
+		                     0);
 	}
 	if (restore) {
-		SystemParametersInfo(SPI_SETSTICKYKEYS, sizeof(STICKYKEYS), &stick_keys, 0);
+		SystemParametersInfo(SPI_SETSTICKYKEYS,
+		                     sizeof(STICKYKEYS),
+		                     &stick_keys,
+		                     0);
 		return;
 	}
-	//Get current sticky keys layout:
+	// Get current sticky keys layout:
 	STICKYKEYS s = {sizeof(STICKYKEYS), 0};
 	SystemParametersInfo(SPI_GETSTICKYKEYS, sizeof(STICKYKEYS), &s, 0);
-	if ( !(s.dwFlags & SKF_STICKYKEYSON)) { //Not on already
+	if (!(s.dwFlags & SKF_STICKYKEYSON)) { // Not on already
 		s.dwFlags &= ~SKF_HOTKEYACTIVE;
 		SystemParametersInfo(SPI_SETSTICKYKEYS, sizeof(STICKYKEYS), &s, 0);
 	}
@@ -2620,16 +2696,17 @@ static void switch_fullscreen(bool pressed)
 // GFX_SetSize call), and assigns 'pitch' to a number of bytes used for a single
 // pixels row in 'pixels' buffer.
 //
-bool GFX_StartUpdate(uint8_t * &pixels, int &pitch)
+bool GFX_StartUpdate(uint8_t*& pixels, int& pitch)
 {
-	if (!sdl.active || sdl.updating)
+	if (!sdl.active || sdl.updating) {
 		return false;
+	}
 
 	switch (sdl.rendering_backend) {
 	case RenderingBackend::Texture:
 		assert(sdl.texture.input_surface);
-		pixels = static_cast<uint8_t *>(sdl.texture.input_surface->pixels);
-		pitch = sdl.texture.input_surface->pitch;
+		pixels = static_cast<uint8_t*>(sdl.texture.input_surface->pixels);
+		pitch        = sdl.texture.input_surface->pitch;
 		sdl.updating = true;
 		return true;
 	case RenderingBackend::OpenGl:
@@ -2661,16 +2738,17 @@ void GFX_EndUpdate(const uint16_t* changedLines)
 	sdl.frame.update(changedLines);
 
 	if (CAPTURE_IsCapturingPostRenderImage()) {
-		// Always present the frame if we want to capture the next rendered
-		// frame, regardless of the presentation mode. This is necessary to
-		// keep the contents of rendered and raw/upscaled screenshots in sync
-		// (so they capture the exact same frame) in multi-output image
-		// capture modes.
+		// Always present the frame if we want to capture the next
+		// rendered frame, regardless of the presentation mode. This is
+		// necessary to keep the contents of rendered and raw/upscaled
+		// screenshots in sync (so they capture the exact same frame) in
+		// multi-output image capture modes.
 		sdl.frame.present();
 	} else {
-		// Helper lambda indicating whether the frame should be presented.
-		// Returns true if the frame has been updated or if the limit of
-		// sequentially skipped duplicate frames has been reached.
+		// Helper lambda indicating whether the frame should be
+		// presented. Returns true if the frame has been updated or if
+		// the limit of sequentially skipped duplicate frames has been
+		// reached.
 		auto vfr_should_present = []() {
 			static uint16_t dupe_tally = 0;
 			if (sdl.updating || ++dupe_tally > sdl.frame.max_dupe_frames) {
@@ -2681,9 +2759,7 @@ void GFX_EndUpdate(const uint16_t* changedLines)
 		};
 
 		switch (sdl.frame.mode) {
-		case FrameMode::Cfr:
-			maybe_present_synced(sdl.updating);
-			break;
+		case FrameMode::Cfr: maybe_present_synced(sdl.updating); break;
 		case FrameMode::Vfr:
 			if (vfr_should_present()) {
 				sdl.frame.present();
@@ -2692,8 +2768,7 @@ void GFX_EndUpdate(const uint16_t* changedLines)
 		case FrameMode::ThrottledVfr:
 			maybe_present_throttled(vfr_should_present());
 			break;
-		case FrameMode::Unset:
-			break;
+		case FrameMode::Unset: break;
 		}
 	}
 
@@ -2731,20 +2806,24 @@ uint32_t GFX_GetRGB(const uint8_t red, const uint8_t green, const uint8_t blue)
 	return 0;
 }
 
-void GFX_Stop() {
-	if (sdl.updating)
+void GFX_Stop()
+{
+	if (sdl.updating) {
 		GFX_EndUpdate(nullptr);
-	sdl.active=false;
+	}
+	sdl.active = false;
 }
 
-void GFX_Start() {
-	sdl.active=true;
+void GFX_Start()
+{
+	sdl.active = true;
 }
 
-static void get_display_dimensions() {
+static void get_display_dimensions()
+{
 	SDL_Rect displayDimensions;
 	SDL_GetDisplayBounds(sdl.display_number, &displayDimensions);
-	sdl.desktop.full.width = displayDimensions.w;
+	sdl.desktop.full.width  = displayDimensions.w;
 	sdl.desktop.full.height = displayDimensions.h;
 }
 
@@ -2760,17 +2839,18 @@ void GFX_UpdateDisplayDimensions(int width, int height)
 		/* Note: We should not use get_display_dimensions()
 		(SDL_GetDisplayBounds) on Android after a screen rotation:
 		The older values from application startup are returned. */
-		sdl.desktop.full.width = width;
+		sdl.desktop.full.width  = width;
 		sdl.desktop.full.height = height;
 	}
 }
 
-static void shutdown_gui(Section *)
+static void shutdown_gui(Section*)
 {
 	GFX_Stop();
 
-	if (sdl.draw.callback)
-		(sdl.draw.callback)( GFX_CallbackStop );
+	if (sdl.draw.callback) {
+		(sdl.draw.callback)(GFX_CallbackStop);
+	}
 
 	GFX_SetMouseCapture(false);
 	GFX_SetMouseVisibility(true);
@@ -2794,56 +2874,55 @@ static void shutdown_gui(Section *)
 static void set_priority(PRIORITY_LEVELS level)
 {
 	// Just let the OS scheduler manage priority
-	if (level == PRIORITY_LEVEL_AUTO)
+	if (level == PRIORITY_LEVEL_AUTO) {
 		return;
+	}
 
-		// TODO replace platform-specific API with SDL_SetThreadPriority
+	// TODO replace platform-specific API with SDL_SetThreadPriority
 #if defined(HAVE_SETPRIORITY)
 	// If the priorities are different, do nothing unless the user is root,
 	// since priority can always be lowered but requires elevated rights
 	// to increase
 
-	if ((sdl.priority.active != sdl.priority.inactive) && (getuid() != 0))
+	if ((sdl.priority.active != sdl.priority.inactive) && (getuid() != 0)) {
 		return;
+	}
 
 #endif
 	switch (level) {
 #ifdef WIN32
 	case PRIORITY_LEVEL_LOWEST:
-		SetPriorityClass(GetCurrentProcess(),IDLE_PRIORITY_CLASS);
+		SetPriorityClass(GetCurrentProcess(), IDLE_PRIORITY_CLASS);
 		break;
 	case PRIORITY_LEVEL_LOWER:
-		SetPriorityClass(GetCurrentProcess(),BELOW_NORMAL_PRIORITY_CLASS);
+		SetPriorityClass(GetCurrentProcess(), BELOW_NORMAL_PRIORITY_CLASS);
 		break;
 	case PRIORITY_LEVEL_NORMAL:
-		SetPriorityClass(GetCurrentProcess(),NORMAL_PRIORITY_CLASS);
+		SetPriorityClass(GetCurrentProcess(), NORMAL_PRIORITY_CLASS);
 		break;
 	case PRIORITY_LEVEL_HIGHER:
-		SetPriorityClass(GetCurrentProcess(),ABOVE_NORMAL_PRIORITY_CLASS);
+		SetPriorityClass(GetCurrentProcess(), ABOVE_NORMAL_PRIORITY_CLASS);
 		break;
 	case PRIORITY_LEVEL_HIGHEST:
-		SetPriorityClass(GetCurrentProcess(),HIGH_PRIORITY_CLASS);
+		SetPriorityClass(GetCurrentProcess(), HIGH_PRIORITY_CLASS);
 		break;
 #elif defined(HAVE_SETPRIORITY)
 		/* Linux use group as dosbox has mulitple threads under linux */
-	case PRIORITY_LEVEL_LOWEST:
-		setpriority (PRIO_PGRP, 0,PRIO_MAX);
-		break;
+	case PRIORITY_LEVEL_LOWEST: setpriority(PRIO_PGRP, 0, PRIO_MAX); break;
 	case PRIORITY_LEVEL_LOWER:
-		setpriority (PRIO_PGRP, 0,PRIO_MAX-(PRIO_TOTAL/3));
+		setpriority(PRIO_PGRP, 0, PRIO_MAX - (PRIO_TOTAL / 3));
 		break;
 	case PRIORITY_LEVEL_NORMAL:
-		setpriority (PRIO_PGRP, 0,PRIO_MAX-(PRIO_TOTAL/2));
+		setpriority(PRIO_PGRP, 0, PRIO_MAX - (PRIO_TOTAL / 2));
 		break;
 	case PRIORITY_LEVEL_HIGHER:
-		setpriority (PRIO_PGRP, 0,PRIO_MAX-((3*PRIO_TOTAL)/5) );
+		setpriority(PRIO_PGRP, 0, PRIO_MAX - ((3 * PRIO_TOTAL) / 5));
 		break;
 	case PRIORITY_LEVEL_HIGHEST:
-		setpriority (PRIO_PGRP, 0,PRIO_MAX-((3*PRIO_TOTAL)/4) );
+		setpriority(PRIO_PGRP, 0, PRIO_MAX - ((3 * PRIO_TOTAL) / 4));
 		break;
 #endif
-	default:
-		break;
+	default: break;
 	}
 }
 
@@ -2879,8 +2958,9 @@ static SDL_Point refine_window_size(const SDL_Point size,
                                     const bool wants_aspect_ratio_correction)
 {
 	// TODO This only works for 320x200 games. We cannot make hardcoded
-	// assumptions about aspect ratios in general, e.g. the pixel aspect ratio
-	// is 1:1 for 640x480 games both with 'aspect = on` and 'aspect = off'.
+	// assumptions about aspect ratios in general, e.g. the pixel aspect
+	// ratio is 1:1 for 640x480 games both with 'aspect = on` and 'aspect =
+	// off'.
 	constexpr SDL_Point ratios_for_stretched_pixels = {4, 3};
 	constexpr SDL_Point ratios_for_square_pixels    = {8, 5};
 
@@ -2906,11 +2986,13 @@ static SDL_Point refine_window_size(const SDL_Point size,
 	return FallbackWindowSize;
 }
 
-static void maybe_limit_requested_resolution(int &w, int &h, const char *size_description)
+static void maybe_limit_requested_resolution(int& w, int& h,
+                                             const char* size_description)
 {
 	const auto desktop = get_desktop_size();
-	if (w <= desktop.w && h <= desktop.h)
+	if (w <= desktop.w && h <= desktop.h) {
 		return;
+	}
 
 	bool was_limited = false;
 
@@ -2918,8 +3000,8 @@ static void maybe_limit_requested_resolution(int &w, int &h, const char *size_de
 
 	// SDL KMSDRM limitations:
 	if (is_using_kmsdrm_driver()) {
-		w = desktop.w;
-		h = desktop.h;
+		w           = desktop.w;
+		h           = desktop.h;
 		was_limited = true;
 		LOG_WARNING("DISPLAY: Limiting '%s' resolution to %dx%d to avoid kmsdrm issues",
 		            size_description,
@@ -2927,22 +3009,24 @@ static void maybe_limit_requested_resolution(int &w, int &h, const char *size_de
 		            h);
 	}
 
-	if (!was_limited)
-		// TODO shouldn't we log the display resolution in physical pixels
-		// instead?
-		LOG_INFO("DISPLAY: Accepted '%s' resolution %dx%d despite exceeding "
-		         "the %dx%d display",
-		         size_description,
-		         w,
-		         h,
-		         desktop.w,
-		         desktop.h);
+	if (!was_limited) {
+		// TODO shouldn't we log the display resolution in physical
+		// pixels instead?
+		LOG_INFO(
+		        "DISPLAY: Accepted '%s' resolution %dx%d despite exceeding "
+		        "the %dx%d display",
+		        size_description,
+		        w,
+		        h,
+		        desktop.w,
+		        desktop.h);
+	}
 }
 
-static SDL_Point parse_window_resolution_from_conf(const std::string &pref)
+static SDL_Point parse_window_resolution_from_conf(const std::string& pref)
 {
-	int w = 0;
-	int h = 0;
+	int w                 = 0;
+	int h                 = 0;
 	const bool was_parsed = sscanf(pref.c_str(), "%dx%d", &w, &h) == 2;
 
 	const bool is_valid = (w >= FallbackWindowSize.x &&
@@ -2953,9 +3037,10 @@ static SDL_Point parse_window_resolution_from_conf(const std::string &pref)
 		return {w, h};
 	}
 
-	LOG_WARNING("DISPLAY: Invalid 'windowresolution' setting: '%s', "
-	            "using 'default'",
-	            pref.c_str());
+	LOG_WARNING(
+	        "DISPLAY: Invalid 'windowresolution' setting: '%s', "
+	        "using 'default'",
+	        pref.c_str());
 
 	return FallbackWindowSize;
 }
@@ -2978,9 +3063,10 @@ static SDL_Point window_bounds_from_label(const std::string& pref,
 		} else if (pref == "desktop") {
 			return 100;
 		} else {
-			LOG_WARNING("DISPLAY: Invalid 'windowresolution' setting: '%s', "
-			            "using 'default'",
-			            pref.c_str());
+			LOG_WARNING(
+			        "DISPLAY: Invalid 'windowresolution' setting: '%s', "
+			        "using 'default'",
+			        pref.c_str());
 			return MediumPercent;
 		}
 	}();
@@ -3011,9 +3097,10 @@ static void setup_initial_window_position_from_conf(const std::string& window_po
 	const auto was_parsed = (sscanf(window_position_val.c_str(), "%d,%d", &x, &y) ==
 	                         2);
 	if (!was_parsed) {
-		LOG_WARNING("DISPLAY: Invalid 'window_position' setting: '%s'. "
-		            "Must be in X,Y format, using 'auto'.",
-		            window_position_val.c_str());
+		LOG_WARNING(
+		        "DISPLAY: Invalid 'window_position' setting: '%s'. "
+		        "Must be in X,Y format, using 'auto'.",
+		        window_position_val.c_str());
 		return;
 	}
 
@@ -3022,12 +3109,13 @@ static void setup_initial_window_position_from_conf(const std::string& window_po
 	const bool is_out_of_bounds = x < 0 || x > desktop.w || y < 0 ||
 	                              y > desktop.h;
 	if (is_out_of_bounds) {
-		LOG_WARNING("DISPLAY: Invalid 'window_position' setting: '%s'. "
-		            "Requested position is outside the bounds of the %dx%d "
-		            "desktop, using 'auto'.",
-		            window_position_val.c_str(),
-		            desktop.w,
-		            desktop.h);
+		LOG_WARNING(
+		        "DISPLAY: Invalid 'window_position' setting: '%s'. "
+		        "Requested position is outside the bounds of the %dx%d "
+		        "desktop, using 'auto'.",
+		        window_position_val.c_str(),
+		        desktop.w,
+		        desktop.h);
 		return;
 	}
 
@@ -3047,7 +3135,7 @@ static void save_window_size(const int w, const int h)
 	sdl.desktop.window.height = h;
 
 	// Initialize the window's canvas size if it hasn't yet been set.
-	auto &window_canvas_size = sdl.desktop.window.canvas_size;
+	auto& window_canvas_size = sdl.desktop.window.canvas_size;
 	if (window_canvas_size.w <= 0 || window_canvas_size.h <= 0) {
 		window_canvas_size.w = w;
 		window_canvas_size.h = h;
@@ -3109,7 +3197,8 @@ DosBox::Rect GFX_CalcDrawRectInPixels(const DosBox::Rect& canvas_size_px,
                                       const DosBox::Rect& render_size_px,
                                       const Fraction& render_pixel_aspect_ratio)
 {
-	const auto viewport_px = RENDER_CalcRestrictedViewportSizeInPixels(canvas_size_px);
+	const auto viewport_px = RENDER_CalcRestrictedViewportSizeInPixels(
+	        canvas_size_px);
 
 	const auto draw_size_fit_px =
 	        render_size_px.Copy()
@@ -3195,7 +3284,7 @@ InterpolationMode GFX_GetTextureInterpolationMode()
 
 static void set_output(Section* sec, const bool wants_aspect_ratio_correction)
 {
-	const auto section = static_cast<const Section_prop *>(sec);
+	const auto section = static_cast<const Section_prop*>(sec);
 	std::string output = section->Get_string("output");
 
 	GFX_DisengageRendering();
@@ -3225,19 +3314,22 @@ static void set_output(Section* sec, const bool wants_aspect_ratio_correction)
 	}
 
 	const std::string screensaver = section->Get_string("screensaver");
-	if (screensaver == "allow")
+	if (screensaver == "allow") {
 		SDL_EnableScreenSaver();
-	if (screensaver == "block")
+	}
+	if (screensaver == "block") {
 		SDL_DisableScreenSaver();
+	}
 
 	sdl.render_driver = section->Get_string("texture_renderer");
 	lowcase(sdl.render_driver);
 	if (sdl.render_driver != "auto") {
 		if (SDL_SetHint(SDL_HINT_RENDER_DRIVER,
 		                sdl.render_driver.c_str()) == SDL_FALSE) {
-			LOG_WARNING("SDL: Failed to set '%s' texture renderer driver; "
-			            "falling back to automatic selection",
-			            sdl.render_driver.c_str());
+			LOG_WARNING(
+			        "SDL: Failed to set '%s' texture renderer driver; "
+			        "falling back to automatic selection",
+			        sdl.render_driver.c_str());
 		}
 	}
 
@@ -3250,16 +3342,21 @@ static void set_output(Section* sec, const bool wants_aspect_ratio_correction)
 	                             wants_aspect_ratio_correction);
 
 #if C_OPENGL
-	if (sdl.want_rendering_backend == RenderingBackend::OpenGl) { /* OPENGL is requested */
+	if (sdl.want_rendering_backend == RenderingBackend::OpenGl) { /* OPENGL
+		                                                         is
+		                                                         requested
+		                                                       */
 		if (!set_default_window_mode()) {
-			LOG_WARNING("OPENGL: Could not create OpenGL window, "
-			            "using 'texture' output mode");
+			LOG_WARNING(
+			        "OPENGL: Could not create OpenGL window, "
+			        "using 'texture' output mode");
 			sdl.want_rendering_backend = RenderingBackend::Texture;
 		} else {
 			sdl.opengl.context = SDL_GL_CreateContext(sdl.window);
 			if (sdl.opengl.context == nullptr) {
-				LOG_WARNING("OPENGL: Could not create context, "
-				            "using 'texture' output mode");
+				LOG_WARNING(
+				        "OPENGL: Could not create context, "
+				        "using 'texture' output mode");
 				sdl.want_rendering_backend = RenderingBackend::Texture;
 			}
 		}
@@ -3315,8 +3412,8 @@ static void set_output(Section* sec, const bool wants_aspect_ratio_correction)
 			         glUniform2f && glUniform1i && glUseProgram &&
 			         glVertexAttribPointer);
 
-			sdl.opengl.framebuf = nullptr;
-			sdl.opengl.texture = 0;
+			sdl.opengl.framebuf    = nullptr;
+			sdl.opengl.texture     = 0;
 			sdl.opengl.displaylist = 0;
 			glGetIntegerv(GL_MAX_TEXTURE_SIZE, &sdl.opengl.max_texsize);
 
@@ -3346,7 +3443,7 @@ static void set_output(Section* sec, const bool wants_aspect_ratio_correction)
 			         npot_support_msg.c_str());
 		}
 	} /* OPENGL is requested end */
-#endif    // OPENGL
+#endif // OPENGL
 
 	if (!set_default_window_mode()) {
 		E_Exit("SDL: Could not initialize video: %s", SDL_GetError());
@@ -3446,7 +3543,8 @@ static void read_gui_config(Section* sec)
 
 	sdl.pause_when_inactive = section->Get_bool("pause_when_inactive");
 
-	sdl.mute_when_inactive = (!sdl.pause_when_inactive) && section->Get_bool("mute_when_inactive");
+	sdl.mute_when_inactive = (!sdl.pause_when_inactive) &&
+	                         section->Get_bool("mute_when_inactive");
 
 	// Assume focus on startup
 	apply_active_settings();
@@ -3457,15 +3555,20 @@ static void read_gui_config(Section* sec)
 	sdl.desktop.full.width  = 0;
 	sdl.desktop.full.height = 0;
 
-	if(!fullresolution.empty()) {
-		lowcase(fullresolution); //so x and X are allowed
+	if (!fullresolution.empty()) {
+		lowcase(fullresolution); // so x and X are allowed
 		if (fullresolution != "original") {
 			sdl.desktop.full.fixed = true;
-			if (fullresolution != "desktop") { // desktop uses 0x0, below sets a custom WxH
-				std::vector<std::string> dimensions = split_with_empties(fullresolution, 'x');
+			if (fullresolution != "desktop") { // desktop uses 0x0,
+				                           // below sets a
+				                           // custom WxH
+				std::vector<std::string> dimensions =
+				        split_with_empties(fullresolution, 'x');
 				if (dimensions.size() == 2) {
-					sdl.desktop.full.width = parse_int(dimensions[0]).value_or(0);
-					sdl.desktop.full.height = parse_int(dimensions[1]).value_or(0);
+					sdl.desktop.full.width =
+					        parse_int(dimensions[0]).value_or(0);
+					sdl.desktop.full.height =
+					        parse_int(dimensions[1]).value_or(0);
 					maybe_limit_requested_resolution(
 					        sdl.desktop.full.width,
 					        sdl.desktop.full.height,
@@ -3510,19 +3613,21 @@ static void read_gui_config(Section* sec)
 
 	const std::string presentation_mode_pref = section->Get_string(
 	        "presentation_mode");
-	if (presentation_mode_pref == "auto")
+	if (presentation_mode_pref == "auto") {
 		sdl.frame.desired_mode = FrameMode::Unset;
-	else if (presentation_mode_pref == "cfr")
+	} else if (presentation_mode_pref == "cfr") {
 		sdl.frame.desired_mode = FrameMode::Cfr;
-	else if (presentation_mode_pref == "vfr")
+	} else if (presentation_mode_pref == "vfr") {
 		sdl.frame.desired_mode = FrameMode::Vfr;
-	else {
+	} else {
 		sdl.frame.desired_mode = FrameMode::Unset;
 		LOG_WARNING("SDL: Invalid 'presentation_mode' setting: '%s', using 'auto'",
 		            presentation_mode_pref.c_str());
 	}
 
-	sdl.desktop.full.display_res = sdl.desktop.full.fixed && (!sdl.desktop.full.width || !sdl.desktop.full.height);
+	sdl.desktop.full.display_res = sdl.desktop.full.fixed &&
+	                               (!sdl.desktop.full.width ||
+	                                !sdl.desktop.full.height);
 	if (sdl.desktop.full.display_res) {
 		get_display_dimensions();
 	}
@@ -3530,11 +3635,14 @@ static void read_gui_config(Section* sec)
 	set_output(section, is_aspect_ratio_correction_enabled());
 
 	/* Get some Event handlers */
-	MAPPER_AddHandler(GFX_RequestExit, SDL_SCANCODE_F9, PRIMARY_MOD,
-	                  "shutdown", "Shutdown");
+	MAPPER_AddHandler(GFX_RequestExit, SDL_SCANCODE_F9, PRIMARY_MOD, "shutdown", "Shutdown");
 
 	MAPPER_AddHandler(switch_fullscreen, SDL_SCANCODE_RETURN, MMOD2, "fullscr", "Fullscreen");
-	MAPPER_AddHandler(restart_hotkey_handler, SDL_SCANCODE_HOME, PRIMARY_MOD | MMOD2, "restart", "Restart");
+	MAPPER_AddHandler(restart_hotkey_handler,
+	                  SDL_SCANCODE_HOME,
+	                  PRIMARY_MOD | MMOD2,
+	                  "restart",
+	                  "Restart");
 	MAPPER_AddHandler(MOUSE_ToggleUserCapture,
 	                  SDL_SCANCODE_F10,
 	                  PRIMARY_MOD,
@@ -3545,12 +3653,10 @@ static void read_gui_config(Section* sec)
 /* Pause binds with activate-debugger */
 #elif defined(MACOSX)
 	// Pause/unpause is hardcoded to Command+P on macOS
-	MAPPER_AddHandler(&pause_emulation, SDL_SCANCODE_P, PRIMARY_MOD,
-	                  "pause", "Pause Emu.");
+	MAPPER_AddHandler(&pause_emulation, SDL_SCANCODE_P, PRIMARY_MOD, "pause", "Pause Emu.");
 #else
 	// Pause/unpause is hardcoded to Alt+Pause on Window & Linux
-	MAPPER_AddHandler(&pause_emulation, SDL_SCANCODE_PAUSE, MMOD2,
-	                  "pause", "Pause Emu.");
+	MAPPER_AddHandler(&pause_emulation, SDL_SCANCODE_PAUSE, MMOD2, "pause", "Pause Emu.");
 #endif
 	/* Get Keyboard state of numlock and capslock */
 	SDL_Keymod keystate = SDL_GetModState();
@@ -3558,7 +3664,7 @@ static void read_gui_config(Section* sec)
 	// A long-standing SDL1 and SDL2 bug prevents it from detecting the
 	// numlock and capslock states on startup. Instead, these states must
 	// be toggled by the user /after/ starting DOSBox.
-	startup_state_numlock = keystate & KMOD_NUM;
+	startup_state_numlock  = keystate & KMOD_NUM;
 	startup_state_capslock = keystate & KMOD_CAPS;
 
 	// Notify MOUSE subsystem that it can start now
@@ -3593,7 +3699,8 @@ static void handle_mouse_motion(SDL_MouseMotionEvent* motion)
 
 static void handle_mouse_wheel(SDL_MouseWheelEvent* wheel)
 {
-    const auto tmp = (wheel->direction == SDL_MOUSEWHEEL_NORMAL) ? -wheel->y : wheel->y;
+	const auto tmp = (wheel->direction == SDL_MOUSEWHEEL_NORMAL) ? -wheel->y
+	                                                             : wheel->y;
 	MOUSE_EventWheel(check_cast<int16_t>(tmp));
 }
 
@@ -3621,11 +3728,13 @@ void GFX_LosingFocus()
 	MAPPER_LosingFocus();
 }
 
-bool GFX_IsFullscreen() {
+bool GFX_IsFullscreen()
+{
 	return sdl.desktop.fullscreen;
 }
 
-void GFX_RegenerateWindow(Section *sec) {
+void GFX_RegenerateWindow(Section* sec)
+{
 	if (first_window) {
 		first_window = false;
 		return;
@@ -3638,7 +3747,7 @@ void GFX_RegenerateWindow(Section *sec) {
 #if defined(MACOSX)
 #define DB_POLLSKIP 3
 #else
-//Not used yet, see comment below
+// Not used yet, see comment below
 #define DB_POLLSKIP 1
 #endif
 
@@ -3700,13 +3809,15 @@ static void finalise_window_state()
 {
 	assert(sdl.window);
 
-	if (!sdl.desktop.lazy_init_window_size)
+	if (!sdl.desktop.lazy_init_window_size) {
 		return;
+	}
 
 	// Don't change window position or size when state changed to
 	// fullscreen.
-	if (sdl.desktop.fullscreen)
+	if (sdl.desktop.fullscreen) {
 		return;
+	}
 
 	// Once window is fixed up once, OS or Window Manager will deal with it
 	// on future expose events.
@@ -3767,8 +3878,7 @@ static void handle_user_event(const SDL_Event& event)
 	case SDL_DosBoxEvents::RefreshAnimatedTitle:
 		GFX_RefreshAnimatedTitle();
 		break;
-	default:
-		assert(false);
+	default: assert(false);
 	}
 }
 
@@ -3781,18 +3891,21 @@ bool GFX_Events()
 	// default max 500). Currently not implemented for all platforms, given
 	// the ALT-TAB stuff for WIN32.
 	static auto last_check = GetTicks();
-	auto current_check = GetTicks();
-	if (GetTicksDiff(current_check, last_check) <= DB_POLLSKIP)
+	auto current_check     = GetTicks();
+	if (GetTicksDiff(current_check, last_check) <= DB_POLLSKIP) {
 		return true;
+	}
 	last_check = current_check;
 #endif
 
 	SDL_Event event;
 	static auto last_check_joystick = GetTicks();
-	auto current_check_joystick = GetTicks();
+	auto current_check_joystick     = GetTicks();
 	if (GetTicksDiff(current_check_joystick, last_check_joystick) > 20) {
 		last_check_joystick = current_check_joystick;
-		if (MAPPER_IsUsingJoysticks()) SDL_JoystickUpdate();
+		if (MAPPER_IsUsingJoysticks()) {
+			SDL_JoystickUpdate();
+		}
 		MAPPER_UpdateJoysticks();
 	}
 	while (SDL_PollEvent(&event)) {
@@ -3816,8 +3929,7 @@ bool GFX_Events()
 				notify_new_mouse_screen_params();
 				break;
 #endif
-			default:
-				break;
+			default: break;
 			};
 			break;
 		case SDL_WINDOWEVENT:
@@ -3857,10 +3969,10 @@ bool GFX_Events()
 				assert(sdl.desktop.window.width > 0 &&
 				       sdl.desktop.window.height > 0);
 
-				// SDL_WINDOWEVENT_RESIZED events are sent twice on macOS when
-				// resizing the window, so we're only logging the display
-				// settings if there is a change since the last window resized
-				// event.
+				// SDL_WINDOWEVENT_RESIZED events are sent twice
+				// on macOS when resizing the window, so we're
+				// only logging the display settings if there is
+				// a change since the last window resized event.
 				static int prev_width  = 0;
 				static int prev_height = 0;
 
@@ -3878,7 +3990,8 @@ bool GFX_Events()
 
 				prev_width  = new_width;
 				prev_height = new_height;
-			}	continue;
+			}
+				continue;
 
 			case SDL_WINDOWEVENT_FOCUS_GAINED:
 				apply_active_settings();
@@ -3900,13 +4013,15 @@ bool GFX_Events()
 				 */
 				// LOG_DEBUG("SDL: Window has gained
 				// keyboard focus");
-				if (sdl.draw.callback)
+				if (sdl.draw.callback) {
 					sdl.draw.callback(GFX_CallbackRedraw);
+				}
 				focus_input();
 				continue;
 
 			case SDL_WINDOWEVENT_FOCUS_LOST:
-				// LOG_DEBUG("SDL: Window has lost keyboard focus");
+				// LOG_DEBUG("SDL: Window has lost keyboard
+				// focus");
 #ifdef WIN32
 				if (sdl.desktop.fullscreen) {
 					VGA_KillDrawing();
@@ -3936,7 +4051,8 @@ bool GFX_Events()
 
 #if C_OPENGL && defined(MACOSX)
 			case SDL_WINDOWEVENT_MOVED:
-				// LOG_DEBUG("SDL: Window has been moved to %d, %d",
+				// LOG_DEBUG("SDL: Window has been moved to %d,
+				// %d",
 				//               event.window.data1,
 				//               event.window.data2);
 				if (sdl.rendering_backend == RenderingBackend::OpenGl) {
@@ -4034,60 +4150,112 @@ bool GFX_Events()
 			default: break;
 			}
 
-			/* Non-focus priority is set to pause; check to see if we've lost window or input focus
-			 * i.e. has the window been minimised or made inactive?
+			/* Non-focus priority is set to pause; check to see if
+			 * we've lost window or input focus i.e. has the window
+			 * been minimised or made inactive?
 			 */
 			if (sdl.pause_when_inactive) {
-				if ((event.window.event == SDL_WINDOWEVENT_FOCUS_LOST) || (event.window.event == SDL_WINDOWEVENT_MINIMIZED)) {
-					/* Window has lost focus, pause the emulator.
-					 * This is similar to what PauseDOSBox() does, but the exit criteria is different.
-					 * Instead of waiting for the user to hit Alt+Break, we wait for the window to
+				if ((event.window.event == SDL_WINDOWEVENT_FOCUS_LOST) ||
+				    (event.window.event == SDL_WINDOWEVENT_MINIMIZED)) {
+					/* Window has lost focus, pause the
+					 * emulator. This is similar to what
+					 * PauseDOSBox() does, but the exit
+					 * criteria is different. Instead of
+					 * waiting for the user to hit
+					 * Alt+Break, we wait for the window to
 					 * regain window or input focus.
 					 */
 					apply_inactive_settings();
 					SDL_Event ev;
 
 					KEYBOARD_ClrBuffer();
-//					Delay(500);
-//					while (SDL_PollEvent(&ev)) {
-						// flush event queue.
-//					}
+					//					Delay(500);
+					//					while
+					//(SDL_PollEvent(&ev)) {
+					// flush event queue.
+					//					}
 
 					bool paused = true;
 
-					// Prevent the mixer from running while in our pause loop
-					// Muting is not ideal for some sound devices such as GUS that loop samples
-					// This also saves CPU time by not rendering samples we're not going to play anyway
+					// Prevent the mixer from running while
+					// in our pause loop Muting is not ideal
+					// for some sound devices such as GUS
+					// that loop samples This also saves CPU
+					// time by not rendering samples we're
+					// not going to play anyway
 					MIXER_LockMixerThread();
 
 					while (paused && !shutdown_requested) {
-						// WaitEvent waits for an event rather than polling, so CPU usage drops to zero
+						// WaitEvent waits for an event
+						// rather than polling, so CPU
+						// usage drops to zero
 						SDL_WaitEvent(&ev);
 
 						switch (ev.type) {
 						case SDL_QUIT:
 							GFX_RequestExit(true);
 							break;
-						case SDL_WINDOWEVENT:     // wait until we get window focus back
-							if ((ev.window.event == SDL_WINDOWEVENT_FOCUS_LOST) || (ev.window.event == SDL_WINDOWEVENT_MINIMIZED) || (ev.window.event == SDL_WINDOWEVENT_FOCUS_GAINED) || (ev.window.event == SDL_WINDOWEVENT_RESTORED) || (ev.window.event == SDL_WINDOWEVENT_EXPOSED)) {
-								// We've got focus back, so unpause and break out of the loop
-								if ((ev.window.event == SDL_WINDOWEVENT_FOCUS_GAINED) || (ev.window.event == SDL_WINDOWEVENT_RESTORED) || (ev.window.event == SDL_WINDOWEVENT_EXPOSED)) {
+						case SDL_WINDOWEVENT: // wait until
+						                      // we get
+						                      // window
+						                      // focus back
+							if ((ev.window.event ==
+							     SDL_WINDOWEVENT_FOCUS_LOST) ||
+							    (ev.window.event ==
+							     SDL_WINDOWEVENT_MINIMIZED) ||
+							    (ev.window.event ==
+							     SDL_WINDOWEVENT_FOCUS_GAINED) ||
+							    (ev.window.event ==
+							     SDL_WINDOWEVENT_RESTORED) ||
+							    (ev.window.event ==
+							     SDL_WINDOWEVENT_EXPOSED)) {
+								// We've got
+								// focus back,
+								// so unpause
+								// and break out
+								// of the loop
+								if ((ev.window.event ==
+								     SDL_WINDOWEVENT_FOCUS_GAINED) ||
+								    (ev.window.event ==
+								     SDL_WINDOWEVENT_RESTORED) ||
+								    (ev.window.event ==
+								     SDL_WINDOWEVENT_EXPOSED)) {
 									sdl.is_paused = false;
 									GFX_RefreshTitle();
-									if (ev.window.event == SDL_WINDOWEVENT_FOCUS_GAINED) {
+									if (ev.window
+									            .event ==
+									    SDL_WINDOWEVENT_FOCUS_GAINED) {
 										paused = false;
 										apply_active_settings();
 									}
 								}
 
-								/* Now poke a "release ALT" command into the keyboard buffer
-								 * we have to do this, otherwise ALT will 'stick' and cause
-								 * problems with the app running in the DOSBox.
+								/* Now poke a
+								 * "release ALT"
+								 * command into
+								 * the keyboard
+								 * buffer we have
+								 * to do this,
+								 * otherwise ALT
+								 * will 'stick'
+								 * and cause
+								 * problems with
+								 * the app running
+								 * in the DOSBox.
 								 */
-								KEYBOARD_AddKey(KBD_leftalt, false);
-								KEYBOARD_AddKey(KBD_rightalt, false);
-								if (ev.window.event == SDL_WINDOWEVENT_RESTORED) {
-									// We may need to re-create a texture and more
+								KEYBOARD_AddKey(KBD_leftalt,
+								                false);
+								KEYBOARD_AddKey(KBD_rightalt,
+								                false);
+								if (ev.window.event ==
+								    SDL_WINDOWEVENT_RESTORED) {
+									// We may
+									// need
+									// to
+									// re-create
+									// a
+									// texture
+									// and more
 									GFX_ResetScreen();
 								}
 							}
@@ -4102,34 +4270,46 @@ bool GFX_Events()
 		case SDL_MOUSEMOTION: handle_mouse_motion(&event.motion); break;
 		case SDL_MOUSEWHEEL: handle_mouse_wheel(&event.wheel); break;
 		case SDL_MOUSEBUTTONDOWN:
-		case SDL_MOUSEBUTTONUP: handle_mouse_button(&event.button); break;
+		case SDL_MOUSEBUTTONUP:
+			handle_mouse_button(&event.button);
+			break;
 
 		case SDL_QUIT: GFX_RequestExit(true); break;
 #ifdef WIN32
 		case SDL_KEYDOWN:
 		case SDL_KEYUP:
 			// ignore event alt+tab
-			if (event.key.keysym.sym == SDLK_LALT)
+			if (event.key.keysym.sym == SDLK_LALT) {
 				sdl.laltstate = (SDL_EventType)event.key.type;
-			if (event.key.keysym.sym == SDLK_RALT)
+			}
+			if (event.key.keysym.sym == SDLK_RALT) {
 				sdl.raltstate = (SDL_EventType)event.key.type;
-			if (((event.key.keysym.sym==SDLK_TAB)) && ((sdl.laltstate==SDL_KEYDOWN) || (sdl.raltstate==SDL_KEYDOWN)))
+			}
+			if (((event.key.keysym.sym == SDLK_TAB)) &&
+			    ((sdl.laltstate == SDL_KEYDOWN) ||
+			     (sdl.raltstate == SDL_KEYDOWN))) {
 				break;
+			}
 			// This can happen as well.
-			if (((event.key.keysym.sym == SDLK_TAB )) && (event.key.keysym.mod & KMOD_ALT)) break;
+			if (((event.key.keysym.sym == SDLK_TAB)) &&
+			    (event.key.keysym.mod & KMOD_ALT)) {
+				break;
+			}
 			// Ignore tab events that arrive just after regaining
 			// focus. Likely the result of Alt+Tab.
 			if ((event.key.keysym.sym == SDLK_TAB) &&
-			    (GetTicksSince(sdl.focus_ticks) < 2))
+			    (GetTicksSince(sdl.focus_ticks) < 2)) {
 				break;
+			}
 			[[fallthrough]];
 #endif
-#if defined (MACOSX)
+#if defined(MACOSX)
 		case SDL_KEYDOWN:
 		case SDL_KEYUP:
 			// On macOS, Command+Q is the default key to close an
 			// application
-			if (is_command_pressed(event) && event.key.keysym.sym == SDLK_q) {
+			if (is_command_pressed(event) &&
+			    event.key.keysym.sym == SDLK_q) {
 				GFX_RequestExit(true);
 				break;
 			}
@@ -4141,22 +4321,20 @@ bool GFX_Events()
 	return !shutdown_requested;
 }
 
-#if defined (WIN32)
-static BOOL WINAPI console_event_handler(DWORD event) {
+#if defined(WIN32)
+static BOOL WINAPI console_event_handler(DWORD event)
+{
 	switch (event) {
 	case CTRL_SHUTDOWN_EVENT:
 	case CTRL_LOGOFF_EVENT:
 	case CTRL_CLOSE_EVENT:
-	case CTRL_BREAK_EVENT:
-		raise(SIGTERM);
-		return TRUE;
+	case CTRL_BREAK_EVENT: raise(SIGTERM); return TRUE;
 	case CTRL_C_EVENT:
-	default: //pass to the next handler
+	default: // pass to the next handler
 		return FALSE;
 	}
 }
 #endif
-
 
 /* static variable to show wether there is not a valid stdout.
  * Fixes some bugs when -noconsole is used in a read only directory */
@@ -4167,12 +4345,14 @@ void GFX_ShowMsg(const char* format, ...)
 	char buf[512];
 
 	va_list msg;
-	va_start(msg,format);
+	va_start(msg, format);
 	safe_sprintf(buf, format, msg);
 	va_end(msg);
 
 	buf[sizeof(buf) - 1] = '\0';
-	if (!no_stdout) puts(buf); //Else buf is parsed again. (puts adds end of line)
+	if (!no_stdout) {
+		puts(buf); // Else buf is parsed again. (puts adds end of line)
+	}
 }
 
 static std::vector<std::string> get_sdl_texture_renderers()
@@ -4183,10 +4363,12 @@ static std::vector<std::string> get_sdl_texture_renderers()
 	drivers.push_back("auto");
 	SDL_RendererInfo info;
 	for (int i = 0; i < n; i++) {
-		if (SDL_GetRenderDriverInfo(i, &info))
+		if (SDL_GetRenderDriverInfo(i, &info)) {
 			continue;
-		if (info.flags & SDL_RENDERER_TARGETTEXTURE)
+		}
+		if (info.flags & SDL_RENDERER_TARGETTEXTURE) {
 			drivers.push_back(info.name);
+		}
 	}
 	return drivers;
 }
@@ -4331,17 +4513,20 @@ static void init_sdl_config_section()
 	pstring->SetDeprecatedWithAlternateValue("texturepp", "texture");
 	pstring->Set_values({
 #if C_OPENGL
-		"opengl",
+	        "opengl",
 #endif
-		        "texture", "texturenb",
+	        "texture",
+	        "texturenb",
 	});
 	pstring->SetEnabledOptions({
 #if C_OPENGL
-		"opengl_default", "opengl",
+	        "opengl_default",
+	        "opengl",
 #else
-		"texture_default",
+	        "texture_default",
 #endif
-		        "texture", "texturenb",
+	        "texture",
+	        "texturenb",
 	});
 
 	pstring = sdl_sec->Add_string("texture_renderer", always, "auto");
@@ -4539,20 +4724,21 @@ static int edit_primary_config()
 }
 
 #if C_DEBUG
-extern void DEBUG_ShutDown(Section * /*sec*/);
+extern void DEBUG_ShutDown(Section* /*sec*/);
 #endif
 
-static void remove_waitpid(std::vector<std::string> &parameters)
+static void remove_waitpid(std::vector<std::string>& parameters)
 {
 	auto it = parameters.begin();
 	while (it != parameters.end()) {
 		if (*it == "-waitpid" || *it == "--waitpid") {
 			it = parameters.erase(it);
 			if (it != parameters.end()) {
-				auto &pid = *it;
+				auto& pid = *it;
 				if (!pid.empty() && std::isdigit(pid[0])) {
-					// The integer value should be the next element following "--waitpid".
-					// If we found an integer, remove it as well.
+					// The integer value should be the next
+					// element following "--waitpid". If we
+					// found an integer, remove it as well.
 					it = parameters.erase(it);
 				}
 			}
@@ -4562,7 +4748,8 @@ static void remove_waitpid(std::vector<std::string> &parameters)
 	}
 }
 
-void DOSBOX_Restart(std::vector<std::string> &parameters) {
+void DOSBOX_Restart(std::vector<std::string>& parameters)
+{
 
 	control->ApplyQueuedValuesToCli(parameters);
 
@@ -4574,8 +4761,8 @@ void DOSBOX_Restart(std::vector<std::string> &parameters) {
 	parameters.emplace_back("--waitpid");
 	parameters.emplace_back(std::to_string(GetCurrentProcessId()));
 	std::string command_line = {};
-	bool first = true;
-	for (const auto &arg : parameters) {
+	bool first               = true;
+	for (const auto& arg : parameters) {
 		if (!first) {
 			command_line.push_back(' ');
 		}
@@ -4585,7 +4772,7 @@ void DOSBOX_Restart(std::vector<std::string> &parameters) {
 #else
 	parameters.emplace_back("--waitpid");
 	parameters.emplace_back(std::to_string(getpid()));
-	char** newargs = new char* [parameters.size() + 1];
+	char** newargs = new char*[parameters.size() + 1];
 	// parameter 0 is the executable path
 	// contents of the vector follow
 	// last one is NULL
@@ -4614,8 +4801,9 @@ void DOSBOX_Restart(std::vector<std::string> &parameters) {
 
 	const BOOL inherit_handles = FALSE;
 
-	// CREATE_NEW_CONSOLE fixes a bug where the parent process exiting kills the child process.
-	// This can manifest when you use the "restart" hotkey action to restart DOSBox.
+	// CREATE_NEW_CONSOLE fixes a bug where the parent process exiting kills
+	// the child process. This can manifest when you use the "restart"
+	// hotkey action to restart DOSBox.
 	// https://github.com/dosbox-staging/dosbox-staging/issues/3346
 	const DWORD creation_flags = CREATE_NEW_CONSOLE;
 
@@ -4628,41 +4816,42 @@ void DOSBOX_Restart(std::vector<std::string> &parameters) {
 	// Input structure with a bunch of stuff we probably don't care about.
 	// Zero it out to use defaults save for the size field.
 	STARTUPINFO startup_info = {};
-	startup_info.cb = sizeof(startup_info);
+	startup_info.cb          = sizeof(startup_info);
 
 	// Output structure we also don't care about.
 	PROCESS_INFORMATION process_information = {};
 
-	if (!CreateProcess(
-			application_name,
-			const_cast<char *>(command_line.c_str()),
-			process_attributes,
-			thread_attributes,
-			inherit_handles,
-			creation_flags,
-			environment_variables,
-			current_directory,
-			&startup_info,
-			&process_information)) {
+	if (!CreateProcess(application_name,
+	                   const_cast<char*>(command_line.c_str()),
+	                   process_attributes,
+	                   thread_attributes,
+	                   inherit_handles,
+	                   creation_flags,
+	                   environment_variables,
+	                   current_directory,
+	                   &startup_info,
+	                   &process_information)) {
 		LOG_ERR("Restart failed: CreateProcess failed");
 	}
 #else
 	int ret = fork();
 	switch (ret) {
-		case -1:
-			LOG_ERR("Restart failed: fork failed: %s", strerror(errno));
-			break;
-		case 0:
-			// Newly created child process immediately executes a new instance of DOSBox.
-			// It is not safe for a child process in a multi-threaded program to do much else.
-			if (execvp(newargs[0], newargs) == -1) {
-				E_Exit("Restart failed: execvp failed: %s", strerror(errno));
-			}
-			break;
+	case -1:
+		LOG_ERR("Restart failed: fork failed: %s", strerror(errno));
+		break;
+	case 0:
+		// Newly created child process immediately executes a new
+		// instance of DOSBox. It is not safe for a child process in a
+		// multi-threaded program to do much else.
+		if (execvp(newargs[0], newargs) == -1) {
+			E_Exit("Restart failed: execvp failed: %s", strerror(errno));
+		}
+		break;
 	}
 	// Original (parent) process continues execution here.
-	// It will proceed to do a normal shutdown due to GFX_RequestExit(true); above.
-	delete [] newargs;
+	// It will proceed to do a normal shutdown due to GFX_RequestExit(true);
+	// above.
+	delete[] newargs;
 #endif // WIN32
 }
 
@@ -5149,19 +5338,20 @@ int sdl_main(int argc, char* argv[])
 		// Add [sdl] config section
 		init_sdl_config_section();
 
-		// Register the config sections and messages of all the other modules
+		// Register the config sections and messages of all the other
+		// modules
 		DOSBOX_InitAllModuleConfigsAndMessages();
 
 		maybe_write_primary_config(arguments);
 
-		// After DOSBOX_InitAllModuleConfigsAndMessages() is done, all the
-		// config sections have been registered, so we're ready to parse the
-		// config files.
-		//	
+		// After DOSBOX_InitAllModuleConfigsAndMessages() is done, all
+		// the config sections have been registered, so we're ready to
+		// parse the config files.
+		//
 		control->ParseConfigFiles(GetConfigDir());
 
-		// Handle command line options that don't start the emulator but only
-		// perform some actions and print the results to the console.
+		// Handle command line options that don't start the emulator but
+		// only perform some actions and print the results to the console.
 		if (const auto return_code = maybe_handle_command_line_output_only_actions(
 		            arguments, argv);
 		    return_code) {
@@ -5178,8 +5368,8 @@ int sdl_main(int argc, char* argv[])
 
 		init_sdl();
 
-		// Handle configuration settings passed with `--set` commands from the
-		// CLI.
+		// Handle configuration settings passed with `--set` commands
+		// from the CLI.
 		handle_cli_set_commands(arguments->set);
 
 		maybe_create_resource_directories();

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1859,7 +1859,7 @@ static std::pair<double, double> get_scale_factors_from_pixel_aspect_ratio(
 	}
 }
 
-static SDL_Window* SetupWindowScaled(const RenderingBackend rendering_backend)
+static SDL_Window* setup_scaled_window(const RenderingBackend rendering_backend)
 {
 	int window_width;
 	int window_height;
@@ -2204,7 +2204,7 @@ uint8_t GFX_SetSize(const int render_width_px, const int render_height_px,
 	case RenderingBackend::Texture: {
 	fallback_texture: // FIXME: Must be replaced with a proper fallback system.
 
-		if (!SetupWindowScaled(RenderingBackend::Texture)) {
+		if (!setup_scaled_window(RenderingBackend::Texture)) {
 			LOG_ERR("DISPLAY: Can't initialise 'texture' window");
 			E_Exit("SDL: Failed to create window");
 		}
@@ -2355,7 +2355,7 @@ uint8_t GFX_SetSize(const int render_width_px, const int render_height_px,
 		                         FallbackWindowSize.x,
 		                         FallbackWindowSize.y);
 
-		SetupWindowScaled(RenderingBackend::OpenGl);
+		setup_scaled_window(RenderingBackend::OpenGl);
 
 		/* We may simply use SDL_BYTESPERPIXEL
 		here rather than SDL_BITSPERPIXEL   */

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -4821,7 +4821,7 @@ static bool check_kmsdrm_setting()
 
 static void init_sdl()
 {
-#if defined(WIN32) && SDL_VERSION_ATLEAST(2, 24, 0)
+#if defined(WIN32)
 	if (SDL_SetHint(SDL_HINT_WINDOWS_DPI_AWARENESS, "permonitorv2") == SDL_FALSE) {
 		LOG_WARNING("SDL: Failed to set DPI awareness flag");
 	}

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -4833,6 +4833,52 @@ static void maybe_write_primary_config(const CommandLineArguments* args)
 	}
 }
 
+static std::optional<int> maybe_handle_command_line_output_only_actions(
+        const CommandLineArguments* args, char* argv[])
+{
+	if (args->version) {
+		printf(version_msg, DOSBOX_PROJECT_NAME, DOSBOX_GetDetailedVersion());
+		return 0;
+	}
+	if (args->help) {
+		assert(argv && argv[0]);
+		const auto program_name = argv[0];
+		const auto help = format_str(MSG_GetForHost("DOSBOX_HELP"),
+		                             program_name);
+		printf("%s", help.c_str());
+		return 0;
+	}
+	if (args->editconf) {
+		return edit_primary_config();
+	}
+	if (args->eraseconf) {
+		return erase_primary_config_file();
+	}
+	if (args->erasemapper) {
+		return erase_mapper_file();
+	}
+	if (args->printconf) {
+		return print_primary_config_location();
+	}
+	if (args->list_countries) {
+		list_countries();
+		return 0;
+	}
+	if (args->list_layouts) {
+		list_keyboard_layouts();
+		return 0;
+	}
+	if (args->list_code_pages) {
+		list_code_pages();
+		return 0;
+	}
+	if (args->list_glshaders) {
+		list_glshaders();
+		return 0;
+	}
+	return {};
+}
+
 static bool check_kmsdrm_setting()
 {
 	// Simple pre-check to see if we're using kmsdrm
@@ -5125,47 +5171,10 @@ int sdl_main(int argc, char* argv[])
 
 		// Handle command line options that don't start the emulator but only
 		// perform some actions and print the results to the console.
-		if (arguments->version) {
-			printf(version_msg,
-			       DOSBOX_PROJECT_NAME,
-			       DOSBOX_GetDetailedVersion());
-			return 0;
-		}
-		if (arguments->help) {
-			assert(argv && argv[0]);
-			const auto program_name = argv[0];
-			const auto help = format_str(MSG_GetForHost("DOSBOX_HELP"),
-			                             program_name);
-			printf("%s", help.c_str());
-			return 0;
-		}
-		if (arguments->editconf) {
-			return edit_primary_config();
-		}
-		if (arguments->eraseconf) {
-			return erase_primary_config_file();
-		}
-		if (arguments->erasemapper) {
-			return erase_mapper_file();
-		}
-		if (arguments->printconf) {
-			return print_primary_config_location();
-		}
-		if (arguments->list_countries) {
-			list_countries();
-			return 0;
-		}
-		if (arguments->list_layouts) {
-			list_keyboard_layouts();
-			return 0;
-		}
-		if (arguments->list_code_pages) {
-			list_code_pages();
-			return 0;
-		}
-		if (arguments->list_glshaders) {
-			list_glshaders();
-			return 0;
+		if (const auto return_code = maybe_handle_command_line_output_only_actions(
+		            arguments, argv);
+		    return_code) {
+			return *return_code;
 		}
 
 #if defined(WIN32) && !(C_DEBUG)

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3432,7 +3432,7 @@ static void set_priority_levels(const std::string& active_pref,
 
 static void restart_hotkey_handler([[maybe_unused]] bool pressed)
 {
-	restart_dosbox();
+	DOSBOX_Restart();
 }
 
 static void read_gui_config(Section* sec)
@@ -4570,8 +4570,7 @@ static void remove_waitpid(std::vector<std::string> &parameters)
 	}
 }
 
-void restart_dosbox(std::vector<std::string> &parameters)
-{
+void DOSBOX_Restart(std::vector<std::string> &parameters) {
 
 	control->ApplyQueuedValuesToCli(parameters);
 

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3386,8 +3386,6 @@ static void set_output(Section* sec, const bool wants_aspect_ratio_correction)
 	RENDER_Reinit();
 }
 
-// extern void UI_Run(bool);
-
 static void apply_active_settings()
 {
 	set_priority(sdl.priority.active);
@@ -5005,8 +5003,11 @@ int sdl_main(int argc, char* argv[])
 			}
 			freopen(STDERR_FILE, "w", stderr);
 
-			setvbuf(stdout, NULL, _IOLBF, BUFSIZ); // Line buffered
-			setvbuf(stderr, NULL, _IONBF, BUFSIZ); // No buffering
+			// Line buffered
+			setvbuf(stdout, NULL, _IOLBF, BUFSIZ);
+			// No buffering
+			setvbuf(stderr, NULL, _IONBF, BUFSIZ);
+
 		} else {
 			if (AllocConsole()) {
 				fclose(stdin);
@@ -5033,8 +5034,9 @@ int sdl_main(int argc, char* argv[])
 		}
 #endif
 #endif // WIN32
+
 		// Seamless mouse integration feels more 'seamless' if mouse
-		// clicks on out-of-focus window are passed to the guest
+		// clicks on unfocused windows are passed to the guest.
 		SDL_SetHint(SDL_HINT_MOUSE_FOCUS_CLICKTHROUGH, "1");
 
 		// We have a keyboard shortcut to exit the fullscreen mode,
@@ -5069,11 +5071,11 @@ int sdl_main(int argc, char* argv[])
 #if defined SDL_HINT_APP_NAME
 		// For KDE 6 volume applet and PipeWire audio driver; further
 		// SetHint calls have no effect in the GUI, only the first
-		// advertised name is used
+		// advertised name is used.
 		SDL_SetHint(SDL_HINT_APP_NAME, DOSBOX_NAME);
 #endif
 #if defined SDL_HINT_AUDIO_DEVICE_STREAM_NAME
-		// Useful for 'pw-top' and possibly other PipeWire CLI tools
+		// Useful for 'pw-top' and possibly other PipeWire CLI tools.
 		SDL_SetHint(SDL_HINT_AUDIO_DEVICE_STREAM_NAME, DOSBOX_NAME);
 #endif
 
@@ -5156,11 +5158,8 @@ int sdl_main(int argc, char* argv[])
 #endif
 
 		control->ParseEnv();
-		//		UI_Init();
-		//		if (control->cmdline->FindExist("-startui"))
-		// UI_Run(false);
 
-		// Init all the sections
+		// Execute all registered section init functions
 		control->Init();
 
 		// Some extra SDL Functions
@@ -5175,7 +5174,7 @@ int sdl_main(int argc, char* argv[])
 			MAPPER_DisplayUI();
 		}
 
-		// Run the machine until shutdown
+		// Start emulation and run it until shutdown
 		control->StartUp();
 
 		// Shutdown and release

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -4353,13 +4353,10 @@ bool GFX_Events()
 		switch (event.type) {
 		case SDL_DISPLAYEVENT:
 			switch (event.display.event) {
-#if (SDL_MAJOR_VERSION > 2 || SDL_MINOR_VERSION > 0 || SDL_PATCHLEVEL >= 14)
-			// Events added in SDL 2.0.14
 			case SDL_DISPLAYEVENT_CONNECTED:
 			case SDL_DISPLAYEVENT_DISCONNECTED:
 				notify_new_mouse_screen_params();
 				break;
-#endif
 			default: break;
 			};
 			break;

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -123,26 +123,36 @@ typedef GLuint(APIENTRYP PFNGLCREATESHADERPROC)(GLenum type);
 typedef void(APIENTRYP PFNGLDELETEPROGRAMPROC)(GLuint program);
 typedef void(APIENTRYP PFNGLDELETESHADERPROC)(GLuint shader);
 typedef void(APIENTRYP PFNGLENABLEVERTEXATTRIBARRAYPROC)(GLuint index);
+
 typedef GLint(APIENTRYP PFNGLGETATTRIBLOCATIONPROC)(GLuint program,
                                                     const GLchar* name);
+
 typedef void(APIENTRYP PFNGLGETPROGRAMIVPROC)(GLuint program, GLenum pname,
                                               GLint* params);
+
 typedef void(APIENTRYP PFNGLGETPROGRAMINFOLOGPROC)(GLuint program, GLsizei bufSize,
                                                    GLsizei* length, GLchar* infoLog);
+
 typedef void(APIENTRYP PFNGLGETSHADERIVPROC)(GLuint shader, GLenum pname,
                                              GLint* params);
+
 typedef void(APIENTRYP PFNGLGETSHADERINFOLOGPROC)(GLuint shader, GLsizei bufSize,
                                                   GLsizei* length, GLchar* infoLog);
+
 typedef GLint(APIENTRYP PFNGLGETUNIFORMLOCATIONPROC)(GLuint program,
                                                      const GLchar* name);
+
 typedef void(APIENTRYP PFNGLLINKPROGRAMPROC)(GLuint program);
+
 // Change to NP, as Khronos changes include guard :(
 typedef void(APIENTRYP PFNGLSHADERSOURCEPROC_NP)(GLuint shader, GLsizei count,
                                                  const GLchar** string,
                                                  const GLint* length);
+
 typedef void(APIENTRYP PFNGLUNIFORM2FPROC)(GLint location, GLfloat v0, GLfloat v1);
 typedef void(APIENTRYP PFNGLUNIFORM1IPROC)(GLint location, GLint v0);
 typedef void(APIENTRYP PFNGLUSEPROGRAMPROC)(GLuint program);
+
 typedef void(APIENTRYP PFNGLVERTEXATTRIBPOINTERPROC)(GLuint index, GLint size,
                                                      GLenum type, GLboolean normalized,
                                                      GLsizei stride,
@@ -340,6 +350,7 @@ bool GFX_HaveDesktopEnvironment()
 
 	static bool already_checked          = false;
 	static bool have_desktop_environment = false;
+
 	if (!already_checked) {
 		constexpr const char* vars[] = {"XDG_CURRENT_DESKTOP",
 		                                "XDG_SESSION_DESKTOP",
@@ -349,7 +360,8 @@ bool GFX_HaveDesktopEnvironment()
 		have_desktop_environment = std::any_of(std::begin(vars),
 		                                       std::end(vars),
 		                                       std::getenv);
-		already_checked          = true;
+
+		already_checked = true;
 	}
 
 	return have_desktop_environment;
@@ -1102,6 +1114,7 @@ static void setup_presentation_mode(FrameMode& previous_mode)
 	// TODO but why is this important? needs explanation.
 	const auto host_rate = get_host_refresh_rate();
 	VGA_SetHostRate(host_rate);
+
 	const auto dos_rate = VGA_GetPreferredRate();
 
 	// Calculate the maximum number of duplicate frames before presenting.
@@ -1155,7 +1168,7 @@ static void setup_presentation_mode(FrameMode& previous_mode)
 #if 0
 		// TODO some of these log statements seem to be wrong and
 		// not reflect actual reality, we'll need to revisit them
-	
+
 		LOG_MSG("SDL: Auto presentation mode conditions:");
 		LOG_MSG("SDL:   - DOS rate is %2.5g Hz", dos_rate);
 		if (has_bench_rate) {
@@ -1335,6 +1348,7 @@ static SDL_Window* SetWindowMode(const RenderingBackend rendering_backend,
 #if C_OPENGL
 		if (rendering_backend == RenderingBackend::OpenGl) {
 			flags |= SDL_WINDOW_OPENGL;
+
 			if (SDL_GL_SetAttribute(SDL_GL_FRAMEBUFFER_SRGB_CAPABLE, 1)) {
 				LOG_ERR("OPENGL: Failed requesting an sRGB framebuffer: %s",
 				        SDL_GetError());
@@ -1349,10 +1363,12 @@ static SDL_Window* SetWindowMode(const RenderingBackend rendering_backend,
 		// restoring the window by WM.
 		const auto default_val = SDL_WINDOWPOS_UNDEFINED_DISPLAY(
 		        sdl.display_number);
+
 		const auto pos = get_initial_window_position_or_default(default_val);
 
 		assert(sdl.window == nullptr); // enusre we don't leak
 		sdl.window = SDL_CreateWindow("", pos.x, pos.y, width, height, flags);
+
 		if (!sdl.window && rendering_backend == RenderingBackend::Texture &&
 		    (flags & SDL_WINDOW_OPENGL)) {
 			// opengl_driver_crash_workaround() call above
@@ -1362,6 +1378,7 @@ static SDL_Window* SetWindowMode(const RenderingBackend rendering_backend,
 			// SDL_CreateWindow(). If we failed to create the
 			// window, try again without it.
 			flags &= ~SDL_WINDOW_OPENGL;
+
 			sdl.window = SDL_CreateWindow("", pos.x, pos.y, width, height, flags);
 		}
 		if (!sdl.window) {
@@ -1381,6 +1398,7 @@ static SDL_Window* SetWindowMode(const RenderingBackend rendering_backend,
 
 			assert(sdl.renderer == nullptr);
 			sdl.renderer = SDL_CreateRenderer(sdl.window, -1, 0);
+
 			if (!sdl.renderer) {
 				LOG_ERR("SDL: Failed to create renderer: %s",
 				        SDL_GetError());
@@ -1396,6 +1414,7 @@ static SDL_Window* SetWindowMode(const RenderingBackend rendering_backend,
 
 			assert(sdl.opengl.context == nullptr);
 			sdl.opengl.context = SDL_GL_CreateContext(sdl.window);
+
 			if (sdl.opengl.context == nullptr) {
 				LOG_ERR("OPENGL: Can't create context: %s",
 				        SDL_GetError());
@@ -1425,6 +1444,7 @@ static SDL_Window* SetWindowMode(const RenderingBackend rendering_backend,
 	if (fullscreen) {
 		SDL_DisplayMode displayMode;
 		SDL_GetWindowDisplayMode(sdl.window, &displayMode);
+
 		displayMode.w = width;
 		displayMode.h = height;
 
@@ -1549,6 +1569,7 @@ static SDL_Window* SetupWindowScaled(const RenderingBackend rendering_backend)
 {
 	int window_width;
 	int window_height;
+
 	if (sdl.desktop.fullscreen) {
 		window_width = sdl.desktop.full.fixed ? sdl.desktop.full.width : 0;
 		window_height = sdl.desktop.full.fixed ? sdl.desktop.full.height : 0;
@@ -1595,6 +1616,7 @@ static GLuint BuildShader(GLenum type, const std::string& source)
 	GLint is_shader_compiled = 0;
 
 	assert(source.length());
+
 	const char* shaderSrc      = source.c_str();
 	const char* src_strings[2] = {nullptr, nullptr};
 	std::string top;
@@ -1708,6 +1730,7 @@ static void initialize_sdl_window_size(SDL_Window* sdl_window,
 	SDL_GetWindowSize(sdl_window, &current_size.x, &current_size.y);
 	SDL_Point bounded_size = {std::max(requested_size.x, requested_min_size.x),
 	                          std::max(requested_size.y, requested_min_size.y)};
+
 	if (current_size != bounded_size) {
 		safe_set_window_size(bounded_size.x, bounded_size.y);
 		// TODO pixels or logical unit?
@@ -1861,6 +1884,7 @@ static bool present_frame_texture()
 			// rendering commands have finished, so we're guaranteed
 			// to read the contents of the up-to-date backbuffer
 			// here right before the buffer swap.
+			//
 			const auto image = get_rendered_output_from_backbuffer();
 			if (image) {
 				CAPTURE_AddPostRenderImage(*image);
@@ -1882,14 +1906,17 @@ static void update_frame_gl(const uint16_t* changedLines)
 	if (changedLines) {
 		const auto framebuf = static_cast<uint8_t*>(sdl.opengl.framebuf);
 		const auto pitch = sdl.opengl.pitch;
-		int y            = 0;
-		size_t index     = 0;
+
+		int y        = 0;
+		size_t index = 0;
+
 		while (y < sdl.draw.render_height_px) {
 			if (!(index & 1)) {
 				y += changedLines[index];
 			} else {
 				const uint8_t* pixels = framebuf + y * pitch;
 				const int height_px   = changedLines[index];
+
 				glTexSubImage2D(GL_TEXTURE_2D,
 				                0,
 				                0,
@@ -1911,11 +1938,14 @@ static void update_frame_gl(const uint16_t* changedLines)
 static bool present_frame_gl()
 {
 	const auto is_presenting = render_pacer->CanRun();
+
 	if (is_presenting) {
 		glClear(GL_COLOR_BUFFER_BIT);
+
 		if (sdl.opengl.program_object) {
 			glUniform1i(sdl.opengl.ruby.frame_count,
 			            sdl.opengl.actual_frame_count++);
+
 			glDrawArrays(GL_TRIANGLES, 0, 3);
 		} else {
 			glCallList(sdl.opengl.displaylist);
@@ -1926,6 +1956,7 @@ static bool present_frame_gl()
 			// rendering commands have finished, so we're
 			// guaranateed to read the contents of the up-to-date
 			// backbuffer here right before the buffer swap.
+			//
 			const auto image = get_rendered_output_from_backbuffer();
 			if (image) {
 				CAPTURE_AddPostRenderImage(*image);
@@ -1993,6 +2024,7 @@ uint8_t GFX_SetSize(const int render_width_px, const int render_height_px,
 		// Use renderer's default format
 		SDL_RendererInfo rinfo;
 		SDL_GetRendererInfo(sdl.renderer, &rinfo);
+
 		const auto texture_format = rinfo.texture_formats[0];
 
 		sdl.texture.texture = SDL_CreateTexture(sdl.renderer,
@@ -2013,7 +2045,9 @@ uint8_t GFX_SetSize(const int render_width_px, const int render_height_px,
 			SDL_FreeSurface(texture_input_surface);
 			texture_input_surface = nullptr;
 		}
+
 		assert(texture_input_surface == nullptr); // ensure we don't leak
+		                                          //
 		texture_input_surface = SDL_CreateRGBSurfaceWithFormat(
 		        0, render_width_px, render_height_px, 32, texture_format);
 		if (!texture_input_surface) {
@@ -2021,12 +2055,14 @@ uint8_t GFX_SetSize(const int render_width_px, const int render_height_px,
 		}
 
 		SDL_SetRenderDrawColor(sdl.renderer, 0, 0, 0, SDL_ALPHA_OPAQUE);
+
 		uint32_t pixel_format;
 		assert(sdl.texture.texture);
 		SDL_QueryTexture(sdl.texture.texture, &pixel_format, nullptr, nullptr, nullptr);
 
 		assert(sdl.texture.pixelFormat == nullptr); // ensure we don't leak
 		sdl.texture.pixelFormat = SDL_AllocFormat(pixel_format);
+
 		switch (SDL_BITSPERPIXEL(pixel_format)) {
 		case 8: retFlags = GFX_CAN_8; break;
 		case 15: retFlags = GFX_CAN_15; break;
@@ -2066,6 +2102,7 @@ uint8_t GFX_SetSize(const int render_width_px, const int render_height_px,
 		}
 		const auto canvas_size_px = get_canvas_size_in_pixels(
 		        sdl.want_rendering_backend);
+
 		// LOG_MSG("Attempting to fix the centering to %d %d %d %d",
 		//         (canvas.w - sdl.clip.w) / 2,
 		//         (canvas.h - sdl.clip.h) / 2,
@@ -2087,6 +2124,7 @@ uint8_t GFX_SetSize(const int render_width_px, const int render_height_px,
 #if C_OPENGL
 		free(sdl.opengl.framebuf);
 		sdl.opengl.framebuf = nullptr;
+
 		if (!(flags & GFX_CAN_32)) {
 			goto fallback_texture;
 		}
@@ -2140,20 +2178,25 @@ uint8_t GFX_SetSize(const int render_width_px, const int render_height_px,
 
 		if (sdl.opengl.use_shader) {
 			GLuint prog = 0;
+
 			// reset error
 			glGetError();
 			glGetIntegerv(GL_CURRENT_PROGRAM, (GLint*)&prog);
+
 			// if there was an error this context doesn't support
 			// shaders
 			if (glGetError() == GL_NO_ERROR &&
 			    (sdl.opengl.program_object == 0 ||
 			     prog != sdl.opengl.program_object)) {
+
 				// check if existing program is valid
 				if (sdl.opengl.program_object) {
 					glUseProgram(sdl.opengl.program_object);
+
 					if (glGetError() != GL_NO_ERROR) {
-						// program is not usable (probably
-						// new context), purge it
+						// program is not usable
+						// (probably new context), purge
+						// it
 						glDeleteProgram(sdl.opengl.program_object);
 						sdl.opengl.program_object = 0;
 					}
@@ -2166,11 +2209,13 @@ uint8_t GFX_SetSize(const int render_width_px, const int render_height_px,
 					if (!LoadGLShaders(sdl.opengl.shader_source,
 					                   &vertexShader,
 					                   &fragmentShader)) {
+
 						LOG_ERR("OPENGL: Failed to compile shader");
 						goto fallback_texture;
 					}
 
 					sdl.opengl.program_object = glCreateProgram();
+
 					if (!sdl.opengl.program_object) {
 						glDeleteShader(vertexShader);
 						glDeleteShader(fragmentShader);
@@ -2180,8 +2225,10 @@ uint8_t GFX_SetSize(const int render_width_px, const int render_height_px,
 						        "falling back to texture");
 						goto fallback_texture;
 					}
+
 					glAttachShader(sdl.opengl.program_object,
 					               vertexShader);
+
 					glAttachShader(sdl.opengl.program_object,
 					               fragmentShader);
 
@@ -2239,12 +2286,15 @@ uint8_t GFX_SetSize(const int render_width_px, const int render_height_px,
 					// upper left
 					sdl.opengl.vertex_data[0] = -1.0f;
 					sdl.opengl.vertex_data[1] = 1.0f;
+
 					// lower left
 					sdl.opengl.vertex_data[2] = -1.0f;
 					sdl.opengl.vertex_data[3] = -3.0f;
+
 					// upper right
 					sdl.opengl.vertex_data[4] = 3.0f;
 					sdl.opengl.vertex_data[5] = 1.0f;
+
 					// Load the vertex positions
 					glVertexAttribPointer(u,
 					                      2,
@@ -2252,6 +2302,7 @@ uint8_t GFX_SetSize(const int render_width_px, const int render_height_px,
 					                      GL_FALSE,
 					                      0,
 					                      sdl.opengl.vertex_data);
+
 					glEnableVertexAttribArray(u);
 
 					u = glGetUniformLocation(sdl.opengl.program_object,
@@ -2261,12 +2312,15 @@ uint8_t GFX_SetSize(const int render_width_px, const int render_height_px,
 					sdl.opengl.ruby.texture_size = glGetUniformLocation(
 					        sdl.opengl.program_object,
 					        "rubyTextureSize");
+
 					sdl.opengl.ruby.input_size = glGetUniformLocation(
 					        sdl.opengl.program_object,
 					        "rubyInputSize");
+
 					sdl.opengl.ruby.output_size = glGetUniformLocation(
 					        sdl.opengl.program_object,
 					        "rubyOutputSize");
+
 					sdl.opengl.ruby.frame_count = glGetUniformLocation(
 					        sdl.opengl.program_object,
 					        "rubyFrameCount");
@@ -2277,6 +2331,7 @@ uint8_t GFX_SetSize(const int render_width_px, const int render_height_px,
 		/* Create the texture and display list */
 		const auto framebuffer_bytes = static_cast<size_t>(render_width_px) *
 		                               render_height_px * MAX_BYTES_PER_PIXEL;
+
 		sdl.opengl.framebuf = malloc(framebuffer_bytes); // 32 bit colour
 		sdl.opengl.pitch = render_width_px * 4;
 
@@ -2343,6 +2398,7 @@ uint8_t GFX_SetSize(const int render_width_px, const int render_height_px,
 		int is_double_buffering_enabled = 0;
 		if (SDL_GL_GetAttribute(SDL_GL_DOUBLEBUFFER,
 		                        &is_double_buffering_enabled)) {
+
 			LOG_WARNING("OPENGL: Failed getting double buffering status: %s",
 			            SDL_GetError());
 		} else {
@@ -2354,6 +2410,7 @@ uint8_t GFX_SetSize(const int render_width_px, const int render_height_px,
 		int is_framebuffer_srgb_capable = 0;
 		if (SDL_GL_GetAttribute(SDL_GL_FRAMEBUFFER_SRGB_CAPABLE,
 		                        &is_framebuffer_srgb_capable)) {
+
 			LOG_WARNING("OPENGL: Failed getting the framebuffer's sRGB status: %s",
 			            SDL_GetError());
 		}
@@ -2389,6 +2446,7 @@ uint8_t GFX_SetSize(const int render_width_px, const int render_height_px,
 		             GL_BGRA_EXT,
 		             GL_UNSIGNED_BYTE,
 		             emptytex);
+
 		delete[] emptytex;
 
 		if (sdl.opengl.framebuffer_is_srgb_encoded) {
@@ -2427,9 +2485,11 @@ uint8_t GFX_SetSize(const int render_width_px, const int render_height_px,
 
 			// The following uniform is *not* set right now
 			sdl.opengl.actual_frame_count = 0;
+
 		} else {
 			GLfloat tex_width  = ((GLfloat)render_width_px /
                                              (GLfloat)texsize_w_px);
+
 			GLfloat tex_height = ((GLfloat)render_height_px /
 			                      (GLfloat)texsize_h_px);
 
@@ -2440,19 +2500,24 @@ uint8_t GFX_SetSize(const int render_width_px, const int render_height_px,
 			if (glIsList(sdl.opengl.displaylist)) {
 				glDeleteLists(sdl.opengl.displaylist, 1);
 			}
+
 			sdl.opengl.displaylist = glGenLists(1);
 			glNewList(sdl.opengl.displaylist, GL_COMPILE);
 
 			// Create one huge triangle and only display a portion.
 			// When using a quad, there was scaling bug (certain
 			// resolutions on Nvidia chipsets) in the seam
+			//
 			glBegin(GL_TRIANGLES);
+
 			// upper left
 			glTexCoord2f(0, 0);
 			glVertex2f(-1.0f, 1.0f);
+
 			// lower left
 			glTexCoord2f(0, tex_height * 2);
 			glVertex2f(-1.0f, -3.0f);
+
 			// upper right
 			glTexCoord2f(tex_width * 2, 0);
 			glVertex2f(3.0f, 1.0f);
@@ -2471,6 +2536,7 @@ uint8_t GFX_SetSize(const int render_width_px, const int render_height_px,
 		assertm(false, "OpenGL is not supported by this executable");
 		LOG_ERR("SDL: OpenGL is not supported by this executable, "
 		        "falling back to texture output");
+
 		goto fallback_texture;
 
 #endif                 // C_OPENGL
@@ -2579,6 +2645,7 @@ void GFX_SetMouseRawInput(const bool requested_raw_input)
 	if (SDL_SetHintWithPriority(SDL_HINT_MOUSE_RELATIVE_MODE_WARP,
 	                            requested_raw_input ? "0" : "1",
 	                            SDL_HINT_OVERRIDE) != SDL_TRUE) {
+
 		LOG_WARNING("SDL: Failed to %s raw mouse input",
 		            requested_raw_input ? "enable" : "disable");
 	}
@@ -2589,6 +2656,7 @@ void GFX_SetMouseCapture(const bool requested_capture)
 	const auto param = requested_capture ? SDL_TRUE : SDL_FALSE;
 	if (SDL_SetRelativeMouseMode(param) != 0) {
 		SDL_ShowCursor(SDL_ENABLE);
+
 		E_Exit("SDL: Failed to %s relative-mode [SDL Bug]",
 		       requested_capture ? "put the mouse in"
 		                         : "take the mouse out of");
@@ -2614,7 +2682,6 @@ static void focus_input()
 	if (!sdl.desktop.fullscreen) {
 		return;
 	}
-
 	// Do we already have focus?
 	if (SDL_GetWindowFlags(sdl.window) & SDL_WINDOW_INPUT_FOCUS) {
 		return;
@@ -2647,6 +2714,7 @@ void sticky_keys(bool restore)
 	// Get current sticky keys layout:
 	STICKYKEYS s = {sizeof(STICKYKEYS), 0};
 	SystemParametersInfo(SPI_GETSTICKYKEYS, sizeof(STICKYKEYS), &s, 0);
+
 	if (!(s.dwFlags & SKF_STICKYKEYSON)) { // Not on already
 		s.dwFlags &= ~SKF_HOTKEYACTIVE;
 		SystemParametersInfo(SPI_SETSTICKYKEYS, sizeof(STICKYKEYS), &s, 0);
@@ -2672,7 +2740,9 @@ void GFX_SwitchFullScreen()
 	sticky_keys(sdl.desktop.fullscreen);
 #endif
 	sdl.desktop.fullscreen = !sdl.desktop.fullscreen;
+
 	GFX_ResetScreen();
+
 	focus_input();
 	setup_presentation_mode(sdl.frame.mode);
 
@@ -2705,19 +2775,25 @@ bool GFX_StartUpdate(uint8_t*& pixels, int& pitch)
 	switch (sdl.rendering_backend) {
 	case RenderingBackend::Texture:
 		assert(sdl.texture.input_surface);
+
 		pixels = static_cast<uint8_t*>(sdl.texture.input_surface->pixels);
-		pitch        = sdl.texture.input_surface->pitch;
+		pitch = sdl.texture.input_surface->pitch;
+
 		sdl.updating = true;
 		return true;
+
 	case RenderingBackend::OpenGl:
 #if C_OPENGL
 		pixels = static_cast<uint8_t*>(sdl.opengl.framebuf);
 		maybe_log_opengl_error("end of start update");
+
 		if (pixels == nullptr) {
 			return false;
 		}
+
 		static_assert(std::is_same<decltype(pitch), decltype((sdl.opengl.pitch))>::value,
 		              "Our internal pitch types should be the same.");
+
 		pitch        = sdl.opengl.pitch;
 		sdl.updating = true;
 		return true;
@@ -2744,6 +2820,7 @@ void GFX_EndUpdate(const uint16_t* changedLines)
 		// screenshots in sync (so they capture the exact same frame) in
 		// multi-output image capture modes.
 		sdl.frame.present();
+
 	} else {
 		// Helper lambda indicating whether the frame should be
 		// presented. Returns true if the frame has been updated or if
@@ -2800,6 +2877,7 @@ uint32_t GFX_GetRGB(const uint8_t red, const uint8_t green, const uint8_t blue)
 	case RenderingBackend::Texture:
 		assert(sdl.texture.pixelFormat);
 		return SDL_MapRGB(sdl.texture.pixelFormat, red, green, blue);
+
 	case RenderingBackend::OpenGl:
 		return ((blue << 0) | (green << 8) | (red << 16)) | (255 << 24);
 	}
@@ -2822,7 +2900,9 @@ void GFX_Start()
 static void get_display_dimensions()
 {
 	SDL_Rect displayDimensions;
+
 	SDL_GetDisplayBounds(sdl.display_number, &displayDimensions);
+
 	sdl.desktop.full.width  = displayDimensions.w;
 	sdl.desktop.full.height = displayDimensions.h;
 }
@@ -2894,30 +2974,38 @@ static void set_priority(PRIORITY_LEVELS level)
 	case PRIORITY_LEVEL_LOWEST:
 		SetPriorityClass(GetCurrentProcess(), IDLE_PRIORITY_CLASS);
 		break;
+
 	case PRIORITY_LEVEL_LOWER:
 		SetPriorityClass(GetCurrentProcess(), BELOW_NORMAL_PRIORITY_CLASS);
 		break;
+
 	case PRIORITY_LEVEL_NORMAL:
 		SetPriorityClass(GetCurrentProcess(), NORMAL_PRIORITY_CLASS);
 		break;
+
 	case PRIORITY_LEVEL_HIGHER:
 		SetPriorityClass(GetCurrentProcess(), ABOVE_NORMAL_PRIORITY_CLASS);
 		break;
+
 	case PRIORITY_LEVEL_HIGHEST:
 		SetPriorityClass(GetCurrentProcess(), HIGH_PRIORITY_CLASS);
 		break;
+
 #elif defined(HAVE_SETPRIORITY)
 		/* Linux use group as dosbox has mulitple threads under linux */
 	case PRIORITY_LEVEL_LOWEST: setpriority(PRIO_PGRP, 0, PRIO_MAX); break;
 	case PRIORITY_LEVEL_LOWER:
 		setpriority(PRIO_PGRP, 0, PRIO_MAX - (PRIO_TOTAL / 3));
 		break;
+
 	case PRIORITY_LEVEL_NORMAL:
 		setpriority(PRIO_PGRP, 0, PRIO_MAX - (PRIO_TOTAL / 2));
 		break;
+
 	case PRIORITY_LEVEL_HIGHER:
 		setpriority(PRIO_PGRP, 0, PRIO_MAX - ((3 * PRIO_TOTAL) / 5));
 		break;
+
 	case PRIORITY_LEVEL_HIGHEST:
 		setpriority(PRIO_PGRP, 0, PRIO_MAX - ((3 * PRIO_TOTAL) / 4));
 		break;
@@ -3000,9 +3088,11 @@ static void maybe_limit_requested_resolution(int& w, int& h,
 
 	// SDL KMSDRM limitations:
 	if (is_using_kmsdrm_driver()) {
-		w           = desktop.w;
-		h           = desktop.h;
+		w = desktop.w;
+		h = desktop.h;
+
 		was_limited = true;
+
 		LOG_WARNING("DISPLAY: Limiting '%s' resolution to %dx%d to avoid kmsdrm issues",
 		            size_description,
 		            w,
@@ -3025,8 +3115,9 @@ static void maybe_limit_requested_resolution(int& w, int& h,
 
 static SDL_Point parse_window_resolution_from_conf(const std::string& pref)
 {
-	int w                 = 0;
-	int h                 = 0;
+	int w = 0;
+	int h = 0;
+
 	const bool was_parsed = sscanf(pref.c_str(), "%dx%d", &w, &h) == 2;
 
 	const bool is_valid = (w >= FallbackWindowSize.x &&
@@ -3055,13 +3146,17 @@ static SDL_Point window_bounds_from_label(const std::string& pref,
 	const int percent = [&] {
 		if (pref.starts_with('s')) {
 			return SmallPercent;
+
 		} else if (pref.starts_with('m') || pref == "default" ||
 		           pref.empty()) {
 			return MediumPercent;
+
 		} else if (pref.starts_with('l')) {
 			return LargePercent;
+
 		} else if (pref == "desktop") {
 			return 100;
+
 		} else {
 			LOG_WARNING(
 			        "DISPLAY: Invalid 'windowresolution' setting: '%s', "
@@ -3136,6 +3231,7 @@ static void save_window_size(const int w, const int h)
 
 	// Initialize the window's canvas size if it hasn't yet been set.
 	auto& window_canvas_size = sdl.desktop.window.canvas_size;
+
 	if (window_canvas_size.w <= 0 || window_canvas_size.h <= 0) {
 		window_canvas_size.w = w;
 		window_canvas_size.h = h;
@@ -3164,6 +3260,7 @@ static void setup_window_sizes_from_conf(const char* windowresolution_val,
 	SDL_Point coarse_size  = FallbackWindowSize;
 
 	sdl.use_exact_window_resolution = pref.find('x') != std::string::npos;
+
 	if (sdl.use_exact_window_resolution) {
 		coarse_size = parse_window_resolution_from_conf(pref);
 	} else {
@@ -3177,13 +3274,16 @@ static void setup_window_sizes_from_conf(const char* windowresolution_val,
 
 	// Refine the coarse resolution and save it in the SDL struct.
 	auto refined_size = coarse_size;
+
 	if (sdl.use_exact_window_resolution) {
 		refined_size = clamp_to_minimum_window_dimensions(coarse_size);
 	} else {
 		refined_size = refine_window_size(coarse_size,
 		                                  wants_aspect_ratio_correction);
 	}
+
 	assert(refined_size.x <= UINT16_MAX && refined_size.y <= UINT16_MAX);
+
 	save_window_size(refined_size.x, refined_size.y);
 
 	// Let the user know the resulting window properties
@@ -3310,6 +3410,7 @@ static void set_output(Section* sec, const bool wants_aspect_ratio_correction)
 	} else {
 		LOG_WARNING("SDL: Unsupported output device '%s', using 'texture' output mode",
 		            output.c_str());
+
 		sdl.want_rendering_backend = RenderingBackend::Texture;
 	}
 
@@ -3323,6 +3424,7 @@ static void set_output(Section* sec, const bool wants_aspect_ratio_correction)
 
 	sdl.render_driver = section->Get_string("texture_renderer");
 	lowcase(sdl.render_driver);
+
 	if (sdl.render_driver != "auto") {
 		if (SDL_SetHint(SDL_HINT_RENDER_DRIVER,
 		                sdl.render_driver.c_str()) == SDL_FALSE) {
@@ -3350,13 +3452,17 @@ static void set_output(Section* sec, const bool wants_aspect_ratio_correction)
 			LOG_WARNING(
 			        "OPENGL: Could not create OpenGL window, "
 			        "using 'texture' output mode");
+
 			sdl.want_rendering_backend = RenderingBackend::Texture;
+
 		} else {
 			sdl.opengl.context = SDL_GL_CreateContext(sdl.window);
+
 			if (sdl.opengl.context == nullptr) {
 				LOG_WARNING(
 				        "OPENGL: Could not create context, "
 				        "using 'texture' output mode");
+
 				sdl.want_rendering_backend = RenderingBackend::Texture;
 			}
 		}
@@ -3365,42 +3471,61 @@ static void set_output(Section* sec, const bool wants_aspect_ratio_correction)
 			sdl.opengl.program_object = 0;
 			glAttachShader = (PFNGLATTACHSHADERPROC)SDL_GL_GetProcAddress(
 			        "glAttachShader");
+
 			glCompileShader = (PFNGLCOMPILESHADERPROC)SDL_GL_GetProcAddress(
 			        "glCompileShader");
+
 			glCreateProgram = (PFNGLCREATEPROGRAMPROC)SDL_GL_GetProcAddress(
 			        "glCreateProgram");
+
 			glCreateShader = (PFNGLCREATESHADERPROC)SDL_GL_GetProcAddress(
 			        "glCreateShader");
+
 			glDeleteProgram = (PFNGLDELETEPROGRAMPROC)SDL_GL_GetProcAddress(
 			        "glDeleteProgram");
+
 			glDeleteShader = (PFNGLDELETESHADERPROC)SDL_GL_GetProcAddress(
 			        "glDeleteShader");
+
 			glEnableVertexAttribArray = (PFNGLENABLEVERTEXATTRIBARRAYPROC)
 			        SDL_GL_GetProcAddress("glEnableVertexAttribArray");
+
 			glGetAttribLocation = (PFNGLGETATTRIBLOCATIONPROC)
 			        SDL_GL_GetProcAddress("glGetAttribLocation");
+
 			glGetProgramiv = (PFNGLGETPROGRAMIVPROC)SDL_GL_GetProcAddress(
 			        "glGetProgramiv");
+
 			glGetProgramInfoLog = (PFNGLGETPROGRAMINFOLOGPROC)
 			        SDL_GL_GetProcAddress("glGetProgramInfoLog");
+
 			glGetShaderiv = (PFNGLGETSHADERIVPROC)SDL_GL_GetProcAddress(
 			        "glGetShaderiv");
+
 			glGetShaderInfoLog = (PFNGLGETSHADERINFOLOGPROC)
 			        SDL_GL_GetProcAddress("glGetShaderInfoLog");
+
 			glGetUniformLocation = (PFNGLGETUNIFORMLOCATIONPROC)
 			        SDL_GL_GetProcAddress("glGetUniformLocation");
+
 			glLinkProgram = (PFNGLLINKPROGRAMPROC)SDL_GL_GetProcAddress(
 			        "glLinkProgram");
+
 			glShaderSource = (PFNGLSHADERSOURCEPROC_NP)SDL_GL_GetProcAddress(
 			        "glShaderSource");
+
 			glUniform2f = (PFNGLUNIFORM2FPROC)SDL_GL_GetProcAddress(
 			        "glUniform2f");
+
 			glUniform1i = (PFNGLUNIFORM1IPROC)SDL_GL_GetProcAddress(
 			        "glUniform1i");
+
 			glUseProgram = (PFNGLUSEPROGRAMPROC)SDL_GL_GetProcAddress(
 			        "glUseProgram");
+
 			glVertexAttribPointer = (PFNGLVERTEXATTRIBPOINTERPROC)
 			        SDL_GL_GetProcAddress("glVertexAttribPointer");
+
 			sdl.opengl.use_shader =
 			        (glAttachShader && glCompileShader &&
 			         glCreateProgram && glDeleteProgram &&
@@ -3415,6 +3540,7 @@ static void set_output(Section* sec, const bool wants_aspect_ratio_correction)
 			sdl.opengl.framebuf    = nullptr;
 			sdl.opengl.texture     = 0;
 			sdl.opengl.displaylist = 0;
+
 			glGetIntegerv(GL_MAX_TEXTURE_SIZE, &sdl.opengl.max_texsize);
 
 			const auto gl_version_string = safe_gl_get_string(GL_VERSION,
@@ -3451,6 +3577,7 @@ static void set_output(Section* sec, const bool wants_aspect_ratio_correction)
 
 	const auto transparency = clamp(section->Get_int("transparency"), 0, 90);
 	const auto alpha = static_cast<float>(100 - transparency) / 100.0f;
+
 	SDL_SetWindowOpacity(sdl.window, alpha);
 	GFX_RefreshTitle();
 
@@ -3557,18 +3684,23 @@ static void read_gui_config(Section* sec)
 
 	if (!fullresolution.empty()) {
 		lowcase(fullresolution); // so x and X are allowed
+								 //
 		if (fullresolution != "original") {
 			sdl.desktop.full.fixed = true;
+
 			if (fullresolution != "desktop") { // desktop uses 0x0,
 				                           // below sets a
 				                           // custom WxH
 				std::vector<std::string> dimensions =
 				        split_with_empties(fullresolution, 'x');
+
 				if (dimensions.size() == 2) {
 					sdl.desktop.full.width =
 					        parse_int(dimensions[0]).value_or(0);
+
 					sdl.desktop.full.height =
 					        parse_int(dimensions[1]).value_or(0);
+
 					maybe_limit_requested_resolution(
 					        sdl.desktop.full.width,
 					        sdl.desktop.full.height,
@@ -3581,10 +3713,13 @@ static void read_gui_config(Section* sec)
 	const std::string host_rate_pref = section->Get_string("host_rate");
 	if (host_rate_pref == "auto") {
 		sdl.desktop.host_rate_mode = HostRateMode::Auto;
+
 	} else if (host_rate_pref == "sdi") {
 		sdl.desktop.host_rate_mode = HostRateMode::Sdi;
+
 	} else if (host_rate_pref == "vrr") {
 		sdl.desktop.host_rate_mode = HostRateMode::Vrr;
+
 	} else {
 		const auto rate = to_finite<double>(host_rate_pref);
 		if (std::isfinite(rate) && rate >= RefreshRateMin) {
@@ -3604,6 +3739,7 @@ static void read_gui_config(Section* sec)
 	                                       Pacer::LogLevel::TIMEOUTS);
 
 	const int display = section->Get_int("display");
+
 	if ((display >= 0) && (display < SDL_GetNumVideoDisplays())) {
 		sdl.display_number = display;
 	} else {
@@ -3615,10 +3751,13 @@ static void read_gui_config(Section* sec)
 	        "presentation_mode");
 	if (presentation_mode_pref == "auto") {
 		sdl.frame.desired_mode = FrameMode::Unset;
+
 	} else if (presentation_mode_pref == "cfr") {
 		sdl.frame.desired_mode = FrameMode::Cfr;
+
 	} else if (presentation_mode_pref == "vfr") {
 		sdl.frame.desired_mode = FrameMode::Vfr;
+
 	} else {
 		sdl.frame.desired_mode = FrameMode::Unset;
 		LOG_WARNING("SDL: Invalid 'presentation_mode' setting: '%s', using 'auto'",
@@ -3643,6 +3782,7 @@ static void read_gui_config(Section* sec)
 	                  PRIMARY_MOD | MMOD2,
 	                  "restart",
 	                  "Restart");
+
 	MAPPER_AddHandler(MOUSE_ToggleUserCapture,
 	                  SDL_SCANCODE_F10,
 	                  PRIMARY_MOD,
@@ -3832,6 +3972,7 @@ static void finalise_window_state()
 	// decorations are rendered off-screen).
 	const auto default_val = SDL_WINDOWPOS_CENTERED_DISPLAY(sdl.display_number);
 	const auto pos = get_initial_window_position_or_default(default_val);
+
 	SDL_SetWindowPosition(sdl.window, pos.x, pos.y);
 
 	// In some cases (not always), leaving fullscreen breaks window content,
@@ -3874,10 +4015,12 @@ static bool is_user_event(const SDL_Event& event)
 static void handle_user_event(const SDL_Event& event)
 {
 	const auto id = event.common.type - sdl.start_event_id;
+
 	switch (static_cast<SDL_DosBoxEvents>(id)) {
 	case SDL_DosBoxEvents::RefreshAnimatedTitle:
 		GFX_RefreshAnimatedTitle();
 		break;
+
 	default: assert(false);
 	}
 }
@@ -3891,7 +4034,9 @@ bool GFX_Events()
 	// default max 500). Currently not implemented for all platforms, given
 	// the ALT-TAB stuff for WIN32.
 	static auto last_check = GetTicks();
+
 	auto current_check     = GetTicks();
+
 	if (GetTicksDiff(current_check, last_check) <= DB_POLLSKIP) {
 		return true;
 	}
@@ -3899,15 +4044,19 @@ bool GFX_Events()
 #endif
 
 	SDL_Event event;
+
 	static auto last_check_joystick = GetTicks();
 	auto current_check_joystick     = GetTicks();
+
 	if (GetTicksDiff(current_check_joystick, last_check_joystick) > 20) {
 		last_check_joystick = current_check_joystick;
+
 		if (MAPPER_IsUsingJoysticks()) {
 			SDL_JoystickUpdate();
 		}
 		MAPPER_UpdateJoysticks();
 	}
+
 	while (SDL_PollEvent(&event)) {
 #if C_DEBUG
 		if (is_debugger_event(event)) {
@@ -3919,6 +4068,7 @@ bool GFX_Events()
 			handle_user_event(event);
 			continue;
 		}
+
 		switch (event.type) {
 		case SDL_DISPLAYEVENT:
 			switch (event.display.event) {
@@ -3932,6 +4082,7 @@ bool GFX_Events()
 			default: break;
 			};
 			break;
+
 		case SDL_WINDOWEVENT:
 			switch (event.window.event) {
 			case SDL_WINDOWEVENT_RESTORED:
@@ -3941,6 +4092,7 @@ bool GFX_Events()
 				 * Update surface while using X11.
 				 */
 				GFX_ResetScreen();
+
 #if C_OPENGL && defined(MACOSX)
 				// LOG_DEBUG("SDL: Reset macOS's GL viewport
 				// after window-restore");
@@ -4195,10 +4347,12 @@ bool GFX_Events()
 						case SDL_QUIT:
 							GFX_RequestExit(true);
 							break;
-						case SDL_WINDOWEVENT: // wait until
+						case SDL_WINDOWEVENT: // wait
+						                      // until
 						                      // we get
 						                      // window
-						                      // focus back
+						                      // focus
+						                      // back
 							if ((ev.window.event ==
 							     SDL_WINDOWEVENT_FOCUS_LOST) ||
 							    (ev.window.event ==
@@ -4234,14 +4388,16 @@ bool GFX_Events()
 								 * "release ALT"
 								 * command into
 								 * the keyboard
-								 * buffer we have
-								 * to do this,
+								 * buffer we
+								 * have to do
+								 * this,
 								 * otherwise ALT
 								 * will 'stick'
 								 * and cause
 								 * problems with
-								 * the app running
-								 * in the DOSBox.
+								 * the app
+								 * running in
+								 * the DOSBox.
 								 */
 								KEYBOARD_AddKey(KBD_leftalt,
 								                false);
@@ -4358,10 +4514,13 @@ void GFX_ShowMsg(const char* format, ...)
 static std::vector<std::string> get_sdl_texture_renderers()
 {
 	const int n = SDL_GetNumRenderDrivers();
+
 	std::vector<std::string> drivers;
 	drivers.reserve(n + 1);
 	drivers.push_back("auto");
+
 	SDL_RendererInfo info;
+
 	for (int i = 0; i < n; i++) {
 		if (SDL_GetRenderDriverInfo(i, &info)) {
 			continue;
@@ -4700,6 +4859,7 @@ static int edit_primary_config()
 
 	// Loop until one succeeds
 	const auto arguments = &control->arguments;
+
 	if (arguments->editconf) {
 		for (const auto& editor : *arguments->editconf) {
 			replace_with_process(editor);
@@ -4761,7 +4921,9 @@ void DOSBOX_Restart(std::vector<std::string>& parameters)
 	parameters.emplace_back("--waitpid");
 	parameters.emplace_back(std::to_string(GetCurrentProcessId()));
 	std::string command_line = {};
+
 	bool first               = true;
+
 	for (const auto& arg : parameters) {
 		if (!first) {
 			command_line.push_back(' ');
@@ -4939,12 +5101,14 @@ static int erase_mapper_file()
 	}
 
 	constexpr auto success = 0;
+
 	if (unlink(path.string().c_str()) != success) {
 		fprintf(stderr,
 		        "Cannot delete mapper file '%s'",
 		        path.string().c_str());
 		return 1;
 	}
+
 	printf("Mapper file '%s' deleted.\n", path.string().c_str());
 	return 0;
 }
@@ -4956,6 +5120,7 @@ static void set_wm_class()
 #else
 #if !defined(WIN32) && !defined(MACOSX)
 	constexpr int overwrite = 0; // don't overwrite
+								 //
 	setenv("SDL_VIDEO_X11_WMCLASS", DOSBOX_APP_ID, overwrite);
 	setenv("SDL_VIDEO_WAYLAND_WMCLASS", DOSBOX_APP_ID, overwrite);
 #endif

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1624,9 +1624,9 @@ static void clean_up_sdl_resources()
 	}
 }
 
-static SDL_Window* SetWindowMode(const RenderingBackend rendering_backend,
-                                 const int width, const int height,
-                                 const bool fullscreen)
+static SDL_Window* set_window_mode(const RenderingBackend rendering_backend,
+                                   const int width, const int height,
+                                   const bool fullscreen)
 {
 	if (sdl.window && sdl.resizing_window) {
 		return sdl.window;
@@ -1880,10 +1880,10 @@ static SDL_Window* SetupWindowScaled(const RenderingBackend rendering_backend)
 		window_height = iround(sdl.draw.render_height_px * draw_scale_y);
 	}
 
-	sdl.window = SetWindowMode(rendering_backend,
-	                           window_width,
-	                           window_height,
-	                           sdl.desktop.fullscreen);
+	sdl.window = set_window_mode(rendering_backend,
+	                             window_width,
+	                             window_height,
+	                             sdl.desktop.fullscreen);
 
 	return sdl.window;
 }
@@ -3072,18 +3072,18 @@ static SDL_Window* set_default_window_mode()
 	if (sdl.desktop.fullscreen) {
 		sdl.desktop.lazy_init_window_size = true;
 
-		return SetWindowMode(sdl.want_rendering_backend,
-		                     sdl.desktop.full.width,
-		                     sdl.desktop.full.height,
-		                     sdl.desktop.fullscreen);
+		return set_window_mode(sdl.want_rendering_backend,
+		                       sdl.desktop.full.width,
+		                       sdl.desktop.full.height,
+		                       sdl.desktop.fullscreen);
 	}
 
 	sdl.desktop.lazy_init_window_size = false;
 
-	return SetWindowMode(sdl.want_rendering_backend,
-	                     sdl.desktop.window.width,
-	                     sdl.desktop.window.height,
-	                     sdl.desktop.fullscreen);
+	return set_window_mode(sdl.want_rendering_backend,
+	                       sdl.desktop.window.width,
+	                       sdl.desktop.window.height,
+	                       sdl.desktop.fullscreen);
 }
 
 static SDL_Point refine_window_size(const SDL_Point size,

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3388,7 +3388,7 @@ static void apply_active_settings()
 	}
 }
 
-static void ApplyInactiveSettings()
+static void apply_inactive_settings()
 {
 	set_priority(sdl.priority.inactive);
 	MOUSE_NotifyWindowActive(false);
@@ -3921,7 +3921,7 @@ bool GFX_Events()
 					GFX_ForceFullscreenExit();
 				}
 #endif
-				ApplyInactiveSettings();
+				apply_inactive_settings();
 				GFX_LosingFocus();
 				break;
 
@@ -4015,7 +4015,7 @@ bool GFX_Events()
 
 			case SDL_WINDOWEVENT_MINIMIZED:
 				// LOG_DEBUG("SDL: Window has been minimized");
-				ApplyInactiveSettings();
+				apply_inactive_settings();
 				break;
 
 			case SDL_WINDOWEVENT_MAXIMIZED:
@@ -4052,7 +4052,7 @@ bool GFX_Events()
 					 * Instead of waiting for the user to hit Alt+Break, we wait for the window to
 					 * regain window or input focus.
 					 */
-					ApplyInactiveSettings();
+					apply_inactive_settings();
 					SDL_Event ev;
 
 					KEYBOARD_ClrBuffer();

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -4225,7 +4225,6 @@ static bool handle_sdl_windowevent(const SDL_Event& event)
 		return true;
 #endif
 
-#if SDL_VERSION_ATLEAST(2, 0, 18)
 	case SDL_WINDOWEVENT_DISPLAY_CHANGED: {
 		// New display might have a different resolution and DPI scaling set,
 		// so recalculate that and set viewport
@@ -4260,7 +4259,6 @@ static bool handle_sdl_windowevent(const SDL_Event& event)
 		notify_new_mouse_screen_params();
 		return true;
 	}
-#endif
 
 	case SDL_WINDOWEVENT_SIZE_CHANGED: {
 		// LOG_DEBUG("SDL: The window size has changed");

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -340,7 +340,7 @@ static GLuint build_shader_gl(GLenum type, const std::string& source)
 	}
 }
 
-static bool LoadGLShaders(const std::string& source, GLuint* vertex, GLuint* fragment)
+static bool load_shader_gl(const std::string& source, GLuint* vertex, GLuint* fragment)
 {
 	if (source.empty()) {
 		return false;
@@ -392,9 +392,9 @@ static bool init_opengl_shader()
 		if (sdl.opengl.program_object == 0) {
 			GLuint vertexShader, fragmentShader;
 
-			if (!LoadGLShaders(sdl.opengl.shader_source,
-			                   &vertexShader,
-			                   &fragmentShader)) {
+			if (!load_shader_gl(sdl.opengl.shader_source,
+			                    &vertexShader,
+			                    &fragmentShader)) {
 
 				LOG_ERR("OPENGL: Failed to compile shader");
 				return false;

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -340,26 +340,24 @@ static GLuint build_shader_gl(GLenum type, const std::string& source)
 	}
 }
 
-static bool load_shader_gl(const std::string& source, GLuint* vertex, GLuint* fragment)
+static bool load_shader_gl(const std::string& source, GLuint& vertex_out,
+                           GLuint& fragment_out)
 {
 	if (source.empty()) {
 		return false;
 	}
 
-	assert(vertex);
-	assert(fragment);
-
 	GLuint s = build_shader_gl(GL_VERTEX_SHADER, source);
 	if (s) {
-		*vertex = s;
+		vertex_out = s;
 
 		s = build_shader_gl(GL_FRAGMENT_SHADER, source);
 
 		if (s) {
-			*fragment = s;
+			fragment_out = s;
 			return true;
 		}
-		glDeleteShader(*vertex);
+		glDeleteShader(vertex_out);
 	}
 	return false;
 }
@@ -393,8 +391,8 @@ static bool init_shader_gl()
 			GLuint vertexShader, fragmentShader;
 
 			if (!load_shader_gl(sdl.opengl.shader_source,
-			                    &vertexShader,
-			                    &fragmentShader)) {
+			                    vertexShader,
+			                    fragmentShader)) {
 
 				LOG_ERR("OPENGL: Failed to compile shader");
 				return false;

--- a/src/hardware/input/intel8042.cpp
+++ b/src/hardware/input/intel8042.cpp
@@ -863,7 +863,7 @@ static void execute_command(const Command command, const uint8_t param)
 		MEM_A20_Enable(bit::is(param, b1));
 		if (!bit::is(param, b0)) {
 			LOG_WARNING("I8042: Clearing P2 bit 0 locks a real PC");
-			restart_dosbox();
+			DOSBOX_Restart();
 		}
 		break;
 	case Command::SimulateInputKbd: // 0xd2
@@ -899,7 +899,7 @@ static void execute_command(const Command command, const uint8_t param)
 			}
 			if (code == 0xf0 && !(lines & 0b0001)) {
 				// System reset via keyboard controller
-				restart_dosbox();
+				DOSBOX_Restart();
 			}
 		} else {
 			// If we are here, than either this function

--- a/src/ints/bios.cpp
+++ b/src/ints/bios.cpp
@@ -1081,7 +1081,7 @@ static Bitu reboot_handler()
 	}
 
 	// Restart
-	restart_dosbox();
+	DOSBOX_Restart();
 	return CBRET_NONE;
 }
 

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -607,7 +607,7 @@ void CONFIG::Run(void)
 				return;
 			}
 			if (pvars.size() == 0) {
-				restart_dosbox();
+				DOSBOX_Restart();
 			} else {
 				std::vector<std::string> restart_params;
 				restart_params.push_back(
@@ -620,7 +620,7 @@ void CONFIG::Run(void)
 				                      remaining_args.begin(),
 				                      remaining_args.end());
 
-				restart_dosbox(restart_params);
+				DOSBOX_Restart(restart_params);
 			}
 			return;
 

--- a/tests/dosbox_test_fixture.h
+++ b/tests/dosbox_test_fixture.h
@@ -52,7 +52,7 @@ public:
 
 		Section *_sec;
 		// This will register all the init functions, but won't run them
-		DOSBOX_Init();
+		DOSBOX_InitAllModuleConfigsAndMessages();
 
 		for (auto section_name : sections) {
 			_sec = control->GetSection(section_name);


### PR DESCRIPTION
# Description

No functional changes (if I haven't screwed anything up), just a lift-and-shift job, basically.

Definitely review commit by commit.

I have grand plans for sdlmain, such as adding OSD support, a multi-pass shader pipeline, collapse all the CRT shaders into a single shader that will be parameterised at runtime, add brightness/contrast/saturation/white balance/etc. monitor controls, and more! I'm intending to add all that soon(ish) (definitely this year, and for 0.83.0), but I need to rein the chaos in a bit first.

Parts 2 & 3 will incorporate parts of GranMinigun's SDL & shader rework/cleanup (see https://github.com/dosbox-staging/dosbox-staging/issues/3971) and moving the OpenGL stuff into its own file.

# Manual testing

- Start up a few games
- Test various the command line params still work
- Test restarting works
- Test pause/unpause and the pause when inactive mode still works

The change has been manually tested on:

- [ ] Windows
- [x] macOS
- [x] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

