### PR TITLE
Implement MDS/MDF CDROM images

### DIFF
--- a/src/dos/cdrom.h
+++ b/src/dos/cdrom.h
@@ -351,6 +351,8 @@ private:
 	void PlayNextAudioTrack();
 	bool PlayAudioTrack(const Track& track, const uint32_t sector_offset);
 
+	bool LoadMdsFile(const char *filename);
+
 	// Private functions for cue sheet processing
 	bool  LoadCueSheet(const char *cuefile);
 	bool  GetRealFileName(std::string& filename, std::string& pathname);

--- a/src/dos/cdrom_mds.h
+++ b/src/dos/cdrom_mds.h
@@ -1,0 +1,213 @@
+// SPDX-FileCopyrightText:  2025-2025 The DOSBox Staging Team
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#ifndef DOSBOX_CDROM_MDS_H
+#define DOSBOX_CDROM_MDS_H
+
+#include <fstream>
+#include <optional>
+#include <stdint.h>
+
+#include "utils/byteorder.h"
+
+// All the structs in this header must be tighly packed.
+// They are directly read in from a file.
+#pragma pack(push, 1)
+
+// MDS structs taken and de-glib'd from https://github.com/cdemu/cdemu/blob/master/libmirage/images/image-mds/image-mds.h
+
+struct MdsHeader
+{
+	uint8_t signature[16];
+	uint8_t version[2];
+	uint16_t medium_type;
+	uint16_t num_sessions;
+	uint16_t dummy1[2];
+	uint16_t bca_len;
+	uint32_t dummy2[2];
+	uint32_t bca_data_offset;
+	uint32_t dummy3[6];
+	uint32_t disc_structures_offset;
+	uint32_t dummy4[3];
+	uint32_t session_block_offset;
+	uint32_t dpm_blocks_offset;
+};
+static_assert(sizeof(MdsHeader) == 88);
+
+inline std::optional<MdsHeader> read_mds_header(std::ifstream &stream)
+{
+	stream.seekg(0);
+	if (stream.fail()) {
+		return {};
+	}
+	MdsHeader mds_header = {};
+	stream.read(reinterpret_cast<char *>(&mds_header), sizeof(mds_header));
+	if (stream.fail()) {
+		return {};
+	}
+
+	#ifdef WORDS_BIGENDIAN
+	mds_header.medium_type = bswap_u16(mds_header.medium_type);
+	mds_header.num_sessions = bswap_u16(mds_header.num_sessions);
+	mds_header.bca_len = bswap_u16(mds_header.bca_len);
+	mds_header.bca_data_offset = bswap_u32(mds_header.bca_data_offset);
+	mds_header.disc_structures_offset = bswap_u32(mds_header.disc_structures_offset);
+	mds_header.session_block_offset = bswap_u32(mds_header.session_block_offset);
+	mds_header.dpm_blocks_offset = bswap_u32(mds_header.dpm_blocks_offset);
+	#endif
+
+	return mds_header;
+}
+
+struct MdsSessionBlock
+{
+	int32_t session_start;
+	int32_t session_end;
+	uint16_t session_number;
+	uint8_t num_all_blocks;
+	uint8_t num_nontrack_blocks;
+	uint16_t first_track;
+	uint16_t last_track;
+	uint32_t dummy1;
+	uint32_t track_block_offset;
+};
+static_assert(sizeof(MdsSessionBlock) == 24);
+
+inline std::optional<MdsSessionBlock> read_mds_session_block(std::ifstream &stream, const std::ifstream::pos_type pos)
+{
+	stream.seekg(pos);
+	if (stream.fail()) {
+		return {};
+	}
+	MdsSessionBlock mds_session_block = {};
+	stream.read(reinterpret_cast<char *>(&mds_session_block), sizeof(mds_session_block));
+	if (stream.fail()) {
+		return {};
+	}
+
+	#ifdef WORDS_BIGENDIAN
+	mds_session_block.session_start = bswap_u32(mds_session_block.session_start);
+	mds_session_block.session_end = bswap_u32(mds_session_block.session_end);
+	mds_session_block.session_number = bswap_u16(mds_session_block.session_number);
+	mds_session_block.first_track = bswap_u16(mds_session_block.first_track);
+	mds_session_block.last_track = bswap_u16(mds_session_block.last_track);
+	mds_session_block.track_block_offset = bswap_u32(mds_session_block.track_block_offset);
+	#endif
+
+	return mds_session_block;
+}
+
+struct MdsTrackBlock
+{
+	uint8_t mode;
+	uint8_t subchannel;
+	uint8_t adr_ctl;
+
+	// We always use point instead of track number.
+	// point == track_number for track entires
+	// and can also differentiate non-track entires.
+	uint8_t track_number;
+	uint8_t point;
+	uint8_t min;
+	uint8_t sec;
+	uint8_t frame;
+	uint8_t zero;
+	uint8_t pmin;
+	uint8_t psec;
+	uint8_t pframe;
+
+	uint32_t extra_offset;
+	uint16_t sector_size;
+
+	uint8_t dummy1[18];
+	uint32_t start_sector;
+	uint64_t start_offset;
+	uint32_t number_of_files;
+	uint32_t footer_offset;
+	uint8_t dummy2[24];
+};
+static_assert(sizeof(MdsTrackBlock) == 80);
+
+inline std::optional<MdsTrackBlock> read_mds_track_block(std::ifstream &stream, const std::ifstream::pos_type pos)
+{
+	stream.seekg(pos);
+	if (stream.fail()) {
+		return {};
+	}
+	MdsTrackBlock mds_track_block = {};
+	stream.read(reinterpret_cast<char *>(&mds_track_block), sizeof(mds_track_block));
+	if (stream.fail()) {
+		return {};
+	}
+
+	#ifdef WORDS_BIGENDIAN
+	mds_track_block.extra_offset = bswap_u32(mds_track_block.extra_offset);
+	mds_track_block.sector_size = bswap_u16(mds_track_block.sector_size);
+	mds_track_block.start_sector = bswap_u32(mds_track_block.start_sector);
+	mds_track_block.start_offset = bswap_u64(mds_track_block.start_offset);
+	mds_track_block.number_of_files = bswap_u32(mds_track_block.number_of_files);
+	mds_track_block.footer_offset = bswap_u32(mds_track_block.footer_offset);
+	#endif
+
+	return mds_track_block;
+}
+
+struct MdsExtraBlock
+{
+    uint32_t pregap;
+    uint32_t length;
+};
+static_assert(sizeof(MdsExtraBlock) == 8);
+
+inline std::optional<MdsExtraBlock> read_mds_extra_block(std::ifstream &stream, const std::ifstream::pos_type pos)
+{
+	stream.seekg(pos);
+	if (stream.fail()) {
+		return {};
+	}
+	MdsExtraBlock mds_extra_block = {};
+	stream.read(reinterpret_cast<char *>(&mds_extra_block), sizeof(mds_extra_block));
+	if (stream.fail()) {
+		return {};
+	}
+
+	#ifdef WORDS_BIGENDIAN
+	mds_extra_block.pregap = bswap_u32(mds_extra_block.pregap);
+	mds_extra_block.length = bswap_u32(mds_extra_block.length);
+	#endif
+
+	return mds_extra_block;
+}
+
+struct MdsFooter
+{
+    uint32_t filename_offset;
+    uint32_t widechar_filename;
+    uint32_t dummy1;
+    uint32_t dummy2;
+};
+static_assert(sizeof(MdsFooter) == 16);
+
+inline std::optional<MdsFooter> read_mds_footer(std::ifstream &stream, const std::ifstream::pos_type pos)
+{
+	stream.seekg(pos);
+	if (stream.fail()) {
+		return {};
+	}
+	MdsFooter mds_footer = {};
+	stream.read(reinterpret_cast<char *>(&mds_footer), sizeof(mds_footer));
+	if (stream.fail()) {
+		return {};
+	}
+
+	#ifdef WORDS_BIGENDIAN
+	mds_footer.filename_offset = bswap_u32(mds_footer.filename_offset);
+	mds_footer.widechar_filename = bswap_u32(mds_footer.widechar_filename);
+	#endif
+
+	return mds_footer;
+}
+
+#pragma pack(pop)
+
+#endif


### PR DESCRIPTION
# Description

Implements MDS/MDF file types for CDROM images. Chance of regression for CUE/ISO types is very low. If the image does not contain the MDS signature as the first 17 bytes, it falls through to the CUE and ISO handlers as it does currently.

Users won't need to pass any additional flags. Just `imgmount game.mds -t cdrom` as they normally would with CUE or ISO types.

I used CDEMU code as reference but did not directly copy any of their code: https://github.com/cdemu/cdemu/blob/master/libmirage/images/image-mds/parser.c

There's a lot of cases we're not handling but most are not relevant for DOS games. Ex: DVDs and copy protection. There are a few DOS copy protected games but implementing that will need further changes to the CDROM code as a whole. This is a stand-alone PR with very minimal changes to existing code.

## Related issues

Fixes #3805

# Release notes

Add support for MDS/MDF cdrom images

# Manual testing

Tested with Star Wars Dark Forces which someone ripped with Alcohol 120% and contains subchannel data.

Tested with Alone in the Dark 2. Converted myself from BIN/CUE to MDS/MDF with Alcohol 120%. Contains 62 small audio tracks and is a good test that the code is seeking correctly. See previous issue #4445 I confirmed that bug did not re-surface here.

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [x] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [x] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

