### PR TITLE
Fix aspect ratio of 40-column text modes on VGA

### DIFF
--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -2680,6 +2680,11 @@ ImageInfo setup_drawing()
 			render_width  = video_mode.width;
 			render_height = video_mode.height;
 
+			if (vga.seq.clocking_mode.is_pixel_doubling &&
+			    !vga.draw.pixel_doubling_allowed) {
+				render_pixel_aspect_ratio *= 2;
+			}
+
 			VGA_DrawLine = draw_text_line_from_dac_palette;
 
 		} else { // M_EGA


### PR DESCRIPTION
# Description

This is a rework of https://github.com/dosbox-staging/dosbox-staging/pull/2852

That almost fixed the issue, but the fix was ineffective for a subset of all machine type & shader combinations, namely
VGA machine types with shaders that have the `#pragma force_no_pixel_doubling` set (e.g., sharp, catmull-rom, scaler/xbr-lv3). All other machine type and shader combinations were fine.

## Related issues

Fixes https://github.com/dosbox-staging/dosbox-staging/issues/2849

Rework of https://github.com/dosbox-staging/dosbox-staging/pull/2852 (first fix attempt)

# Release notes

- Fix 40-column text modes appearing half-width on emulated VGA adapters with certain shaders (e.g., `sharp` and all upscalers such as `scaler/xbr-lv3`). This fixes the inventory screen in Sierra AGI adventure games appearing half wide (e.g., **Police Quest 1-2**, **Space Quest 1-2**, **Gold Rush**, etc.)

# Manual testing

Test the inventory screen in any Sierra AGI game (I used PQ1), or alternatively set the 40x25 mode with `MODE 40x25`.

- Tested the following shaders on `machine = svga_s3`:
  - sharp, xbr-lv3, none, crt-auto, crt-auto-arcade
- Regression tested all these shaders on `machine = ega`.
- Also regression tested with `output = texture`

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [ ] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [ ] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [ ] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [ ] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

