### PR TITLE
Add FROM_HASH option to the compile commits script

### DIFF
--- a/scripts/tools/compile-commits.sh
+++ b/scripts/tools/compile-commits.sh
@@ -80,12 +80,16 @@ compile_commit() {
 
 #-----------------------------------------------------------------------------
 
-if [ $# -ne 1 ]; then
-	echo "Usage: compile-commits.sh CMAKE_PRESET"
+if [ $# -lt 1 ] || [ $# -gt 2 ]; then
+	echo "Usage: compile-commits.sh CMAKE_PRESET [FROM_HASH]"
+	echo
+	echo "If FROM_HASH is not specified, the script compiles all commits in the"
+	echo "current branch (assuming the parent branch is 'main')."
 	exit 1
 fi
 
 CMAKE_PRESET=$1
+FROM_HASH=$2
 BUILD_DIR=build
 echo
 
@@ -95,7 +99,11 @@ rm -rf "${BUILD_DIR:?}/$CMAKE_PRESET"
 PARENT_BRANCH=main
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
-COMMITS=$(git log --format="%h" HEAD --not "$PARENT_BRANCH" --reverse)
+if [ -z "$FROM_HASH" ]; then
+	COMMITS=$(git log --format="%h" HEAD --not "$PARENT_BRANCH" --reverse)
+else
+	COMMITS=$(git log --format="%h" "$FROM_HASH"^.. --reverse)
+fi
 NUM_COMMITS=$(wc -w <<< "$COMMITS")
 
 COMMIT_NO=1


### PR DESCRIPTION
# Description

Pretty handy enhancement to the compile commits script when you have 20-30+ commits and you don't wanna start from the beginning after fixing a failure in the middle. So now you can optionally pass a start hash as the second argument:

```
% ./scripts/tools/compile-commits.sh debug-macos daff27849
```

I've been using it successfully for the past two weeks (I've pulled it out of the notifications PR).




# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [ ] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

