### PR TITLE
Update mapper.cpp - correct comment about ABNT1

### DIFF
--- a/src/gui/mapper.cpp
+++ b/src/gui/mapper.cpp
@@ -2462,12 +2462,12 @@ static struct {
                    {"kp_period", SDL_SCANCODE_KP_PERIOD},
                    {"kp_enter", SDL_SCANCODE_KP_ENTER},
 
-                   // ABNT-arrangement, key between Left-Shift and Z: SDL
+                   // ABNT-arrangement, key between Left-Shift and Z:, SDL
                    // scancode 100 (0x64) maps to OEM102 key with scancode 86
                    // (0x56)
                    {"oem102", SDL_SCANCODE_NONUSBACKSLASH},
 
-                   // ABNT-arrangement, key between Left-Shift and Z: SDL
+                   // ABNT-arrangement, key to the left of Right-Shift, SDL
                    // scancode 135 (0x87) maps to first ABNT key with scancode
                    // 115 (0x73)
                    {"abnt1", SDL_SCANCODE_INTERNATIONAL1},


### PR DESCRIPTION
# Description

Comment for ABNT1 key position was a copy of the above OEM102 key. Corrected it per [ABNT layout](https://kbdlayout.info/KBDBR/overview+scancodes?arrangement=ABNT).

## Related issues

- #2209

# Manual testing

None, changing only a comment.

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [ ] Linux


# Checklist

I have:

- [ ] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [ ] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

