### PR TITLE
Show stack trace symbols in Loguru dump

### DIFF
--- a/src/libs/loguru/CMakeLists.txt
+++ b/src/libs/loguru/CMakeLists.txt
@@ -6,4 +6,5 @@ check_include_files("${STACK_INCLUDES}" HAS_STACK_INCLUDES LANGUAGE CXX)
 
 if (HAS_STACK_INCLUDES)
 	target_compile_definitions(loguru PRIVATE LOGURU_STACKTRACES=1)
+	target_link_options(dosbox PRIVATE "-rdynamic")
 endif()


### PR DESCRIPTION
# Description

Behold my one-liner!

This adds the "-rdynamic" linker flag to CMake.
This matches what we were previously doing in Meson.

## Related issues

Fixes #4466
#2679 - Meson bug report
#2682 - Meson PR

# Manual testing

Press Ctrl+C in the terminal to send a SIGINT and print a stack trace from Loguru. Symbols are now visible in both Debug and Release CMake builds.

The change has been manually tested on:

- [ ] Windows
- [x] macOS
- [x] Linux

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [ ] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

