### PR TITLE
Do not promote code pages to modern replacements

### DIFF
--- a/docs/TRANSLATING.md
+++ b/docs/TRANSLATING.md
@@ -273,9 +273,29 @@ editor.
 > Don't try to convert the `PO` file to the binary `MO` format, it is not
 > supported by DOSBox Staging.
 
-Once you've done these steps and you've tested your translations (see the next
+Once you've done these steps and you've tested your translations (see the last
 chapter for some tips), you can submit the updated translation for inclusion
 into DOSBox Staging.
+
+## Language-specific remarks
+
+Sometimes the DOS code page does not contain all the characters needed by the
+translation. Contrary to most Unicode engines, the DOSBox Staging internal one
+was specially designed to be able to replace the missing characters with sane
+alternatives (if it does not work correctly for your language — let us know,
+the rules can be tweaked to some extent).
+
+But it, too, has some limitations. For example it can only replace a single
+character with another single character; it can't replace a digraph with two
+characters, as this could break the message layout — make the line too long to
+display or break the indentation.
+
+## French
+
+DOS code page 850 does not contain `Œ` and `œ` digraphs — please replace them
+with `OE` and `oe`, respectively.
+The digraphs are present on the modified code page 859, but we want to stay
+compatible with the standard MS-DOS code page.
 
 ## Message-specific remarks
 

--- a/src/dos/dos_keyboard_layout.cpp
+++ b/src/dos/dos_keyboard_layout.cpp
@@ -832,33 +832,20 @@ KeyboardLayoutResult DOS_LoadKeyboardLayout(const std::string& keyboard_layout,
 
 	auto new_layout = std::make_unique<KeyboardLayout>();
 
-	std::vector<uint16_t> code_pages = {};
-
 	if (!DOS_CanLoadScreenFonts()) {
 		// Can't set custom code page on pre-EGA display adapters
 		if (code_page_autodetect) {
-			code_pages.push_back(DefaultCodePage);
+			code_page = DefaultCodePage;
 		} else if (code_page != DefaultCodePage || !cpi_file.empty()) {
 			return KeyboardLayoutResult::IncompatibleMachine;
 		}
 	} else if (code_page_autodetect) {
 		// Get the preferred code page
-		const auto bundled = DOS_GetBundledCodePage(keyboard_layout);
-		code_pages = DOS_SuggestBetterCodePages(bundled, keyboard_layout);
-		code_pages.push_back(bundled);
-	} else {
-		code_pages.push_back(code_page);
+		code_page = DOS_GetBundledCodePage(keyboard_layout);
 	}
 
 	// Try to read the keyboard layout
-	KeyboardLayoutResult result = KeyboardLayoutResult::LayoutNotKnown;
-	for (const auto try_code_page : code_pages) {
-		code_page = try_code_page;
-		result = new_layout->ReadKeyboardFile(keyboard_layout, code_page);
-		if (result == KeyboardLayoutResult::OK) {
-			break;
-		}
-	}
+	auto result = new_layout->ReadKeyboardFile(keyboard_layout, code_page);
 
 	// Allow using 'us' layout with any code page
 	if ((result == KeyboardLayoutResult::LayoutNotKnown ||

--- a/src/dos/dos_locale.cpp
+++ b/src/dos/dos_locale.cpp
@@ -45,7 +45,6 @@ static struct {
 static struct Populated {
 	bool is_country_international = false;
 	bool is_country_overriden     = false;
-	bool is_using_euro_currency   = false;
 	bool is_using_fallback_period = false;
 	bool is_using_native_numeric  = false;
 	bool is_using_native_time     = false;
@@ -82,8 +81,6 @@ constexpr size_t InfoOffsetReserved           = 0x18;
 constexpr size_t MaxCurrencySymbolLength = 4;
 constexpr size_t MaxCurrencyPrecision    = 4;
 constexpr size_t ReservedAreaSize        = 10;
-
-const std::string EuroCurrencyCode = "EUR";
 
 static DosCountry get_default_country()
 {
@@ -296,7 +293,6 @@ static bool try_override_date_format(const StdLibLocale& locale)
 static void populate_currency_format(const LocaleInfoEntry& source)
 {
 	const auto& destination = dos.tables.country;
-	populated.is_using_euro_currency = (source.currency_code == EuroCurrencyCode);
 
 	assert(source.currency_code.size() < MaxCurrencySymbolLength);
 	memset(&destination[InfoOffsetCurrencySymbol], 0, MaxCurrencySymbolLength + 1);
@@ -359,7 +355,6 @@ static bool try_override_currency_format(const StdLibLocale& locale)
 
 	// Yes, this is suitable for using - populate
 	const auto& destination = dos.tables.country;
-	populated.is_using_euro_currency = (currency == EuroCurrencyCode);
 
 	memset(&destination[InfoOffsetCurrencySymbol], 0, MaxCurrencySymbolLength + 1);
 
@@ -1045,21 +1040,6 @@ std::vector<uint16_t> DOS_SuggestBetterCodePages(const uint16_t code_page,
         if ((code_page == 850 || code_page == 858) &&
             (keyboard_layout == "be" || keyboard_layout == "fr")) {
                 suggestions.emplace_back(859);
-        }
-
-        // Suggest replacing certain code pages with EUR currency variants
-        if (populated.is_using_euro_currency) {
-                switch (code_page) {
-                case 819:  suggestions.emplace_back(61235); break;
-                case 850:  suggestions.emplace_back(858);   break;
-                case 855:  suggestions.emplace_back(872);   break;
-                case 866:  suggestions.emplace_back(808);   break;
-                case 914:  suggestions.emplace_back(58258); break;
-                case 921:  suggestions.emplace_back(901);   break;
-                case 922:  suggestions.emplace_back(902);   break;
-                case 1125: suggestions.emplace_back(848);   break;
-                default: break;
-                }
         }
 
 	return suggestions;

--- a/src/dos/dos_locale.h
+++ b/src/dos/dos_locale.h
@@ -527,9 +527,7 @@ uint16_t DOS_GetCountry();
 std::string DOS_GetBundledCpiFileName(const uint16_t code_page);
 uint16_t DOS_GetBundledCodePage(const std::string& keyboard_layout);
 
-// Tries to find better code page than the given one. Currently only checks if
-// the country uses euro currency - if so, proposes euro variant of the original
-// code page, for example 858 instead of 850.
+// Tries to find better code page than the given one.
 std::vector<uint16_t> DOS_SuggestBetterCodePages(const uint16_t code_page,
                                                  const std::string& keyboard_layout);
 // Puts the country-related locale information into DOS memory;

--- a/src/dos/dos_locale.h
+++ b/src/dos/dos_locale.h
@@ -527,9 +527,6 @@ uint16_t DOS_GetCountry();
 std::string DOS_GetBundledCpiFileName(const uint16_t code_page);
 uint16_t DOS_GetBundledCodePage(const std::string& keyboard_layout);
 
-// Tries to find better code page than the given one.
-std::vector<uint16_t> DOS_SuggestBetterCodePages(const uint16_t code_page,
-                                                 const std::string& keyboard_layout);
 // Puts the country-related locale information into DOS memory;
 // should be called when code page changes
 void DOS_RepopulateCountryInfo();


### PR DESCRIPTION
# Description

According to feedback from @Grounded0, promoting traditional DOS code pages (like 850) to modern ones containing EUR symbol (like 858) is not worth the hassle; productivity software often complains, which might confuse the user.

Thus, the following changes were done:
- got rid of he mechanism to promote code pages for countries using EUR currency
- do not promote code page 850 to 859 for French and Belgian keyboard layout
- updated the translation guide - added a note about missing French characters in the standard MS-DOS encoding

# Release notes

(no need to mention this in release notes; we are already going to notify our users about a locale autodetection rewrite) 

# Manual testing

- `keyb fr` command now always sets the code page to 850 (even if `locale_period` is set to `modern` or `native`
- `keyboard_layout = auto` setting should work as before, just possibly selecting slightly different code pages (type `keyb` in the DOSBox Staging shell to display the code page and keyboard layout selected).

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [x] Linux (change is mostly trivial)

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [x] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [x] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

