### PR TITLE
Check HAVE_CLOCK_GETTIME in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -214,10 +214,11 @@ set(NOMINMAX ON)
 set(C_HAS_BUILTIN_EXPECT OFF)
 
 # TODO Check other functions
-check_symbol_exists(strnlen  "string.h"   HAVE_STRNLEN)
-check_symbol_exists(mprotect "sys/mman.h" HAVE_MPROTECT)
-check_symbol_exists(mmap     "sys/mman.h" HAVE_MMAP)
-check_symbol_exists(MAP_JIT  "sys/mman.h" HAVE_MAP_JIT)
+check_symbol_exists(strnlen       "string.h"   HAVE_STRNLEN)
+check_symbol_exists(mprotect      "sys/mman.h" HAVE_MPROTECT)
+check_symbol_exists(mmap          "sys/mman.h" HAVE_MMAP)
+check_symbol_exists(MAP_JIT       "sys/mman.h" HAVE_MAP_JIT)
+check_symbol_exists(clock_gettime "time.h"     HAVE_CLOCK_GETTIME)
 
 check_symbol_exists(
   pthread_jit_write_protect_np "pthread.h" HAVE_PTHREAD_WRITE_PROTECT_NP


### PR DESCRIPTION
# Description

`HAVE_CLOCK_GETTIME` was not being set in the CMake build resulting in a fallback to `ftime` for Linux and Mac builds and this deprecated warning:

```
[176/333] Building CXX object src/ints/CMakeFiles/libints.dir/bios.cpp.o
/home/daniel/code/dosbox-staging/src/ints/bios.cpp: In function ‘void BIOS_HostTimeSync()’:
/home/daniel/code/dosbox-staging/src/ints/bios.cpp:418:14: warning: ‘int ftime(timeb*)’ is deprecated: Use gettimeofday or clock_gettime instead [-Wdeprecated-declarations]
  418 |         ftime(&timebuffer);
      |         ~~~~~^~~~~~~~~~~~~
In file included from /home/daniel/code/dosbox-staging/src/ints/bios.cpp:49:
/usr/include/x86_64-linux-gnu/sys/timeb.h:29:12: note: declared here
   29 | extern int ftime (struct timeb *__timebuf)
      |            ^~~~~

``` 

This allows for the more modern/accurate `clock_gettime` which should always be available on Linux and is available on Mac since 10.12 (our minimum supported MacOS is 11).

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

