### PR TITLE
Improve FPU FCOM emulation for non-x86

### DIFF
--- a/src/fpu/fpu_instructions.h
+++ b/src/fpu/fpu_instructions.h
@@ -433,18 +433,44 @@ static void FPU_FST(Bitu st, Bitu other){
 }
 
 static void FPU_FCOM(Bitu st, Bitu other){
-	if(((fpu.tags[st] != TAG_Valid) && (fpu.tags[st] != TAG_Zero)) || 
-		((fpu.tags[other] != TAG_Valid) && (fpu.tags[other] != TAG_Zero))){
-		FPU_SET_C3(1);FPU_SET_C2(1);FPU_SET_C0(1);return;
+	if (((fpu.tags[st] != TAG_Valid) && (fpu.tags[st] != TAG_Zero)) ||
+	    ((fpu.tags[other] != TAG_Valid) && (fpu.tags[other] != TAG_Zero))) {
+		FPU_SET_C3(1);
+		FPU_SET_C2(1);
+		FPU_SET_C0(1);
+		return;
 	}
-	if(fpu.regs[st].d == fpu.regs[other].d){
-		FPU_SET_C3(1);FPU_SET_C2(0);FPU_SET_C0(0);return;
+
+	const auto st_val    = fpu.regs[st].d;
+	const auto other_val = fpu.regs[other].d;
+
+	bool are_equal = false;
+	
+	const auto prec_mode = fpu.cw & PrecisionModeMask;
+	if (prec_mode == ExtendedPrecisionMode) {
+		are_equal = are_almost_equal_relative(st_val, other_val);
+	} else {
+		are_equal = (st_val == other_val);
 	}
-	if(fpu.regs[st].d < fpu.regs[other].d){
-		FPU_SET_C3(0);FPU_SET_C2(0);FPU_SET_C0(1);return;
+
+	if (are_equal) {
+		FPU_SET_C3(1);
+		FPU_SET_C2(0);
+		FPU_SET_C0(0);
+		return;
 	}
+
+	if (st_val < other_val) {
+		FPU_SET_C3(0);
+		FPU_SET_C2(0);
+		FPU_SET_C0(1);
+		return;
+	}
+
 	// st > other
-	FPU_SET_C3(0);FPU_SET_C2(0);FPU_SET_C0(0);return;
+	FPU_SET_C3(0);
+	FPU_SET_C2(0);
+	FPU_SET_C0(0);
 }
 
 static void FPU_FUCOM(Bitu st, Bitu other){

--- a/src/utils/math_utils.h
+++ b/src/utils/math_utils.h
@@ -111,6 +111,16 @@ inline bool are_almost_equal_relative(
         const double a, const double b,
         const double epsilon = std::numeric_limits<double>::epsilon())
 {
+	if (a == b) {
+		return true;
+	}
+
+	// algorithm below is only expecting finite numbers, e.g.,
+	// it will consider +inf and -inf equal
+	if (!std::isfinite(a) || !std::isfinite(b)) {
+		return a == b;
+	}
+
 	const auto diff    = std::fabs(a - b);
 	const auto largest = std::max(std::fabs(a), std::fabs(b));
 


### PR DESCRIPTION
# Description

Improves the accuracy of the FPU FCOM emulation for extended precision mode.

* In `FPU_FCOM`, the equality check now uses the `are_almost_equal_relative` function when the FPU is set to extended precision mode, similar to the rounding fix in #3149.
* The `are_almost_equal_relative` function in `math_utils.h` has been updated to immediately return true if the two values are exactly equal, and to properly handle non-finite values (such as infinities and NaNs) by comparing them directly; fixes the case where -inf and +inf were considered "equal".

## Related issues

#4524 

# Manual testing

I ran through my gamut of standard FPU change testing, including:

- MCPDIAG
- Quake
- Sunflower
- moralhardcandy
- Heaven 7
- multikolor

The change has been manually tested on:

- [ ] Windows
- [x] macOS
- [ ] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

