### PR TITLE
Remove early-exit protection

### DIFF
--- a/contrib/resources/translations/br.lng
+++ b/contrib/resources/translations/br.lng
@@ -3874,10 +3874,6 @@ Exemplos:
   [color=light-green]exit[reset]
 
 .
-:SHELL_CMD_EXIT_TOO_SOON
-Impedindo que uma chamada 'exit' precoce termine.
-
-.
 :SHELL_CMD_HELP_HELP
 Exibe informações de ajuda para os comandos do DOS.
 

--- a/contrib/resources/translations/de.lng
+++ b/contrib/resources/translations/de.lng
@@ -3937,10 +3937,6 @@ Beispiel:
   [color=light-green]exit[reset]
 
 .
-:SHELL_CMD_EXIT_TOO_SOON
-Verhindert, dass ein vorzeitiger 'exit'-Anruf DOSBox beendet.
-
-.
 :SHELL_CMD_HELP_HELP
 Zeigt Hilfeinformationen zu DOS-Befehlen an.
 

--- a/contrib/resources/translations/en.lng
+++ b/contrib/resources/translations/en.lng
@@ -3739,10 +3739,6 @@ Examples:
   [color=light-green]exit[reset]
 
 .
-:SHELL_CMD_EXIT_TOO_SOON
-Preventing an early 'exit' call from terminating.
-
-.
 :SHELL_CMD_HELP_HELP
 Display help information for DOS commands.
 

--- a/contrib/resources/translations/es.lng
+++ b/contrib/resources/translations/es.lng
@@ -3959,10 +3959,6 @@ Ejemplos:
   [color=light-green]exit[reset]
 
 .
-:SHELL_CMD_EXIT_TOO_SOON
-Previniendo que una llamada temprana a 'exit' termine.
-
-.
 :SHELL_CMD_HELP_HELP
 Mostrar información de ayuda para comandos de DOS.
 

--- a/contrib/resources/translations/fr.lng
+++ b/contrib/resources/translations/fr.lng
@@ -2259,10 +2259,6 @@ Examples:
   [color=light-green]exit[reset]
 
 .
-:SHELL_CMD_EXIT_TOO_SOON
-Preventing an early 'exit' call from terminating.
-
-.
 :SHELL_CMD_HELP_HELP_LONG
 Usage:
   [color=light-green]help[reset]

--- a/contrib/resources/translations/it.lng
+++ b/contrib/resources/translations/it.lng
@@ -5323,10 +5323,6 @@ Esempi:
   [color=light-green]exit[reset]
 
 .
-:SHELL_CMD_EXIT_TOO_SOON
-Interruzione del tentativo di eseguire una chiamata 'exit' prematura.
-
-.
 :SHELL_CMD_HELP_HELP
 Visualizza la guida per i comandi DOS.
 

--- a/contrib/resources/translations/nl.lng
+++ b/contrib/resources/translations/nl.lng
@@ -5076,10 +5076,6 @@ Voorbeelden:
   [color=light-green]exit[reset]
 
 .
-:SHELL_CMD_EXIT_TOO_SOON
-Voorkomen dat een vroegtijdig 'exit' wordt beëindigd.
-
-.
 :SHELL_CMD_HELP_HELP
 Toont help-informatie voor DOS-commando's.
 

--- a/contrib/resources/translations/pl.lng
+++ b/contrib/resources/translations/pl.lng
@@ -4946,9 +4946,6 @@ Uwagi:
 
 Przykłady:
   [color=light-green]exit[reset]
-.
-:SHELL_CMD_EXIT_TOO_SOON
-Próba zbyt wczesnego wykonania polecenia 'exit'.
 
 .
 :SHELL_CMD_HELP_HELP

--- a/contrib/resources/translations/ru.lng
+++ b/contrib/resources/translations/ru.lng
@@ -2494,10 +2494,6 @@ https://github.com/dosbox-staging/dosbox-staging/wiki
   [color=light-green]exit[reset]
 
 .
-:SHELL_CMD_EXIT_TOO_SOON
-Предотвращение раннего вызова 'exit' от прерывания.
-
-.
 :SHELL_CMD_HELP_HELP_LONG
 Использование:
   [color=light-green]help[reset]

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -819,7 +819,6 @@ void SHELL_Init() {
 	        "\n"
 	        "Examples:\n"
 	        "  [color=light-green]exit[reset]\n");
-	MSG_Add("SHELL_CMD_EXIT_TOO_SOON", "Preventing an early 'exit' call from terminating.\n");
 
 	MSG_Add("SHELL_CMD_HELP_HELP",
 	        "Display help information for DOS commands.\n");

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -458,29 +458,7 @@ void DOS_Shell::CMD_ECHO(char * args){
 void DOS_Shell::CMD_EXIT(char *args)
 {
 	HELP("EXIT");
-
-	assert(control);
-	const bool wants_force_exit = control->arguments.exit;
-
-	assert(control->cmdline);
-	const auto is_instant_launch = control->cmdline->HasExecutableName();
-
-	// Check if this is an early-exit situation, in which case we avoid
-	// exiting because the user might have a configuration problem and we
-	// should let them see any errors in their console.
-	constexpr auto early_exit_seconds = 1.5;
-	const auto exiting_after_seconds  = DOSBOX_GetUptime();
-
-	const auto not_early_exit = exiting_after_seconds > early_exit_seconds;
-
-	if (wants_force_exit || is_instant_launch || not_early_exit) {
-		exit_cmd_called = true;
-		return;
-	}
-
-	WriteOut(MSG_Get("SHELL_CMD_EXIT_TOO_SOON"));
-	LOG_WARNING("SHELL: Exit blocked because program quit after only %.1f seconds",
-	            exiting_after_seconds);
+	exit_cmd_called = true;
 }
 
 void DOS_Shell::CMD_CHDIR(char * args) {


### PR DESCRIPTION
# Description

Don't throw an error if exit is called in the first couple seconds after launching. Just exit.

## Related issues

Fixes #4444

# Release notes

The "exit" command is no longer prevented if ran in the first few seconds after launching. If Staging quits immediately after launching, check your [autoexec] section in the config file and remove any "exit" commands so you can see any errors error messages.

# Manual testing

Exit command still works and no longer shows the early-exit error.

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [x] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [x] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

