### PR TITLE
Fix missing translation error log

### DIFF
--- a/src/misc/messages.cpp
+++ b/src/misc/messages.cpp
@@ -698,7 +698,8 @@ static bool load_messages_from_path(const std_fs::path& file_path)
 {
 	PoReader reader(file_path);
 	if (!reader.IsFileOk()) {
-		LOG_ERR("LOCALE: I/O error opening the translation file");
+		LOG_ERR("LOCALE: Error opening the translation file '%s'",
+		        file_path.string().c_str());
 		return false;
 	}
 
@@ -906,6 +907,12 @@ static bool load_messages_by_name(const std::string& language_file)
 	const auto file_with_extension = get_file_name_with_extension(language_file);
 	const auto file_path = get_resource_path(Subdirectory, file_with_extension);
 
+	if (file_path.empty()) {
+		LOG_WARNING("LOCALE: Translation file '%s' not found",
+		            file_with_extension.c_str());
+		return false;
+	}
+
 	const auto result = load_messages_from_path(file_path);
 	if (!result) {
 		LOG_MSG("LOCALE: Could not load language file '%s', "
@@ -1002,6 +1009,9 @@ void MSG_LoadMessages()
 		        detected_file);
 		const auto file_path = get_resource_path(Subdirectory,
 		                                         file_with_extension);
+		if (file_path.empty()) {
+			continue;
+		}
 
 		if (load_messages_from_path(file_path)) {
 			LOG_MSG("LOCALE: Loaded language file '%s' "


### PR DESCRIPTION
# Description

This fixes a problem (noticed by @johnnovak ) with I/O error being logged when `language = auto` and we don't have a translation for the detected host language.


# Manual testing

Set `language = auto` in the config file, run the emulator with host OS language set to something we don't support - there should be no error log.
Change the host language to something we do have a translation - the language should be detected and the emulator should start with the correct translation.

It is probably the easiest to test this on Linux, just use the commands like this to make sure the translation autodetection won't succeed:

```bash
LANGUAGE="aa_AA" dosbox
```

or like this to load Polish translation:

```bash
LANGUAGE="pl_PL" dosbox
```

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [x] Linux (the change is trivial)


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

