### PR TITLE
Reintroduce vcpkg binary caching

### DIFF
--- a/.github/actions/cache-vcpkg/action.yml
+++ b/.github/actions/cache-vcpkg/action.yml
@@ -1,0 +1,59 @@
+name: Cache vcpkg binaries
+
+inputs:
+  name_os:
+    description: "Name or OS"
+    required: true
+  arch:
+    description: "Architecture"
+    required: true
+  compiler:
+    description: "Compiler"
+    required: false
+    default: ""
+  compiler_vers:
+    description: "Compiler version"
+    required: false
+    default: ""
+
+runs:
+  using: "composite"
+  steps:
+    - name: Set vcpkg cache env variable
+      if: ${{ runner.os != 'Windows'}}
+      shell: bash
+      run: |
+        echo "VCPKG_DEFAULT_BINARY_CACHE=${{ github.workspace }}/vcpkg_bin_cache" >> $GITHUB_ENV
+    
+    - name: Set vcpkg cache env variable (Windows)
+      if: ${{ runner.os == 'Windows'}}
+      shell: pwsh
+      run: |
+        Write-Output "VCPKG_DEFAULT_BINARY_CACHE=C:\vcpkg_bin_cache" >> $Env:GITHUB_ENV
+    
+    - name:  Set vcpkg binary cache key
+      id:    vcpkg_bin_cache_key
+      shell: bash
+      run: |
+        if [ -n "${{ inputs.compiler }}" ]; then INPUTS_COMPILER="${{ inputs.compiler }}-"; fi
+        if [ -n "${{ inputs.compiler_vers }}" ]; then INPUTS_COMPILER_VERS="${{ inputs.compiler_vers }}-"; fi
+        echo "cacheKey=vcpkg-bin-cache-${{ inputs.name_os }}-${{ inputs.arch }}-${INPUTS_COMPILER}${INPUTS_COMPILER_VERS}${ImageOS}-${ImageVersion}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json', 'vcpkg-ports/**') }}" >> $GITHUB_OUTPUT
+    
+    - name: Restore vcpkg binary cache
+      uses: actions/cache@v4
+      id:   vcpkg_bin_cache
+      with:
+        path: ${{ env.VCPKG_DEFAULT_BINARY_CACHE }}
+        key:  ${{ steps.vcpkg_bin_cache_key.outputs.cacheKey }}
+
+    - name: Create binary cache directory
+      if: ${{ steps.vcpkg_bin_cache.outputs.cache-hit != 'true' && runner.os != 'Windows'}}
+      shell: bash
+      run: |
+        mkdir "${VCPKG_DEFAULT_BINARY_CACHE}"
+
+    - name: Create binary cache directory (Windows)
+      if: ${{ steps.vcpkg_bin_cache.outputs.cache-hit != 'true' && runner.os == 'Windows'}}
+      shell: pwsh
+      run: |
+        New-Item -Path "${Env:VCPKG_DEFAULT_BINARY_CACHE}" -ItemType Directory

--- a/.github/actions/cache-vcpkg/action.yml
+++ b/.github/actions/cache-vcpkg/action.yml
@@ -30,6 +30,12 @@ runs:
       shell: pwsh
       run: |
         Write-Output "VCPKG_DEFAULT_BINARY_CACHE=C:\vcpkg_bin_cache" >> $Env:GITHUB_ENV
+
+    - name: Get vcpkg commit
+      shell: bash
+      run: |
+        cd ${VCPKG_ROOT}
+        echo "VCPKG_SHORT_HASH=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
     
     - name:  Set vcpkg binary cache key
       id:    vcpkg_bin_cache_key
@@ -37,7 +43,7 @@ runs:
       run: |
         if [ -n "${{ inputs.compiler }}" ]; then INPUTS_COMPILER="${{ inputs.compiler }}-"; fi
         if [ -n "${{ inputs.compiler_vers }}" ]; then INPUTS_COMPILER_VERS="${{ inputs.compiler_vers }}-"; fi
-        echo "cacheKey=vcpkg-bin-cache-${{ inputs.name_os }}-${{ inputs.arch }}-${INPUTS_COMPILER}${INPUTS_COMPILER_VERS}${ImageOS}-${ImageVersion}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json', 'vcpkg-ports/**') }}" >> $GITHUB_OUTPUT
+        echo "cacheKey=vcpkg-${VCPKG_SHORT_HASH}-bin-cache-${{ inputs.name_os }}-${{ inputs.arch }}-${INPUTS_COMPILER}${INPUTS_COMPILER_VERS}${ImageOS}-${ImageVersion}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json', 'vcpkg-ports/**') }}" >> $GITHUB_OUTPUT
     
     - name: Restore vcpkg binary cache
       uses: actions/cache@v4

--- a/.github/actions/setup-vcpkg/action.yml
+++ b/.github/actions/setup-vcpkg/action.yml
@@ -1,4 +1,4 @@
-name: Cache vcpkg binaries
+name: Set up vcpkg
 
 inputs:
   name_os:
@@ -19,22 +19,24 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Set vcpkg cache env variable
+    - name: Set vcpkg env variables
       if: ${{ runner.os != 'Windows'}}
       shell: bash
       run: |
+        echo "VCPKG_ROOT=${VCPKG_INSTALLATION_ROOT}" >> $GITHUB_ENV
         echo "VCPKG_DEFAULT_BINARY_CACHE=${{ github.workspace }}/vcpkg_bin_cache" >> $GITHUB_ENV
     
     - name: Set vcpkg cache env variable (Windows)
       if: ${{ runner.os == 'Windows'}}
       shell: pwsh
       run: |
+        Write-Output "VCPKG_ROOT=$Env:VCPKG_INSTALLATION_ROOT" >> $Env:GITHUB_ENV
         Write-Output "VCPKG_DEFAULT_BINARY_CACHE=C:\vcpkg_bin_cache" >> $Env:GITHUB_ENV
 
     - name: Get vcpkg commit
       shell: bash
       run: |
-        cd ${VCPKG_ROOT}
+        cd "${VCPKG_ROOT}"
         echo "VCPKG_SHORT_HASH=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
     
     - name:  Set vcpkg binary cache key

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -24,14 +24,14 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  VCPKG_ROOT: ${{ github.workspace }}/vcpkg
+
 jobs:
   build_linux:
     name:    ${{ matrix.conf.name }} ${{ matrix.arch }}
     runs-on: ${{ matrix.conf.os }}${{ matrix.arch == 'arm64' && '-arm' || '' }}
     if:      github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
-    env:
-      VCPKG_ROOT: ${{ github.workspace }}/vcpkg
-
     strategy:
       matrix:
 #       TODO enable arm64 builds
@@ -92,6 +92,13 @@ jobs:
           cd $VCPKG_ROOT
           ./bootstrap-vcpkg.sh
 
+      - name: Set up vcpkg cache
+        uses: ./.github/actions/cache-vcpkg
+        with:
+          name_os: linux
+          arch: "${{ matrix.arch }}"
+          compiler: "${{ matrix.conf.cc }}"
+
       - name: Log environment
         run: ./scripts/ci/log-env.sh
 
@@ -124,9 +131,6 @@ jobs:
     name:    Release build
     runs-on: ubuntu-22.04
     if:      github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
-    env:
-      VCPKG_ROOT: ${{ github.workspace }}/vcpkg
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -149,6 +153,13 @@ jobs:
         run: |
           cd $VCPKG_ROOT
           ./bootstrap-vcpkg.sh
+
+      - name: Set up vcpkg cache
+        uses: ./.github/actions/cache-vcpkg
+        with:
+          name_os: linux
+          arch: "x64"
+          compiler: "gcc"
 
       - name: Log environment
         run: ./scripts/ci/log-env.sh

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -24,9 +24,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  VCPKG_ROOT: ${{ github.workspace }}/vcpkg
-
 jobs:
   build_linux:
     name:    ${{ matrix.conf.name }} ${{ matrix.arch }}
@@ -84,16 +81,8 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y $(cat packages/ubuntu-22.04-apt.txt)
 
-      - name: Clone vcpkg
-        run: git clone https://github.com/microsoft/vcpkg.git $VCPKG_ROOT
-
-      - name: Bootstrap vcpkg
-        run: |
-          cd $VCPKG_ROOT
-          ./bootstrap-vcpkg.sh
-
-      - name: Set up vcpkg cache
-        uses: ./.github/actions/cache-vcpkg
+      - name: Set up vcpkg
+        uses: ./.github/actions/setup-vcpkg
         with:
           name_os: linux
           arch: "${{ matrix.arch }}"
@@ -146,16 +135,8 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y $(cat packages/ubuntu-22.04-apt.txt)
 
-      - name: Clone vcpkg
-        run: git clone https://github.com/microsoft/vcpkg.git $VCPKG_ROOT
-
-      - name: Bootstrap vcpkg
-        run: |
-          cd $VCPKG_ROOT
-          ./bootstrap-vcpkg.sh
-
-      - name: Set up vcpkg cache
-        uses: ./.github/actions/cache-vcpkg
+      - name: Set up vcpkg
+        uses: ./.github/actions/setup-vcpkg
         with:
           name_os: linux
           arch: "x64"

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -63,6 +63,12 @@ jobs:
           cd $VCPKG_ROOT
           ./bootstrap-vcpkg.sh
 
+      - name: Set up vcpkg cache
+        uses: ./.github/actions/cache-vcpkg
+        with:
+          name_os: "${{ matrix.conf.host }}"
+          arch: "${{ matrix.conf.arch }}"
+      
       - name: Log environment
         run: arch -arch=${{ matrix.conf.arch }} ./scripts/ci/log-env.sh
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -31,7 +31,6 @@ jobs:
     if:      github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     env:
       MACOSX_DEPLOYMENT_TARGET: ${{ matrix.conf.minimum_deployment }}
-      VCPKG_ROOT: ${{ github.workspace }}/vcpkg
 
     strategy:
       matrix:
@@ -55,16 +54,8 @@ jobs:
       - name: Setup CMake
         uses: lukka/get-cmake@6b3e96a9bc9976b8b546346fdd102effedae0ca8 # v4.0.3
 
-      - name: Clone vcpkg
-        run: git clone https://github.com/microsoft/vcpkg.git $VCPKG_ROOT
-
-      - name: Bootstrap vcpkg
-        run: |
-          cd $VCPKG_ROOT
-          ./bootstrap-vcpkg.sh
-
-      - name: Set up vcpkg cache
-        uses: ./.github/actions/cache-vcpkg
+      - name: Set up vcpkg
+        uses: ./.github/actions/setup-vcpkg
         with:
           name_os: "${{ matrix.conf.host }}"
           arch: "${{ matrix.conf.arch }}"

--- a/.github/workflows/pvs-studio.yml
+++ b/.github/workflows/pvs-studio.yml
@@ -52,6 +52,13 @@ jobs:
           cd $VCPKG_ROOT
           ./bootstrap-vcpkg.sh
 
+      - name: Set up vcpkg cache
+        uses: ./.github/actions/cache-vcpkg
+        with:
+          name_os: pvs
+          arch: "x64"
+          compiler: "gcc"
+
       - name: Log environment
         run:  ./scripts/ci/log-env.sh
 

--- a/.github/workflows/pvs-studio.yml
+++ b/.github/workflows/pvs-studio.yml
@@ -19,8 +19,6 @@ jobs:
   pvs_studio_analyzer:
     name: PVS-Studio static analyzer
     runs-on: ubuntu-22.04
-    env:
-      VCPKG_ROOT: ${{ github.workspace }}/vcpkg
 
     steps:
       - name: Checkout repository
@@ -44,16 +42,8 @@ jobs:
           sudo apt-get install -y $(cat packages/ubuntu-22.04-apt.txt)
           sudo apt-get install pvs-studio
 
-      - name: Clone vcpkg
-        run: git clone https://github.com/microsoft/vcpkg.git $VCPKG_ROOT
-
-      - name: Bootstrap vcpkg
-        run: |
-          cd $VCPKG_ROOT
-          ./bootstrap-vcpkg.sh
-
-      - name: Set up vcpkg cache
-        uses: ./.github/actions/cache-vcpkg
+      - name: Set up vcpkg
+        uses: ./.github/actions/setup-vcpkg
         with:
           name_os: pvs
           arch: "x64"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -64,6 +64,12 @@ jobs:
           git -c advice.detachedHead=false checkout $baseline
           bootstrap-vcpkg.bat -disableMetrics
 
+      - name: Set up vcpkg cache
+        uses: ./.github/actions/cache-vcpkg
+        with:
+          name_os: "windows"
+          arch: "${{ matrix.conf.arch }}"
+
       - name: Setup CMake
         uses: lukka/get-cmake@v4.0.3
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -24,9 +24,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  VCPKG_ROOT: C:\vcpkg
-
 jobs:
   build_windows_release:
     name: Release ${{ matrix.conf.debugger && 'w/ debugger' || '' }} (${{ matrix.conf.arch }})
@@ -54,8 +51,8 @@ jobs:
         with:
           submodules: false
 
-      - name: Set up vcpkg cache
-        uses: ./.github/actions/cache-vcpkg
+      - name: Set up vcpkg
+        uses: ./.github/actions/setup-vcpkg
         with:
           name_os: "windows"
           arch: "${{ matrix.conf.arch }}"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -54,16 +54,6 @@ jobs:
         with:
           submodules: false
 
-      - name:  Checkout vcpkg baseline
-        shell: pwsh
-        run: |
-          $baseline = (Get-Content vcpkg.json | ConvertFrom-Json).'builtin-baseline'
-          cd $env:VCPKG_INSTALLATION_ROOT
-          git fetch
-          rm vcpkg.exe
-          git -c advice.detachedHead=false checkout $baseline
-          bootstrap-vcpkg.bat -disableMetrics
-
       - name: Set up vcpkg cache
         uses: ./.github/actions/cache-vcpkg
         with:


### PR DESCRIPTION
# Description

We used to cache vcpkg binaries, first using the Github packages NuGet repository, then with the integrated GH actions cache in vcpkg. However when the integrated solution stopped working (it was removed by vcpkg), we have been rebuilding our dependencies for every push/pull request.

This PR adds back caching using the default `files` mechanism, and `actions/cache`.

The cache key I've chosen contains:

- OS/workflow
- CPU architecture
- GH runner ImageOS
- GH runner ImageVersion
- A hash of our vcpkg manifest and overlay files

I believe this combination should be robust, and not get stale. In general, the cache should be invalidated approximately once a week as GH update their runners. Using the runner version in the cache key is important, as vcpkg includes things such as exact compiler versions, cmake version, powershell versions as part of its ABI hash.

The result is even faster CI times. Due to the inconsistent nature of the GH runners, an exact speedup cannot be specified, but it appears to be in the order of 3-8 minutes when restoring the cache.

# Manual testing

The change has been manually tested on:

- [x] Windows
- [x] macOS
- [x] Linux

This is a CI change, All actions were green before opening the PR.

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] my change has been manually tested on Windows, macOS, and Linux.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

