### PR TITLE
Fix new PVS Studio warning in mouseif_dos_driver.cpp

### DIFF
--- a/src/hardware/input/mouseif_dos_driver.cpp
+++ b/src/hardware/input/mouseif_dos_driver.cpp
@@ -2246,7 +2246,7 @@ static void prepare_driver_info()
 	static_assert(high_nibble(DriverVersionMajor) <= 9);
 
 	std::string str_version = "version ";
-	if (high_nibble(DriverVersionMajor) > 0) {
+	if constexpr(high_nibble(DriverVersionMajor) > 0) {
 		str_version = str_version + high_nibble_str(DriverVersionMajor);
 	}
 


### PR DESCRIPTION
# Description

It seems the PVS Studio started reporting a new warning in `mouseif_dos_driver.cpp` (see example report here, https://github.com/dosbox-staging/dosbox-staging/actions/runs/18386426648/job/52385929449#step:12:60):

> [V547](https://pvs-studio.com/en/docs/warnings/v547/) Expression 'high_nibble(DriverVersionMajor) > 0' is always false.

The fix is trivial.


# Manual testing

Started `msd.exe` from MS-DOS 6.22, using the mouse selected `Mouse`, checked that driver version is precisely `8.05`.

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [x] Linux (the change is trivial)


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

