### PR TITLE
Fixed reversed audio channels for SoundBlaster Pro

### DIFF
--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -990,7 +990,11 @@ static std::vector<AudioFrame>& maybe_silence(const T* samples,
 		                          ? left
 		                          : to_float(samples[i * 2 + 1]);
 
-		frames.emplace_back(left, right);
+		if (sb.type == SbType::SBPro1 || sb.type == SbType::SBPro2) {
+			frames.emplace_back(right, left);
+		} else {
+			frames.emplace_back(left, right);
+		}
 	}
 
 	return frames;


### PR DESCRIPTION
# Description

First commit simple reverses the left and right audio channels when `sbtype` is either `sbpro1` or `sbpro2`. This is what real hardware does.

Some games compensate for this by detecting the SBPro and reversing the channels again in software. I confirmed this is what Doom does by patching the function that reports the DSP version. I ran with `sbtype = sb16` but made it report the DSP version corresponding to SBPro1. Doom then reversed the channels automatically.

```
                case SbType::SB16:
-                       dsp_add_data(0x04);
-                       dsp_add_data(0x05);
+                       dsp_add_data(0x03);
+                       dsp_add_data(0x00);
                        break;
```

Second commit ignores a single sample DMA transfer if it is the first one to occur since a DSP reset. This is odd-ball behavior but it's been (mostly) confirmed to work this way on real hardware. Quake and SBTEST.EXE both do this.

https://www.vogons.org/viewtopic.php?p=536104#p536104

[SBTEST.zip](https://github.com/user-attachments/files/21091048/SBTEST.zip)


## Related issues

Fixes #2942

# Release notes

Fix incorrectly inverted audio channels for SoundBlaster Pro

# Manual testing

- Doom - Audio channels are now correct (was reversed before)
- Quake - Audio channels continue to be correct (the 2 bugs canceled each other out in this case on `main` :laughing: )
- SBTEST.EXE - Now chimes L->L matching reported behavior on real SBPro hardware. SB16 continues to chime R->L. Needs testing to confirm if this is correct.
- Duke3D - Was unable to test as the version 1.3D I have switches to mono PCM sound when using SoundBlaster Pro.

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [x] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [x] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

