### PR TITLE
Rework the VMware mouse emulation, support the official Windows 9x driver

### DIFF
--- a/src/hardware/input/mouse.h
+++ b/src/hardware/input/mouse.h
@@ -192,6 +192,8 @@ struct MouseVmWarePointerStatus {
 
 bool MOUSEVMM_IsSupported(const MouseVmmProtocol protocol);
 
+void MOUSEVMM_EnableImmediateInterrupts(const bool enable);
+
 void MOUSEVMM_Activate(const MouseVmmProtocol protocol);
 void MOUSEVMM_Deactivate(const MouseVmmProtocol protocol);
 void MOUSEVMM_DeactivateAll();

--- a/src/hardware/input/mouse_config.cpp
+++ b/src/hardware/input/mouse_config.cpp
@@ -638,7 +638,7 @@ static void init_mouse_config_settings(SectionProp& secprop)
 	prop_bool = secprop.AddBool("vmware_mouse", OnlyAtStart, true);
 	prop_bool->SetHelp(
 	        "VMware mouse interface ('on' by default).\n"
-	        "with experimental 3rd party Windows 3.1x driver.\n"
+	        "Fully compatible only with 3rd party Windows 3.1x driver.\n"
 	        "Note: Requires PS/2 mouse to be enabled.");
 
 	prop_bool = secprop.AddBool("virtualbox_mouse", OnlyAtStart, true);

--- a/src/hardware/input/mouse_interfaces.h
+++ b/src/hardware/input/mouse_interfaces.h
@@ -57,10 +57,12 @@ void MOUSEPS2_UpdateButtonSquish();
 // - understands up to 3 buttons in other modes
 
 void MOUSEPS2_NotifyMoved(const float x_rel, const float y_rel);
-void MOUSEPS2_NotifyMovedDummy(); // for virtual machine interfaces
 void MOUSEPS2_NotifyButton(const MouseButtons12S buttons_12S,
                            const MouseButtonsAll buttons_all);
 void MOUSEPS2_NotifyWheel(const float w_rel);
+
+// For the VirtualBox and VMware seamless mouse protocol emulation
+void MOUSEPS2_NotifyInterruptNeeded(const bool immediately);
 
 // ***************************************************************************
 // BIOS mouse interface for PS/2 mouse

--- a/src/hardware/input/mouseif_ps2_bios.cpp
+++ b/src/hardware/input/mouseif_ps2_bios.cpp
@@ -685,13 +685,6 @@ void MOUSEPS2_NotifyMoved(const float x_rel, const float y_rel)
 	vmm_needs_dummy_event = false;
 }
 
-void MOUSEPS2_NotifyMovedDummy()
-{
-	if (should_report()) {
-		vmm_needs_dummy_event = true;
-	}
-}
-
 void MOUSEPS2_NotifyButton(const MouseButtons12S new_buttons_12S,
                            const MouseButtonsAll new_buttons_all)
 {
@@ -733,6 +726,15 @@ void MOUSEPS2_NotifyWheel(const float w_rel)
 void MOUSEPS2_SetDelay(const uint8_t new_delay_ms)
 {
 	delay_ms = new_delay_ms;
+}
+
+void MOUSEPS2_NotifyInterruptNeeded(const bool immediately)
+{
+	if (immediately) {
+		I8042_TriggerAuxInterrupt();
+	} else if (should_report()) {
+		vmm_needs_dummy_event = true;
+	}
 }
 
 // ***************************************************************************

--- a/src/hardware/input/mouseif_virtual_machines.cpp
+++ b/src/hardware/input/mouseif_virtual_machines.cpp
@@ -45,8 +45,12 @@ static struct {
 	float delta_wheel = 0.0f;   // accumulated mouse wheel movement
 } vmware;
 
-static bool use_relative = true; // true = ignore absolute mouse position, use relative
-static bool is_input_raw = true; // true = no host mouse acceleration pre-applied
+// true = ignore absolute mouse position, use relative
+static bool use_relative = true;
+// true = no host mouse acceleration pre-applied
+static bool is_input_raw = true;
+// true = trigger interrupt without waiting and creating the data packet
+static bool immediate_interrupts = false;
 
 static float pos_x = 0.0f; // absolute mouse position in guest-side pixels
 static float pos_y = 0.0f;
@@ -103,6 +107,11 @@ bool MOUSEVMM_IsSupported(const MouseVmmProtocol protocol)
 	return false;
 }
 
+void MOUSEVMM_EnableImmediateInterrupts(const bool enable)
+{
+	immediate_interrupts = enable;
+}
+
 void MOUSEVMM_Activate(const MouseVmmProtocol protocol)
 {
 	bool is_activating = false;
@@ -130,7 +139,7 @@ void MOUSEVMM_Activate(const MouseVmmProtocol protocol)
 			pos_y = static_cast<float>(mouse_shared.resolution_y) / 2.0f;
 			scaled_x = 0;
 			scaled_y = 0;
-			MOUSEPS2_NotifyMovedDummy();
+			MOUSEPS2_NotifyInterruptNeeded(immediate_interrupts);
 		}
 	}
 
@@ -283,7 +292,7 @@ void MOUSEVMM_NotifyMoved(const float x_rel, const float y_rel,
 	}
 
 	vmware.updated = vmware.is_active;
-	MOUSEPS2_NotifyMovedDummy();
+	MOUSEPS2_NotifyInterruptNeeded(immediate_interrupts);
 }
 
 void MOUSEVMM_NotifyButton(const MouseButtons12S buttons_12S)
@@ -305,7 +314,7 @@ void MOUSEVMM_NotifyButton(const MouseButtons12S buttons_12S)
 	}
 
 	vmware.updated = vmware.is_active;
-	MOUSEPS2_NotifyMovedDummy();
+	MOUSEPS2_NotifyInterruptNeeded(immediate_interrupts);
 }
 
 void MOUSEVMM_NotifyWheel(const float w_rel)
@@ -327,7 +336,7 @@ void MOUSEVMM_NotifyWheel(const float w_rel)
 	}
 
 	vmware.updated = vmware.is_active;
-	MOUSEPS2_NotifyMovedDummy();
+	MOUSEPS2_NotifyInterruptNeeded(immediate_interrupts);
 }
 
 void MOUSEVMM_NewScreenParams(const float x_abs, const float y_abs)

--- a/src/hardware/input/private/intel8042.h
+++ b/src/hardware/input/private/intel8042.h
@@ -21,6 +21,8 @@ void I8042_AddKbdFrame(const std::vector<uint8_t>& bytes);
 bool I8042_IsReadyForAuxFrame();
 bool I8042_IsReadyForKbdFrame();
 
+void I8042_TriggerAuxInterrupt();
+
 // The following routines needs to be implemented by keyboard/mouse
 // emulation code:
 

--- a/src/hardware/virtualbox.cpp
+++ b/src/hardware/virtualbox.cpp
@@ -252,7 +252,7 @@ static void warn_unsupported_request(const VBoxRequestType request_type)
 {
 	static std::set<VBoxRequestType> already_warned = {};
 	if (already_warned.contains(request_type)) {
-		LOG_WARNING("VIRTUALBOX: unimplemented request #%d",
+		LOG_WARNING("VIRTUALBOX: Unimplemented request #%d",
 		            enum_val(request_type));
 		already_warned.insert(request_type);
 	}
@@ -263,7 +263,7 @@ static void warn_unsupported_struct_version(const RequestHeader& header)
 	static std::map<VBoxRequestType, std::set<uint32_t>> already_warned = {};
 	auto& already_warned_set = already_warned[header.request_type];
 	if (already_warned_set.contains(header.struct_version)) {
-		LOG_WARNING("VIRTUALBOX: unimplemented request #%d structure v%d.%02d",
+		LOG_WARNING("VIRTUALBOX: Unimplemented request #%d structure v%d.%02d",
 		            enum_val(header.request_type),
 		            header.struct_version >> 16,
 		            header.struct_version & 0xffff);
@@ -469,7 +469,7 @@ static void handle_report_guest_info(const RequestHeader& header,
 		const VirtualBox_GuestInfo_1_01 payload(struct_pointer);
 
 		if (payload.interface_version != ver_1_04) {
-			LOG_WARNING("VIRTUALBOX: unimplemented protocol v%d.%02d",
+			LOG_WARNING("VIRTUALBOX: Unimplemented protocol v%d.%02d",
 			            payload.interface_version >> 16,
 			            payload.interface_version & 0xffff);
 			client_disconnect();

--- a/src/hardware/vmware.cpp
+++ b/src/hardware/vmware.cpp
@@ -21,8 +21,19 @@ CHECK_NARROWING();
 // Drivers:
 // - https://git.javispedro.com/cgit/vbados.git
 // - https://github.com/NattyNarwhal/vmwmouse (warning: release 0.1 is unstable)
+// - official Windows 9x VMware mouse driver
 
+static bool is_interface_enabled = false;
+static bool has_feature_mouse    = false;
+
+// Whether Intel 8042 entry point API is currently enabled
+static bool is_i8042_unlocked = false;
+
+// Currently running program
 static std::string program_segment_name = {};
+
+// Queued data, waiting to be fectehd by the guest side driver
+static std::vector<uint32_t> abs_pointer_queue = {};
 
 // ***************************************************************************
 // Various common constants and type definitions
@@ -36,92 +47,232 @@ static std::set<std::string> SegmentBlackList = {
 };
 
 // Magic number for all VMware calls
-static constexpr uint32_t VMWARE_MAGIC = 0x564d5868u;
+static constexpr uint32_t VmWareMagic = 0x564d5868u;
+
+// The exact meaning of the version ID below is unknown - so far we know that:
+// - Linux kernel requires precisely this particular version ID, otherwise
+//   it refuses to talk to the VmWare mouse interface.
+// - The official VMware mouse driver for Windows 9x seems to be doing a version
+//   ID validation, too - you can't just provide any random value. Details are
+//   unknown, but this particular value works.
+static constexpr uint32_t VmMouseVersionId = 0x3442554au;
 
 enum class VmWareCommand : uint16_t {
-	GetVersion        = 10,
-	AbsPointerData    = 39,
-	AbsPointerStatus  = 40,
-	AbsPointerCommand = 41,
+	GetVersion         = 10,
+	AbsPointerData     = 39,
+	AbsPointerStatus   = 40,
+	AbsPointerCommand  = 41,
+	AbsPointerRestrict = 86,
 };
 
-enum class VmWarePointer : uint32_t {
-	Enable   = 0x45414552,
-	Relative = 0xf5,
-	Absolute = 0x53424152,
+enum class VmMouseCommand : uint32_t {
+	Enable   = 0x45414552u,
+	Disable  = 0xf5u,
+	Absolute = 0x53424152u,
+	Relative = 0x4c455252u,
 };
 
 // ***************************************************************************
-// Request handling
+// Mouse queue and commands
+// ***************************************************************************
+
+static uint32_t fetch_from_abs_pointer_queue()
+{
+	if (abs_pointer_queue.empty()) {
+		return 0;
+	}
+
+	const auto result = abs_pointer_queue.back();
+	abs_pointer_queue.pop_back();
+
+	return result;
+}
+
+static void mouse_status_to_abs_pointer_queue()
+{
+	if (!MOUSEVMM_CheckIfUpdated_VmWare()) {
+		return;
+	}
+
+	if (abs_pointer_queue.size() == 1) {
+		// We have a status response waiting in the queue, do not
+		// override it
+		return;
+	}
+
+	MouseVmWarePointerStatus status = {};
+	MOUSEVMM_GetPointerStatus(status);
+
+	abs_pointer_queue.clear();
+	abs_pointer_queue.push_back(status.wheel_counter);
+	abs_pointer_queue.push_back(status.absolute_y);
+	abs_pointer_queue.push_back(status.absolute_x);
+	abs_pointer_queue.push_back(status.buttons);
+}
+
+static void execute_command(const VmMouseCommand command)
+{
+	abs_pointer_queue.clear();
+	switch (command) {
+	case VmMouseCommand::Enable:
+		abs_pointer_queue = {VmMouseVersionId};
+		break;
+	case VmMouseCommand::Disable:
+		MOUSEVMM_Deactivate(MouseVmmProtocol::VmWare);
+		break;
+	case VmMouseCommand::Absolute:
+		MOUSEVMM_Activate(MouseVmmProtocol::VmWare);
+		break;
+	case VmMouseCommand::Relative:
+		LOG_WARNING("VMWARE: Relative mouse packets not implemented");
+		break;
+	default:
+		LOG_WARNING("VMWARE: Unimplemented mouse subcommand 0x%08x", reg_ebx);
+		break;
+	}
+}
+
+// ***************************************************************************
+// Low bandwidth I/O port interface
 // ***************************************************************************
 
 static void command_get_version()
 {
-	// This command is a common way to detect VMware - since we only provide
-	// a mouse support, hide the interface from software which is known to
-	// misbehave with our limited implementation
+	// This command is a common way to detect VMware - since currently we
+	// only implement  mouse support, hide the interface from software which
+	// is known to misbehave with our limited implementation
 	if (!SegmentBlackList.contains(program_segment_name)) {
 		reg_eax = 0; // protocol version
-		reg_ebx = VMWARE_MAGIC;
+		reg_ebx = VmWareMagic;
 	}
 }
 
 static void command_abs_pointer_data()
 {
-	MouseVmWarePointerStatus status = {};
-	MOUSEVMM_GetPointerStatus(status);
-
-	reg_eax = status.buttons;
-	reg_ebx = status.absolute_x;
-	reg_ecx = status.absolute_y;
-	reg_edx = status.wheel_counter;
+	if (abs_pointer_queue.empty() || abs_pointer_queue.size() == 4) {
+		reg_eax = fetch_from_abs_pointer_queue();
+		reg_ebx = fetch_from_abs_pointer_queue();
+		reg_ecx = fetch_from_abs_pointer_queue();
+		reg_edx = fetch_from_abs_pointer_queue();
+	} else {
+		// Should not happen with a properly functioning guest driver
+		LOG_WARNING("VMWARE: No valid mouse pointer status in the queue");
+		abs_pointer_queue.clear();
+		reg_eax = 0;
+		reg_ebx = 0;
+		reg_ecx = 0;
+		reg_edx = 0;
+	}
 }
 
 static void command_abs_pointer_status()
 {
-	constexpr uint32_t ABS_UPDATED     = 4;
-	constexpr uint32_t ABS_NOT_UPDATED = 0;
-
-	reg_eax = MOUSEVMM_CheckIfUpdated_VmWare() ? ABS_UPDATED : ABS_NOT_UPDATED;
+	mouse_status_to_abs_pointer_queue();
+	reg_eax = check_cast<uint32_t>(abs_pointer_queue.size());
 }
 
 static void command_abs_pointer()
 {
-	switch (static_cast<VmWarePointer>(reg_ebx)) {
-	case VmWarePointer::Enable: break; // can be safely ignored
-	case VmWarePointer::Relative:
-		MOUSEVMM_Deactivate(MouseVmmProtocol::VmWare);
-		break;
-	case VmWarePointer::Absolute:
-		MOUSEVMM_Activate(MouseVmmProtocol::VmWare);
-		break;
-	default:
-		LOG_WARNING("VMWARE: unimplemented mouse subcommand 0x%08x", reg_ebx);
-		break;
+	const auto command = static_cast<VmMouseCommand>(reg_ebx);
+	if (command == VmMouseCommand::Enable) {
+		// For the standard VMware port interface we need regular PS/2
+		// auxilary (mouse) interrupt handling
+		MOUSEVMM_EnableImmediateInterrupts(false);
+	}
+	execute_command(command);
+	if (abs_pointer_queue.size() == 1) {
+		reg_eax = fetch_from_abs_pointer_queue();
 	}
 }
 
-// ***************************************************************************
-// I/O port
-// ***************************************************************************
-
 static uint32_t port_read_vmware(const io_port_t, const io_width_t)
 {
-	if (reg_eax != VMWARE_MAGIC) {
+	if (reg_eax != VmWareMagic) {
 		return 0;
 	}
 
 	switch (static_cast<VmWareCommand>(reg_cx)) {
-	case VmWareCommand::GetVersion: command_get_version(); break;
-	case VmWareCommand::AbsPointerData: command_abs_pointer_data(); break;
-	case VmWareCommand::AbsPointerStatus: command_abs_pointer_status(); break;
-	case VmWareCommand::AbsPointerCommand: command_abs_pointer(); break;
+	case VmWareCommand::GetVersion:
+		command_get_version();
+		break;
+	case VmWareCommand::AbsPointerData:
+		command_abs_pointer_data();
+		break;
+	case VmWareCommand::AbsPointerStatus:
+		command_abs_pointer_status();
+		break;
+	case VmWareCommand::AbsPointerCommand:
+		command_abs_pointer();
+		break;
+	case VmWareCommand::AbsPointerRestrict:
+		LOG_WARNING("VMWARE: Mouse pointer restrictions not implemented");
+		break;
 	default:
-		LOG_WARNING("VMWARE: unimplemented command 0x%08x", reg_ecx);
+		LOG_WARNING("VMWARE: Unimplemented command 0x%08x", reg_ecx);
 		break;
 	}
 
 	return reg_eax;
+}
+
+// ***************************************************************************
+// Intel 8042 interface
+// ***************************************************************************
+
+bool VMWARE_I8042_ReadTakeover()
+{
+	return is_i8042_unlocked;
+}
+
+uint32_t VMWARE_I8042_ReadStatusRegister()
+{
+	// Port 0x64 read handler
+
+	assert(is_i8042_unlocked);
+
+	mouse_status_to_abs_pointer_queue();
+	return check_cast<uint32_t>(abs_pointer_queue.size());
+}
+
+uint32_t VMWARE_I8042_ReadDataPort()
+{
+	// Port 0x60 read handler
+
+	assert(is_i8042_unlocked);
+
+	return fetch_from_abs_pointer_queue();
+}
+
+bool VMWARE_I8042_WriteCommandPort(const uint32_t value)
+{
+	// Port 0x64 write handler
+
+	if (!has_feature_mouse) {
+		return false;
+	}
+
+	const auto command = static_cast<VmMouseCommand>(value);
+
+	if (!is_i8042_unlocked && command == VmMouseCommand::Enable) {
+		is_i8042_unlocked = true;
+		// For the Intel 8042 VMware port interface we need the PS/2
+		// auxilary (mouse) interrupts to be triggered immediately,
+		// without creating mouse data packets - these are not being
+		// fetched by the official Windows 9x VMware mouse driver
+		MOUSEVMM_EnableImmediateInterrupts(true);
+	}
+
+	const auto was_taken_over = is_i8042_unlocked;
+	if (is_i8042_unlocked) {
+		execute_command(command);
+	}
+
+	if (command == VmMouseCommand::Disable) {
+		is_i8042_unlocked = false;
+		MOUSEVMM_EnableImmediateInterrupts(false);
+	}
+
+	return was_taken_over;
 }
 
 // ***************************************************************************
@@ -142,9 +293,6 @@ void VMWARE_NotifyProgramName(const std::string& segment_name)
 // ***************************************************************************
 // Lifecycle
 // ***************************************************************************
-
-static bool is_interface_enabled = false;
-static bool has_feature_mouse    = false;
 
 void VMWARE_Init()
 {

--- a/src/hardware/vmware.h
+++ b/src/hardware/vmware.h
@@ -14,4 +14,15 @@ void VMWARE_Destroy();
 void VMWARE_NotifyBooting();
 void VMWARE_NotifyProgramName(const std::string& segment_name);
 
+// Returns true if Intel 8042 port read should be taken over by the VMware API
+bool VMWARE_I8042_ReadTakeover();
+
+// Intel 8042 port read handlers
+uint32_t VMWARE_I8042_ReadStatusRegister();
+uint32_t VMWARE_I8042_ReadDataPort();
+
+// Intel 8042 port write handler, returns true if port write has been taken over
+// by the VMware API
+bool VMWARE_I8042_WriteCommandPort(const uint32_t value);
+
 #endif // DOSBOX_VMWARE_H


### PR DESCRIPTION
# Description

Rework the VMware mouse protocol support, one can now use the official VMWare Windows 9x mouse driver.

**Research background**

At first I thought the driver did not communicate with my emulation code due to some failed "hardware" check - I was wrong.

On the DOSBox-X issue tracker (https://github.com/joncampbell123/dosbox-x/issues/3384), @javispedro notices that the driver actually uses a different protocol - similar, but utilizing the PS/2 port I/O addresses instead of VMWare-specific port 0x5658. See the comment: https://github.com/joncampbell123/dosbox-x/issues/3384#issuecomment-1090235571

Last year Broadcom contributed an improved VMWare mouse support code to the Linux kernel - after reading the code and the comments, I realized that it is normal for VMWare to expose the same functionalities over several different interfaces, using mostly the same protocol. I have found a `VMMOUSE_VERSION_ID` constant there, which happens to be crucial to make the Windows 9x driver work. Another crucial information found there was that `magic value 4`, indicating that a new mouse packet is ready, is not a magic value at all - it's just a number of bytes in the queue waiting to be picked up by the driver.

The protocol is simple:
- a 32-bit write to port `0x64` is a command, same as `reg_ebx` value when reading from port `0x5658` with `reg_cx` equal to 41
- a 32-bit read from port `0x60` is a check how many 32-bit values of response is waiting
- a 32-bit read from port `0x64` retrieves one 32-bit value from the response
- the driver always starts with a command `0x45414552` (`Enable`), we have to respond with one 32-bit value of version ID (value `0x3442554a`, which is a version ID required by the Linux kernel, works)
- to signal mouse movement, button press/release, or wheel scrolling it's enough to trigger the mouse interrupt, without putting any mouse data to the emulated Intel 8042 microcontroller (the PS/2 mouse data packet won't be read nevertheless)
- mouse data packet is a set of 4 32-bit values, same format as used by the `0x5658` port protocol


## Related issues

https://github.com/dosbox-staging/dosbox-staging/discussions/4231 (discussion)


# Manual testing

- Checked that unofficial Windows 3.1x VMWare driver (https://github.com/NattyNarwhal/vmwmouse) driver still works (warning: driver has stability issues!)
- Checked that the official Windows 9x VMWare mouse driver works

To install the Windows 9x driver, extract it from the pre-Vista VMWare Tools ISO, copy `VMMOUSE.INF` and `VMMOUSE.VXD` to the Windows 9x partition, boot Windows, and to the following (instruction for the Windows 98SE):
- press the Start button, go to _Settings_,  start the _Control Panel_
- go to _System_, _Device Manager_, unfold _Mouse_
- right click on the _Standard PS/2 Port Mouse_
- select _Properties_ -> _Driver_ -> _Update Driver..._
- _Next >_, _Display the list of all the drivers_, _Next >_, _Have Disk..._, and point it to the directory with the driver

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [x] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [x] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

