### PR TITLE
Correct EMS Set Handle Name to read from correct registers

### DIFF
--- a/src/ints/ems.cpp
+++ b/src/ints/ems.cpp
@@ -584,7 +584,7 @@ static uint8_t GetSetHandleName(void) {
 		break;
 	case 0x01:	/* Set Handle Name */
 		if (handle>=EMM_MAX_HANDLES || emm_handles[handle].pages==NULL_HANDLE) return EMM_INVALID_HANDLE;
-		MEM_BlockRead(SegPhys(es)+reg_di,emm_handles[handle].name,8);
+		MEM_BlockRead(SegPhys(ds)+reg_si,emm_handles[handle].name,8);
 		break;
 	default:
 		LOG(LOG_MISC,LOG_ERROR)("EMS:Call %2X Subfunction %2X not supported",reg_ah,reg_al);


### PR DESCRIPTION
# Description

[INT 67h function 5301h](https://stanislavs.org/helppc/int_67-53.html) is supposed to read the handle name from ds:si, but in Staging it reads from es:di.

This seems to be inherited from SVN as the bug is still present there.

X fixed it years ago: https://github.com/joncampbell123/dosbox-x/blob/d1a6e4d79857455ffee77ed9ac48bff516504f8d/src/ints/ems.cpp#L722

Merging this will close #4493.

## Related issues

- #4493 

# Release notes

EMS Set Handle Name was reading from wrong registers and has been now corrected.

# Manual testing

Seems to pass automated checks.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [x] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

