### PR TITLE
Cleanup some code related to machine types

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -39,12 +39,12 @@ jobs:
           - host: macos-15
             arch: x86_64
             minimum_deployment: '11.0'
-            max_warnings: 9
+            max_warnings: 7
 
           - host: macos-15
             arch: arm64
             minimum_deployment: '11.0'
-            max_warnings: 9
+            max_warnings: 7
 
     steps:
       - name: Checkout repository

--- a/include/bios.h
+++ b/include/bios.h
@@ -83,8 +83,8 @@
 
 #define BIOS_WAIT_FLAG_POINTER          0x498
 #define BIOS_WAIT_FLAG_COUNT	        0x49c		
-#define BIOS_WAIT_FLAG_ACTIVE			0x4a0
-#define BIOS_WAIT_FLAG_TEMP				0x4a1
+#define BIOS_WAIT_FLAG_ACTIVE		0x4a0
+#define BIOS_WAIT_FLAG_TEMP		0x4a1
 
 
 #define BIOS_PRINT_SCREEN_FLAG          0x500
@@ -92,12 +92,12 @@
 #define BIOS_VIDEO_SAVEPTR              0x4a8
 
 
-#define BIOS_DEFAULT_HANDLER_LOCATION	(RealMake(0xf000,0xff53))
-#define BIOS_DEFAULT_INT5_LOCATION		(RealMake(0xf000,0xff54))
-#define BIOS_DEFAULT_IRQ0_LOCATION		(RealMake(0xf000,0xfea5))
-#define BIOS_DEFAULT_IRQ1_LOCATION		(RealMake(0xf000,0xe987))
-#define BIOS_DEFAULT_IRQ2_LOCATION		(RealMake(0xf000,0xff55))
-#define BIOS_DEFAULT_RESET_LOCATION		(RealMake(0xf000,(machine==MCH_PCJR)?0x0043:0xe05b))
+#define BIOS_DEFAULT_HANDLER_LOCATION	(RealMake(0xf000, 0xff53))
+#define BIOS_DEFAULT_INT5_LOCATION	(RealMake(0xf000, 0xff54))
+#define BIOS_DEFAULT_IRQ0_LOCATION	(RealMake(0xf000, 0xfea5))
+#define BIOS_DEFAULT_IRQ1_LOCATION	(RealMake(0xf000, 0xe987))
+#define BIOS_DEFAULT_IRQ2_LOCATION	(RealMake(0xf000, 0xff55))
+#define BIOS_DEFAULT_RESET_LOCATION	(RealMake(0xf000, is_machine_pcjr() ? 0x0043 : 0xe05b))
 
 // The maximum "normal key" scancode value handled by keyboard bios routines.
 // This should match the maximum return value set in KEYBOARD_AddKey()'s switch

--- a/include/dosbox.h
+++ b/include/dosbox.h
@@ -70,8 +70,10 @@ enum class MachineType {
 	// PC XT with Hercules
 	Hercules,
 
-	// PC XT with CGA
-	Cga,
+	// PC XT with CGA and monochrome monitor
+	CgaMono,
+	// PC XT with CGA and color monitor
+	CgaColor,
 	// IBM PCjr
 	Pcjr,
 	// Tandy 1000
@@ -98,8 +100,6 @@ enum class SvgaType {
 
 extern MachineType machine;
 extern SvgaType    svga_type;
-
-extern bool mono_cga;
 
 inline bool is_machine_svga() {
 	return svga_type != SvgaType::None;
@@ -129,8 +129,17 @@ inline bool is_machine_pcjr_or_tandy() {
 	return is_machine_pcjr() || is_machine_tandy();
 }
 
-inline bool is_machine_cga() {
-	return machine == MachineType::Cga;
+inline bool is_machine_cga_mono() {
+	return machine == MachineType::CgaMono;
+}
+
+inline bool is_machine_cga_color() {
+	return machine == MachineType::CgaColor;
+}
+
+inline bool is_machine_cga()
+{
+	return is_machine_cga_mono() || is_machine_cga_color();
 }
 
 inline bool is_machine_cga_or_better() {

--- a/include/dosbox.h
+++ b/include/dosbox.h
@@ -63,37 +63,85 @@ int64_t DOSBOX_GetTicksDone();
 void DOSBOX_SetTicksDone(const int64_t ticks_done);
 void DOSBOX_SetTicksScheduled(const int64_t ticks_scheduled);
 
-enum SVGACards {
-	SVGA_None,
-	SVGA_S3Trio,
-	SVGA_TsengET4K,
-	SVGA_TsengET3K,
-	SVGA_ParadisePVGA1A
-}; 
+enum class MachineType {
+	// Value not set yet
+	None,
 
-extern SVGACards svgaCard;
-extern bool mono_cga;
+	// PC XT with Hercules
+	Hercules,
 
-enum MachineType {
-	// In rough age-order: Hercules is the oldest and VGA is the newest
-	// (Tandy started out as a clone of the PCjr, so PCjr came first)
-	MCH_INVALID = 0,
-	MCH_HERC    = 1 << 0,
-	MCH_CGA     = 1 << 1,
-	MCH_TANDY   = 1 << 2,
-	MCH_PCJR    = 1 << 3,
-	MCH_EGA     = 1 << 4,
-	MCH_VGA     = 1 << 5,
+	// PC XT with CGA
+	Cga,
+	// IBM PCjr
+	Pcjr,
+	// Tandy 1000
+	Tandy,
+
+	// PC AT with EGA
+	Ega,
+	// PC AT with VGA or SVGA
+	Vga
 };
 
-extern MachineType machine;
+enum class SvgaType {
+	// Non-SVGA card
+	None,
+	// S3 Graphics series (emulated card is mostly Trio64 compatible)
+	S3,
+	// Tseng Labs ET3000
+	TsengEt3k,
+	// Tseng Labs ET4000
+	TsengEt4k,
+	// Paradise Systems PVGA1A
+	Paradise
+}; 
 
-inline bool is_machine(const int type) {
-	return machine & type;
+extern MachineType machine;
+extern SvgaType    svga_type;
+
+extern bool mono_cga;
+
+inline bool is_machine_svga() {
+	return svga_type != SvgaType::None;
 }
-#define IS_TANDY_ARCH ((machine==MCH_TANDY) || (machine==MCH_PCJR))
-#define IS_EGAVGA_ARCH ((machine==MCH_EGA) || (machine==MCH_VGA))
-#define IS_VGA_ARCH (machine==MCH_VGA)
+
+inline bool is_machine_vga_or_better() {
+	return machine == MachineType::Vga;
+}
+
+inline bool is_machine_ega() {
+	return machine == MachineType::Ega;	
+}
+
+inline bool is_machine_ega_or_better() {
+	return is_machine_ega() || is_machine_vga_or_better();
+}
+
+inline bool is_machine_tandy() {
+	return machine == MachineType::Tandy;
+}
+
+inline bool is_machine_pcjr() {
+	return machine == MachineType::Pcjr;
+}
+
+inline bool is_machine_pcjr_or_tandy() {
+	return is_machine_pcjr() || is_machine_tandy();
+}
+
+inline bool is_machine_cga() {
+	return machine == MachineType::Cga;
+}
+
+inline bool is_machine_cga_or_better() {
+	return is_machine_cga() ||
+               is_machine_pcjr_or_tandy() ||
+               is_machine_ega_or_better();
+}
+
+inline bool is_machine_hercules() {
+	return machine == MachineType::Hercules;
+}
 
 #ifndef DOSBOX_LOGGING_H
 #include "logging.h"

--- a/include/mem.h
+++ b/include/mem.h
@@ -141,6 +141,14 @@ static inline void phys_writeq(PhysPt addr, uint64_t val)
 	host_writeq(MemBase + addr, val);
 }
 
+static inline void phys_writes(PhysPt addr, const std::string& string)
+{
+	auto destination = MemBase + addr;
+	for (auto character : string) {
+		host_writeb(destination++, character);
+	}
+}
+
 static inline uint8_t phys_readb(PhysPt addr)
 {
 	return host_readb(MemBase + addr);

--- a/include/vga.h
+++ b/include/vga.h
@@ -1219,11 +1219,11 @@ struct SVGA_Driver {
 
 extern SVGA_Driver svga;
 
-void SVGA_Setup_S3Trio();
-void SVGA_Setup_TsengET4K(void);
-void SVGA_Setup_TsengET3K(void);
-void SVGA_Setup_ParadisePVGA1A(void);
-void SVGA_Setup_Driver(void);
+void SVGA_Setup_S3();
+void SVGA_Setup_TsengEt4k();
+void SVGA_Setup_TsengEt3k();
+void SVGA_Setup_Paradise();
+void SVGA_Setup_Driver();
 
 // Amount of video memory required for a mode, implemented in int10_modes.cpp
 uint32_t VideoModeMemSize(uint16_t mode);

--- a/src/cpu/callback.cpp
+++ b/src/cpu/callback.cpp
@@ -674,10 +674,13 @@ void CALLBACK_Init(Section* /*sec*/) {
 		rint_base += 6;
 	}
 	// setup a few interrupt handlers that point to bios IRETs by default
-	real_writed(0,0x66*4,CALLBACK_RealPointer(call_default));	//war2d
-	real_writed(0,0x67*4,CALLBACK_RealPointer(call_default));
-	if (machine==MCH_CGA) real_writed(0,0x68*4,0);				//Popcorn
-	real_writed(0,0x5c*4,CALLBACK_RealPointer(call_default));	//Network stuff
+	real_writed(0, 0x66 * 4, CALLBACK_RealPointer(call_default));	//war2d
+	real_writed(0, 0x67 * 4, CALLBACK_RealPointer(call_default));
+	if (is_machine_cga()) {
+		// Popcorn
+		real_writed(0, 0x68*4,0);
+	}
+	real_writed(0, 0x5c * 4, CALLBACK_RealPointer(call_default));	//Network stuff
 	//real_writed(0,0xf*4,0); some games don't like it
 
 	call_priv_io=CALLBACK_Allocate();

--- a/src/dos/dev_con.h
+++ b/src/dos/dev_con.h
@@ -74,7 +74,7 @@ bool device_CON::Read(uint8_t* data, uint16_t* size)
 		readcache = 0;
 	}
 	while (*size > count) {
-		reg_ah = (IS_EGAVGA_ARCH) ? 0x10 : 0x0;
+		reg_ah = is_machine_ega_or_better() ? 0x10 : 0x0;
 
 		CALLBACK_RunRealInt(0x16);
 		switch (reg_al) {
@@ -318,7 +318,7 @@ bool device_CON::Write(uint8_t* data, uint16_t* size)
 				LOG(LOG_IOCTL, LOG_WARN)("ANSI SEQUENCES USED");
 			}
 			ncols = real_readw(BIOSMEM_SEG, BIOSMEM_NB_COLS);
-			nrows = IS_EGAVGA_ARCH
+			nrows = is_machine_ega_or_better()
 			              ? (real_readb(BIOSMEM_SEG, BIOSMEM_NB_ROWS) + 1)
 			              : 25;
 			// Turn them into positions that are on the screen
@@ -358,7 +358,7 @@ bool device_CON::Write(uint8_t* data, uint16_t* size)
 		case 'B': // Cursor Down
 			col      = CURSOR_POS_COL(page);
 			row      = CURSOR_POS_ROW(page);
-			nrows    = IS_EGAVGA_ARCH
+			nrows    = is_machine_ega_or_better()
 			                 ? (real_readb(BIOSMEM_SEG, BIOSMEM_NB_ROWS) + 1)
 			                 : 25;
 			tempdata = (ansi.data[0] ? ansi.data[0] : 1);
@@ -441,7 +441,7 @@ bool device_CON::Write(uint8_t* data, uint16_t* size)
 		case 'M': // Delete line (NANSI)
 			row   = CURSOR_POS_ROW(page);
 			ncols = real_readw(BIOSMEM_SEG, BIOSMEM_NB_COLS);
-			nrows = IS_EGAVGA_ARCH
+			nrows = is_machine_ega_or_better()
 			              ? (real_readb(BIOSMEM_SEG, BIOSMEM_NB_ROWS) + 1)
 			              : 25;
 			INT10_ScrollWindow(row,

--- a/src/dos/dos_code_page.cpp
+++ b/src/dos/dos_code_page.cpp
@@ -2132,7 +2132,7 @@ static void load_default_screen_font()
 
 bool DOS_CanLoadScreenFonts()
 {
-	return machine == MCH_EGA || machine == MCH_VGA;
+	return is_machine_ega_or_better();
 }
 
 KeyboardLayoutResult DOS_LoadScreenFont(const uint16_t code_page,

--- a/src/dos/dos_execute.cpp
+++ b/src/dos/dos_execute.cpp
@@ -348,7 +348,7 @@ bool DOS_Execute(char * name,PhysPt block_pt,uint8_t flags) {
 		uint16_t minsize,maxsize;uint16_t maxfree=0xffff;DOS_AllocateMemory(&pspseg,&maxfree);
 		if (iscom) {
 			minsize=0x1000;maxsize=0xffff;
-			if (machine==MCH_PCJR) {
+			if (is_machine_pcjr()) {
 				/* try to load file into memory below 96k */ 
 				pos=0;DOS_SeekFile(fhandle,&pos,DOS_SEEK_SET);	
 				uint16_t dataread=0x1800;
@@ -380,7 +380,7 @@ bool DOS_Execute(char * name,PhysPt block_pt,uint8_t flags) {
 		if (maxfree<maxsize) memsize=maxfree;
 		else memsize=maxsize;
 		if (!DOS_AllocateMemory(&pspseg,&memsize)) E_Exit("DOS:Exec error in memory");
-		if (iscom && (machine==MCH_PCJR) && (pspseg<0x2000)) {
+		if (iscom && is_machine_pcjr() && (pspseg < 0x2000)) {
 			maxsize=0xffff;
 			/* resize to full extent of memory block */
 			DOS_ResizeMemory(pspseg,&maxsize);

--- a/src/dos/dos_memory.cpp
+++ b/src/dos/dos_memory.cpp
@@ -374,8 +374,9 @@ bool DOS_FreeMemory(uint16_t segment) {
 }
 
 
-void DOS_BuildUMBChain(bool umb_active,bool ems_active) {
-	if (umb_active  && (!IS_TANDY_ARCH)) {
+void DOS_BuildUMBChain(bool umb_active, bool ems_active)
+{
+	if (umb_active && !is_machine_pcjr_or_tandy()) {
 		uint16_t first_umb_seg = 0xd000;
 		uint16_t first_umb_size = 0x2000;
 		if(ems_active) first_umb_size = 0x1000;
@@ -497,14 +498,14 @@ void DOS_SetupMemory(void) {
 	mcb_sizes+=17;
 	tempmcb2.SetType(middle_mcb_type);
 
-	if (machine==MCH_TANDY) {
+	if (is_machine_tandy()) {
 		/* memory up to 608k available, the rest (to 640k) is used by
 			the tandy graphics system's variable mapping of 0xb800 */
 		DOS_MCB free_block((uint16_t)DOS_MEM_START+mcb_sizes);
 		free_block.SetPSPSeg(MCB_FREE);
 		free_block.SetType(ending_mcb_type);
 		free_block.SetSize(0x9BFF - DOS_MEM_START - mcb_sizes);
-	} else if (machine==MCH_PCJR) {
+	} else if (is_machine_pcjr()) {
 		const auto pcjr_start = DOS_MEM_START + mcb_sizes;
 		constexpr auto mcb_entry_size = 1;
 

--- a/src/dos/program_boot.cpp
+++ b/src/dos/program_boot.cpp
@@ -270,7 +270,7 @@ void BOOT::Run(void)
 	        ->Read_Sector(0, 0, 1, reinterpret_cast<uint8_t*>(&bootarea));
 	if ((bootarea.rawdata[0] == 0x50) && (bootarea.rawdata[1] == 0x43) &&
 	    (bootarea.rawdata[2] == 0x6a) && (bootarea.rawdata[3] == 0x72)) {
-		if (machine != MCH_PCJR) {
+		if (!is_machine_pcjr()) {
 			WriteOut(MSG_Get("PROGRAM_BOOT_CART_WO_PCJR"));
 		} else {
 			uint8_t rombuf[65536];
@@ -489,7 +489,7 @@ void BOOT::Run(void)
 			real_writeb(0, 0x7c00 + i, bootarea.rawdata[i]);
 
 		/* create appearance of floppy drive DMA usage (Demon's Forge) */
-		if (!IS_TANDY_ARCH && floppysize != 0)
+		if (!is_machine_pcjr_or_tandy() && floppysize != 0)
 			DMA_GetChannel(2)->has_reached_terminal_count = true;
 
 		/* revector some dos-allocated interrupts */

--- a/src/dos/program_loadrom.cpp
+++ b/src/dos/program_loadrom.cpp
@@ -60,7 +60,7 @@ void LOADROM::Run(void)
 		if (data_read >= 0x4000 && rom_buffer[0] == 0x55 &&
 		    rom_buffer[1] == 0xaa && (rom_buffer[3] & 0xfc) == 0xe8 &&
 		    strncmp((char*)(&rom_buffer[0x1e]), "IBM", 3) == 0) {
-			if (!IS_EGAVGA_ARCH) {
+			if (!is_machine_ega_or_better()) {
 				WriteOut(MSG_Get("PROGRAM_LOADROM_INCOMPATIBLE"));
 				return;
 			}

--- a/src/dos/program_mode.cpp
+++ b/src/dos/program_mode.cpp
@@ -110,7 +110,8 @@ void MODE::HandleSetDisplayMode(const std::string& _mode_str)
 		}
 		break;
 
-	case MachineType::Cga:
+	case MachineType::CgaMono:
+	case MachineType::CgaColor:
 	case MachineType::Tandy:
 	case MachineType::Pcjr:
 		if (mode_str == "40x25") {

--- a/src/dos/program_mode.cpp
+++ b/src/dos/program_mode.cpp
@@ -101,7 +101,7 @@ void MODE::HandleSetDisplayMode(const std::string& _mode_str)
 	}
 
 	switch (machine) {
-	case MCH_HERC:
+	case MachineType::Hercules:
 		if (mode_str == "80x25") {
 			INT10_SetVideoMode(0x07);
 		} else {
@@ -110,9 +110,9 @@ void MODE::HandleSetDisplayMode(const std::string& _mode_str)
 		}
 		break;
 
-	case MCH_CGA:
-	case MCH_TANDY:
-	case MCH_PCJR:
+	case MachineType::Cga:
+	case MachineType::Tandy:
+	case MachineType::Pcjr:
 		if (mode_str == "40x25") {
 			INT10_SetVideoMode(0x01);
 
@@ -125,7 +125,7 @@ void MODE::HandleSetDisplayMode(const std::string& _mode_str)
 		}
 		break;
 
-	case MCH_EGA:
+	case MachineType::Ega:
 		if (mode_str == "40x25") {
 			INT10_SetVideoMode(0x01);
 
@@ -142,8 +142,8 @@ void MODE::HandleSetDisplayMode(const std::string& _mode_str)
 		}
 		break;
 
-	case MCH_VGA:
-		if (svgaCard == SVGA_S3Trio) {
+	case MachineType::Vga:
+		if (svga_type == SvgaType::S3) {
 			if (const auto it = video_mode_map_svga_s3.find(mode_str);
 			    it != video_mode_map_svga_s3.end()) {
 

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -135,8 +135,6 @@ void DOSBOX_SetTicksScheduled(const int64_t ticks_scheduled)
 	ticks.scheduled = ticks_scheduled;
 }
 
-bool mono_cga = false;
-
 void Null_Init([[maybe_unused]] Section *sec) {
 	// do nothing
 }
@@ -477,11 +475,9 @@ void DOSBOX_SetMachineTypeFromConfig(Section_prop* section)
 	int10.vesa_oldvbe = false;
 
 	if (machine_str == "cga") {
-		machine = MachineType::Cga;
-		mono_cga = false;
+		machine = MachineType::CgaColor;
 	} else if (machine_str == "cga_mono") {
-		machine = MachineType::Cga;
-		mono_cga = true;
+		machine = MachineType::CgaMono;
 	} else if (machine_str == "tandy") {
 		machine = MachineType::Tandy;
 	} else if (machine_str == "pcjr") {

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -45,8 +45,9 @@
 #include "video.h"
 
 bool shutdown_requested = false;
-MachineType machine;
-SVGACards svgaCard;
+
+MachineType machine   = MachineType::None;
+SvgaType    svga_type = SvgaType::None;
 
 void LOG_StartUp();
 void MEM_Init(Section *);
@@ -467,40 +468,49 @@ void DOSBOX_SetMachineTypeFromConfig(Section_prop* section)
 		                         arguments->machine);
 	}
 
-	std::string mtype = section->Get_string("machine");
-	svgaCard = SVGA_None;
-	machine = MCH_VGA;
-	int10.vesa_nolfb = false;
+	const auto machine_str = section->Get_string("machine");
+
+	svga_type = SvgaType::None;
+	machine   = MachineType::Vga;
+
+	int10.vesa_nolfb  = false;
 	int10.vesa_oldvbe = false;
-	if      (mtype == "cga")      { machine = MCH_CGA; mono_cga = false; }
-	else if (mtype == "cga_mono") { machine = MCH_CGA; mono_cga = true; }
-	else if (mtype == "tandy")    { machine = MCH_TANDY; }
-	else if (mtype == "pcjr")     { machine = MCH_PCJR;
-	} else if (mtype == "hercules") {
-		machine = MCH_HERC;
-	} else if (mtype == "ega") {
-		machine = MCH_EGA;
-	} else if (mtype == "svga_s3") {
-		svgaCard = SVGA_S3Trio;
-	} else if (mtype == "vesa_nolfb") {
-		svgaCard = SVGA_S3Trio;
+
+	if (machine_str == "cga") {
+		machine = MachineType::Cga;
+		mono_cga = false;
+	} else if (machine_str == "cga_mono") {
+		machine = MachineType::Cga;
+		mono_cga = true;
+	} else if (machine_str == "tandy") {
+		machine = MachineType::Tandy;
+	} else if (machine_str == "pcjr") {
+		machine = MachineType::Pcjr;
+	} else if (machine_str == "hercules") {
+		machine = MachineType::Hercules;
+	} else if (machine_str == "ega") {
+		machine = MachineType::Ega;
+	} else if (machine_str == "svga_s3") {
+		svga_type = SvgaType::S3;
+	} else if (machine_str == "vesa_nolfb") {
+		svga_type = SvgaType::S3;
 		int10.vesa_nolfb = true;
-	} else if (mtype == "vesa_oldvbe") {
-		svgaCard = SVGA_S3Trio;
+	} else if (machine_str == "vesa_oldvbe") {
+		svga_type = SvgaType::S3;
 		int10.vesa_oldvbe = true;
-	} else if (mtype == "svga_et4000") {
-		svgaCard = SVGA_TsengET4K;
-	} else if (mtype == "svga_et3000") {
-		svgaCard = SVGA_TsengET3K;
-	} else if (mtype == "svga_paradise") {
-		svgaCard = SVGA_ParadisePVGA1A;
+	} else if (machine_str == "svga_et3000") {
+		svga_type = SvgaType::TsengEt3k;
+	} else if (machine_str == "svga_et4000") {
+		svga_type = SvgaType::TsengEt4k;
+	} else if (machine_str == "svga_paradise") {
+		svga_type = SvgaType::Paradise;
 	} else {
-		E_Exit("DOSBOX: Invalid machine type '%s'", mtype.c_str());
+		E_Exit("DOSBOX: Invalid machine type '%s'", machine_str.c_str());
 	}
 
 	// VGA-type machine needs an valid SVGA card and vice-versa
-	assert((machine == MCH_VGA && svgaCard != SVGA_None) ||
-	       (machine != MCH_VGA && svgaCard == SVGA_None));
+	assert((machine == MachineType::Vga && svga_type != SvgaType::None) ||
+	       (machine != MachineType::Vga && svga_type == SvgaType::None));
 }
 
 static void DOSBOX_RealInit(Section* sec)

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -602,7 +602,7 @@ void RENDER_NotifyEgaModeWithVgaPalette()
 {
 	// If we're getting these notifications on non-VGA cards, that's a
 	// programming error.
-	assert(machine == MCH_VGA);
+	assert(is_machine_vga_or_better());
 
 	auto video_mode = VGA_GetCurrentVideoMode();
 

--- a/src/gui/shader_manager.cpp
+++ b/src/gui/shader_manager.cpp
@@ -560,21 +560,21 @@ std::string ShaderManager::FindShaderAutoMachine() const
 
 	// DOSBOX_RealInit may have not been run yet.
 	// If not, go ahead and set the globals from the config.
-	if (machine == MCH_INVALID) {
+	if (machine == MachineType::None) {
 		DOSBOX_SetMachineTypeFromConfig(
 		        static_cast<Section_prop*>(control->GetSection("dosbox")));
 	}
 
 	switch (machine) {
-	case MCH_HERC: return GetHerculesShader();
+	case MachineType::Hercules: return GetHerculesShader();
 
-	case MCH_CGA:
-	case MCH_PCJR: return GetCgaShader();
+	case MachineType::Cga:
+	case MachineType::Pcjr: return GetCgaShader();
 
-	case MCH_TANDY:
-	case MCH_EGA: return GetEgaShader();
+	case MachineType::Tandy:
+	case MachineType::Ega: return GetEgaShader();
 
-	case MCH_VGA: return GetVgaShader();
+	case MachineType::Vga: return GetVgaShader();
 	default: assertm(false, "Invalid MachineType value"); return {};
 	};
 }

--- a/src/gui/shader_manager.cpp
+++ b/src/gui/shader_manager.cpp
@@ -568,7 +568,8 @@ std::string ShaderManager::FindShaderAutoMachine() const
 	switch (machine) {
 	case MachineType::Hercules: return GetHerculesShader();
 
-	case MachineType::Cga:
+	case MachineType::CgaMono:
+	case MachineType::CgaColor:
 	case MachineType::Pcjr: return GetCgaShader();
 
 	case MachineType::Tandy:

--- a/src/hardware/dma.cpp
+++ b/src/hardware/dma.cpp
@@ -565,7 +565,7 @@ DmaController::DmaController(const uint8_t controller_index)
 			io_read_handlers[i].Install(i, DMA_Read_Port, width);
 		}
 		// Install handler for secondary DMA controller ports
-		else if (IS_EGAVGA_ARCH) {
+		else if (is_machine_ega_or_better()) {
 			assert(index == 1);
 			const auto dma_port = static_cast<io_port_t>(0xc0 + i * 2);
 			io_write_handlers[i].Install(dma_port, DMA_Write_Port, width);
@@ -580,7 +580,7 @@ DmaController::DmaController(const uint8_t controller_index)
 		io_read_handlers[0x11].Install(0x87, DMA_Read_Port, io_width_t::byte, 1);
 	}
 	// Install handlers for ports 0x89-0x8b,0x8f (on the secondary)
-	else if (IS_EGAVGA_ARCH) {
+	else if (is_machine_ega_or_better()) {
 		assert(index == 1);
 		io_write_handlers[0x10].Install(0x89, DMA_Write_Port, io_width_t::byte, 3);
 		io_read_handlers[0x10].Install(0x89, DMA_Read_Port, io_width_t::byte, 3);

--- a/src/hardware/input/intel8042.cpp
+++ b/src/hardware/input/intel8042.cpp
@@ -364,7 +364,7 @@ static uint8_t get_irq_mouse()
 
 static uint8_t get_irq_keyboard()
 {
-	if (machine == MCH_PCJR) {
+	if (is_machine_pcjr()) {
 		return IrqNumKbdPcjr;
 	} else {
 		return IrqNumKbdIbmPc;
@@ -542,7 +542,7 @@ static uint8_t get_input_port() // aka port P1
 
 	} port;
 
-	port.lacks_cga = (machine < MCH_CGA);
+	port.lacks_cga = !is_machine_cga_or_better();
 
 	return port.data;
 }

--- a/src/hardware/input/intel8255.cpp
+++ b/src/hardware/input/intel8255.cpp
@@ -53,7 +53,7 @@ static void write_p61(io_port_t, io_val_t value, io_width_t)
 	// Update the state
 	port_b.data = new_port_b.data;
 
-	if (machine < MCH_EGA && port_b.xt_clear_keyboard) {
+	if (!is_machine_ega_or_better() && port_b.xt_clear_keyboard) {
 		// On XT only, bit 7 is a request to clear keyboard. This is
 		// only a pulse, and is normally kept at 0. We "ack" the
 		// request by switching the bit back normal (0) state. However,
@@ -94,7 +94,7 @@ static uint8_t read_p61(io_port_t, io_width_t)
 	port_b.read_toggle.flip();
 
 	// On PC/AT systems, bit 5 sets the timer 2 output status
-	if (is_machine(MCH_EGA | MCH_VGA)) {
+	if (is_machine_ega_or_better()) {
 		port_b.timer2_gating_alias = TIMER_GetOutput2();
 	} else {
 		// On XT systems always toggle bit 5 (Spellicopter CGA)
@@ -137,7 +137,7 @@ void I8255_Init()
 {
 	IO_RegisterWriteHandler(port_num_i8255_1, write_p61, io_width_t::byte);
 	IO_RegisterReadHandler(port_num_i8255_1, read_p61, io_width_t::byte);
-	if (machine == MCH_CGA || machine == MCH_HERC) {
+	if (is_machine_cga() || is_machine_hercules()) {
 		IO_RegisterReadHandler(port_num_i8255_2,
 		                       read_p62,
 		                       io_width_t::byte);

--- a/src/hardware/input/mouseif_dos_driver.cpp
+++ b/src/hardware/input/mouseif_dos_driver.cpp
@@ -433,7 +433,7 @@ static struct {
 
 static void save_vga_registers()
 {
-	if (IS_VGA_ARCH) {
+	if (is_machine_vga_or_better()) {
 		for (uint8_t i = 0; i < 9; i++) {
 			IO_Write(VGAREG_GRDC_ADDRESS, i);
 			vga_regs.grdc_address[i] = IO_Read(VGAREG_GRDC_DATA);
@@ -451,7 +451,7 @@ static void save_vga_registers()
 		IO_Write(VGAREG_SEQU_ADDRESS, 2);
 		vga_regs.sequ_data = IO_Read(VGAREG_SEQU_DATA);
 		IO_Write(VGAREG_SEQU_DATA, 0xF);
-	} else if (machine == MCH_EGA) {
+	} else if (is_machine_ega()) {
 		// Set Map to all planes.
 		IO_Write(VGAREG_SEQU_ADDRESS, 2);
 		IO_Write(VGAREG_SEQU_DATA, 0xF);
@@ -460,7 +460,7 @@ static void save_vga_registers()
 
 static void restore_vga_registers()
 {
-	if (IS_VGA_ARCH) {
+	if (is_machine_vga_or_better()) {
 		for (uint8_t i = 0; i < 9; i++) {
 			IO_Write(VGAREG_GRDC_ADDRESS, i);
 			IO_Write(VGAREG_GRDC_DATA, vga_regs.grdc_address[i]);
@@ -979,7 +979,7 @@ void MOUSEDOS_AfterNewVideoMode(const bool is_mode_changing)
 
 	const uint8_t bios_screen_mode = mem_readb(BIOS_VIDEO_MODE);
 
-	const bool is_svga_mode = IS_VGA_ARCH &&
+	const bool is_svga_mode = is_machine_vga_or_better() &&
 	                          (bios_screen_mode > LastNonSvgaModeNumber);
 	const bool is_svga_text = is_svga_mode && INT10_IsTextMode(*CurMode);
 

--- a/src/hardware/memory.cpp
+++ b/src/hardware/memory.cpp
@@ -754,7 +754,7 @@ public:
 		install_rom_page_handlers(pc_rom_range);
 
 		// Setup PCjr Cartridge ROM page handlers between 0xe0000-0xf0000
-		if (machine == MCH_PCJR) {
+		if (is_machine_pcjr()) {
 			constexpr page_range_t pcjr_rom_range = {0xe0, 0xf0};
 			install_rom_page_handlers(pcjr_rom_range);
 		}

--- a/src/hardware/pic.cpp
+++ b/src/hardware/pic.cpp
@@ -123,8 +123,9 @@ uint32_t PIC_Ticks = 0;
 uint32_t PIC_IRQCheck = 0; // x86 dynamic core expects a 32 bit variable size
 std::atomic<double> atomic_pic_index = 0.0;
 
-void PIC_Controller::set_imr(uint8_t val) {
-	if (machine == MCH_PCJR) {
+void PIC_Controller::set_imr(uint8_t val)
+{
+	if (is_machine_pcjr()) {
 		//irq 6 is a NMI on the PCJR
 		if (this == &primary_controller)
 			val &= ~(1 << (6));
@@ -655,12 +656,12 @@ public:
 		// Ref: https://dosdays.co.uk/topics/io_addresses_irq_dma.php
 		// If present, the MPU-401 activates and uses IRQ 9.
 		//
-		if (IS_EGAVGA_ARCH) {
+		if (is_machine_ega_or_better()) {
 			PIC_SetIRQMask(9, false);
 			PIC_DeActivateIRQ(9);
 		}
 
-		if (machine == MCH_PCJR) {
+		if (is_machine_pcjr()) {
 			/* Enable IRQ6 (replacement for the NMI for PCJr) */
 			PIC_SetIRQMask(6,false);
 		}

--- a/src/hardware/tandy_sound.cpp
+++ b/src/hardware/tandy_sound.cpp
@@ -647,7 +647,7 @@ void TANDYSOUND_Init(Section* section)
 	const auto prop = static_cast<Section_prop*>(section);
 	const auto pref = prop->Get_string("tandy");
 
-	if (has_false(pref) || (!IS_TANDY_ARCH && pref == "auto")) {
+	if (has_false(pref) || (!is_machine_pcjr_or_tandy() && pref == "auto")) {
 		BIOS_ConfigureTandyDacCallbacks(false);
 		return;
 	}
@@ -655,8 +655,8 @@ void TANDYSOUND_Init(Section* section)
 	ConfigProfile cfg;
 
 	switch (machine) {
-	case MCH_PCJR: cfg = ConfigProfile::PcjrSystem; break;
-	case MCH_TANDY: cfg = ConfigProfile::TandySystem; break;
+	case MachineType::Pcjr:  cfg = ConfigProfile::PcjrSystem; break;
+	case MachineType::Tandy: cfg = ConfigProfile::TandySystem; break;
 	default: cfg = ConfigProfile::SoundCardOnly; break;
 	}
 
@@ -666,7 +666,7 @@ void TANDYSOUND_Init(Section* section)
 	//
 	DMA_ShutdownSecondaryController();
 
-	const auto wants_dac = has_true(pref) || (IS_TANDY_ARCH && pref == "auto");
+	const auto wants_dac = has_true(pref) || (is_machine_pcjr_or_tandy() && pref == "auto");
 	if (wants_dac) {
 		tandy_dac = std::make_unique<TandyDAC>(
 		        cfg, prop->Get_string("tandy_dac_filter"));

--- a/src/hardware/vga.cpp
+++ b/src/hardware/vga.cpp
@@ -64,7 +64,7 @@ void VGA_DetermineMode(void) {
 	switch (vga.s3.misc_control_2 >> 4) {
 	case 0:
 		if (vga.attr.mode_control.is_graphics_enabled) {
-			if (IS_VGA_ARCH && (vga.gfx.mode & 0x40)) {
+			if (is_machine_vga_or_better() && (vga.gfx.mode & 0x40)) {
 				// access above 256k?
 				if (vga.s3.reg_31 & 0x8) VGA_SetMode(M_LIN8);
 				else VGA_SetMode(M_VGA);
@@ -352,7 +352,7 @@ void VGA_SetCGA4Table(uint8_t val0,uint8_t val1,uint8_t val2,uint8_t val3) {
 
 void VGA_AllowVgaScanDoubling(const bool allow)
 {
-	if (machine != MCH_VGA) {
+	if (!is_machine_vga_or_better()) {
 		return;
 	}
 	if (allow && !vga.draw.scan_doubling_allowed) {
@@ -446,18 +446,18 @@ void VGA_Init(Section* sec)
 void SVGA_Setup_Driver(void) {
 	memset(&svga, 0, sizeof(SVGA_Driver));
 
-	switch(svgaCard) {
-	case SVGA_S3Trio:
-		SVGA_Setup_S3Trio();
+	switch(svga_type) {
+	case SvgaType::S3:
+		SVGA_Setup_S3();
 		break;
-	case SVGA_TsengET4K:
-		SVGA_Setup_TsengET4K();
+	case SvgaType::TsengEt3k:
+		SVGA_Setup_TsengEt3k();
 		break;
-	case SVGA_TsengET3K:
-		SVGA_Setup_TsengET3K();
+	case SvgaType::TsengEt4k:
+		SVGA_Setup_TsengEt4k();
 		break;
-	case SVGA_ParadisePVGA1A:
-		SVGA_Setup_ParadisePVGA1A();
+	case SvgaType::Paradise:
+		SVGA_Setup_Paradise();
 		break;
 	default:
 		vga.vmemsize = vga.vmemwrap = 256*1024;

--- a/src/hardware/vga_attr.cpp
+++ b/src/hardware/vga_attr.cpp
@@ -139,7 +139,7 @@ static void write_p3c0(io_port_t, io_val_t value, io_width_t)
 		case 0x10: { // Mode Control Register (EGA & VGA)
 			// Not really correct, but should do it
 			AttributeModeControlRegister new_value = {val};
-			if (!IS_VGA_ARCH) {
+			if (!is_machine_vga_or_better()) {
 				new_value.is_pixel_panning_enabled = 0;
 				new_value.is_8bit_color_enabled    = 0;
 				new_value.palette_bits_5_4_select  = 0;
@@ -229,7 +229,7 @@ static void write_p3c0(io_port_t, io_val_t value, io_width_t)
 			case M_LIN16:
 			default: vga.config.pel_panning = (val & 0x7);
 			}
-			if (machine == MCH_EGA) {
+			if (is_machine_ega()) {
 				// On the EGA panning can be programmed for
 				// every scanline:
 				vga.draw.panning = vga.config.pel_panning;
@@ -244,7 +244,7 @@ static void write_p3c0(io_port_t, io_val_t value, io_width_t)
 			break;
 
 		case 0x14: // Color Select Register (VGA only)
-			if (!IS_VGA_ARCH) {
+			if (!is_machine_vga_or_better()) {
 				vga.attr.color_select = 0;
 				break;
 			}
@@ -323,20 +323,20 @@ static uint8_t read_p3c1(io_port_t, io_width_t)
 
 void VGA_SetupAttr()
 {
+	if (!is_machine_ega_or_better()) {
+		return;
+	}
+
 	// The Attribute Control Registers can be written on port 3C0h on EGA
 	// and VGA.
-	if (machine == MCH_EGA || machine == MCH_VGA) {
-		IO_RegisterWriteHandler(0x3c0, write_p3c0, io_width_t::byte);
-	}
+	IO_RegisterWriteHandler(0x3c0, write_p3c0, io_width_t::byte);
 
-	if (machine == MCH_EGA) {
-		IO_RegisterWriteHandler(0x3c1, write_p3c0, io_width_t::byte);
-	}
-
-	if (machine == MCH_VGA) {
+	if (is_machine_vga_or_better()) {
 		// The Attribute Control Registers canbe also read from port
 		// 3C1h on VGA only.
 		IO_RegisterReadHandler(0x3c1, read_p3c1, io_width_t::byte);
 		IO_RegisterReadHandler(0x3c0, read_p3c0, io_width_t::byte);
+	} else {
+		IO_RegisterWriteHandler(0x3c1, write_p3c0, io_width_t::byte);
 	}
 }

--- a/src/hardware/vga_crtc.cpp
+++ b/src/hardware/vga_crtc.cpp
@@ -147,7 +147,7 @@ void vga_write_p3d5(io_port_t, io_val_t value, io_width_t)
 		vga.crtc.preset_row_scan  = val;
 		vga.config.hlines_skip = val & 31;
 
-		if (IS_VGA_ARCH) {
+		if (is_machine_vga_or_better()) {
 			vga.config.bytes_skip = (val >> 5) & 3;
 		} else {
 			vga.config.bytes_skip = 0;
@@ -162,7 +162,7 @@ void vga_write_p3d5(io_port_t, io_val_t value, io_width_t)
 		break;
 
 	case 0x09: {
-		if (IS_VGA_ARCH) {
+		if (is_machine_vga_or_better()) {
 			vga.config.line_compare = (vga.config.line_compare & 0x5ff) |
 			                          (val & 0x40) << 3;
 		}
@@ -186,7 +186,7 @@ void vga_write_p3d5(io_port_t, io_val_t value, io_width_t)
 	case 0x0a: // Cursor Start Register
 		vga.crtc.cursor_start    = val;
 		vga.draw.cursor.sline = val & 0x1f;
-		if (IS_VGA_ARCH) {
+		if (is_machine_vga_or_better()) {
 			vga.draw.cursor.enabled = !(val & 0x20);
 		} else {
 			vga.draw.cursor.enabled = true;
@@ -250,13 +250,13 @@ void vga_write_p3d5(io_port_t, io_val_t value, io_width_t)
 	case 0x11: // Vertical Retrace End Register
 		vga.crtc.vertical_retrace_end = val;
 
-		if (IS_EGAVGA_ARCH && !(val & 0x10)) {
+		if (is_machine_ega_or_better() && !(val & 0x10)) {
 			vga.draw.vret_triggered = false;
-			if (machine == MCH_EGA) {
+			if (is_machine_ega()) {
 				PIC_DeActivateIRQ(9);
 			}
 		}
-		if (IS_VGA_ARCH) {
+		if (is_machine_vga_or_better()) {
 			vga.crtc.read_only = (val & 128) > 0;
 		} else {
 			vga.crtc.read_only = false;
@@ -310,7 +310,7 @@ void vga_write_p3d5(io_port_t, io_val_t value, io_width_t)
 
 	case 0x14: // Underline Location Register
 		vga.crtc.underline_location = val;
-		if (IS_VGA_ARCH) {
+		if (is_machine_vga_or_better()) {
 			// Byte,word,dword mode
 			if (vga.crtc.underline_location & 0x20) {
 				vga.config.addr_shift = 2;

--- a/src/hardware/vga_dac.cpp
+++ b/src/hardware/vga_dac.cpp
@@ -113,7 +113,7 @@ static void vga_dac_send_color(const uint8_t palette_idx, const uint8_t color_id
 	// Fortunately, no commercial game developers seemed to use such
 	// horrible practices.
 	//
-	if (machine == MCH_VGA && !INT10_VideoModeChangeInProgress() &&
+	if (is_machine_vga_or_better() && !INT10_VideoModeChangeInProgress() &&
 	    !vga.ega_mode_with_vga_colors) {
 
 		// Even thought the video mode change has been completed at this
@@ -334,7 +334,7 @@ void VGA_DAC_CombineColor(const uint8_t palette_idx, const uint8_t color_idx)
 		// Mimic the legacy palette behaviour when emulating the Paradise
 		// card (the oldest SVGA card we emulate). This fixes the wrong
 		// colours appearing in some rare titles (e.g., Spell It Plus).
-		if (svgaCard == SVGA_ParadisePVGA1A) {
+		if (svga_type == SvgaType::Paradise) {
 			break;
 		}
 		[[fallthrough]];
@@ -368,7 +368,7 @@ void VGA_SetupDAC(void)
 	vga.dac.read_index  = 0;
 	vga.dac.write_index = 0;
 
-	if (IS_VGA_ARCH) {
+	if (is_machine_vga_or_better()) {
 		// Set up the DAC IO port handlers
 		IO_RegisterWriteHandler(0x3c6, write_p3c6, io_width_t::byte);
 		IO_RegisterReadHandler(0x3c6, read_p3c6, io_width_t::byte);

--- a/src/hardware/vga_gfx.cpp
+++ b/src/hardware/vga_gfx.cpp
@@ -210,15 +210,15 @@ static uint8_t read_p3cf(io_port_t port, io_width_t)
 	return 0;	/* Compiler happy */
 }
 
-void VGA_SetupGFX(void) {
-	if (IS_EGAVGA_ARCH) {
+void VGA_SetupGFX()
+{
+	if (is_machine_ega_or_better()) {
 		IO_RegisterWriteHandler(0x3ce, write_p3ce, io_width_t::byte);
 		IO_RegisterWriteHandler(0x3cf, write_p3cf, io_width_t::byte);
-		if (IS_VGA_ARCH) {
-			IO_RegisterReadHandler(0x3ce, read_p3ce, io_width_t::byte);
-			IO_RegisterReadHandler(0x3cf, read_p3cf, io_width_t::byte);
-		}
+	}
+
+	if (is_machine_vga_or_better()) {
+		IO_RegisterReadHandler(0x3ce, read_p3ce, io_width_t::byte);
+		IO_RegisterReadHandler(0x3cf, read_p3cf, io_width_t::byte);
 	}
 }
-
-

--- a/src/hardware/vga_memory.cpp
+++ b/src/hardware/vga_memory.cpp
@@ -964,7 +964,8 @@ void VGA_SetupHandlers(void) {
 
 	PageHandler *newHandler;
 	switch (machine) {
-	case MachineType::Cga:
+	case MachineType::CgaMono:
+	case MachineType::CgaColor:
 	case MachineType::Pcjr:
 		MEM_SetPageHandler( VGA_PAGE_A0, 16, &vgaph.empty );
 		MEM_SetPageHandler( VGA_PAGE_B0, 8, &vgaph.empty );

--- a/src/hardware/vga_misc.cpp
+++ b/src/hardware/vga_misc.cpp
@@ -111,9 +111,15 @@ static uint8_t read_p3c2(io_port_t, io_width_t)
 {
 	uint8_t retval = 0;
 
-	if (machine==MCH_EGA) retval = 0x0F;
-	else if (IS_VGA_ARCH) retval = 0x60;
-	if ((machine==MCH_VGA) || (((vga.misc_output>>2)&3)==0) || (((vga.misc_output>>2)&3)==3)) {
+	if (is_machine_ega()) {
+		retval = 0x0f;
+	} else if (is_machine_vga_or_better()) {
+		retval = 0x60;
+	}
+
+	if (is_machine_vga_or_better() ||
+	    (((vga.misc_output >> 2) & 3) == 0) ||
+	    (((vga.misc_output >> 2) & 3) == 3)) {
 		retval |= 0x10;
 	}
 
@@ -133,18 +139,19 @@ static uint8_t read_p3c2(io_port_t, io_width_t)
 	*/
 }
 
-void VGA_SetupMisc(void) {
-	if (IS_EGAVGA_ARCH) {
+void VGA_SetupMisc()
+{
+	if (is_machine_ega_or_better()) {
 		vga.draw.vret_triggered=false;
 		IO_RegisterReadHandler(0x3c2, read_p3c2, io_width_t::byte);
 		IO_RegisterWriteHandler(0x3c2, write_p3c2, io_width_t::byte);
-		if (IS_VGA_ARCH) {
+		if (is_machine_vga_or_better()) {
 			IO_RegisterReadHandler(0x3ca, read_p3ca, io_width_t::byte);
 			IO_RegisterReadHandler(0x3cc, read_p3cc, io_width_t::byte);
 		} else {
 			IO_RegisterReadHandler(0x3c8, read_p3c8, io_width_t::byte);
 		}
-	} else if (machine==MCH_CGA || IS_TANDY_ARCH) {
+	} else if (is_machine_cga() || is_machine_pcjr_or_tandy()) {
 		IO_RegisterReadHandler(0x3da, vga_read_p3da, io_width_t::byte);
 	}
 }

--- a/src/hardware/vga_other.cpp
+++ b/src/hardware/vga_other.cpp
@@ -733,7 +733,7 @@ static void write_cga(io_port_t port, io_val_t value, io_width_t)
 				if (cga_comp == COMPOSITE_STATE::ON ||
 				    ((cga_comp == COMPOSITE_STATE::AUTO &&
 				      !(val & 0x4)) &&
-				     !mono_cga)) {
+				     !is_machine_cga_mono())) {
 
 					// composite ntsc 640x200 16 color mode
 					if (is_machine_pcjr()) {
@@ -1153,7 +1153,7 @@ void VGA_SetMonochromePalette(const enum MonochromePalette _palette)
 		hercules_palette = _palette;
 		VGA_SetHerculesPalette();
 
-	} else if (is_machine_cga() && mono_cga) {
+	} else if (is_machine_cga_mono()) {
 		mono_cga_palette = _palette;
 		VGA_SetMonochromeCgaPalette();
 	}
@@ -1365,7 +1365,7 @@ void VGA_SetupOther()
 	if (is_machine_cga()) {
 		IO_RegisterWriteHandler(0x3d8, write_cga, io_width_t::byte);
 		IO_RegisterWriteHandler(0x3d9, write_cga, io_width_t::byte);
-		if (mono_cga) {
+		if (is_machine_cga_mono()) {
 			MAPPER_AddHandler(cycle_mono_cga_palette,
 			                  SDL_SCANCODE_F11,
 			                  0,
@@ -1388,7 +1388,7 @@ void VGA_SetupOther()
 		IO_RegisterWriteHandler(0x3df, write_pcjr, io_width_t::byte);
 	}
 	// Add composite hotkeys for CGA, Tandy, and PCjr
-	if ((is_machine_cga() && !mono_cga) || is_machine_pcjr_or_tandy()) {
+	if (is_machine_cga_color() || is_machine_pcjr_or_tandy()) {
 		MAPPER_AddHandler(select_next_crt_knob, SDL_SCANCODE_F10, 0,
 		                  "select", "Sel Knob");
 		MAPPER_AddHandler(turn_crt_knob_positive, SDL_SCANCODE_F11, 0,

--- a/src/hardware/vga_paradise.cpp
+++ b/src/hardware/vga_paradise.cpp
@@ -192,7 +192,7 @@ bool AcceptsMode_PVGA1A(Bitu mode) {
 	return VideoModeMemSize(mode) < vga.vmemsize;
 }
 
-void SVGA_Setup_ParadisePVGA1A(void) {
+void SVGA_Setup_Paradise(void) {
 	svga.write_p3cf = &write_p3cf_pvga1a;
 	svga.read_p3cf = &read_p3cf_pvga1a;
 

--- a/src/hardware/vga_s3.cpp
+++ b/src/hardware/vga_s3.cpp
@@ -812,7 +812,7 @@ void filter_compatible_s3_vesa_modes()
 	CurMode = std::prev(ModeList_VGA.end());
 }
 
-void SVGA_Setup_S3Trio()
+void SVGA_Setup_S3()
 {
 	svga.write_p3d5 = &SVGA_S3_WriteCRTC;
 	svga.read_p3d5  = &SVGA_S3_ReadCRTC;

--- a/src/hardware/vga_seq.cpp
+++ b/src/hardware/vga_seq.cpp
@@ -29,7 +29,7 @@ void write_p3c5(io_port_t, io_val_t value, io_width_t)
 
 		// If the user is forcing the clocking mode's 8/9-dot-mode bit high,
 		// then adjust the incoming value before processing it.
-		if (vga.seq.wants_vga_8dot_font && IS_VGA_ARCH) {
+		if (vga.seq.wants_vga_8dot_font && is_machine_vga_or_better()) {
 			auto reg = ClockingModeRegister{val};
 			reg.is_eight_dot_mode = true;
 			val = reg.data;
@@ -73,12 +73,14 @@ void write_p3c5(io_port_t, io_val_t value, io_width_t)
 		{
 			seq(character_map_select)=val;
 		        auto font1 = static_cast<uint8_t>((val & 0x3) << 1);
-		        if (IS_VGA_ARCH)
+		        if (is_machine_vga_or_better()) {
 			        font1 |= (val & 0x10) >> 4;
+		        }
 		        vga.draw.font_tables[0] = &vga.draw.font[font1 * 8 * 1024];
 		        uint8_t font2 = ((val & 0xc) >> 1);
-		        if (IS_VGA_ARCH)
+		        if (is_machine_vga_or_better()) {
 			        font2 |= (val & 0x20) >> 5;
+		        }
 		        vga.draw.font_tables[1] = &vga.draw.font[font2 * 8 * 1024];
 	}
 	/*
@@ -100,7 +102,7 @@ void write_p3c5(io_port_t, io_val_t value, io_width_t)
 		                rather than the Map Mask and Read Map Select Registers.
 		*/
 		seq(memory_mode)=val;
-		if (IS_VGA_ARCH) {
+		if (is_machine_vga_or_better()) {
 			/* Changing this means changing the VGA Memory Read/Write Handler */
 			if (val&0x08) vga.config.chained=true;
 			else vga.config.chained=false;
@@ -134,12 +136,13 @@ uint8_t read_p3c5(io_port_t, io_width_t)
 	return 0;
 }
 
-void VGA_SetupSEQ(void) {
-	if (IS_EGAVGA_ARCH) {
+void VGA_SetupSEQ()
+{
+	if (is_machine_ega_or_better()) {
 		IO_RegisterWriteHandler(0x3c4, write_p3c4, io_width_t::byte);
 		IO_RegisterWriteHandler(0x3c5, write_p3c5, io_width_t::byte);
-		if (IS_VGA_ARCH) {
 
+		if (is_machine_vga_or_better()) {
 			// Let the user force the clocking mode's 8/9-dot-mode bit high
 			const auto conf    = control->GetSection("dosbox");
 			const auto section = static_cast<Section_prop*>(conf);

--- a/src/hardware/vga_tseng.cpp
+++ b/src/hardware/vga_tseng.cpp
@@ -405,7 +405,8 @@ bool AcceptsMode_ET4K(Bitu mode) {
 //	return mode != 0x3d;
 }
 
-void SVGA_Setup_TsengET4K(void) {
+void SVGA_Setup_TsengEt4k()
+{
     svga.write_p3d5 = &write_p3d5_et4k;
 	svga.read_p3d5 = &read_p3d5_et4k;
 	svga.write_p3c5 = &write_p3c5_et4k;
@@ -772,7 +773,8 @@ bool AcceptsMode_ET3K(Bitu mode) {
 	return mode <= 0x37 && mode != 0x2f && VideoModeMemSize(mode) < vga.vmemsize;
 }
 
-void SVGA_Setup_TsengET3K(void) {
+void SVGA_Setup_TsengEt3k()
+{
 	svga.write_p3d5 = &write_p3d5_et3k;
 	svga.read_p3d5 = &read_p3d5_et3k;
 	svga.write_p3c5 = &write_p3c5_et3k;

--- a/src/hardware/vga_xga.cpp
+++ b/src/hardware/vga_xga.cpp
@@ -1512,8 +1512,11 @@ uint32_t XGA_Read(io_port_t port, io_width_t width)
 	return 0xffffffff;
 }
 
-void VGA_SetupXGA(void) {
-	if (!IS_VGA_ARCH) return;
+void VGA_SetupXGA()
+{
+	if (!is_machine_vga_or_better()) {
+		return;
+	}
 
 	memset(&xga, 0, sizeof(XGAStatus));
 

--- a/src/hardware/voodoo.cpp
+++ b/src/hardware/voodoo.cpp
@@ -7887,8 +7887,7 @@ static void voodoo_init(Section* sec)
 	auto* section = dynamic_cast<Section_prop*>(sec);
 
 	// Only activate on SVGA machines and when requested
-	if (machine != MCH_VGA || svgaCard == SVGA_None || !section ||
-	    !section->Get_bool("voodoo")) {
+	if (!is_machine_svga() || !section || !section->Get_bool("voodoo")) {
 		return;
 	}
 	//

--- a/src/ints/bios.cpp
+++ b/src/ints/bios.cpp
@@ -1471,7 +1471,8 @@ public:
 			//Startup monochrome
 			config|=0x30;
 			break;
-		case MachineType::Cga:
+		case MachineType::CgaMono:
+		case MachineType::CgaColor:
 		case MachineType::Pcjr:
 		case MachineType::Tandy:
 		case MachineType::Ega:

--- a/src/ints/bios_disk.cpp
+++ b/src/ints/bios_disk.cpp
@@ -336,17 +336,21 @@ static Bitu INT13_DiskHandler(void) {
 			 */
 			if (any_images && driveInactive(drivenum)) {
 				/* driveInactive sets carry flag if the specified drive is not available */
-				if ((machine==MCH_CGA) || (machine==MCH_PCJR)) {
+				if (is_machine_cga() || is_machine_pcjr()) {
 					/* those bioses call floppy drive reset for invalid drive values */
 					if (((imageDiskList[0]) && (imageDiskList[0]->active)) || ((imageDiskList[1]) && (imageDiskList[1]->active))) {
-						if (machine!=MCH_PCJR && reg_dl<0x80) reg_ip++;
+						if (!is_machine_pcjr() && reg_dl < 0x80) {
+							reg_ip++;
+						}
 						last_status = 0x00;
 						CALLBACK_SCF(false);
 					}
 				}
 				return CBRET_NONE;
 			}
-			if (machine!=MCH_PCJR && reg_dl<0x80) reg_ip++;
+			if (!is_machine_pcjr() && reg_dl < 0x80) {
+				reg_ip++;
+			}
 			last_status = 0x00;
 			CALLBACK_SCF(false);
 		}

--- a/src/ints/bios_keyboard.cpp
+++ b/src/ints/bios_keyboard.cpp
@@ -166,7 +166,7 @@ static const KeyCodes& get_key_codes_for(const uint8_t scan_code)
 bool BIOS_AddKeyToBuffer(uint16_t code) {
 	if (mem_readb(BIOS_KEYBOARD_FLAGS2)&8) return true;
 	uint16_t start,end,head,tail,ttail;
-	if (machine==MCH_PCJR) {
+	if (is_machine_pcjr()) {
 		/* should be done for cga and others as well, to be tested */
 		start=0x1e;
 		end=0x3e;
@@ -194,7 +194,7 @@ static void add_key(uint16_t code) {
 
 static bool get_key(uint16_t &code) {
 	uint16_t start,end,head,tail,thead;
-	if (machine==MCH_PCJR) {
+	if (is_machine_pcjr()) {
 		/* should be done for cga and others as well, to be tested */
 		start=0x1e;
 		end=0x3e;
@@ -645,7 +645,7 @@ void BIOS_SetupKeyboard(void) {
 	CALLBACK_Setup(call_irq1,&IRQ1_Handler,CB_IRQ1,RealToPhysical(BIOS_DEFAULT_IRQ1_LOCATION),"IRQ 1 Keyboard");
 	RealSetVec(0x09,BIOS_DEFAULT_IRQ1_LOCATION);
 
-	if (machine==MCH_PCJR) {
+	if (is_machine_pcjr()) {
 		call_irq6=CALLBACK_Allocate();
 		CALLBACK_Setup(call_irq6,nullptr,CB_IRQ6_PCJR,"PCJr kb irq");
 		RealSetVec(0x0e,CALLBACK_RealPointer(call_irq6));

--- a/src/ints/ems.cpp
+++ b/src/ints/ems.cpp
@@ -1402,7 +1402,7 @@ public:
 		ems_type=GetEMSType(section);
 		if (ems_type<=0) return;
 
-		if (machine==MCH_PCJR) {
+		if (is_machine_pcjr()) {
 			ems_type=0;
 			LOG_MSG("EMS disabled for PCJr machine");
 			return;

--- a/src/ints/int10.h
+++ b/src/ints/int10.h
@@ -156,9 +156,9 @@ union BiosVgaFlagsRec {
 #define VGAMEM_CTEXT 0xB800
 #define VGAMEM_MTEXT 0xB000
 
-#define BIOS_NCOLS uint16_t ncols=real_readw(BIOSMEM_SEG,BIOSMEM_NB_COLS);
-#define BIOS_NROWS uint16_t nrows=IS_EGAVGA_ARCH?((uint16_t)real_readb(BIOSMEM_SEG,BIOSMEM_NB_ROWS)+1):25;
-#define BIOS_CHEIGHT uint8_t cheight=IS_EGAVGA_ARCH?real_readb(BIOSMEM_SEG,BIOSMEM_CHAR_HEIGHT):8;
+#define BIOS_NCOLS uint16_t ncols = real_readw(BIOSMEM_SEG, BIOSMEM_NB_COLS);
+#define BIOS_NROWS uint16_t nrows = is_machine_ega_or_better() ? ((uint16_t) real_readb(BIOSMEM_SEG,BIOSMEM_NB_ROWS) + 1) : 25;
+#define BIOS_CHEIGHT uint8_t cheight = is_machine_ega_or_better() ? real_readb(BIOSMEM_SEG,BIOSMEM_CHAR_HEIGHT) : 8;
 
 uint16_t INT10_GetTextColumns();
 uint16_t INT10_GetTextRows();

--- a/src/ints/int10_char.cpp
+++ b/src/ints/int10_char.cpp
@@ -450,8 +450,9 @@ void ReadCharAttr(uint16_t col,uint16_t row,uint8_t page,uint16_t * result) {
 	case M_TANDY16:
 		split_chr = true;
 		switch (machine) {
-		case MachineType::Cga:
 		case MachineType::Hercules:
+		case MachineType::CgaMono:
+		case MachineType::CgaColor:
 			fontdata = RealMake(0xf000, 0xfa6e);
 			break;
 		case MachineType::Pcjr:
@@ -544,8 +545,9 @@ void WriteChar(uint16_t col,uint16_t row,uint8_t page,uint8_t chr,uint8_t attr,b
 			break;
 		}
 		switch (machine) {
-		case MachineType::Cga:
 		case MachineType::Hercules:
+		case MachineType::CgaMono:
+		case MachineType::CgaColor:
 			fontdata = RealMake(0xf000, 0xfa6e);
 			break;
 		case MachineType::Pcjr:
@@ -688,7 +690,8 @@ void write_char(const uint8_t chr, const uint8_t attr, uint8_t page,
 				}
 				break;
 
-			case MachineType::Cga:
+		        case MachineType::CgaMono:
+		        case MachineType::CgaColor:
 			case MachineType::Pcjr:
 				page    = 0;
 				pospage = 0;

--- a/src/ints/int10_modes.cpp
+++ b/src/ints/int10_modes.cpp
@@ -728,7 +728,8 @@ void INT10_SetCurMode(void)
 		bool mode_changed = false;
 
 		switch (machine) {
-		case MachineType::Cga:
+		case MachineType::CgaMono:
+		case MachineType::CgaColor:
 			if (bios_mode < 7) {
 				mode_changed = set_cur_mode(ModeList_OTHER, bios_mode);
 			}
@@ -909,7 +910,8 @@ static void finish_set_mode(bool clearmem) {
 static bool INT10_SetVideoMode_OTHER(uint16_t mode, bool clearmem)
 {
 	switch (machine) {
-	case MachineType::Cga:
+	case MachineType::CgaMono:
+	case MachineType::CgaColor:
 		if (mode > 6)
 			return false;
 		[[fallthrough]];
@@ -1022,7 +1024,8 @@ static bool INT10_SetVideoMode_OTHER(uint16_t mode, bool clearmem)
 
 		real_writeb(BIOSMEM_SEG,BIOSMEM_CURRENT_MSR,0x29); // attribute controls blinking
 		break;
-	case MachineType::Cga:
+	case MachineType::CgaMono:
+	case MachineType::CgaColor:
 		mode_control=mode_control_list[CurMode->mode];
 		if (CurMode->mode == 0x6) color_select=0x3f;
 		else color_select=0x30;
@@ -1031,7 +1034,7 @@ static bool INT10_SetVideoMode_OTHER(uint16_t mode, bool clearmem)
 		real_writeb(BIOSMEM_SEG,BIOSMEM_CURRENT_MSR,mode_control);
 		real_writeb(BIOSMEM_SEG,BIOSMEM_CURRENT_PAL,color_select);
 
-		if (mono_cga) {
+		if (is_machine_cga_mono()) {
 			VGA_SetMonochromeCgaPalette();
 		}
 		break;

--- a/src/ints/int10_pal.cpp
+++ b/src/ints/int10_pal.cpp
@@ -78,7 +78,8 @@ void INT10_SetSinglePaletteRegister(uint8_t reg, uint8_t val)
 		break;
 
 	case MachineType::Hercules:
-	case MachineType::Cga:
+	case MachineType::CgaMono:
+	case MachineType::CgaColor:
 		break;
 
 	default: assertm(false, "Invalid MachineType value");
@@ -104,7 +105,8 @@ void INT10_SetOverscanBorderColor(uint8_t val)
 		break;
 
 	case MachineType::Hercules:
-	case MachineType::Cga:
+	case MachineType::CgaMono:
+	case MachineType::CgaColor:
 		break;
 
 	default: assertm(false, "Invalid MachineType value");
@@ -142,7 +144,8 @@ void INT10_SetAllPaletteRegisters(PhysPt data)
 		break;
 
 	case MachineType::Hercules:
-	case MachineType::Cga:
+	case MachineType::CgaMono:
+	case MachineType::CgaColor:
 		break;
 
 	default: assertm(false, "Invalid MachineType value");
@@ -333,9 +336,10 @@ void INT10_SetBackgroundBorder(uint8_t val)
 	real_writeb(BIOSMEM_SEG,BIOSMEM_CURRENT_PAL,color_select);
 
 	switch (machine) {
-	case MachineType::Cga:
+	case MachineType::CgaMono:
+	case MachineType::CgaColor:
 		// only write the color select register
-		IO_Write(0x3d9,color_select);
+		IO_Write(0x3d9, color_select);
 		break;
 
 	case MachineType::Tandy:

--- a/src/ints/int10_put_pixel.cpp
+++ b/src/ints/int10_put_pixel.cpp
@@ -33,7 +33,7 @@ void INT10_PutPixel(uint16_t x,uint16_t y,uint8_t page,uint8_t color) {
 		} else {
 			// a 32k mode: PCJr special case (see M_TANDY16)
 			uint16_t seg;
-			if (machine==MCH_PCJR) {
+			if (is_machine_pcjr()) {
 				Bitu cpupage =
 					(real_readb(BIOSMEM_SEG, BIOSMEM_CRTCPU_PAGE) >> 3) & 0x7;
 				seg = cpupage << 10; // A14-16 to addr bits 14-16
@@ -78,7 +78,7 @@ void INT10_PutPixel(uint16_t x,uint16_t y,uint8_t page,uint8_t color) {
 
 		uint16_t segment, offset;
 		if (is_32k) {
-			if (machine==MCH_PCJR) {
+			if (is_machine_pcjr()) {
 				Bitu cpupage =
 					(real_readb(BIOSMEM_SEG, BIOSMEM_CRTCPU_PAGE) >> 3) & 0x7;
 				segment = cpupage << 10; // A14-16 to addr bits 14-16
@@ -114,8 +114,8 @@ void INT10_PutPixel(uint16_t x,uint16_t y,uint8_t page,uint8_t color) {
 	}
 	break;
 	case M_LIN4:
-		if ((machine!=MCH_VGA) || (svgaCard!=SVGA_TsengET4K) ||
-				(CurMode->swidth>800)) {
+		if (!is_machine_vga_or_better() || svga_type != SvgaType::TsengEt4k ||
+		    (CurMode->swidth > 800)) {
 			// the ET4000 BIOS supports text output in 800x600 SVGA
 			// (Gateway 2)
 			putpixelwarned = true;
@@ -214,7 +214,7 @@ void INT10_GetPixel(uint16_t x,uint16_t y,uint8_t page,uint8_t * color) {
 			bool is_32k = (real_readb(BIOSMEM_SEG, BIOSMEM_CURRENT_MODE) >= 9)?true:false;
 			uint16_t segment, offset;
 			if (is_32k) {
-				if (machine==MCH_PCJR) {
+				if (is_machine_pcjr()) {
 					Bitu cpupage = (real_readb(BIOSMEM_SEG, BIOSMEM_CRTCPU_PAGE) >> 3) & 0x7;
 					segment = cpupage << 10;
 				} else segment = 0xb800;

--- a/src/ints/int10_video_state.cpp
+++ b/src/ints/int10_video_state.cpp
@@ -11,13 +11,23 @@
 
 Bitu INT10_VideoState_GetSize(Bitu state) {
 	// state: bit0=hardware, bit1=bios data, bit2=color regs/dac state
-	if ((state&7)==0) return 0;
+	if ((state & 7) == 0) {
+		return 0;
+	}
 
-	Bitu size=0x20;
-	if (state&1) size+=0x46;
-	if (state&2) size+=0x3a;
-	if (state&4) size+=0x303;
-	if ((svgaCard==SVGA_S3Trio) && (state&8)) size+=0x43;
+	Bitu size = 0x20;
+	if (state & 1) {
+		size += 0x46;
+	}
+	if (state & 2) {
+		size += 0x3a;
+	}
+	if (state & 4) {
+		size += 0x303;
+	}
+	if ((svga_type == SvgaType::S3) && (state & 8)) {
+		size += 0x43;
+	}
 	assert(size > 0);
 	return (size - 1) / 64 + 1;
 }
@@ -158,7 +168,7 @@ bool INT10_VideoState_Save(Bitu state,RealPt buffer) {
 		base_dest+=0x303;
 	}
 
-	if ((svgaCard==SVGA_S3Trio) && (state&8))  {
+	if ((svga_type == SvgaType::S3) && (state & 8)) {
 		real_writew(base_seg,RealOffset(buffer)+6,base_dest);
 
 		uint16_t crt_reg=real_readw(BIOSMEM_SEG,BIOSMEM_CRTC_ADDRESS);
@@ -312,7 +322,7 @@ bool INT10_VideoState_Restore(Bitu state,RealPt buffer) {
 		}
 	}
 
-	if ((svgaCard==SVGA_S3Trio) && (state&8))  {
+	if ((svga_type == SvgaType::S3) && (state & 8))  {
 		base_dest=real_readw(base_seg,RealOffset(buffer)+6);
 
 		uint16_t crt_reg=real_readw(BIOSMEM_SEG,BIOSMEM_CRTC_ADDRESS);

--- a/src/ints/int10_vptable.cpp
+++ b/src/ints/int10_vptable.cpp
@@ -501,8 +501,9 @@ static uint8_t video_parameter_table_ega[0x40*0x17]={
 };
 
 
-uint16_t INT10_SetupVideoParameterTable(PhysPt basepos) {
-	if (IS_VGA_ARCH) {
+uint16_t INT10_SetupVideoParameterTable(PhysPt basepos)
+{
+	if (is_machine_vga_or_better()) {
 		for (Bitu i=0;i<0x40*0x1d;i++) {
 			phys_writeb(basepos+i,video_parameter_table_vga[i]);
 		}
@@ -519,12 +520,12 @@ void INT10_SetupBasicVideoParameterTable(void) {
 	/* video parameter table at F000:F0A4 */
 	RealSetVec(0x1d,RealMake(0xF000, 0xF0A4));
 	switch (machine) {
-	case MCH_TANDY:
+	case MachineType::Tandy:
 		for (uint16_t i = 0; i < sizeof(vparams_tandy); i++) {
 			phys_writeb(0xFF0A4+i,vparams_tandy[i]);
 		}
 		break;
-	case MCH_PCJR:
+	case MachineType::Pcjr:
 		for (uint16_t i = 0; i < sizeof(vparams_pcjr); i++) {
 			phys_writeb(0xFF0A4+i,vparams_pcjr[i]);
 		}
@@ -539,7 +540,7 @@ void INT10_SetupBasicVideoParameterTable(void) {
 
 #if 0
 void INT10_GenerateVideoParameterTable(void) {
-	if (!IS_VGA_ARCH) E_Exit("Be sure that all graphics registers are readable!");
+	if (!is_machine_vga_or_better()) E_Exit("Be sure that all graphics registers are readable!");
 	Bitu i;
 	for (i=0; i<4; i++) {
 		LOG_MSG("// video parameter table for mode %x (cga emulation)",i);
@@ -663,7 +664,7 @@ void INT10_GenerateVideoParameterTable(void) {
 			gfx_regs[0x04],gfx_regs[0x05],gfx_regs[0x06],gfx_regs[0x07],gfx_regs[0x08]);
 	}
 	for (i=0; i<4; i++) {
-		if (IS_VGA_ARCH) {
+		if (is_machine_vga_or_better()) {
 			LOG_MSG("// video parameter table for mode %x (350 lines)",i);
 			LOG_MSG("  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,");
 			LOG_MSG("  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,");
@@ -720,7 +721,7 @@ void INT10_GenerateVideoParameterTable(void) {
 				gfx_regs[0x04],gfx_regs[0x05],gfx_regs[0x06],gfx_regs[0x07],gfx_regs[0x08]);
 		}
 	}
-	if (IS_VGA_ARCH) {
+	if (is_machine_vga_or_better()) {
 		for (i=0x0e; i<0x14; i++) {
 			Bitu ct=i;
 			if (i==0x0e) ct=1;

--- a/src/misc/unicode.cpp
+++ b/src/misc/unicode.cpp
@@ -2137,7 +2137,7 @@ uint16_t get_utf8_code_page()
 	constexpr uint16_t RomCodePage = 437; // United States
 
 	// Below EGA it wasn't possible to change the character set
-	const uint16_t code_page = IS_EGAVGA_ARCH
+	const uint16_t code_page = is_machine_ega_or_better()
 	                                 ? deduplicate_code_page(dos.loaded_codepage)
 	                                 : RomCodePage;
 

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -451,12 +451,13 @@ void DOS_Shell::Run()
 			WriteOut(MSG_Get("SHELL_STARTUP_DEBUG"), MMOD2_NAME);
 #endif
 			if (is_machine_cga()) {
-				if (mono_cga)
+				if (is_machine_cga_mono()) {
 					WriteOut(MSG_Get("SHELL_STARTUP_CGA_MONO"),
 					         MMOD2_NAME);
-				else
+				} else {
 					WriteOut(MSG_Get("SHELL_STARTUP_CGA"),
 					         MMOD2_NAME);
+				}
 			}
 			if (is_machine_hercules()) {
 				WriteOut(MSG_Get("SHELL_STARTUP_HERC"));

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -450,7 +450,7 @@ void DOS_Shell::Run()
 #if C_DEBUG
 			WriteOut(MSG_Get("SHELL_STARTUP_DEBUG"), MMOD2_NAME);
 #endif
-			if (machine == MCH_CGA) {
+			if (is_machine_cga()) {
 				if (mono_cga)
 					WriteOut(MSG_Get("SHELL_STARTUP_CGA_MONO"),
 					         MMOD2_NAME);
@@ -458,8 +458,9 @@ void DOS_Shell::Run()
 					WriteOut(MSG_Get("SHELL_STARTUP_CGA"),
 					         MMOD2_NAME);
 			}
-			if (machine == MCH_HERC)
+			if (is_machine_hercules()) {
 				WriteOut(MSG_Get("SHELL_STARTUP_HERC"));
+			}
 			WriteOut(MSG_Get("SHELL_STARTUP_END"));
 		}
 		safe_strcpy(input_line, line.c_str());


### PR DESCRIPTION
# Description

This is a cleanup only PR:

- variables `machine` and `svgaCard` are now `enum class`
- replaced macros to check for machine type with inline functions
- cleaned up code to put string signature into SVGA BIOS ROM 
- reduced number of allowed macOS warnings

Motivation: I intend to look once again into possibility of porting DOSBox-X S3 improvement (most likely with S3 model selection), but I want to do some cleanup first.


# Manual testing

- checked that Windows 3.11 still works with S3 964 1.41B5 drivers
- checked that my Windows 98 install still boots in SVGA resolution and does not detect any new hardware
- checked that DOSBox started with `--noprimaryconf --set machine=hercules` starts in Hercules mode (also checked other machine types)

The change has been manually tested on:

- [x] Windows
- [x] macOS
- [x] Linux


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

