### PR TITLE
Minor DOS command improvements

### DIFF
--- a/include/programs.h
+++ b/include/programs.h
@@ -36,6 +36,17 @@ public:
 
 	bool FindExistRemoveAll(const std::string& name);
 
+	// Removes all the supplied arguments from the list, returns 'true' if
+	// at least one of them was found. Use it if argument has aliases, for
+	// example if '/a' and '/all' request the same action.
+	template <typename... Names>
+	bool FindExistRemoveAll(const std::string& name, Names... names)
+	{
+		const auto found_1 = FindExistRemoveAll(name);
+		const auto found_2 = FindExistRemoveAll(names...);
+		return found_1 || found_2;
+	}
+
 	bool FindInt(const std::string& name, int& value, bool remove = false);
 
 	bool FindString(const std::string& name, std::string& value,

--- a/src/dos/program_boot.cpp
+++ b/src/dos/program_boot.cpp
@@ -173,6 +173,13 @@ void BOOT::Run(void)
 		output.Display();
 		return;
 	}
+
+	// Booting would have terminated the running Windows, don't do it
+	if (WINDOWS_IsStarted()) {
+		WriteOut(MSG_Get("SHELL_CANT_RUN_UNDER_WINDOWS"));
+		return;
+	}
+
 	if (cmd->GetCount() == 1) {
 		if (cmd->FindCommand(1, temp_line)) {
 			if (temp_line.length() == 2 && toupper(temp_line[0]) >= 'A' &&

--- a/src/dos/program_loadrom.cpp
+++ b/src/dos/program_loadrom.cpp
@@ -9,6 +9,7 @@
 #include <cstdio>
 
 #include "callback.h"
+#include "dos_windows.h"
 #include "drives.h"
 #include "program_more_output.h"
 #include "regs.h"
@@ -25,6 +26,13 @@ void LOADROM::Run(void)
 		output.Display();
 		return;
 	}
+
+	// Loading the ROM when Windows is running is asking for trouble
+	if (WINDOWS_IsStarted()) {
+		WriteOut(MSG_Get("SHELL_CANT_RUN_UNDER_WINDOWS"));
+		return;
+	}
+
 	uint8_t drive;
 	char fullname[DOS_PATHLENGTH];
 	if (!DOS_MakeName(temp_line.c_str(), fullname, &drive)) {

--- a/src/dos/program_ls.cpp
+++ b/src/dos/program_ls.cpp
@@ -25,8 +25,7 @@ void LS::Run()
 		return;
 	}
 
-	constexpr bool remove_if_found = true;
-	const bool has_option_all = cmd->FindExist("/a", remove_if_found);
+	const bool has_option_all = cmd->FindExistRemoveAll("/a");
 
 	auto patterns = cmd->GetArguments();
 

--- a/src/dos/program_more.cpp
+++ b/src/dos/program_more.cpp
@@ -40,15 +40,10 @@ void MORE::Run()
 
 bool MORE::ParseCommandLine(MoreOutputFiles &output)
 {
-	// Check (and remove if found) all the simple arguments
-	auto has_arg = [&](const char* arg) {
-		constexpr bool remove_if_found = true;
-		return cmd->FindExist(arg, remove_if_found);
-	};
-	output.SetOptionClear(has_arg("/c"));
-	output.SetOptionExtendedMode(has_arg("/e"));
-	output.SetOptionExpandFormFeed(has_arg("/p"));
-	output.SetOptionSquish(has_arg("/s"));
+	output.SetOptionClear(cmd->FindExistRemoveAll("/c"));
+	output.SetOptionExtendedMode(cmd->FindExistRemoveAll("/e"));
+	output.SetOptionExpandFormFeed(cmd->FindExistRemoveAll("/p"));
+	output.SetOptionSquish(cmd->FindExistRemoveAll("/s"));
 
 	std::string tmp_str;
 

--- a/src/dos/program_setver.cpp
+++ b/src/dos/program_setver.cpp
@@ -45,17 +45,14 @@ void SETVER::Run()
 	}
 
 	// Retrieve all the switches
-	constexpr bool remove_if_found = true;
-	const bool has_arg_delete = cmd->FindExist("/d", remove_if_found) ||
-	                            cmd->FindExist("/delete", remove_if_found);
-	const bool has_arg_quiet = cmd->FindExist("/q", remove_if_found) ||
-	                           cmd->FindExist("/quiet", remove_if_found);
+	const bool has_arg_delete = cmd->FindExistRemoveAll("/d", "/delete");
+	const bool has_arg_quiet  = cmd->FindExistRemoveAll("/q", "/quiet");
 	// DR-DOS extensions
-	const bool has_arg_batch  = cmd->FindExist("/b", remove_if_found);
-	const bool has_arg_global = cmd->FindExist("/g", remove_if_found);
-	const bool has_arg_paged  = cmd->FindExist("/p", remove_if_found);
+	const bool has_arg_batch  = cmd->FindExistRemoveAll("/b");
+	const bool has_arg_global = cmd->FindExistRemoveAll("/g");
+	const bool has_arg_paged  = cmd->FindExistRemoveAll("/p");
 	// DOSBox Staging extensions
-	const bool has_arg_all = cmd->FindExist("/all", remove_if_found);
+	const bool has_arg_all = cmd->FindExistRemoveAll("/all");
 
 	// TODO: DR-DOS also provides /x switch to deal with BDOS versions - for
 	// now this is not implemented, it is unclear to me what it exactly does

--- a/src/dos/program_tree.cpp
+++ b/src/dos/program_tree.cpp
@@ -30,14 +30,12 @@ void TREE::Run()
 	has_option_ascii = false;
 	has_option_files = false;
 
-	constexpr bool remove_if_found = true;
-
-	has_option_ascii = cmd->FindExist("/a", remove_if_found);
-	has_option_files = cmd->FindExist("/f", remove_if_found);
+	has_option_ascii = cmd->FindExistRemoveAll("/a");
+	has_option_files = cmd->FindExistRemoveAll("/f");
 	// DR-DOS
-	has_option_brief = cmd->FindExist("/b", remove_if_found);
+	has_option_brief = cmd->FindExistRemoveAll("/b");
 	// DR-DOS, pdTree
-	has_option_paging = cmd->FindExist("/p", remove_if_found);
+	has_option_paging = cmd->FindExistRemoveAll("/p");
 	// According to http://help.fdos.org/en/hhstndrd/tree.htm there were
 	// plans to implement the following options in FreeDOS:
 	// - /DF - display file sizes
@@ -45,41 +43,56 @@ void TREE::Run()
 	// - /DH - display hidden and system files (normally not shown)
 	// - /DR - display results (file and subdirectory count) after each one
 	// - /On - sort options, like with DIR command
-	has_option_attr   = cmd->FindExist("/da", remove_if_found);
-	has_option_size   = cmd->FindExist("/df", remove_if_found);
-	has_option_hidden = cmd->FindExist("/dh", remove_if_found);
-	if (cmd->FindExist("/on", remove_if_found)) {
+	has_option_attr   = cmd->FindExistRemoveAll("/da");
+	has_option_size   = cmd->FindExistRemoveAll("/df");
+	has_option_hidden = cmd->FindExistRemoveAll("/dh");
+
+	int sorting_switch_count = 0;
+	if (cmd->FindExistRemoveAll("/on")) {
 		option_sorting = ResultSorting::ByName;
 		option_reverse = false;
+		sorting_switch_count++;
 	}
-	if (cmd->FindExist("/o-n", remove_if_found)) {
+	if (cmd->FindExistRemoveAll("/o-n")) {
 		option_sorting = ResultSorting::ByName;
 		option_reverse = true;
+		sorting_switch_count++;
 	}
-	if (cmd->FindExist("/os", remove_if_found)) {
+	if (cmd->FindExistRemoveAll("/os")) {
 		option_sorting = ResultSorting::BySize;
 		option_reverse = false;
+		sorting_switch_count++;
 	}
-	if (cmd->FindExist("/o-s", remove_if_found)) {
+	if (cmd->FindExistRemoveAll("/o-s")) {
 		option_sorting = ResultSorting::BySize;
 		option_reverse = true;
+		sorting_switch_count++;
 	}
-	if (cmd->FindExist("/od", remove_if_found)) {
+	if (cmd->FindExistRemoveAll("/od")) {
 		option_sorting = ResultSorting::ByDateTime;
 		option_reverse = false;
+		sorting_switch_count++;
 	}
-	if (cmd->FindExist("/o-d", remove_if_found)) {
+	if (cmd->FindExistRemoveAll("/o-d")) {
 		option_sorting = ResultSorting::ByDateTime;
 		option_reverse = true;
+		sorting_switch_count++;
 	}
-	if (cmd->FindExist("/oe", remove_if_found)) {
+	if (cmd->FindExistRemoveAll("/oe")) {
 		option_sorting = ResultSorting::ByExtension;
 		option_reverse = false;
+		sorting_switch_count++;
 	}
-	if (cmd->FindExist("/o-e", remove_if_found)) {
+	if (cmd->FindExistRemoveAll("/o-e")) {
 		option_sorting = ResultSorting::ByExtension;
 		option_reverse = true;
+		sorting_switch_count++;
 	}
+	if (sorting_switch_count > 1) {
+		WriteOut(MSG_Get("SHELL_ILLEGAL_SWITCH_COMBO"));
+		return;
+	}
+
 	// TODO: consider implementing /DR in some form
 
 	// Make sure no other switches are supplied


### PR DESCRIPTION
# Description

Minor improvement to some of our DOS commands:
- don't allow doing some dangerous actions to be executed under Windows 2.x or 3.x
- built-in programs now tolerate repeating some switches; the real DOS command behavior varies, for example MS-DOS 6.22 does not allow the `tree /a /a` command, while DR-DOS 7.03 runs it just fine - I prefer to implement more tolerant approach
- the `tree` command no longer allows conflicting sorting switches

# Release notes

Built-in commands  `BOOT`, `LOADROM`, and `MOUSE` won't allow to perform actions which are not safe if run from the Windows 2.x or 3.x command prompt.

Built-in commands `LS`, `MORE`, `SETVER`, and `TREE` now tolerate repeating some option switches. Command `TREE`  can now detect conflicting switches.


# Manual testing

- execute command `tree /a /a` - should now print the directory tree, using plain ASCII characters
- execute command `tree /on /o-n` or `tree /on /os` - should now complain about invalid switch combination
- start Windows 3.11, from the MS DOS Prompt execute command `boot (some bootable floppy image)` - command should refuse to run under Windows

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [x] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [x] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

