### PR TITLE
Fix several compiler warnings

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -43,14 +43,14 @@ jobs:
             cmake_preset: release-linux-vcpkg
             cc:  gcc
             cxx: g++
-            max_warnings: 14
+            max_warnings: 0
 
           - name: Clang 15, Ubuntu 22.04
             os: ubuntu-22.04
             cmake_preset: release-linux-vcpkg
             cc:  clang
             cxx: clang++
-            max_warnings: 14
+            max_warnings: 0
 
           - name: GCC 12, Ubuntu 22.04, debugger build
             os: ubuntu-22.04
@@ -58,7 +58,7 @@ jobs:
             cmake_flags: -DOPT_HEAVY_DEBUG=ON
             cc:  gcc
             cxx: g++
-            max_warnings: 14
+            max_warnings: 0
 
           # TODO turn this into a minimal build target once we have CMake
           # feature toggling implemented
@@ -67,7 +67,7 @@ jobs:
             cmake_preset: release-linux-vcpkg
             cc:  gcc
             cxx: g++
-            max_warnings: 14
+            max_warnings: 0
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -42,11 +42,11 @@ jobs:
           # external vcpkg dependencies for AMR64 first
           - arch: x64
             debugger: false
-            max_warnings: 20
+            max_warnings: 9
 
           - arch: x64
             debugger: true
-            max_warnings: 20
+            max_warnings: 9
 
     steps:
       - name: Check out repository

--- a/.kdev4/dosbox-staging.main.kdev4
+++ b/.kdev4/dosbox-staging.main.kdev4
@@ -1,0 +1,56 @@
+[Buildset]
+BuildItems=@Variant(\x00\x00\x00\t\x00\x00\x00\x00\x00)
+
+[Cppcheck]
+useSystemIncludes=true
+
+[CustomDefinesAndIncludes][ProjectPath0]
+Path=.
+parseAmbiguousAsCPP=true
+parserArguments=-ferror-limit=100 -fspell-checking -Wdocumentation -Wunused-parameter -Wunreachable-code -Wall -std=c++2a
+parserArgumentsC=-ferror-limit=100 -fspell-checking -Wdocumentation -Wunused-parameter -Wunreachable-code -Wall -std=c99
+parserArgumentsCuda=-ferror-limit=100 -fspell-checking -Wdocumentation -Wunused-parameter -Wunreachable-code -Wall -std=c++11
+parserArgumentsOpenCL=-ferror-limit=100 -fspell-checking -Wdocumentation -Wunused-parameter -Wunreachable-code -Wall -cl-std=CL1.1
+
+[CustomDefinesAndIncludes][ProjectPath0][Compiler]
+Name=GCC
+
+[CustomDefinesAndIncludes][ProjectPath0][Includes]
+1=/home/roman/GIT-DOS/integration/dosbox-staging.main/include/
+2=/lib/gcc/x86_64-pc-linux-gnu/14/include/g++-v14
+3=/home/roman/GIT-DOS/integration/dosbox-staging.main/src/libs/manymouse
+
+[Launch]
+Launch Configurations=Launch Configuration 0
+
+[Launch][Launch Configuration 0]
+Configured Launch Modes=execute
+Configured Launchers=nativeAppLauncher
+Name=New Compiled Binary Launcher
+Type=Native Application
+
+[Launch][Launch Configuration 0][Data]
+Arguments=
+Dependencies=@Variant(\x00\x00\x00\t\x00\x00\x00\x00\x00)
+Dependency Action=Nothing
+EnvironmentGroup=
+Executable=file:///home/roman/GIT-DOS/integration/dosbox-staging.main
+External Terminal=konsole --noclose --workdir %workdir -e %exe
+Kill Before Executing Again=4194304
+Project Target=dosbox-staging.main,dosbox
+Use External Terminal=false
+Working Directory=
+isExecutable=false
+
+[MesonManager]
+Current Build Directory Index=0
+Number of Build Directories=1
+
+[MesonManager][BuildDir 0]
+Additional meson arguments=
+Build Directory Path=/home/roman/GIT-DOS/integration/dosbox-staging.main/build
+Meson Generator Backend=ninja
+Meson executable=/usr/bin/meson
+
+[Project]
+VersionControlSupport=kdevgit

--- a/dosbox-staging.main.kde4
+++ b/dosbox-staging.main.kde4
@@ -1,0 +1,4 @@
+[Project]
+CreatedFrom=meson.build
+Manager=KDevMesonManager
+Name=dosbox-staging.main

--- a/include/string_utils.h
+++ b/include/string_utils.h
@@ -299,6 +299,8 @@ std::string format_str(const std::string& format, const Args&... args) noexcept
 {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wformat-security"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-security"
 
 	// Perform a non-writing format to determine the size
 	const auto required_size = std::snprintf(nullptr, 0, format.c_str(), args...);
@@ -315,6 +317,8 @@ std::string format_str(const std::string& format, const Args&... args) noexcept
 	std::string result(out_size, '\0');
 
 	std::snprintf(result.data(), result.size(), format.c_str(), args...);
+
+#pragma GCC diagnostic pop
 #pragma clang diagnostic pop
 
 	// The buffer should now have the determined output length plus the

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -930,11 +930,13 @@ void GFX_ResetScreen()
 	VGA_SetupDrawing(0);
 }
 
+#ifdef WIN32
 static void exit_fullscreen()
 {
 	sdl.desktop.fullscreen = false;
 	GFX_ResetScreen();
 }
+#endif
 
 [[maybe_unused]] static int int_log2(int val)
 {

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -5255,7 +5255,7 @@ static void handle_cli_set_commands(const std::vector<std::string>& set_args)
 				value.erase(0, 1);
 			}
 
-			for (auto i = 3; i < pvars.size(); i++) {
+			for (size_t i = 3; i < pvars.size(); i++) {
 				value += (std::string(" ") + pvars[i]);
 			}
 

--- a/src/hardware/adlib_gold.h
+++ b/src/hardware/adlib_gold.h
@@ -9,7 +9,13 @@
 #include "bit_view.h"
 #include "mixer.h"
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-enum-enum-conversion"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-enum-enum-conversion"
 #include "YM7128B_emu/YM7128B_emu.h"
+#pragma GCC diagnostic pop
+#pragma clang diagnostic pop
 
 class SurroundProcessor {
 public:

--- a/src/hardware/serialport/misc_util.h
+++ b/src/hardware/serialport/misc_util.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText:  2002-2021 The DOSBox Team
+// SPDX-FileCopyrightText:  2002-2025 The DOSBox Team
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #ifndef DOSBOX_MISC_UTIL_H
@@ -43,7 +43,13 @@
 
 #include <SDL_net.h>
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-enum-enum-conversion"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-enum-enum-conversion"
 #include "enet/include/enet.h"
+#pragma GCC diagnostic pop
+#pragma clang diagnostic pop
 
 enum class SocketType {
 	Tcp  = 0, // +SOCK0 modem command


### PR DESCRIPTION
# Description

1. Silenced several compiler warnings produced by CMake build (not all of them)
2. Fixed warnings produced by GCC 14.3.0 on the `main` branch, even with `Meson` build:

```
../src/gui/sdlmain.cpp: In function ‘void handle_cli_set_commands(const std::vector<std::__cxx11::basic_string<char> >&)’:
../src/gui/sdlmain.cpp:5275:44: warning: comparison of integer expressions of different signedness: ‘int’ and ‘std::vector<std::__cxx11::basic_string<char> >::size_type’ {aka ‘long unsigned int’} [-Wsign-compare]
 5275 |                         for (auto i = 3; i < pvars.size(); i++) {
      |                                          ~~^~~~~~~~~~~~~~
../src/gui/sdlmain.cpp: At global scope:
../src/gui/sdlmain.cpp:950:13: warning: ‘void exit_fullscreen()’ defined but not used [-Wunused-function]
  950 | static void exit_fullscreen()
      |             ^~~~~~~~~~~~~~~

```


## Related issues

https://github.com/dosbox-staging/dosbox-staging/issues/4196


# Manual testing

Checked that there is much less compilation warnings on Linux (no warnings are present if using Meson build system).

Started DOSBox with `dosbox -set umb=foobar` command, checked that `CONFIG: Cannot set 'umb=foobar'` appears in the log.

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [x] Linux (changes are trivial)


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.
