### PR TITLE
Add and fix additional warnings to the CMake build

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -38,12 +38,12 @@ jobs:
           - host: macos-15
             arch: x86_64
             minimum_deployment: '11.0'
-            max_warnings: 9
+            max_warnings: 0
 
           - host: macos-15
             arch: arm64
             minimum_deployment: '11.0'
-            max_warnings: 9
+            max_warnings: 0
 
     steps:
       - name: Check out repository

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ if(MSVC)
   # Disable cl/clangcl warnings about insecure C functions
   add_compile_definitions(_CRT_SECURE_NO_WARNINGS)
 else()
-  add_compile_options("-Wno-conversion" "-Wno-narrowing")
+  add_compile_options("-Wall" "-Wextra" "-Wno-unknown-pragmas" "-Wno-conversion" "-Wno-narrowing")
 endif()
 
 option(OPT_DEBUGGER "Enable debugger" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,8 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 # CHECK_NARROWING() macro to opt-in these checks on a per-file basis. See
 # `src/util/checks.h` for details.
 if(MSVC)
-  add_compile_options("/wd4244" "/MP")
+  # /W4 displays level 1, level 2, and level 3 warnings, and all level 4 (informational) warnings that aren't off by default.
+  add_compile_options("/wd4244" "/MP" "/W4")
 
   # Disable cl/clangcl warnings about insecure C functions
   add_compile_definitions(_CRT_SECURE_NO_WARNINGS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,12 @@ else()
   add_compile_options("-Wall" "-Wextra" "-Wno-unknown-pragmas" "-Wno-conversion" "-Wno-narrowing")
 endif()
 
+# TODO: These are sprintf deprecated warnings.
+# We probably do want to remove sprintf usage at some point.
+if(APPLE)
+  add_compile_options("-Wno-deprecated-declarations")
+endif()
+
 option(OPT_DEBUGGER "Enable debugger" OFF)
 option(OPT_HEAVY_DEBUGGER "Enable heavy debugger" OFF)
 if(OPT_HEAVY_DEBUGGER)

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -74,7 +74,7 @@ constexpr uint32_t sdl_version_to_uint32(const SDL_version version)
 	return (version.major << 16) + (version.minor << 8) + version.patch;
 }
 
-static bool is_runtime_sdl_version_at_least(const SDL_version min_version)
+[[maybe_unused]] static bool is_runtime_sdl_version_at_least(const SDL_version min_version)
 {
 	SDL_version version = {};
 	SDL_GetVersion(&version);

--- a/src/hardware/reelmagic/video_mixer.cpp
+++ b/src/hardware/reelmagic/video_mixer.cpp
@@ -489,11 +489,12 @@ static void setup_video_mixer(const bool update_render_mode)
 
 	// check to make sure we have enough horizontal line buffer for the
 	// current VGA mode...
-	[[maybe_unused]] const Bitu maxRenderWidth =
+	[[maybe_unused]] constexpr auto MaxRenderWidth =
+	        check_cast<int>(
 	        sizeof(_finalMixedRenderLineBuffer) /
-	        sizeof(_finalMixedRenderLineBuffer[0]);
+	        sizeof(_finalMixedRenderLineBuffer[0]));
 
-	assert(_vgaImageInfo.width <= maxRenderWidth);
+	assert(_vgaImageInfo.width <= MaxRenderWidth);
 
 	// set the RENDER mode only if requested...
 	if (update_render_mode) {
@@ -527,21 +528,21 @@ static void setup_video_mixer(const bool update_render_mode)
 	const bool vgaOver  = mpeg->GetConfig().UnderVga;
 	const char* modeStr = "UNKNOWN";
 
-	if ((_vgaImageInfo.width == _mpegPictureWidth) &&
-	    (_vgaImageInfo.height == _mpegPictureHeight)) {
+	if ((check_cast<uint32_t>(_vgaImageInfo.width) == _mpegPictureWidth) &&
+	    (check_cast<uint32_t>(_vgaImageInfo.height) == _mpegPictureHeight)) {
 		modeStr = "Matching Sized MPEG to VGA Pictures";
 		ASSIGN_RMR_DRAWLINE_FUNCTION(RMR_DrawLine_VGAMPEGSameSize,
 		                             _vgaImageInfo.pixel_format,
 		                             vgaOver);
 
-	} else if ((_vgaImageInfo.width == (_mpegPictureWidth * 2)) &&
-	           (_vgaImageInfo.height == ((_mpegPictureHeight * 2)))) {
+	} else if ((check_cast<uint32_t>(_vgaImageInfo.width) == (_mpegPictureWidth * 2)) &&
+	           (check_cast<uint32_t>(_vgaImageInfo.height) == ((_mpegPictureHeight * 2)))) {
 		modeStr = "Double Sized MPEG to VGA Pictures";
 		ASSIGN_RMR_DRAWLINE_FUNCTION(RMR_DrawLine_VSO_MPEGDoubleVGASize,
 		                             _vgaImageInfo.pixel_format,
 		                             vgaOver);
 
-	} else if ((_vgaImageInfo.width == _mpegPictureWidth) &&
+	} else if ((check_cast<uint32_t>(_vgaImageInfo.width) == _mpegPictureWidth) &&
 	           ((_mpegPictureHeight /
 	             (_mpegPictureHeight - _vgaImageInfo.height)) == 6)) {
 		modeStr = "Matching Sized MPEG to VGA Pictures, skipping every 6th MPEG line";
@@ -549,7 +550,7 @@ static void setup_video_mixer(const bool update_render_mode)
 		                             _vgaImageInfo.pixel_format,
 		                             vgaOver);
 
-	} else if ((_vgaImageInfo.width == (_mpegPictureWidth * 2)) &&
+	} else if ((check_cast<uint32_t>(_vgaImageInfo.width) == (_mpegPictureWidth * 2)) &&
 	           (((_mpegPictureHeight * 2) /
 	             ((_mpegPictureHeight * 2) - _vgaImageInfo.height)) == 6)) {
 		modeStr = "Double Sized MPEG to VGA Pictures, skipping every 6th MPEG line";

--- a/src/hardware/reelmagic/video_mixer.cpp
+++ b/src/hardware/reelmagic/video_mixer.cpp
@@ -17,8 +17,11 @@
 
 #include "gui/render_scalers.h" //SCALER_MAXWIDTH SCALER_MAXHEIGHT
 #include "config/setup.h"
+#include "utils/checks.h"
 #include "utils/rgb565.h"
 #include "misc/video.h"
+
+CHECK_NARROWING();
 
 namespace {
 // XXX currently duplicating this in realmagic_*.cpp files to avoid header pollution... TDB if this

--- a/src/libs/glad/CMakeLists.txt
+++ b/src/libs/glad/CMakeLists.txt
@@ -1,3 +1,7 @@
+if(APPLE)
+  add_compile_options("-Wno-cast-function-type-mismatch")
+endif()
+
 add_library(libglad STATIC
   src/gl.c
 )

--- a/src/misc/logging.h
+++ b/src/misc/logging.h
@@ -82,6 +82,11 @@ void GFX_ShowMsg(const char* format, ...)
 #define LOG_TRACE(...)
 #else
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wformat-security"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-security"
+
 template <typename... Args>
 void LOG_DEBUG(const std::string& format, const Args&... args) noexcept
 {
@@ -102,6 +107,8 @@ void LOG_TRACE(const std::string& format, const Args&... args) noexcept
 	DLOG_F(INFO, format_purple.c_str(), args...);
 }
 
+#pragma GCC diagnostic pop
+#pragma clang diagnostic pop
 
 #endif // NDEBUG
 

--- a/src/utils/bit_view.h
+++ b/src/utils/bit_view.h
@@ -88,6 +88,27 @@ big-endian.
 #include "utils/bitops.h"
 #include "misc/support.h"
 
+// Clang does not have -Wmaybe-uninitialized so it needs -Wunknown-warning-option
+// to supress a warning about unknown warnings.
+
+// We can't just remove the pragma clang stuff because from testing,
+// Clang accepts pragma GCC but GCC does not accept pragma clang.
+
+// Also, GCC does not have -Wunknown-warning-option,
+// so if we *only* have pragma GCC, we get warned about
+// an unkown warning that's supposed to supress unkown warnings.
+// Sheesh...
+
+// All of this is needed because "data_type data;" is explcitly left uninitialized.
+// See comment below.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunknown-warning-option"
+#pragma clang diagnostic ignored "-Wuninitialized"
+#pragma clang diagnostic ignored "-Wmaybe-uninitialized"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wuninitialized"
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+
 template <int view_index, int view_width>
 class bit_view {
 private:
@@ -280,5 +301,8 @@ public:
 		return static_cast<data_type>(*this);
 	}
 };
+
+#pragma GCC diagnostic pop
+#pragma clang diagnostic pop
 
 #endif

--- a/tests/string_utils_tests.cpp
+++ b/tests/string_utils_tests.cpp
@@ -183,12 +183,6 @@ TEST(SafeStrlen, EmptyString)
 	EXPECT_EQ(0, safe_strlen(buffer));
 }
 
-TEST(SafeStrlen, Uninitialized)
-{
-	char buffer[4];
-	EXPECT_GT(sizeof(buffer), safe_strlen(buffer));
-}
-
 TEST(SafeStrlen, FixedSize)
 {
 	constexpr size_t N = 5;


### PR DESCRIPTION
# Description

In Meson, we had set `warning_level=3` which according to Meson docs sets `-Wall -Wextra -Wpedantic`. CMake does not have an equivalent that I could find so we just need to set these compiler flags directly.

`-Wpedantic` shows several warnings that are not shown in Meson so either the Meson docs are incorrect or we are supressing these warnings elsewhere. The warnings are mostly regarding 128-bit SIMD types. Example:

```
/home/daniel/code/dosbox-staging/src/libs/simde/x86/mmx.h:7679:30: warning: ISO C++ does not support ‘__int128’ for ‘simde_poly128’ [-Wpedantic]
 7679 | #  define SIMDE_POLY128_TYPE __int128
```

For now, I'm only setting `-Wall` and `-Wextra`.

Regarding the warnings in `video_mixer.cpp`, the internal `_mpegPictureWidth` and `_mpegPictureHeight` are used in bit-shifting and pointer arithmetic so it's a bit risky to change their types. I just added some `check_cast`'s to resolve the warnings.

# Manual testing

It compiled and I played Doom for a bit. Pretty low risk of regression I think.

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [x] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

