### PR TITLE
Tone down FluidSynth logging

### DIFF
--- a/src/midi/fluidsynth.cpp
+++ b/src/midi/fluidsynth.cpp
@@ -594,6 +594,7 @@ MidiDeviceFluidSynth::MidiDeviceFluidSynth()
 	fluid_set_log_function(FLUID_DBG, NULL, NULL);
 
 #ifdef NDEBUG
+	fluid_set_log_function(FLUID_INFO, NULL, NULL);
 	fluid_set_log_function(FLUID_ERR, NULL, NULL);
 	fluid_set_log_function(FLUID_WARN, NULL, NULL);
 #endif


### PR DESCRIPTION
# Description

FluidSynth debug logging is enabled in our debug builds now, and it's incredibly chatty (there's pages of log entries when loading a SoundFont).

This change disables debug logging in debug builds and also disables info level logging in release builds for good measure. 

# Manual testing

Set `mididevice fluidsynth` using a debug build; there should be no FluidSynth debug log entries.

The change has been manually tested on:

- [ ] Windows
- [x] macOS
- [ ] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

