### PR TITLE
Fix for translated '-list-countries' and similar messages

### DIFF
--- a/src/dos/dos_locale.cpp
+++ b/src/dos/dos_locale.cpp
@@ -558,7 +558,7 @@ static std::string get_output_header(const char* header_msg_id,
 	} else {
 		std::string header_str = MSG_GetForHost(header_msg_id);
 		return std::string("\n") + header_str.c_str() + "\n" +
-		       std::string(header_str.size(), '-') + "\n\n";
+		       std::string(length_utf8(header_str), '-') + "\n\n";
 	}
 }
 


### PR DESCRIPTION
# Description

Due to mistake in the code (ASCII string length calculation used instead of UTF8 string length function) the underline in some messages might be slightly too long if translation is being used - example:

![Screenshot-bug](https://github.com/user-attachments/assets/98bcb8c7-c6b6-4615-b88d-5984adab62b5)

This one-line PR fixes the problem.


# Manual testing

Start DOSBox with command:

```dosbox --lang de -list-countries```

and observe the output.

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [x] Linux (change is trivial)


# Checklist
I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

