### PR TITLE
Fix release package name generation on macOS

### DIFF
--- a/scripts/ci/get-version.sh
+++ b/scripts/ci/get-version.sh
@@ -31,7 +31,7 @@ ROOT=$(git rev-parse --show-toplevel)
 
 VERSION=$(
     grep "project(dosbox-staging" -A 2 "$ROOT/CMakeLists.txt" \
-        | grep "VERSION" | sed "s/\\s*VERSION\\s*//g" | cut -d"\"" -f2
+        | grep "VERSION" | sed "s/ *VERSION *//g" | cut -d"\"" -f2
 )
 
 SUFFIX=$(


### PR DESCRIPTION
# Description

The `sed` command that comes with macOS is the BSD variant which doesn't understand GNU-style character classes. (I'm using GNU sed on macOS, but the CI image doesn't, that's why I did not run into it when I introduced the change).

So the original `"s/\\s*VERSION\\s*//g"` expression did not trim the trailing whitespaces from the version string:

<img width="870" height="42" alt="image" src="https://github.com/user-attachments/assets/40ddb602-2e15-451e-bfc1-c634a2fce9bc" />

This broke the macOS downloads on the development builds page because the regexp in the JavaScript does not expect spaces in the release artifact name.

The fix is to not use character classes:

<img width="853" height="42" alt="image" src="https://github.com/user-attachments/assets/29c7173e-d623-40be-8e51-be8428f7bb54" />


## Related issues

_Related issues can be listed here (remove the section if not applicable.)_


# Manual testing

Release artifact names are looking good. I can only test the dev builds download page after merging.

<img width="815" height="103" alt="image" src="https://github.com/user-attachments/assets/3cb68a68-ad0c-4e66-9675-0c8b6f0df0d3" />

<img width="954" height="220" alt="image" src="https://github.com/user-attachments/assets/55564d8d-ad9e-4203-a456-c97d1ab2d781" />

<img width="864" height="107" alt="image" src="https://github.com/user-attachments/assets/4451c719-3afe-4a6c-8a05-d2a99956745c" />



The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [ ] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

