### PR TITLE
Always set SB per-frame callback for DAC

### DIFF
--- a/src/hardware/audio/soundblaster.cpp
+++ b/src/hardware/audio/soundblaster.cpp
@@ -1956,11 +1956,13 @@ static void dsp_do_command()
 		if (sblaster->MaybeWakeUp()) {
 			// If we're waking up, then the DAC hasn't been running
 			// (or maybe wasn't running at all), so start with a
-			// fresh DAC state and ensure we're using per-frame
-			// callback timing.
+			// fresh DAC state.
 			sb.dac = {};
-			callback_type.SetPerFrame();
 		}
+
+		// Ensure we're using per-frame callback timing because DAC samples
+		// are sent one after another with sub-millisecond timing.
+		callback_type.SetPerFrame();
 
 		if (const auto dac_rate_hz = sb.dac.MeasureDacRateHz(); dac_rate_hz) {
 			sblaster->SetChannelRateHz(*dac_rate_hz);


### PR DESCRIPTION
# Description

A bug in the SB DAC prevented switching to the per-frame timing mode if the Sound Blaster was already active (not sleeping). This PR moves that timing change outside of the sleep check conditional.

## Related issues

#4560

# Release notes

N/A (bug & fix occurred after the last release)

# Manual testing

Confirmed the bug is fixed.

https://github.com/user-attachments/assets/1a7cbc62-7abf-4100-8f81-a53357d0a207

Also tested Along in the Dark and confirmed the DAC continues to work correctly.

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] my change has been manually tested on Windows, macOS, and Linux.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

