### PR TITLE
Restore deprecated mixer channel name aliases

### DIFF
--- a/include/channel_names.h
+++ b/include/channel_names.h
@@ -35,6 +35,9 @@ constexpr auto StereoOn1Dac         = "STON1";
 constexpr auto TandyDac             = "TANDYDAC";
 constexpr auto TandyPsg             = "TANDY";
 
+constexpr auto OplDeprecated        = "FM";
+constexpr auto PcSpeakerDeprecated  = "SPKR";
+
 } // namespace ChannelName
 
 // A list of all possible mixer channel names (for enhancements only;

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -754,29 +754,6 @@ MixerChannelPtr MIXER_FindChannel(const char* name)
 {
 	auto it = mixer.channels.find(name);
 
-	if (it == mixer.channels.end()) {
-		// Deprecated alias SPKR to PCSPEAKER
-		if (std::string_view(name) == "SPKR") {
-			NOTIFY_DisplayWarning(Notification::Source::Console,
-			                      "MIXER",
-			                      "MIXER_CHANNEL_DEPRECATED",
-			                      "SPKR",
-			                      ChannelName::PcSpeaker);
-
-			it = mixer.channels.find(ChannelName::PcSpeaker);
-
-			// Deprecated alias FM to OPL
-		} else if (std::string_view(name) == "FM") {
-			NOTIFY_DisplayWarning(Notification::Source::Console,
-			                      "MIXER",
-			                      "MIXER_CHANNEL_DEPRECATED",
-			                      "FM",
-			                      ChannelName::Opl);
-
-			it = mixer.channels.find(ChannelName::Opl);
-		}
-	}
-
 	const auto chan = (it != mixer.channels.end()) ? it->second : nullptr;
 
 	return chan;
@@ -3211,10 +3188,6 @@ static void init_mixer_dosbox_settings(Section_prop& sec_prop)
 
 static void register_mixer_text_messages()
 {
-	MSG_Add("MIXER_CHANNEL_DEPRECATED",
-	        "Channel name [color=light-cyan]%s[reset] is deprecated, "
-	        "use [color=light-cyan]%s[reset] instead");
-
 	MSG_Add("MIXER_INVALID_CUSTOM_FILTER",
 	        "Invalid custom filter definition: [color=white]'%s'[reset].\n"
 	        "Must be specified in [color=light-cyan]"


### PR DESCRIPTION
# Description

As it says on the tin.

# Release notes

Minor change, so no notes.

# Manual testing

<img width="1133" height="895" alt="image" src="https://github.com/user-attachments/assets/2f65a86f-a593-4c42-9c43-9d996c7feeae" />


The change has been manually tested on:

- [ ] Windows
- [x] macOS
- [ ] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

