### PR TITLE
Improvements to the resource loader

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -156,7 +156,7 @@ jobs:
           curl -L https://github.com/johnnovak/Nuked-SC55-CLAP/releases/download/$NUKED_SC55_CLAP_VERSION/$ZIP_NAME -o $ZIP_NAME
           unzip $ZIP_NAME -d nuked-sc55-clap
 
-          PLUGINS_DIR="dist/DOSBox Staging.app/Contents/Resources/plugins"
+          PLUGINS_DIR="dist/DOSBox Staging.app/Contents/PlugIns"
           mkdir "$PLUGINS_DIR"
           cp -R nuked-sc55-clap/* "$PLUGINS_DIR"
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ include(CheckIncludeFile)
 include(CheckIncludeFiles)
 include(CheckCXXSourceCompiles)
 include(CheckSymbolExists)
+include(GNUInstallDirs)
 
 if(WIN32)
   set(DOSBOX_PLATFORM_WINDOWS ON)
@@ -297,7 +298,7 @@ check_symbol_exists(
   sys_icache_invalidate "libkern/OSCacheControl.h" HAVE_SYS_ICACHE_INVALIDATE
 )
 
-set(CUSTOM_DATADIR " ")
+set(CUSTOM_DATADIR "${CMAKE_INSTALL_FULL_DATADIR}")
 
 set(project_name "${PROJECT_NAME}")
 set(version      "${PROJECT_VERSION}")

--- a/include/support.h
+++ b/include/support.h
@@ -256,6 +256,11 @@ int64_t stdio_num_sectors(FILE* f);
 const std_fs::path& get_executable_path();
 std_fs::path get_resource_path(const std_fs::path& name);
 std_fs::path get_resource_path(const std_fs::path& subdir, const std_fs::path& name);
+const std::vector<std_fs::path>& get_resource_parent_paths();
+
+std::vector<std_fs::path> get_directory_entries(
+        const std_fs::path& dir, const std::string_view files_ext,
+        const bool only_regular_files);
 
 std::map<std_fs::path, std::vector<std_fs::path>> get_files_in_resource(
         const std_fs::path& res_name, const std::string_view files_ext,

--- a/include/support.h
+++ b/include/support.h
@@ -16,7 +16,6 @@
 #include <cstring>
 #include <functional>
 #include <limits>
-#include <map>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -261,10 +260,6 @@ std::vector<std_fs::path> get_plugin_paths();
 
 std::vector<std_fs::path> get_directory_entries(
         const std_fs::path& dir, const std::string_view files_ext,
-        const bool only_regular_files);
-
-std::map<std_fs::path, std::vector<std_fs::path>> get_files_in_resource(
-        const std_fs::path& res_name, const std::string_view files_ext,
         const bool only_regular_files);
 
 enum class ResourceImportance { Mandatory, Optional };

--- a/include/support.h
+++ b/include/support.h
@@ -257,6 +257,7 @@ const std_fs::path& get_executable_path();
 std_fs::path get_resource_path(const std_fs::path& name);
 std_fs::path get_resource_path(const std_fs::path& subdir, const std_fs::path& name);
 const std::vector<std_fs::path>& get_resource_parent_paths();
+std::vector<std_fs::path> get_plugin_paths();
 
 std::vector<std_fs::path> get_directory_entries(
         const std_fs::path& dir, const std::string_view files_ext,

--- a/src/audio/clap/plugin_manager.cpp
+++ b/src/audio/clap/plugin_manager.cpp
@@ -49,13 +49,9 @@ void PluginManager::EnumeratePlugins()
 
 	constexpr auto OnlyRegularFiles = false;
 
-	for (const auto& [dir, plugin_names] :
-	     get_files_in_resource(PluginsDir, ".clap", OnlyRegularFiles)) {
-
-		LOG_DEBUG("CLAP: Enumerating CLAP plugins in '%s'",
-		          dir.string().c_str());
-
-		for (const auto& name : plugin_names) {
+	for (const auto& dir : get_plugin_paths()) {
+		LOG_DEBUG("CLAP: Enumerating CLAP plugins in '%s'", dir.string().c_str());
+		for (const auto& name : get_directory_entries(dir, ".clap", OnlyRegularFiles)) {
 			auto library_path = dir / name;
 
 			LOG_DEBUG("CLAP: Trying to load plugin library '%s'",

--- a/src/config.h.in.cmake
+++ b/src/config.h.in.cmake
@@ -200,10 +200,10 @@
 // Modern MSVC provides POSIX-like routines, so prefer that over built-in
 #cmakedefine HAVE_STRNLEN
 
-// Holds the "--datadir" specified during project setup. This can
+// Holds the CMAKE_INSTALL_DATADIR specified during project setup. This can
 // be used as a fallback if the user hasn't populated their
-// XDG_DATA_HOME or XDG_DATA_DIRS to include the --datadir.
-#cmakedefine CUSTOM_DATADIR
+// XDG_DATA_HOME or XDG_DATA_DIRS.
+#cmakedefine CUSTOM_DATADIR "@CUSTOM_DATADIR@"
 
 
 #endif

--- a/src/gui/shader_manager.cpp
+++ b/src/gui/shader_manager.cpp
@@ -188,8 +188,9 @@ std::deque<std::string> ShaderManager::GenerateShaderInventoryMessage() const
 
 	constexpr auto OnlyRegularFiles = true;
 
-	for (auto& [dir, shaders] :
-	     get_files_in_resource(GlShadersDir, ".glsl", OnlyRegularFiles)) {
+	for (const auto& parent : get_resource_parent_paths()) {
+		const auto dir = parent / GlShadersDir;
+		auto shaders = get_directory_entries(dir, ".glsl", OnlyRegularFiles);
 
 		const auto dir_exists      = std_fs::is_directory(dir, ec);
 		auto shader                = shaders.begin();
@@ -220,6 +221,7 @@ std::deque<std::string> ShaderManager::GenerateShaderInventoryMessage() const
 		}
 		inventory.emplace_back("");
 	}
+
 	inventory.emplace_back(MSG_GetTranslatedRaw("DOSBOX_HELP_LIST_GLSHADERS_2"));
 
 	return inventory;

--- a/src/misc/support.cpp
+++ b/src/misc/support.cpp
@@ -305,8 +305,9 @@ static const std::vector<std_fs::path>& GetResourceParentPaths()
 #endif
 	// macOS, POSIX, and even MinGW/MSYS2/Cygwin:
 
-	// Third priority is a potentially customized --datadir specified at
-	// compile time.
+	// Third priority is the install path set at compile time.
+	// In CMake this is the CMAKE_INSTALL_DATADIR variable.
+	// In Meson it is set by --datadir.
 	add_if_exists(std_fs::path(CUSTOM_DATADIR) / DOSBOX_PROJECT_NAME);
 
 	// Fourth priority is the user and system XDG data specification

--- a/src/misc/support.cpp
+++ b/src/misc/support.cpp
@@ -342,6 +342,38 @@ const std::vector<std_fs::path>& get_resource_parent_paths()
 	return paths;
 }
 
+// Searches mostly the same parent paths as get_resource_parent_paths()
+std::vector<std_fs::path> get_plugin_paths()
+{
+	// Intentionally not using the static cache as this function only gets called once.
+	std::vector<std_fs::path> paths = {};
+
+	// Current working directory
+	maybe_add_path(std_fs::path(PluginsDir), paths);
+
+	maybe_add_path(get_executable_path() / PluginsDir, paths);
+
+	// This will also resolve `$APP_BUNDLE/Contents/PlugIns` on macOS,
+	// as the filesystem is case-preserving.
+	maybe_add_path(get_executable_path() / ".." / PluginsDir, paths);
+
+	maybe_add_path(std_fs::path(CUSTOM_DATADIR) / DOSBOX_PROJECT_NAME / PluginsDir, paths);
+
+#if !defined(WIN32) && !defined(MACOSX)
+	maybe_add_path(get_xdg_data_home() / DOSBOX_PROJECT_NAME / PluginsDir, paths);
+
+	for (const auto& data_dir : get_xdg_data_dirs()) {
+		maybe_add_path(data_dir / DOSBOX_PROJECT_NAME / PluginsDir, paths);
+	}
+
+	maybe_add_path(get_executable_path() / "../share" / DOSBOX_PROJECT_NAME / PluginsDir, paths);
+#endif
+
+	maybe_add_path(GetConfigDir() / PluginsDir, paths);
+
+	return paths;
+}
+
 // Select either an integer or real-based uniform distribution
 template <typename T>
 using uniform_distributor_t =

--- a/src/misc/support.cpp
+++ b/src/misc/support.cpp
@@ -13,7 +13,6 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
-#include <deque>
 #include <fstream>
 #include <functional>
 #include <iterator>
@@ -275,9 +274,9 @@ const std_fs::path& get_executable_path()
 	return exe_path;
 }
 
-static const std::deque<std_fs::path>& GetResourceParentPaths()
+static const std::vector<std_fs::path>& GetResourceParentPaths()
 {
-	static std::deque<std_fs::path> paths = {};
+	static std::vector<std_fs::path> paths = {};
 	if (!paths.empty()) {
 		return paths;
 	}

--- a/src/misc/support.cpp
+++ b/src/misc/support.cpp
@@ -298,7 +298,6 @@ static const std::vector<std_fs::path>& GetResourceParentPaths()
 #if defined(MACOSX)
 	constexpr auto macos_resource_dir_name = "Resources";
 	add_if_exists(get_executable_path() / ".." / macos_resource_dir_name);
-	add_if_exists(get_executable_path() / ".." / macos_resource_dir_name);
 #else
 	add_if_exists(get_executable_path() / resource_dir_name);
 	add_if_exists(get_executable_path() / ".." / resource_dir_name);

--- a/src/misc/support.cpp
+++ b/src/misc/support.cpp
@@ -291,7 +291,7 @@ static void maybe_add_path(const std_fs::path& path, std::vector<std_fs::path>& 
 	}
 }
 
-static const std::vector<std_fs::path>& GetResourceParentPaths()
+static const std::vector<std_fs::path>& get_resource_parent_paths()
 {
 	static std::vector<std_fs::path> paths = {};
 	if (!paths.empty()) {
@@ -380,7 +380,7 @@ std_fs::path get_resource_path(const std_fs::path& name)
 	}
 
 	// Try the resource paths
-	for (const auto& parent : GetResourceParentPaths()) {
+	for (const auto& parent : get_resource_parent_paths()) {
 		const auto resource = parent / name;
 		if (std_fs::exists(resource, ec)) {
 			return resource;
@@ -440,7 +440,7 @@ std::map<std_fs::path, std::vector<std_fs::path>> get_files_in_resource(
 {
 	std::map<std_fs::path, std::vector<std_fs::path>> paths_and_files;
 
-	for (const auto& parent : GetResourceParentPaths()) {
+	for (const auto& parent : get_resource_parent_paths()) {
 		auto res_path  = parent / res_name;
 		auto res_files = get_directory_entries(res_path,
 		                                       files_ext,
@@ -473,7 +473,7 @@ std::vector<std::string> get_resource_lines(const std_fs::path& name,
 	LOG_ERR("RESOURCE: Could not open mandatory resource '%s', tried:",
 	        name.string().c_str());
 
-	for (const auto& path : GetResourceParentPaths()) {
+	for (const auto& path : get_resource_parent_paths()) {
 		LOG_WARNING("RESOURCE:  - '%s'", (path / name).string().c_str());
 	}
 
@@ -505,7 +505,7 @@ std::vector<uint8_t> load_resource_blob(const std_fs::path& name,
 		LOG_ERR("RESOURCE: Could not open mandatory resource '%s', tried:",
 		        name.string().c_str());
 
-		for (const auto& path : GetResourceParentPaths()) {
+		for (const auto& path : get_resource_parent_paths()) {
 			LOG_WARNING("RESOURCE:  - '%s'",
 			            (path / name).string().c_str());
 		}

--- a/src/misc/support.cpp
+++ b/src/misc/support.cpp
@@ -16,7 +16,6 @@
 #include <fstream>
 #include <functional>
 #include <iterator>
-#include <map>
 #include <random>
 #include <stdexcept>
 #include <string>
@@ -464,24 +463,6 @@ std::vector<std_fs::path> get_directory_entries(
 
 	std::sort(files.begin(), files.end());
 	return files;
-}
-
-std::map<std_fs::path, std::vector<std_fs::path>> get_files_in_resource(
-        const std_fs::path& res_name, const std::string_view files_ext,
-        const bool only_regular_files = true)
-{
-	std::map<std_fs::path, std::vector<std_fs::path>> paths_and_files;
-
-	for (const auto& parent : get_resource_parent_paths()) {
-		auto res_path  = parent / res_name;
-		auto res_files = get_directory_entries(res_path,
-		                                       files_ext,
-		                                       only_regular_files);
-
-		paths_and_files.emplace(std::move(res_path), std::move(res_files)); //-V823
-	}
-
-	return paths_and_files;
 }
 
 // Get resource lines from a text file

--- a/src/misc/support.cpp
+++ b/src/misc/support.cpp
@@ -291,7 +291,7 @@ static void maybe_add_path(const std_fs::path& path, std::vector<std_fs::path>& 
 	}
 }
 
-static const std::vector<std_fs::path>& get_resource_parent_paths()
+const std::vector<std_fs::path>& get_resource_parent_paths()
 {
 	static std::vector<std_fs::path> paths = {};
 	if (!paths.empty()) {
@@ -394,9 +394,9 @@ std_fs::path get_resource_path(const std_fs::path& subdir, const std_fs::path& n
 	return get_resource_path(subdir / name);
 }
 
-static std::vector<std_fs::path> get_directory_entries(
+std::vector<std_fs::path> get_directory_entries(
         const std_fs::path& dir, const std::string_view files_ext,
-        const bool only_regular_files = true)
+        const bool only_regular_files)
 {
 	using namespace std_fs;
 	std::vector<std_fs::path> files = {};

--- a/src/misc/support.cpp
+++ b/src/misc/support.cpp
@@ -326,7 +326,6 @@ const std::vector<std_fs::path>& get_resource_parent_paths()
 	for (const auto& data_dir : get_xdg_data_dirs()) {
 		maybe_add_path(data_dir / DOSBOX_PROJECT_NAME, paths);
 	}
-#endif
 
 	// Fifth priority is a best-effort fallback for --prefix installations
 	// into paths not pointed to by the system's XDG_DATA_ variables. Note
@@ -335,6 +334,7 @@ const std::vector<std_fs::path>& get_resource_parent_paths()
 	// which would destroy this portable aspect).
 	//
 	maybe_add_path(get_executable_path() / "../share" / DOSBOX_PROJECT_NAME, paths);
+#endif
 
 	// Last priority is the user's configuration directory
 	maybe_add_path(GetConfigDir(), paths);


### PR DESCRIPTION
# Description

Found and fixed several bugs with the resource loader. View commit by commit as I wrote the problems in the commit messages.

CLAP plugins now searches executable root / plugins rather than the resources directory.

Need some help with Mac. CI is still throwing Nuked.clap  in Resources directory and I have no idea what the folder structure for a Mac app is.

## Related issues

Fixes #4434

# Manual testing

Tested CLAP plugin loads

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [x] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

