### PR TITLE
Warn about MOUSE.COM options which are not going to be implemented

### DIFF
--- a/src/dos/programs/mouse.h
+++ b/src/dos/programs/mouse.h
@@ -19,6 +19,8 @@ public:
 	void Run() override;
 
 private:
+	void RemoveUnsupportedOptions();
+
 	static void AddMessages();
 };
 


### PR DESCRIPTION
# Description

`MOUSE.COM` now prints out more descriptive error messages for several MS-DOS switches, which are most likely not going to be implemented.

# Release notes

(not needed - `MOUSE.COM` is a new tool, release notes already given in other PRs).


# Manual testing

Try to run `MOUSE.COM` with switch like `/R1`, `/S50`, or `/le` - a descriptive error message should be displayed, telling the user what to do instead.

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [x] Linux


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [x] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

