### PR TITLE
Add sanitizer options to CMake build system, for Linux and macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,6 @@ endif()
 
 option(OPT_DEBUG "Enable debugging" OFF)
 option(OPT_HEAVY_DEBUG "Enable heavy debugging" OFF)
-
 if(OPT_HEAVY_DEBUG)
   set(OPT_DEBUG ON CACHE INTERNAL "")
 endif()
@@ -53,6 +52,50 @@ elseif(LINUX)
 
 else()
   message(FATAL_ERROR "Unknown system ${CMAKE_SYSTEM_NAME}")
+endif()
+
+# Sanitizers
+option(OPT_SANITIZER        "Enable general sanitizer checks")
+option(OPT_THREAD_SANITIZER "Enable thread sanitizer")
+
+if(OPT_SANITIZER AND OPT_THREAD_SANITIZER)
+  message(FATAL_ERROR
+          "-DOPT_SANITIZER and -DOPT_THREAD_SANITIZER are mutually exclusive")
+endif()
+
+if(OPT_SANITIZER)
+  if(DOSBOX_PLATFORM_MACOS)
+    set(SANITIZER_FLAGS "address,pointer-compare,pointer-subtract,undefined")
+  else()
+    set(SANITIZER_FLAGS "address,pointer-compare,pointer-subtract,leak,undefined")
+  endif()
+elseif(OPT_THREAD_SANITIZER)
+  if(DOSBOX_PLATFORM_MACOS)
+    message(WARNING "Thread sanitizer does not work well on macOS")
+  endif()
+  set(SANITIZER_FLAGS "thread")
+endif()
+
+if(OPT_SANITIZER OR OPT_THREAD_SANITIZER)
+  if(MSVC)
+    message(FATAL_ERROR "Sanitizers are only supported for CLANG and GCC compilers")
+  endif()
+
+  if(DOSBOX_PLATFORM_WINDOWS)
+    message(WARNING "Sanitizers were not tested on Windows")
+  endif()
+
+  # Disable optimizations, increase amount of debug info
+  add_compile_options("-O0")
+  add_compile_options("-fno-omit-frame-pointer")
+  add_compile_options("-g")
+
+  # Enable selected sanitizer mechanisms
+  add_compile_options("-fsanitize=${SANITIZER_FLAGS}")
+  add_link_options("-fsanitize=${SANITIZER_FLAGS}")
+
+  # Ask to recover sanitizer output
+  add_compile_options("-fsanitize-recover=all")
 endif()
 
 # Check host endianness

--- a/docs/build-linux.md
+++ b/docs/build-linux.md
@@ -395,3 +395,24 @@ cmake --build --preset=release-linux-vcpkg
 ```bash
 ./build/release-linux/dosbox
 ```
+
+### Sanitizer build
+
+There are two (mutually exclusive) sanitizer settings available:
+- `OPT_SANITIZER` - detects memory errors and undefined behaviors
+- `OPT_THREAD_SANITIZER` - data race detector
+
+To use any of these, pass the appropriate option when configuring the sources,
+for example:
+
+```bash
+cmake -DOPT_SANITIZER=ON --preset=release-linux
+cmake --build --preset=release-linux
+```
+
+For more information about sanitizers check the `GCC` or `clang` documentation
+on the `-fsanitize` option.
+
+As sanitizer availability and performance are highly dependent on the concrete
+platform (CPU, OS, compiler), you might need to manually adapt the
+`SANITIZER_FLAGS` variable in the `CMakeLists.txt` file to suit your needs.

--- a/docs/build-macos.md
+++ b/docs/build-macos.md
@@ -222,6 +222,27 @@ sudo port install gsed
 ln -s /opt/local/bin/gsed ~/bin/sed
 ```
 
+### Sanitizer build (CMake)
+
+There are two (mutually exclusive) sanitizer settings available:
+- `OPT_SANITIZER` - detects memory errors and undefined behaviors
+- `OPT_THREAD_SANITIZER` - data race detector
+
+To use any of these, pass the appropriate option when configuring the sources,
+for example:
+
+```bash
+cmake -DOPT_SANITIZER=ON --preset=release-macos
+cmake --build --preset=release-macos
+```
+
+For more information about sanitizers check the `clang` documentation on the
+`-fsanitize` option.
+
+As sanitizer availability and performance are highly dependent on the concrete
+platform (CPU, OS, compiler), you might need to manually adapt the
+`SANITIZER_FLAGS` variable in the `CMakeLists.txt` file to suit your needs.
+
 ## Using FluidSynth and Slirp during local development
 
 FluidSynth and Slirp are difficult and time-consuming to build, therefore they


### PR DESCRIPTION
# Description

Introduces `OPT_SANITIZER` and `OPT_THREAD_SANITIZER` options to the CMake build system. They should work with **GCC** and **clang** compilers. Example usage:

```
cmake -DOPT_THREAD_SANITIZER=ON --preset=release-linux
cmake --build --preset=release-linux
```

### Limitations

- The `shadow-call-stack` sanitizer is not enabled yet; currently it works on RISC-V and ARM only, but requires CLang version 21, which is newer than what currently Apple ships.
- The `leak` sanitizer is not enabled on `macOS` - not currently supported.
- Thread sanitizer is mutually exclusive with the normal sanitizer build - this is a sanitizer system limitation.
- In my tests I was unable to use the thread sanitizer on macOS - DOSBox was unusable. The buid system prints out a warning if someone tries to use the sanitizer on macOS.
- Windows support is completely untested at the moment - I don't even know how to setup the build environment nowadays, I'm just using CI builds for testing. It would be best if this was tested by someone familiar with this OS.


## Related issues

https://github.com/dosbox-staging/dosbox-staging/issues/4196


# Manual testing

The change has been manually tested on:

- [ ] Windows
- [x] macOS
- [x] Linux


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [x] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [x] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

