### PR TITLE
Fix tripping debug assert when starting with `--startmapper` and exiting the mapper

### DIFF
--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -381,11 +381,11 @@ void GFX_ResetScreen()
 	if (sdl.draw.callback) {
 		(sdl.draw.callback)(GFX_CallbackReset);
 	}
-	GFX_Start();
 
 	CPU_ResetAutoAdjust();
 
 	VGA_SetupDrawing(0);
+	GFX_Start();
 }
 
 static bool is_vsync_enabled()


### PR DESCRIPTION
# Description

Fixes https://github.com/dosbox-staging/dosbox-staging/issues/4552

Release builds were fine even without the fix, btw.

## Related issues

- https://github.com/dosbox-staging/dosbox-staging/issues/4552

# Manual testing

1. Start with `--startmapper` using a debug build.
2. Exit mapper.
3. No debug assert is triggered.

Tested with `cpu_cycles = 100`, `1000000`, and `max` using the normal core for good measure (I thought this could somewhat timing related, but probably not; you can never be 100% sure with the VGA code 😅).


- [ ] Windows
- [x] macOS
- [ ] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

