### PR TITLE
Improve GCC 15.x support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,11 @@ else()
                       "-Wdisabled-optimization")
 endif()
 
+# GCC needs more memory reserved to fully optimize the CPU emulation code
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  add_compile_options("--param" "max-gcse-memory=250000")
+endif()
+
 # TODO: These are sprintf deprecated warnings.
 # We probably do want to remove sprintf usage at some point.
 if(APPLE)


### PR DESCRIPTION
# Description

Background: after upgrading from GCC 14.3 to 15.2 I have noticed the following warnings reported by the Meson build system (CMake did not produce any warnings):

```
[192/323] Compiling C++ object src/misc/libmisc.a.p/host_locale_posix.cpp.o
../src/misc/host_locale_posix.cpp: In function ‘void __static_initialization_and_destruction_0()’:
../src/misc/host_locale_posix.cpp:1463:1: warning: ext-dce disabled: 9556 basic blocks and 22163 registers; increase ‘--param max-gcse-memory’ above 206825 [-Wdisabled-optimization]
 1463 | }
      | ^
[200/323] Compiling C++ object src/cpu/libcpu.a.p/core_prefetch.cpp.o
../src/cpu/core_prefetch.cpp: In function ‘Bits CPU_Core_Prefetch_Run()’:
../src/cpu/core_prefetch.cpp:305:1: warning: ext-dce disabled: 4823 basic blocks and 31553 registers; increase ‘--param max-gcse-memory’ above 148613 [-Wdisabled-optimization]
  305 | }
      | ^
[240/323] Compiling C++ object src/cpu/libcpu.a.p/core_normal.cpp.o
../src/cpu/core_normal.cpp: In function ‘Bits CPU_Core_Normal_Run()’:
../src/cpu/core_normal.cpp:187:1: warning: ext-dce disabled: 4730 basic blocks and 37003 registers; increase ‘--param max-gcse-memory’ above 170922 [-Wdisabled-optimization]
  187 | }
      | ^
[302/323] Compiling C++ object src/dos/libdos.a.p/dos_locale_data.cpp.o
../src/dos/dos_locale_data.cpp: In function ‘void __static_initialization_and_destruction_0()’:
../src/dos/dos_locale_data.cpp:3410:2: warning: ext-dce disabled: 9297 basic blocks and 25192 registers; increase ‘--param max-gcse-memory’ above 228720 [-Wdisabled-optimization]
 3410 | };
      |  ^
[319/323] Compiling C++ object src/misc/libmisc_stubs.a.p/host_locale_posix.cpp.o
../src/misc/host_locale_posix.cpp: In function ‘void __static_initialization_and_destruction_0()’:
../src/misc/host_locale_posix.cpp:1463:1: warning: ext-dce disabled: 9556 basic blocks and 22163 registers; increase ‘--param max-gcse-memory’ above 206825 [-Wdisabled-optimization]
```

This PR does the following:
- enables these warnings also in the CMake script (this should only affect GCC, according to the documentation clang currently ignores the `-Wdisabled-optimization` flag) - we should be informed if the compiler has any problems optimizing our code
- silenced the warning by increasing the GCC memory pool; unfortunately, I could not measure any performance difference


# Manual testing

Checked that there is no performance regression - used a Quake benchmark (press the tilde, type `timedemo demo1`),  `cpu_cycles=max`, both normal and dynamic core.

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [x] Linux


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

