### PR TITLE
Remove max frame time check in frame presentation

### DIFF
--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3770,17 +3770,15 @@ void GFX_MaybePresentFrame()
 
 	if (force_present || (curr_frame_time_us >= present_window_start_us)) {
 
-		[[maybe_unused]] const auto t0 = GetTicksUs();
-
 		sdl.presentation.update();
 		sdl.presentation.present();
 
-		const auto t1 = GetTicksUs();
+		const auto end_us = GetTicksUs();
 #if 0
-		LOG_TRACE("DISPLAY: present took %2.4f ms", 0.001 * GetTicksDiff(t1, t0));
+		LOG_TRACE("DISPLAY: present took %2.4f ms", 0.001 * GetTicksDiff(end_us, start_us));
 
 		const auto measured_frame_time_us = GetTicksDiff(
-			t1, sdl.presentation.last_present_time_us);
+			end_us, sdl.presentation.last_present_time_us);
 
 		LOG_TRACE("DISPLAY: frame time: %2.4f ms", 0.001 * measured_frame_time_us);
 
@@ -3789,11 +3787,11 @@ void GFX_MaybePresentFrame()
 			LOG_WARNING("DISPLAY: missed vsync (long frame)");
 		}
 #endif
-		sdl.presentation.last_present_time_us = t1;
-	}
+		sdl.presentation.last_present_time_us = end_us;
 
-	// Adjust "ticks done" counter by the time it took to present the frame
-	adjust_ticks_after_present_frame(GetTicksUsSince(start_us));
+		// Adjust "ticks done" counter by the time it took to present the frame
+		adjust_ticks_after_present_frame(GetTicksDiff(end_us, start_us));
+	}
 }
 
 // Returns:


### PR DESCRIPTION
# Description

Discussed at length in #4497

The short of it is, if we take too long to render a frame (ex: when the CPU cycles are set higher than the host CPU can emulate in real-time), then we skip frame presentation.

First commit addresses the bug using the exact solution @johnnovak proposed.

Second commit just removes some redundant `GetTicksUs()` calls. We only need to check the time twice: Before and after we present. See my commit message for details but there's a potential performance issue for a minority of systems and it shouldn't change anything for everyone else.

## Related issues

Fixes #4497


# Manual testing

Tested `dos-rate` and `host-rate` in Doom and Tyrian with the cycles cranked up and confirmed the issue is resolved.

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [x] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

