### PR TITLE
ci: Fix getting the current version with `get-version.sh`

### DIFF
--- a/scripts/ci/get-version.sh
+++ b/scripts/ci/get-version.sh
@@ -30,15 +30,20 @@ fi
 ROOT=$(git rev-parse --show-toplevel)
 
 VERSION=$(
-    grep "#define\\s*DOSBOX_VERSION\\s*\"" "$ROOT/include/version.h" \
-        | cut -d"\"" -f2
+    grep "project(dosbox-staging" -A 2 "$ROOT/CMakeLists.txt" \
+        | grep "VERSION" | sed "s/\\s*VERSION\\s*//g" | cut -d"\"" -f2
+)
+
+SUFFIX=$(
+    grep "set(DOSBOX_VERSION" "$ROOT/CMakeLists.txt" | cut -d" " -f2 \
+        | sed "s/\${PROJECT_VERSION}//g" | sed "s/)//g"
 )
 
 GIT_HASH=$(git rev-parse --short=5 HEAD)
 
 case $1 in
-    version)          echo "$VERSION" ;;
+    version)          echo "$VERSION$SUFFIX" ;;
     hash)             echo "$GIT_HASH" ;;
-    version-and-hash) echo "$VERSION-$GIT_HASH" ;;
+    version-and-hash) echo "$VERSION$SUFFIX-$GIT_HASH" ;;
     *)                usage; exit 1 ;;
 esac


### PR DESCRIPTION
# Description

I deleted the obsolete `include/version.h` last week, but forgot to update the `get-version.sh` script that still attempted to fetch the current version from this file.

This had the unfortunate consequence of the version being dropped from the release package file names which in turn broke the dev downloads page.

For instance:

<img width="573" height="55" alt="image" src="https://github.com/user-attachments/assets/138e7d17-b002-487f-b276-264ab4b881dd" />

This has been broken for almost a week now and I'm kinda disappointed no one in our Discorded has reported it yet...

Wake up, people! ⏰ 😆 


# Manual testing

## Case 1

`CMakeLists.txt`

<img width="365" height="103" alt="image" src="https://github.com/user-attachments/assets/86fe5e84-c4d9-4eaa-92bd-e58b1d47257d" />

**Script output:**

<img width="400" height="118" alt="image" src="https://github.com/user-attachments/assets/553ac88f-4526-4f9e-a296-0d19b3e8ca8b" />

## Case 2

`CMakeLists.txt`

<img width="331" height="105" alt="image" src="https://github.com/user-attachments/assets/aaf47738-62d8-4f88-ab3b-2fb77eb1f8c8" />

**Script output:**

<img width="401" height="119" alt="image" src="https://github.com/user-attachments/assets/a95aed63-58e6-4188-888b-b741e3452154" />

---

CI's looking good:

<img width="649" height="57" alt="image" src="https://github.com/user-attachments/assets/0ee0dbfe-0b72-479e-adf5-95d9881e949d" />

CI generated artifact looking good:

<img width="1179" height="940" alt="image" src="https://github.com/user-attachments/assets/40479529-be98-492b-9165-f605ffb6f9c0" />



The change has been manually tested on:

- [ ] Windows
- [x] macOS
- [ ] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

