### PR TITLE
Add forced borderless fullscreen mode & general window config settings rework

### DIFF
--- a/include/sdlmain.h
+++ b/include/sdlmain.h
@@ -218,7 +218,7 @@ struct SDL_Block {
 
 		float dpi_scale = 1.0f;
 
-		bool fullscreen = false;
+		bool is_fullscreen = false;
 
 		// This flag indicates, that we are in the process of switching
 		// between fullscreen or window (as oppososed to changing

--- a/include/sdlmain.h
+++ b/include/sdlmain.h
@@ -194,7 +194,7 @@ struct SDL_Block {
 			int height       = 0;
 			bool fixed       = false;
 			bool display_res = false;
-		} full = {};
+		} fullscreen = {};
 
 		struct {
 			// User-configured window size

--- a/include/sdlmain.h
+++ b/include/sdlmain.h
@@ -126,6 +126,8 @@ enum class HostRateMode {
 
 enum class VsyncMode { Unset, Off, On, Adaptive, Yield };
 
+enum class FullscreenMode { Standard, Original };
+
 struct VsyncSettings {
 	// The vsync mode the user asked for.
 	VsyncMode requested = VsyncMode::Unset;
@@ -190,10 +192,10 @@ struct SDL_Block {
 
 	struct {
 		struct {
-			int width        = 0;
-			int height       = 0;
-			bool fixed       = false;
-			bool display_res = false;
+			FullscreenMode mode = {};
+
+			int width  = 0;
+			int height = 0;
 		} fullscreen = {};
 
 		struct {

--- a/include/sdlmain.h
+++ b/include/sdlmain.h
@@ -126,7 +126,7 @@ enum class HostRateMode {
 
 enum class VsyncMode { Unset, Off, On, Adaptive, Yield };
 
-enum class FullscreenMode { Standard, Original };
+enum class FullscreenMode { Standard, Original, ForcedBorderless };
 
 struct VsyncSettings {
 	// The vsync mode the user asked for.
@@ -196,16 +196,26 @@ struct SDL_Block {
 
 			int width  = 0;
 			int height = 0;
+
+			bool is_forced_borderless_fullscreen = false;
+
+			struct {
+				int width     = 0;
+				int height    = 0;
+				int x_pos     = 0;
+				int y_pos     = 0;
+			} prev_window;
 		} fullscreen = {};
 
 		struct {
 			// User-configured window size
-			int width                  = 0;
-			int height                 = 0;
+			int width  = 0;
+			int height = 0;
+			int x_pos  = SDL_WINDOWPOS_UNDEFINED;
+			int y_pos  = SDL_WINDOWPOS_UNDEFINED;
+
 			bool show_decorations      = true;
 			bool adjusted_initial_size = false;
-			int initial_x_pos          = -1;
-			int initial_y_pos          = -1;
 
 			// Instantaneous canvas size of the window
 			SDL_Rect canvas_size = {};

--- a/include/video.h
+++ b/include/video.h
@@ -377,7 +377,6 @@ void GFX_ResetScreen(void);
 void GFX_RequestExit(const bool requested);
 void GFX_Start(void);
 void GFX_Stop(void);
-void GFX_SwitchFullScreen(void);
 bool GFX_StartUpdate(uint8_t * &pixels, int &pitch);
 void GFX_EndUpdate( const uint16_t *changedLines );
 void GFX_LosingFocus();

--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -3296,9 +3296,8 @@ void init_cpu_dosbox_settings(Section_prop& secprop)
 	                                               DeprecatedButAllowed,
 	                                               " ");
 	pmulti_remain->Set_help(
-	        "The 'cycles' setting is deprecated but still accepted; please use the\n"
-	        "'cpu_cycles', 'cpu_cycles_protected' and 'cpu_throttle' settings instead as\n"
-	        "support will be removed in the future.");
+	        "The 'cycles' setting is deprecated but still accepted;\n"
+	        "please use 'cpu_cycles', 'cpu_cycles_protected' and 'cpu_throttle' instead.");
 
 	pstring = pmulti_remain->GetSection()->Add_string("type", Always, "auto");
 	pmulti_remain->SetValue(" ");

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -1880,7 +1880,6 @@ static void SetActiveEvent(CEvent * event) {
 }
 
 extern SDL_Window* GFX_GetWindow();
-extern void GFX_UpdateDisplayDimensions(int width, int height);
 
 static void DrawButtons() {
 	SDL_SetRenderDrawColor(mapper.renderer,
@@ -2760,8 +2759,6 @@ void BIND_MappingEvents()
 			 */
 			if ((event.window.event == SDL_WINDOWEVENT_RESIZED) ||
 			    (event.window.event == SDL_WINDOWEVENT_RESTORED)) {
-				GFX_UpdateDisplayDimensions(event.window.data1,
-				                            event.window.data2);
 				SDL_RenderSetLogicalSize(mapper.renderer, 640, 480);
 				mapper.redraw = true;
 			}

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -2622,7 +2622,7 @@ static void sticky_keys(bool restore)
 }
 #endif
 
-void GFX_SwitchFullScreen()
+static void switch_fullscreen()
 {
 	sdl.desktop.switching_fullscreen = true;
 
@@ -2649,10 +2649,10 @@ void GFX_SwitchFullScreen()
 	sdl.desktop.switching_fullscreen = false;
 }
 
-static void switch_fullscreen(bool pressed)
+static void switch_fullscreen_handler(bool pressed)
 {
 	if (pressed) {
-		GFX_SwitchFullScreen();
+		switch_fullscreen();
 	}
 }
 
@@ -3608,7 +3608,7 @@ static void read_gui_config(Section* sec)
 	/* Get some Event handlers */
 	MAPPER_AddHandler(GFX_RequestExit, SDL_SCANCODE_F9, PRIMARY_MOD, "shutdown", "Shutdown");
 
-	MAPPER_AddHandler(switch_fullscreen, SDL_SCANCODE_RETURN, MMOD2, "fullscr", "Fullscreen");
+	MAPPER_AddHandler(switch_fullscreen_handler, SDL_SCANCODE_RETURN, MMOD2, "fullscr", "Fullscreen");
 	MAPPER_AddHandler(restart_hotkey_handler,
 	                  SDL_SCANCODE_HOME,
 	                  PRIMARY_MOD | MMOD2,

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3024,7 +3024,7 @@ static SDL_Point parse_window_resolution_from_conf(const std::string& pref)
 	}
 
 	LOG_WARNING(
-	        "DISPLAY: Invalid 'windowresolution' setting: '%s', "
+	        "DISPLAY: Invalid 'window_size' setting: '%s', "
 	        "using 'default'",
 	        pref.c_str());
 
@@ -3054,7 +3054,7 @@ static SDL_Point window_bounds_from_label(const std::string& pref,
 
 		} else {
 			LOG_WARNING(
-			        "DISPLAY: Invalid 'windowresolution' setting: '%s', "
+			        "DISPLAY: Invalid 'window_size' setting: '%s', "
 			        "using 'default'",
 			        pref.c_str());
 			return MediumPercent;
@@ -3134,7 +3134,7 @@ static void save_window_size(const int w, const int h)
 }
 
 // Takes in:
-//  - The user's windowresolution: default, WxH, small, medium, large,
+//  - The user's window_size setting: default, WxH, small, medium, large,
 //    desktop, or an invalid setting.
 //  - If aspect correction is requested.
 //
@@ -3327,7 +3327,7 @@ static void set_output(Section* sec, const bool wants_aspect_ratio_correction)
 	setup_initial_window_position_from_conf(
 	        section->Get_string("window_position"));
 
-	setup_window_sizes_from_conf(section->Get_string("windowresolution").c_str(),
+	setup_window_sizes_from_conf(section->Get_string("window_size").c_str(),
 	                             wants_aspect_ratio_correction);
 
 #if C_OPENGL
@@ -4473,9 +4473,12 @@ static void init_sdl_config_section()
 	        "What resolution to use for fullscreen: 'original', 'desktop'\n"
 	        "or a fixed size, e.g. 1024x768 ('desktop' by default).");
 
-	pstring = sdl_sec->Add_string("windowresolution", on_start, "default");
+	pstring = sdl_sec->Add_string("windowresolution", deprecated, "");
+	pstring->Set_help("Renamed to 'window_size'.");
+
+	pstring = sdl_sec->Add_string("window_size", on_start, "default");
 	pstring->Set_help(
-	        "Set intial window size for windowed mode. You can still resize the window\n"
+	        "Set initial window size for windowed mode. You can still resize the window\n"
 	        "after startup.\n"
 	        "  default:   Select the best option based on your environment and other\n"
 	        "             settings (such as whether aspect ratio correction is enabled).\n"

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -4464,9 +4464,7 @@ static void init_sdl_config_section()
 	        "settings (0 by default).");
 
 	auto pbool = sdl_sec->Add_bool("fullscreen", always, false);
-	pbool->Set_help(
-	        "Start directly in fullscreen ('off' by default).\n"
-	        "Run INTRO and see Special Keys for window control hotkeys.");
+	pbool->Set_help("Start in fullscreen mode ('off' by default).");
 
 	pstring = sdl_sec->Add_string("fullresolution", always, "desktop");
 	pstring->Set_help(

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -4491,7 +4491,7 @@ static void init_sdl_config_section()
 	pstring->Set_help(
 	        "Set initial window position for windowed mode:\n"
 	        "  auto:      Let the window manager decide the position (default).\n"
-	        "  X,Y:       Set window position in X,Y format (e.g., 250,100).\n"
+	        "  X,Y:       Set window position in X,Y format in logical units (e.g., 250,100).\n"
 	        "             0,0 is the top-left corner of the screen.");
 
 	pbool = sdl_sec->Add_bool("window_decorations", always, true);

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -2865,23 +2865,6 @@ void GFX_Start()
 	sdl.active = true;
 }
 
-/* Manually update display dimensions in case of a window resize,
- * IF there is the need for that ("yes" on Android, "no" otherwise).
- * Used for the mapper UI on Android.
- * Reason is the usage of GFX_GetSDLSurfaceSubwindowDims, as well as a
- * mere notification of the fact that the window's dimensions are modified.
- */
-void GFX_UpdateDisplayDimensions(int width, int height)
-{
-	if (sdl.desktop.is_fullscreen) {
-		/* Note: We should not use get_display_dimensions()
-		(SDL_GetDisplayBounds) on Android after a screen rotation:
-		The older values from application startup are returned. */
-		sdl.desktop.fullscreen.width  = width;
-		sdl.desktop.fullscreen.height = height;
-	}
-}
-
 static void shutdown_gui(Section*)
 {
 	GFX_Stop();


### PR DESCRIPTION
# Description

Graphics card drivers might opt-out of fullscreen optimisations on Windows when they decide the performance loss would be too great compared to exclusive fullscreen. This means you'll get exclusive fullscreen even if you asked for borderless fullscreen at the SDL API level (`SDL_WINDOW_FULLSCREEN_DESKTOP` flag).

This is exactly what happens on my Windows 10 / Nvidia RTX 3060 setup when I use 120 Hz refresh rate at 4k. With 4k@60 Hz, borderless mode is working; 1080p@120 Hz is fine too, but 4k@120 Hz is deemed too ambitious by the GPU gods 😆, so I'm always getting exclusive fullscreen! This is a pain during DOSBox dev because I cannot freely Alt-Tab anymore, and when playing undemanding adventure games and RPGs where the performance drop simply doesn't matter.

The SDL devs have [explicitly stated](https://github.com/libsdl-org/SDL/issues/12791) they won't add workarounds for forcing borderless mode, so we'll need to take matters into our own hands.

There are a few different ways to go about this, one is in that ticket, another one [here](https://stackoverflow.com/questions/79614593/forcing-non-exclusive-borderless-fullscreen-with-sdl3-opengl-on-windows-11) (which doesn't work, btw; I've tried). In the end, I opted for only using the SDL API to mimic borderless mode, so no low-level messing around with Windows APIs. Basically, creating a window 1px wider than the desktop resolution does the trick, as the trigger for borderless fullscreen is having a window with exactly the same dimensions as the desktop size and with disabled window decorations. Then it's in the driver's hands: it might keep the window and exclude it from the compositor for more direct access, or it might enter the old legacy fullscreen mode.

Borderless fullscreen optimisation is a Windows-only thing, making `forced-borderless` a Windows-only option. macOS doesn't have the equivalent of borderless fullscreen, so it doesn't make any sense there. I imagine Linux users have a lot more fine-grained control over the driver/OS behaviour, so they can force "always borderless" elsewhere.

Other changes:

- renamed `windowresolution` to `window_size` while I was it
- `fullresolution = desktop` has become `fullscreen_mode = standard`
- `fullresolution = WxH` has been dropped. I don't think there's any good use case for that. We still support `fullscreen_mode = original` for using Staging with a CRT monitor, but it's a bit janky (a concession for the guy who raised [this ticket](https://github.com/dosbox-staging/dosbox-staging/issues/3206); Phil also made a [video](https://www.youtube.com/watch?v=pQ-DWEY3E7M) about it, he uses `original` with a bunch of custom modes)
- the usual SDL cleanups

On a related note, I can only get perfectly smooths 2D scrolling in games like Pinball Dreams in exclusive fullscreen mode. That's 100% smooth. In forced borderless fullscreen, the scrolling is only about 85-90% smooth. Still very good, but I can notice a _tiny_ jitter that manifests more as a slight blur rather than actual jerky motion.


## Related issues

https://github.com/dosbox-staging/dosbox-staging/issues/3206

# Release notes

- The `windowresolution` setting has been renamed to `window_size`.
- The `fullresolution` setting has been renamed to `fullscreen_mode`, and `fullresolution = desktop` is now available as `fullscreen_mode = standard`. The option to explicitly set screen resolutions in `WxH` format has been removed as it's not useful neither on modern hardware nor when using DOSBox Staging with a real CRT monitor.
- A new `forced-borderless` fullscreen mode has been introduced to force borderless operation on Windows systems where the graphics card driver opts out of fullscreen optimisations, resulting in exclusive fullscreen which makes Alt+Tabbing very cumbersome. See the setting's help for further info (run `fullscreen_mode /?` from the DOS prompt).


# Manual testing

- Tested `forced-borderless` results in borderless fullscreen that's visually indistinguishable from "true" borderless mode (quick Alt-Tabbing works, etc). You can only meaningfully test this on Windows systems that opt-out of fullscreen optimisations when using certain driver settings (e.g., Windows 10, Nvidia RTX 3060, 120 Hz over DisplayPort to a 4k screen in my case).
- Tested that maximising the window then toggling forced borderless mode works correctly.
- Tested toggling "show desktop" with Win+D works correctly when in forced borderless mode.
- Confirmed the `forced-borderless` option doesn't show up on macOS and it cannot be set.
- Confirmed the `original` option works as before on Windows and macOS.
- Confirmed `window_position`, `window_size`, and `window_decorations` still work.
- Confirmed the mapper still works and resizing the window with the mapper active works.

## New `fullscreen_mode` description

![image](https://github.com/user-attachments/assets/2bb7e441-e5a6-47b0-a5b8-01a91ffb2934)

The change has been manually tested on:

- [x] Windows
- [x] macOS
- [x] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [x] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

