### PR TITLE
Fix several SonarCube warnings

### DIFF
--- a/include/callback.h
+++ b/include/callback.h
@@ -113,10 +113,10 @@ public:
 
 	//Only allocate a callback number
 	void Allocate(Callback_Handler handler,const char* description=nullptr);
-	uint16_t Get_callback() {
+	uint16_t Get_callback() const {
 		return m_cb_number;
 	}
-	RealPt Get_RealPointer() {
+	RealPt Get_RealPointer() const {
 		return CALLBACK_RealPointer(m_cb_number);
 	}
 	void Set_RealVec(uint8_t vec);

--- a/include/dos_system.h
+++ b/include/dos_system.h
@@ -123,7 +123,7 @@ public:
 	virtual Bits RemoveRef() { return --refCtr; }
 
 	void SetDrive(uint8_t drv) { hdrive=drv;}
-	uint8_t GetDrive(void) { return hdrive;}
+	uint8_t GetDrive() const { return hdrive;}
 	uint8_t flags    = 0;
 	uint16_t time    = 0;
 	uint16_t date    = 0;

--- a/include/fraction.h
+++ b/include/fraction.h
@@ -100,7 +100,7 @@ public:
 
 	constexpr Fraction operator-(const Fraction& that) const
 	{
-		return {num * that.denom - that.num * denom, denom * that.denom};;
+		return {num * that.denom - that.num * denom, denom * that.denom};
 	}
 
 	// Multiplication
@@ -123,7 +123,7 @@ public:
 
 	constexpr Fraction operator*(const Fraction& that) const
 	{
-		return {num * that.num, denom * that.denom};;
+		return {num * that.num, denom * that.denom};
 	}
 
 	// Division

--- a/include/logging.h
+++ b/include/logging.h
@@ -59,7 +59,7 @@ void DEBUG_ShowMsg(const char* format, ...)
 struct LOG
 {
 	inline LOG(LOG_TYPES, LOG_SEVERITIES){ }
-	inline void operator()(const char*, ...) {}
+	inline void operator()(const char*, ...) const {}
 }; //add missing operators to here
 
 	//try to avoid anything smaller than bit32...

--- a/include/math_utils.h
+++ b/include/math_utils.h
@@ -36,7 +36,7 @@ constexpr int wrap(int val, const int lower_bound, const int upper_bound)
 
 // Unsigned-only integer division with ceiling
 template<typename T1, typename T2>
-inline constexpr T1 ceil_udivide(const T1 x, const T2 y) noexcept {
+constexpr T1 ceil_udivide(const T1 x, const T2 y) noexcept {
 	static_assert(std::is_unsigned<T1>::value, "First parameter should be unsigned");
 	static_assert(std::is_unsigned<T2>::value, "Second parameter should be unsigned");
 	return (x != 0) ? 1 + ((x - 1) / y) : 0;
@@ -45,7 +45,7 @@ inline constexpr T1 ceil_udivide(const T1 x, const T2 y) noexcept {
 
 // Signed-only integer division with ceiling
 template<typename T1, typename T2>
-inline constexpr T1 ceil_sdivide(const T1 x, const T2 y) noexcept {
+constexpr T1 ceil_sdivide(const T1 x, const T2 y) noexcept {
 	static_assert(std::is_signed<T1>::value, "First parameter should be signed");
 	static_assert(std::is_signed<T2>::value, "Second parameter should be signed.");
 	return x / y + (((x < 0) ^ (y > 0)) && (x % y));

--- a/include/serialport.h
+++ b/include/serialport.h
@@ -55,10 +55,10 @@ public:
 	{
 		assert(n <= SERIAL_MAX_FIFO_SIZE);
 	}
-	size_t getFree() { return size - used; }
-	bool isEmpty() { return used == 0; }
-	bool isFull() { return (size - used) == 0; }
-	size_t getUsage() { return used; }
+	size_t getFree() const { return size - used; }
+	bool isEmpty() const { return used == 0; }
+	bool isFull() const { return (size - used) == 0; }
+	size_t getUsage() const { return used; }
 	void setSize(size_t n)
 	{
 		assert(n <= SERIAL_MAX_FIFO_SIZE);

--- a/include/serialport.h
+++ b/include/serialport.h
@@ -69,8 +69,9 @@ public:
 	}
 	void clear() {
 		pos = used = 0;
-		if (data.size() > 0)
+		if (!data.empty()) {
 			std::fill(data.begin(), data.end(), 0);
+		}
 	}
 
 	bool addb(uint8_t val)

--- a/include/setup.h
+++ b/include/setup.h
@@ -188,7 +188,7 @@ public:
 	std::vector<Value> GetDeprecatedValues() const;
 	const Value& GetAlternateForDeprecatedValue(const Value& value) const;
 
-	Value::Etype Get_type()
+	Value::Etype Get_type() const
 	{
 		return default_value.type;
 	}

--- a/src/audio/clap/library.cpp
+++ b/src/audio/clap/library.cpp
@@ -31,7 +31,7 @@ namespace Clap {
 		}
 	}
 
-	if (files.size() == 0) {
+	if (files.empty()) {
 		return {};
 	}
 

--- a/src/capture/image/image_capturer.cpp
+++ b/src/capture/image/image_capturer.cpp
@@ -44,7 +44,7 @@ void ImageCapturer::ConfigureGroupedMode(const std::string& prefs)
 	grouped_mode.wants_rendered = false;
 
 	const auto formats = split_with_empties(prefs, ' ');
-	if (formats.size() == 0) {
+	if (formats.empty()) {
 		LOG_WARNING(
 		        "CAPTURE: 'default_image_capture_formats' not specified, "
 		        "using '%s'",

--- a/src/capture/image/image_saver.cpp
+++ b/src/capture/image/image_saver.cpp
@@ -124,7 +124,7 @@ static void write_upscaled_png(FILE* outfile, PngWriter& png_writer,
 			return;
 		}
 		break;
-	};
+	}
 
 	auto rows_to_write = image_scaler.GetOutputHeight();
 	while (rows_to_write--) {
@@ -167,7 +167,7 @@ void ImageSaver::SaveRawImage(const RenderedImage& image)
 		                             src.video_mode,
 		                             image.palette_data)) {
 			return;
-		};
+		}
 	} else {
 		if (!png_writer.InitRgb888(outfile,
 		                           output_width,
@@ -175,7 +175,7 @@ void ImageSaver::SaveRawImage(const RenderedImage& image)
 		                           pixel_aspect_ratio,
 		                           src.video_mode)) {
 			return;
-		};
+		}
 	}
 
 	constexpr uint8_t MaxBytesPerPixel = 3;
@@ -243,7 +243,7 @@ void ImageSaver::SaveRenderedImage(const RenderedImage& image)
 	                           square_pixel_aspect_ratio,
 	                           src.video_mode)) {
 		return;
-	};
+	}
 
 	// We always write the final rendered image displayed on the host monitor
 	// as-is.

--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -948,7 +948,6 @@ do_interrupt:
 			       gate.Type(), num);
 		}
 	}
-	assert(1);
 	return ; // make compiler happy
 }
 
@@ -1253,7 +1252,6 @@ CODE_jmp:
 			E_Exit("JMP Illegal descriptor type 0x%x", desc.Type());
 		}
 	}
-	assert(1);
 }
 
 
@@ -1490,7 +1488,6 @@ call_code:
 			E_Exit("CALL:Descriptor type 0x%x unsupported", call.Type());
 		}
 	}
-	assert(1);
 }
 
 

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -176,7 +176,7 @@ void DOS_ExecuteRegisteredCallbacks(DiskType disk_type)
 		return;
 	}
 
-	if (io_callbacks.size() > 0) {
+	if (!io_callbacks.empty()) {
 		for (auto& callback : io_callbacks) {
 			callback();
 		}

--- a/src/dos/dos_execute.cpp
+++ b/src/dos/dos_execute.cpp
@@ -78,7 +78,7 @@ void DOS_UpdateCurrentProgramName()
 	// Retrieve canonical program name, if possible
 	std::string canonical_name = {};
 	if (!PAGING_Enabled()) {
-		if (psp_to_canonical_map.count(psp_segment)) {
+		if (psp_to_canonical_map.contains(psp_segment)) {
 			canonical_name = psp_to_canonical_map.at(psp_segment);
 		}
 	}

--- a/src/dos/dos_locale.cpp
+++ b/src/dos/dos_locale.cpp
@@ -1703,22 +1703,20 @@ void DOS_Locale_AddMessages()
 	for (auto it = LocaleData::CountryInfo.begin();
 	     it != LocaleData::CountryInfo.end();
 	     ++it) {
-		MSG_Add(it->second.GetMsgName().c_str(),
-		        it->second.country_name.c_str());
+		MSG_Add(it->second.GetMsgName(), it->second.country_name);
 	}
 
 	// Add strings with code page descriptions
 	for (const auto& pack : LocaleData::CodePageInfo) {
 		for (const auto& entry : pack) {
-			MSG_Add(entry.second.GetMsgName(entry.first).c_str(),
-			        entry.second.description.c_str());
+			MSG_Add(CodePageInfoEntry::GetMsgName(entry.first),
+			        entry.second.description);
 		}
 	}
 
 	// Add strings with script names
 	for (const auto& entry : LocaleData::ScriptInfo) {
-		MSG_Add(entry.second.GetMsgName().c_str(),
-		        entry.second.script_name.c_str());
+		MSG_Add(entry.second.GetMsgName(), entry.second.script_name);
 	}
 
 	MSG_Add("SCRIPT_PROPERTY_PHONETIC", "phonetic");

--- a/src/dos/drive_cache.cpp
+++ b/src/dos/drive_cache.cpp
@@ -354,8 +354,9 @@ void DOS_Drive_Cache::CacheOut(const char* path, bool ignoreLastDir) {
 	save_dir = nullptr;
 }
 
-bool DOS_Drive_Cache::IsCachedIn(CFileInfo* curDir) {
-	return (curDir->isOverlayDir || curDir->fileList.size()>0);
+bool DOS_Drive_Cache::IsCachedIn(CFileInfo* curDir)
+{
+	return curDir->isOverlayDir || !curDir->fileList.empty();
 }
 
 
@@ -673,7 +674,7 @@ void DOS_Drive_Cache::CreateShortName(CFileInfo* curDir, CFileInfo* info) {
 		}
 
 		// keep list sorted for CreateShortNameID to work correctly
-		if (curDir->longNameList.size()>0) {
+		if (!curDir->longNameList.empty()) {
 			if (!(strcmp(info->shortname,curDir->longNameList.back()->shortname)<0)) {
 				// append at end of list
 				curDir->longNameList.push_back(info);
@@ -841,7 +842,7 @@ void DOS_Drive_Cache::CreateEntry(CFileInfo* dir, const char* name, bool is_dire
 	bool found = false;
 
 	// keep list sorted (so GetLongName works correctly, used by CreateShortName in this routine)
-	if (dir->fileList.size()>0) {
+	if (!dir->fileList.empty()) {
 		if (!(strcmp(info->shortname,dir->fileList.back()->shortname)<0)) {
 			// append at end of list
 			dir->fileList.push_back(info);

--- a/src/dos/drive_iso.cpp
+++ b/src/dos/drive_iso.cpp
@@ -68,7 +68,7 @@ bool isoFile::Read(uint8_t *data, uint16_t *size) {
 		}
 	}
 
-	static_assert(ISO_FRAMESIZE <= UINT16_MAX, "");
+	static_assert(ISO_FRAMESIZE <= UINT16_MAX);
 	auto sectorPos = static_cast<uint16_t>(filePos % ISO_FRAMESIZE);
 
 	while (nowSize < *size) {

--- a/src/dos/program_imgmount.cpp
+++ b/src/dos/program_imgmount.cpp
@@ -337,7 +337,7 @@ void IMGMOUNT::Run(void)
 		}
 		paths.push_back(temp_line);
 	}
-	if (paths.size() == 0) {
+	if (paths.empty()) {
 		WriteOut(MSG_Get("PROGRAM_IMGMOUNT_SPECIFY_FILE"));
 		return;
 	}

--- a/src/dos/program_mixer.cpp
+++ b/src/dos/program_mixer.cpp
@@ -699,8 +699,7 @@ ChannelInfos::ChannelInfos(const ChannelInfosMap& channel_infos)
 
 bool ChannelInfos::HasChannel(const std::string& channel_name) const
 {
-	return features_by_channel_name.find(channel_name) !=
-	       features_by_channel_name.end();
+	return features_by_channel_name.contains(channel_name);
 }
 
 bool ChannelInfos::HasFeature(const std::string& channel_name,
@@ -709,7 +708,7 @@ bool ChannelInfos::HasFeature(const std::string& channel_name,
 	if (auto it = features_by_channel_name.find(channel_name);
 	    it != features_by_channel_name.end()) {
 		const auto [_, features] = *it;
-		return (features.find(feature) != features.end());
+		return features.contains(feature);
 	}
 	return false;
 }

--- a/src/dos/program_mount.cpp
+++ b/src/dos/program_mount.cpp
@@ -49,7 +49,7 @@ void MOUNT::ListMounts()
 	for (uint8_t d = 0; d < DOS_DRIVES; d++) {
 		if (Drives[d]) {
 			print_row(std::string{drive_letter(d)},
-			          Drives[d]->GetInfoString().c_str(),
+			          Drives[d]->GetInfoString(),
 			          To_Label(Drives[d]->GetLabel()));
 		}
 	}

--- a/src/dos/program_mousectl.cpp
+++ b/src/dos/program_mousectl.cpp
@@ -43,10 +43,10 @@ bool MOUSECTL::ParseAndRun()
 	};
 
 	// CmdShow
-	if (list_ids.size() == 0 && params.empty()) {
+	if (list_ids.empty() && params.empty()) {
 		return CmdShow(false);
         }
-	if (list_ids.size() == 0 && params.size() == 1) {
+	if (list_ids.empty() && params.size() == 1) {
 		if (param_equal(0, "-all")) {
 			return CmdShow(true);
                 }

--- a/src/dos/program_serial.cpp
+++ b/src/dos/program_serial.cpp
@@ -120,7 +120,7 @@ void SERIAL::Run()
 			commandLineString.append(" ");
 		}
 		CommandLine *commandLine = new CommandLine("SERIAL.COM",
-		                                           commandLineString.c_str());
+		                                           commandLineString);
 		// Remove existing port.
 		delete serialports[port_index];
 		// Recreate the port with the new type.

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -459,7 +459,7 @@ private:
 	const char * BindStart() override {
 		return "Key";
 	}
-protected:
+
 	const char *configname = "key";
 	CBindList *lists = nullptr;
 	Bitu keys = 0;
@@ -508,7 +508,7 @@ public:
 		return buf;
 	}
 
-protected:
+private:
 	CBindGroup *group;
 	int axis;
 	bool positive;
@@ -537,7 +537,7 @@ public:
 		return buf;
 	}
 
-protected:
+private:
 	CBindGroup *group;
 	int button;
 };
@@ -584,7 +584,7 @@ public:
 		return buf;
 	}
 
-protected:
+private:
 	CBindGroup *group;
 	uint8_t hat;
 	uint8_t dir;
@@ -1172,7 +1172,7 @@ public:
 		JOYSTICK_Button(1,1,(bt_state&1)==0);
 	}
 
-protected:
+private:
 	uint16_t button_state = 0;
 };
 
@@ -1415,7 +1415,7 @@ public:
 		SetActiveEvent(event);
 		last_clicked=this;
 	}
-protected:
+private:
 	CEvent * event = nullptr;
 };
 
@@ -1432,7 +1432,7 @@ public:
 		if (!enabled) return;
 		DrawText(rect.x + 2, rect.y + 2, caption, color);
 	}
-protected:
+private:
 	char caption[128] = {};
 };
 
@@ -1492,7 +1492,7 @@ public:
 			break;
 		}
 	}
-protected:
+private:
 	BB_Types type;
 };
 
@@ -1556,7 +1556,7 @@ public:
 		}
 		mapper.redraw=true;
 	}
-protected:
+private:
 	BC_Types type;
 };
 
@@ -1619,7 +1619,7 @@ public:
 		/* caring for joystick movement into the opposite direction */
 		opposite_axis->Active(true);
 	}
-protected:
+private:
 	void SetOppositeAxis(CJAxisEvent * _opposite_axis) {
 		opposite_axis=_opposite_axis;
 	}
@@ -1641,7 +1641,7 @@ public:
 		virtual_joysticks[stick].button_pressed[button]=pressed;
 	}
 
-protected:
+private:
 	Bitu stick,button;
 };
 
@@ -1659,7 +1659,7 @@ public:
 		virtual_joysticks[stick].hat_pressed[(hat<<2)+dir]=pressed;
 	}
 
-protected:
+private:
 	Bitu stick,hat,dir;
 };
 
@@ -1678,7 +1678,7 @@ public:
 			mapper.mods &= ~(static_cast<Bitu>(1) << (wmod-1));
 	}
 
-protected:
+private:
 	int wmod;
 };
 
@@ -1715,7 +1715,7 @@ public:
 		        defmod & MMOD3 ? " mod3" : "");
 	}
 
-protected:
+private:
 	SDL_Scancode defkey;
 	uint32_t defmod;
 	MAPPER_Handler * handler;

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -1171,9 +1171,6 @@ public:
 		JOYSTICK_Button(1,0,(bt_state&2)==0);
 		JOYSTICK_Button(1,1,(bt_state&1)==0);
 	}
-
-private:
-	uint16_t button_state = 0;
 };
 
 

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1837,8 +1837,8 @@ static std::pair<double, double> get_scale_factors_from_pixel_aspect_ratio(
 
 static SDL_Window* setup_scaled_window(const RenderingBackend rendering_backend)
 {
-	int window_width;
-	int window_height;
+	int window_width  = 0;
+	int window_height = 0;
 
 	switch (sdl.desktop.fullscreen.mode) {
 	case FullscreenMode::Standard:

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -5180,8 +5180,7 @@ static void handle_cli_set_commands(const std::vector<std::string>& set_args)
 
 			std::string inputline = pvars[1] + "=" + value;
 
-			bool change_success = tsec->HandleInputline(
-			        inputline.c_str());
+			bool change_success = tsec->HandleInputline(inputline);
 
 			if (!change_success && !value.empty()) {
 				LOG_WARNING("CONFIG: Cannot set '%s'",

--- a/src/hardware/covox.h
+++ b/src/hardware/covox.h
@@ -14,11 +14,11 @@
 class Covox final : public LptDac {
 public:
 	Covox() : LptDac(ChannelName::CovoxDac, UseMixerRate) {}
-	void BindToPort(const io_port_t lpt_port) final;
-	void ConfigureFilters(const FilterState state) final;
+	void BindToPort(const io_port_t lpt_port) override;
+	void ConfigureFilters(const FilterState state) override;
 
 protected:
-	AudioFrame Render() final;
+	AudioFrame Render() override;
 
 private:
 	void WriteData(const io_port_t, const io_val_t value, const io_width_t);

--- a/src/hardware/disney.h
+++ b/src/hardware/disney.h
@@ -15,13 +15,13 @@
 class Disney final : public LptDac {
 public:
 	Disney();
-	~Disney() final;
+	~Disney() override;
 
-	void BindToPort(const io_port_t lpt_port) final;
-	void ConfigureFilters(const FilterState state) final;
+	void BindToPort(const io_port_t lpt_port) override;
+	void ConfigureFilters(const FilterState state) override;
 
 protected:
-	AudioFrame Render() final;
+	AudioFrame Render() override;
 
 private:
 	bool IsFifoFull() const;

--- a/src/hardware/input/mouse_manymouse.cpp
+++ b/src/hardware/input/mouse_manymouse.cpp
@@ -290,7 +290,7 @@ bool ManyMouseGlue::ProbeForMapping(uint8_t &physical_device_idx)
 
 uint8_t ManyMouseGlue::GetIdx(const std::regex &regex)
 {
-	assert(max_mice < UINT8_MAX);
+	static_assert(max_mice < UINT8_MAX);
 
 	// Try to match the mouse name which is not mapped yet
 

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -307,7 +307,7 @@ MixerChannel::MixerChannel(MIXER_Handler _handler, const char* _name,
 bool MixerChannel::HasFeature(const ChannelFeature feature)
 {
 	std::lock_guard lock(mutex);
-	return features.find(feature) != features.end();
+	return features.contains(feature);
 }
 
 std::set<ChannelFeature> MixerChannel::GetFeatures()
@@ -713,8 +713,7 @@ MixerChannelPtr MIXER_AddChannel(MIXER_Handler handler,
 	}
 
 	// Try to restore saved channel settings from the cache first.
-	if (mixer.channel_settings_cache.find(name) !=
-	    mixer.channel_settings_cache.end()) {
+	if (mixer.channel_settings_cache.contains(name)) {
 		chan->SetSettings(mixer.channel_settings_cache[name]);
 	} else {
 		// If no saved settings exist, set the defaults.

--- a/src/hardware/pci_bus.cpp
+++ b/src/hardware/pci_bus.cpp
@@ -236,7 +236,6 @@ class PCI final : public Module_base {
 private:
 	bool initialized = false;
 
-protected:
 	IO_WriteHandleObject PCI_WriteHandler[5];
 	IO_ReadHandleObject PCI_ReadHandler[5];
 

--- a/src/hardware/pcspeaker_discrete.h
+++ b/src/hardware/pcspeaker_discrete.h
@@ -16,14 +16,14 @@
 class PcSpeakerDiscrete final : public PcSpeaker {
 public:
 	PcSpeakerDiscrete();
-	~PcSpeakerDiscrete() final;
+	~PcSpeakerDiscrete() override;
 
-	void SetFilterState(const FilterState filter_state) final;
-	bool TryParseAndSetCustomFilter(const std::string& filter_choice) final;
-	void SetCounter(const int cntr, const PitMode m) final;
-	void SetPITControl(const PitMode) final {}
-	void SetType(const PpiPortB& b) final;
-	void PicCallback(const int requested_frames) final;
+	void SetFilterState(const FilterState filter_state) override;
+	bool TryParseAndSetCustomFilter(const std::string& filter_choice) override;
+	void SetCounter(const int cntr, const PitMode m) override;
+	void SetPITControl(const PitMode) override {}
+	void SetType(const PpiPortB& b) override;
+	void PicCallback(const int requested_frames) override;
 
 private:
 	void AddDelayEntry(const float index, float vol);

--- a/src/hardware/pcspeaker_impulse.h
+++ b/src/hardware/pcspeaker_impulse.h
@@ -16,14 +16,14 @@
 class PcSpeakerImpulse final : public PcSpeaker {
 public:
 	PcSpeakerImpulse();
-	~PcSpeakerImpulse() final;
+	~PcSpeakerImpulse() override;
 
-	void SetFilterState(const FilterState filter_state) final;
-	bool TryParseAndSetCustomFilter(const std::string& filter_choice) final;
-	void SetCounter(const int cntr, const PitMode pit_mode) final;
-	void SetPITControl(const PitMode pit_mode) final;
-	void SetType(const PpiPortB& port_b) final;
-	void PicCallback(const int requested_frames) final;
+	void SetFilterState(const FilterState filter_state) override;
+	bool TryParseAndSetCustomFilter(const std::string& filter_choice) override;
+	void SetCounter(const int cntr, const PitMode pit_mode) override;
+	void SetPITControl(const PitMode pit_mode) override;
+	void SetType(const PpiPortB& port_b) override;
+	void PicCallback(const int requested_frames) override;
 
 private:
 	void AddImpulse(float index, const int16_t amplitude);

--- a/src/hardware/serialport/softmodem.h
+++ b/src/hardware/serialport/softmodem.h
@@ -203,7 +203,7 @@ public:
 	std::unique_ptr<CFifo> rqueue;
 	std::unique_ptr<CFifo> tqueue;
 
-protected:
+private:
 	// The AT command line can consist of a 99-character command sequence
 	// including the AT prefix followed by "D<phone/hostname>", where the
 	// hostname can reach a length of up to 253 characters.

--- a/src/hardware/serialport/softmodem.h
+++ b/src/hardware/serialport/softmodem.h
@@ -224,7 +224,6 @@ private:
 	uint8_t waiting_tx_character = 0;
 	uint32_t cmdpause = 0;
 	int32_t ringtimer = 0;
-	int32_t ringcount = 0;
 	uint32_t plusinc = 0;
 	uint32_t cmdpos = 0;
 	uint32_t flowcontrol = 0;

--- a/src/hardware/ston1_dac.h
+++ b/src/hardware/ston1_dac.h
@@ -18,11 +18,11 @@ public:
 	                 {ChannelFeature::Stereo})
 	{}
 
-	void BindToPort(const io_port_t lpt_port) final;
-	void ConfigureFilters(const FilterState state) final;
+	void BindToPort(const io_port_t lpt_port) override;
+	void ConfigureFilters(const FilterState state) override;
 
 protected:
-	AudioFrame Render() final;
+	AudioFrame Render() override;
 	void WriteData(const io_port_t, const io_val_t value, const io_width_t);
 	uint8_t ReadStatus(const io_port_t, const io_width_t);
 	void WriteControl(const io_port_t, const io_val_t value, const io_width_t);

--- a/src/hardware/ston1_dac.h
+++ b/src/hardware/ston1_dac.h
@@ -21,13 +21,12 @@ public:
 	void BindToPort(const io_port_t lpt_port) override;
 	void ConfigureFilters(const FilterState state) override;
 
-protected:
+private:
 	AudioFrame Render() override;
 	void WriteData(const io_port_t, const io_val_t value, const io_width_t);
 	uint8_t ReadStatus(const io_port_t, const io_width_t);
 	void WriteControl(const io_port_t, const io_val_t value, const io_width_t);
 
-private:
 	static constexpr auto SampleRateHz = 30000;
 
 	uint8_t stereo_data[2] = {data_reg, data_reg};

--- a/src/hardware/virtualbox.cpp
+++ b/src/hardware/virtualbox.cpp
@@ -251,7 +251,7 @@ struct VirtualBox_MousePointer_1_01 {
 static void warn_unsupported_request(const VBoxRequestType request_type)
 {
 	static std::set<VBoxRequestType> already_warned = {};
-	if (already_warned.find(request_type) != already_warned.end()) {
+	if (already_warned.contains(request_type)) {
 		LOG_WARNING("VIRTUALBOX: unimplemented request #%d",
 		            enum_val(request_type));
 		already_warned.insert(request_type);
@@ -262,8 +262,7 @@ static void warn_unsupported_struct_version(const RequestHeader& header)
 {
 	static std::map<VBoxRequestType, std::set<uint32_t>> already_warned = {};
 	auto& already_warned_set = already_warned[header.request_type];
-	if (already_warned_set.find(header.struct_version) !=
-	    already_warned_set.end()) {
+	if (already_warned_set.contains(header.struct_version)) {
 		LOG_WARNING("VIRTUALBOX: unimplemented request #%d structure v%d.%02d",
 		            enum_val(header.request_type),
 		            header.struct_version >> 16,

--- a/src/midi/midi_soundcanvas.cpp
+++ b/src/midi/midi_soundcanvas.cpp
@@ -728,8 +728,7 @@ void SOUNDCANVAS_ListDevices(MidiDeviceSoundCanvas* device, Program* caller)
 		constexpr auto green    = "[color=light-green]";
 		constexpr auto reset    = "[reset]";
 
-		const bool is_missing = (available_models.find(model) ==
-		                         available_models.end());
+		const bool is_missing = !available_models.contains(model);
 
 		const auto is_active = active_sc_model && *active_sc_model == model;
 

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -194,7 +194,7 @@ void Program::ChangeToLongCmd()
 
 	if (/*control->SecureMode() ||*/ cmd->Get_arglength() > 100) {
 		CommandLine* temp = new CommandLine(cmd->GetFileName(),
-		                                    full_arguments.c_str());
+		                                    full_arguments);
 		delete cmd;
 		cmd = temp;
 	}
@@ -820,13 +820,12 @@ void CONFIG::Run(void)
 						return;
 					}
 					// it's a property name
-					const auto val_dos = utf8_to_dos(sec->GetPropValue(pvars[0].c_str()),
+					const auto val_dos = utf8_to_dos(sec->GetPropValue(pvars[0]),
 					                                 DosStringConvertMode::NoSpecialCharacters,
 					                                 UnicodeFallback::Simple);
 					WriteOut("%s", val_dos.c_str());
 					DOS_PSP(psp->GetParent())
-					        .SetEnvironmentValue("CONFIG",
-					                             val_dos.c_str());
+					        .SetEnvironmentValue("CONFIG", val_dos);
 				}
 				break;
 			}
@@ -853,7 +852,7 @@ void CONFIG::Run(void)
 				                                 UnicodeFallback::Simple);
 				WriteOut("%s\n", val_dos.c_str());
 				DOS_PSP(psp->GetParent())
-				        .SetEnvironmentValue("CONFIG", val_dos.c_str());
+				        .SetEnvironmentValue("CONFIG", val_dos);
 				break;
 			}
 			default:
@@ -928,8 +927,7 @@ void CONFIG::Run(void)
 				const auto line_utf8 = dos_to_utf8(inputline,
 					                           DosStringConvertMode::NoSpecialCharacters);
 
-				bool change_success = tsec->HandleInputline(
-				        line_utf8.c_str());
+				bool change_success = tsec->HandleInputline(line_utf8);
 
 				if (!change_success) {
 					trim(value);

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -591,7 +591,7 @@ void CONFIG::Run(void)
 			if (CheckSecureMode()) {
 				return;
 			}
-			if (pvars.size() == 0) {
+			if (pvars.empty()) {
 				DOSBOX_Restart();
 			} else {
 				std::vector<std::string> restart_params;
@@ -635,7 +635,7 @@ void CONFIG::Run(void)
 				}
 			}
 
-			if (control->startup_params.size() > 0) {
+			if (!control->startup_params.empty()) {
 				std::string test;
 				for (size_t k = 0; k < control->startup_params.size();
 				     ++k) {
@@ -654,7 +654,7 @@ void CONFIG::Run(void)
 			if (CheckSecureMode()) {
 				return;
 			}
-			if (pvars.size() > 0) {
+			if (!pvars.empty()) {
 				WriteOut(MSG_Get("SHELL_TOO_MANY_PARAMETERS"));
 				return;
 			}
@@ -711,7 +711,7 @@ void CONFIG::Run(void)
 		}
 
 		case P_AUTOEXEC_ADD: {
-			if (pvars.size() == 0) {
+			if (pvars.empty()) {
 				WriteOut(MSG_Get("PROGRAM_CONFIG_MISSINGPARAM"));
 				return;
 			}
@@ -762,7 +762,7 @@ void CONFIG::Run(void)
 			// "property"
 			// "section"
 			// "section" "property"
-			if (pvars.size() == 0) {
+			if (pvars.empty()) {
 				WriteOut(MSG_Get("PROGRAM_CONFIG_GET_SYNTAX"));
 				return;
 			}
@@ -864,7 +864,7 @@ void CONFIG::Run(void)
 		}
 
 		case P_SETPROP: {
-			if (pvars.size() == 0) {
+			if (pvars.empty()) {
 				WriteOut(MSG_Get("PROGRAM_CONFIG_SET_SYNTAX"));
 				return;
 			}

--- a/src/misc/unicode.cpp
+++ b/src/misc/unicode.cpp
@@ -468,7 +468,7 @@ void Grapheme::Decompose()
 		return;
 	}
 
-	while (decomposition_rules.count(code_point) > 0) {
+	while (decomposition_rules.contains(code_point)) {
 		const auto& rule = decomposition_rules.at(code_point);
 		code_point       = rule.code_point;
 		for (const auto mark : rule.marks) {
@@ -775,7 +775,7 @@ static std::string wide_to_utf8(const wide_string& str)
 static void warn_code_point(const uint16_t code_point)
 {
 	static std::set<uint16_t> already_warned;
-	if (already_warned.count(code_point) > 0) {
+	if (already_warned.contains(code_point)) {
 		return;
 	}
 	already_warned.insert(code_point);
@@ -785,7 +785,7 @@ static void warn_code_point(const uint16_t code_point)
 static void warn_code_page(const uint16_t code_page)
 {
 	static std::set<uint16_t> already_warned;
-	if (already_warned.count(code_page) > 0) {
+	if (already_warned.contains(code_page)) {
 		return;
 	}
 	already_warned.insert(code_page);
@@ -863,7 +863,7 @@ static std::string wide_to_dos(const wide_string& str,
 		}
 
 		const auto code_point = grapheme.GetCodePoint();
-		if (mapping_box->count(code_point) == 0) {
+		if (!mapping_box->contains(code_point)) {
 			return false; // not a box drawing character
 		}
 
@@ -1013,8 +1013,8 @@ static wide_string dos_to_wide(const std::string& str,
 			// Take from code page mapping
 			auto& mappings = per_code_page_mappings[code_page];
 
-			if ((per_code_page_mappings.count(code_page) == 0) ||
-			    (mappings.grapheme_to_dos.count(byte) == 0)) {
+			if (!per_code_page_mappings.contains(code_page) ||
+			    !mappings.grapheme_to_dos.contains(byte)) {
 				str_out.push_back(UnknownCharacter);
 			} else {
 				mappings.grapheme_to_dos[byte].PushInto(str_out);
@@ -1426,8 +1426,8 @@ static void import_config_main(const std_fs::path& path_root)
 
 		} else if (tokens[0] == "CODEPAGE") {
 			auto check_no_code_page = [&](const uint16_t code_page) {
-				if ((new_config_mappings.find(code_page) != new_config_mappings.end() && new_config_mappings[code_page].valid) ||
-				    new_config_duplicates.find(code_page) != new_config_duplicates.end()) {
+				if ((new_config_mappings.contains(code_page) && new_config_mappings[code_page].valid) ||
+				    new_config_duplicates.contains(code_page)) {
 					error_code_page_defined(file_name, line_num);
 					return false;
 				}
@@ -1716,8 +1716,8 @@ static void import_mapping_case(const std_fs::path& path_root)
 			}
 
 			// Make sure there are no repetitions
-			if ((all_lowercase.count(code_point_lower) > 0) ||
-			    (all_uppercase.count(code_point_lower) > 0)) {
+			if (all_lowercase.contains(code_point_lower) ||
+			    all_uppercase.contains(code_point_lower)) {
 				        error_code_point_found_twice(code_point_lower,
 				                                     file_name,
 				                                     line_num);
@@ -1737,8 +1737,8 @@ static void import_mapping_case(const std_fs::path& path_root)
 			}
 
 			// Make sure there are no repetitions
-			if ((all_lowercase.count(code_point_upper) > 0) ||
-			    (all_uppercase.count(code_point_upper) > 0)) {
+			if (all_lowercase.contains(code_point_upper) ||
+			    all_uppercase.contains(code_point_upper)) {
 				        error_code_point_found_twice(code_point_upper,
 				                                     file_name,
 				                                     line_num);
@@ -1758,15 +1758,15 @@ static void import_mapping_case(const std_fs::path& path_root)
 		}
 
 		// Make sure there are no repetitions
-		if ((all_lowercase.count(code_point_lower) > 0) ||
-		    (all_uppercase.count(code_point_lower) > 0)) {
+		if (all_lowercase.contains(code_point_lower) ||
+		    all_uppercase.contains(code_point_lower)) {
 			error_code_point_found_twice(code_point_lower,
 			                             file_name,
 			                             line_num);
 			return;
 		}
-		if ((all_lowercase.count(code_point_upper) > 0) ||
-		    (all_uppercase.count(code_point_upper) > 0)) {
+		if (all_lowercase.contains(code_point_upper) ||
+		    all_uppercase.contains(code_point_upper)) {
 			error_code_point_found_twice(code_point_upper,
 			                             file_name,
 			                             line_num);
@@ -1825,7 +1825,7 @@ static void construct_box_fallback(const map_grapheme_to_dos_t& code_page_mappin
 		// to be adapted due to missing characters in the given
 		// code page
 		for (const auto& [from, target] : out_box_code_points) {
-			if (code_page_mapping.count(target) == 0) {
+			if (!code_page_mapping.contains(target)) {
 				return true;
 			}
 		}
@@ -1847,12 +1847,12 @@ static void construct_box_fallback(const map_grapheme_to_dos_t& code_page_mappin
 					continue;
 				}
 
-				if (code_page_mapping.count(alias.second) == 0) {
+				if (!code_page_mapping.contains(alias.second)) {
 					// We cannot apply this alias group
 					return false;
 				}
 
-				if (code_page_mapping.count(target) == 0) {
+				if (!code_page_mapping.contains(target)) {
 					is_group_profitable = true;
 				}
 			}
@@ -1907,7 +1907,7 @@ static void construct_box_fallback(const map_grapheme_to_dos_t& code_page_mappin
 	// Last resort fallback - use 7-bit ASCII fallback for everything
 	out_box_code_points.clear();
 	for (const auto& code_point : BoxDrawingSetRegular) {
-		if (mapping_ascii.count(code_point) > 0) {
+		if (mapping_ascii.contains(code_point)) {
 			out_box_code_points[code_point] = mapping_ascii.at(code_point);
 		} else {
 			out_box_code_points[code_point] = UnknownCharacter;
@@ -1922,7 +1922,7 @@ static void construct_case_mapping(const map_code_point_case_t& map_case_global,
 	out_map_case.resize(UINT8_MAX + 1);
 	for (uint16_t idx = 0; idx < UINT8_MAX + 1; ++idx) {
 		if (idx < DecodeThresholdNonAscii &&
-		    (map_case_global.count(idx) > 0)) {
+		    map_case_global.contains(idx)) {
 			out_map_case[idx] = static_cast<uint8_t>(
 			        map_case_global.at(idx));
 		} else {
@@ -1931,7 +1931,7 @@ static void construct_case_mapping(const map_code_point_case_t& map_case_global,
 	}
 
 	for (const auto& [grapheme, character_code] : code_page_mapping) {
-		if (map_case_global.count(grapheme.GetCodePoint()) == 0) {
+		if (!map_case_global.contains(grapheme.GetCodePoint())) {
 			// No information how to switch case for this code point
 			continue;
 		}
@@ -1940,7 +1940,7 @@ static void construct_case_mapping(const map_code_point_case_t& map_case_global,
 			grapheme.GetCodePoint());
 		grapheme_switched.CopyMarksFrom(grapheme);
 
-		if (code_page_mapping.count(grapheme_switched) == 0) {
+		if (!code_page_mapping.contains(grapheme_switched)) {
 			// Code page does not contain switched case character
 			continue;
 		}
@@ -1955,12 +1955,12 @@ static bool construct_mapping(const uint16_t code_page)
 	// also protect against circular dependencies
 
 	static std::set<uint16_t> already_tried;
-	if (already_tried.count(code_page) > 0) {
+	if (already_tried.contains(code_page)) {
 		return false;
 	}
 	already_tried.insert(code_page);
 
-	assert(per_code_page_mappings.count(code_page) == 0);
+	assert(!per_code_page_mappings.contains(code_page));
 
 	// First apply mapping found in main config file
 
@@ -2058,8 +2058,8 @@ static void construct_aliases(const uint16_t code_page)
 
 	auto add_alias = [&](const alias_t& alias) {
 		const auto found_it = mapping_normalized.find(alias.second);
-		if ((mapping_normalized.count(alias.first) == 0) &&
-		    (aliases_normalized.count(alias.first) == 0) &&
+		if (!mapping_normalized.contains(alias.first) &&
+		    !aliases_normalized.contains(alias.first) &&
 		    (found_it != mapping_normalized.end())) {
 			aliases_normalized[alias.first] = found_it->second;
 		}
@@ -2080,11 +2080,11 @@ static void construct_aliases(const uint16_t code_page)
 
 static bool prepare_code_page(const uint16_t code_page)
 {
-	if (per_code_page_mappings.count(code_page) > 0) {
+	if (per_code_page_mappings.contains(code_page)) {
 		return true; // code page already prepared
 	}
 
-	if ((config_mappings.count(code_page) == 0) || !construct_mapping(code_page)) {
+	if (!config_mappings.contains(code_page) || !construct_mapping(code_page)) {
 		// Unsupported code page or error
 		per_code_page_mappings.erase(code_page);
 		return false;

--- a/src/shell/autoexec.cpp
+++ b/src/shell/autoexec.cpp
@@ -463,7 +463,7 @@ void AutoExecModule::ProcessConfigFile(const Section_line& section,
 		}
 
 		lowcase(tmp);
-		if (tmp.substr(0, 4) != "echo" || !tmp.ends_with("off")) {
+		if (!tmp.starts_with("echo") || !tmp.ends_with("off")) {
 			return false;
 		}
 

--- a/src/shell/autoexec.cpp
+++ b/src/shell/autoexec.cpp
@@ -747,7 +747,7 @@ void AUTOEXEC_SetVariable(const std::string& name, const std::string& value)
 
 	// If shell is already running, refresh variable content
 	if (first_shell) {
-		first_shell->SetEnv(name_upcase.c_str(), value.c_str());
+		first_shell->SetEnv(name_upcase, value);
 	}
 
 	// Update our internal list of variables to set in AUTOEXEC.BAT

--- a/src/shell/file_reader.h
+++ b/src/shell/file_reader.h
@@ -13,14 +13,14 @@ class FileReader final : public LineReader {
 public:
 	static std::unique_ptr<FileReader> GetFileReader(const std::string& file);
 
-	void Reset() final;
-	std::optional<std::string> Read() final;
+	void Reset() override;
+	std::optional<std::string> Read() override;
 
 	FileReader(const FileReader&)            = delete;
 	FileReader& operator=(const FileReader&) = delete;
 	FileReader(FileReader&&)                 = default;
 	FileReader& operator=(FileReader&&)      = default;
-	~FileReader() final                      = default;
+	~FileReader() override                   = default;
 
 private:
 	explicit FileReader(std::string filename);


### PR DESCRIPTION
# Description

135 SonarCube warnings fixed. All the changes were trivial.


# Manual testing

- executed unit tests
- started Windows 3.11, played a little with it
- started DOOM, played for a short while
- tried some commands to exercise the Unicode engine:

```
help /all
keyb us 437
config -set language=de
help /all
keyb de
help /all
```

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [x] Linux


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [ ] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

