### PR TITLE
Add macOS .dosbox package support for double-click launching

### DIFF
--- a/extras/macos/Info.plist.template
+++ b/extras/macos/Info.plist.template
@@ -52,5 +52,45 @@
 	<key>x86_64</key>
 	<string>10.10.0</string>
 	</dict>
+	<key>CFBundleDocumentTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>dosbox</string>
+			</array>
+			<key>CFBundleTypeName</key>
+			<string>DOSBox Staging Package</string>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>org.dosbox-staging.dosbox-package</string>
+			</array>
+			<key>LSTypeIsPackage</key>
+			<true/>
+		</dict>
+	</array>
+	<key>UTExportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>com.apple.package</string>
+				<string>public.directory</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>DOSBox Staging Package</string>
+			<key>UTTypeIdentifier</key>
+			<string>org.dosbox-staging.dosbox-package</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>dosbox</string>
+				</array>
+			</dict>
+		</dict>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
Allow users to organize DOS packages and games in .dosbox documents and launch them by double-clicking in Finder or dropping onto the Dock or the Finder icon.

Implementation:
- Document type registration in Info.plist.template to associate .dosbox folder packages with DOSBox Staging
- Simplified inline package detection in src/gui/sdl_gui.cpp with platform ifdefs (#ifdef MACOSX).
- SDL_DROPFILE event polling in GFX_Init() to catch package paths before module initialization completes
- Direct restart with expanded --working-dir

When a .dosbox package is opened (by double-clicking or dropping on top of the Dock Icon), the handler will relaunch the app passing the package directory as --working-dir, allowing the DOS and configuration files to be self-contained within the package folder and handled naturally by the application.

To convert any DOSBox folder into a macOS .dosbox document package simply add ".dosbox" as an extension to the folder name.

For example, if folder "Abuse (1996)" contains game files and a dosbox.conf, renaming the folder to "Abuse (1996).dosbox" will make it appear as a document icon that can be double-clicked to be opened by DOSBox Staging in macOS.

This feature is macOS-only and does not affect other platforms. The renamed folder will continue to behave normally in all other platforms.

# Description

When a user double-clicks a .dosbox document package in Finder, macOS launches the application but delivers the document path via an SDL_DROPFILE event rather than through command-line arguments.

Event polling in GFX_Init() added immediately after SDL_Init() to catch these events. When a .dosbox package is detected, it's scanned for .conf files in the first two directory levels, then a new process is forked with the document package path expanded into a --working-dir argument. The parent process exits cleanly, allowing the child to run with standard command-line argument.

This change also makes it trivial to add folder dropping onto the DOSBox-Staging icon in the Dock in the future and have the app treat that folder as if it was a path passed to the command line (not included in this change, but .dosbox folder dropping is already supported)

Modified: extras/macos/info.plist.template to include the entries for the document package.
Modified: src/gui/sdl_gui.cpp handles the event and passes it for parsing relaunch if necessary.

## Related issues

- https://github.com/dosbox-staging/dosbox-staging/issues/4553

# Release notes

Added support for .dosbox document packages in MacOS. Add ".dosbox" to a folder and it can be double-clicked to open. Document package will become the working directory.

# Manual testing

Tested .dosbox packages of various forms. Autoexec mount commands relative to .dosbox folder work. Dropping .dosbox folder onto icon opens them correctly. Having/missing dosbox.conf files work.

Code also ensures the document opened has the correct extension, as masOS can be coerced to open other document types with DOSBox Staging.

CLI behaviour is not changed but CLI command "open folder.dosbox" will behave properly in MacOSX by interpreting the document package mapping.

To test, just add .dosbox to any folder. It sholuld behave exactly as if its path had been passed via the command line to the application.

Tested in Tahoe, Big Sur, Sonoma.

All changes are made specific to MacOS via #IFDEF but tests have been made only on MacOS.

The change has been manually tested on:

- [ ] Windows
- [X] macOS
- [ ] Linux

# Checklist

I have:

- [X] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [X] performed a self-review of my code.
- [X] commented on the particularly hard-to-understand areas of my code.
- [X] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [ ] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [X] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [X] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [X] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

