### PR TITLE
Builtin DOS mouse driver improvements

### DIFF
--- a/src/hardware/input/mouseif_dos_driver.cpp
+++ b/src/hardware/input/mouseif_dos_driver.cpp
@@ -93,6 +93,9 @@ static bool rate_is_set     = false;
 static uint16_t rate_hz     = 0;
 static uint16_t min_rate_hz = 0;
 
+// Language of messages displayed by the driver - fake value, not used
+static uint16_t driver_language = 0;
+
 // Data from mouse events which were already received,
 // but not necessary visible to the application
 
@@ -1951,11 +1954,11 @@ static Bitu int33_handler()
 		// 00h = English, 01h = French, 02h = Dutch, 03h = German, 04h =
 		// Swedish 05h = Finnish, 06h = Spanish, 07h = Portugese, 08h =
 		// Italian
-		state.SetLanguage(reg_bx);
+		driver_language = reg_bx;
 		break;
 	case 0x23:
 		// MS MOUSE v6.0+ - get language for messages
-		reg_bx = state.GetLanguage();
+		reg_bx = driver_language;
 		break;
 	case 0x24:
 		// MS MOUSE v6.26+ - get software version, mouse type, and IRQ
@@ -2662,6 +2665,8 @@ static void start_driver()
 	set_sensitivity(50, 50, 50);
 	reset_hardware();
 	reset();
+
+	driver_language = 0;
 
 	MouseInterface::GetDOS()->NotifyDosDriverStartup();
 }

--- a/src/hardware/input/mouseif_dos_driver_state.cpp
+++ b/src/hardware/input/mouseif_dos_driver_state.cpp
@@ -703,16 +703,6 @@ void MouseDriverState::SetUpdateRegionY(const size_t index, const int16_t value)
 	SET_INT16_ARRAY(update_region_y, index, value);
 }
 
-uint16_t MouseDriverState::GetLanguage() const
-{
-	return GET_UINT16(language);
-}
-
-void MouseDriverState::SetLanguage(const uint16_t value)
-{
-	SET_UINT16(language, value);
-}
-
 uint8_t MouseDriverState::GetBiosScreenMode() const
 {
 	return GET_UINT8(bios_screen_mode);

--- a/src/hardware/input/private/mouseif_dos_driver_state.h
+++ b/src/hardware/input/private/mouseif_dos_driver_state.h
@@ -153,9 +153,6 @@ public:
 	void SetUpdateRegionX(const size_t index, const int16_t value);
 	void SetUpdateRegionY(const size_t index, const int16_t value);
 
-	uint16_t GetLanguage() const;
-	void SetLanguage(const uint16_t value);
-
 	uint8_t GetBiosScreenMode() const;
 	void SetBiosScreenMode(const uint8_t value);
 
@@ -315,9 +312,6 @@ public:
 
 		int16_t update_region_x[MaxUpdateRegions] = {0};
 		int16_t update_region_y[MaxUpdateRegions] = {0};
-
-		// Language of driver messages, not used
-		uint16_t language = 0;
 
 		uint8_t bios_screen_mode = 0;
 


### PR DESCRIPTION
# Description

Two very small changes to the builtin DOS mouse driver:

1. The VBADOS mouse driver extension, telling the guest software that the driver is using an absolute (seamless) mode, is now only in effect if Windows 3.1x is running and the VBADOS Int33 mouse driver is used.
This extension sets a bit in `reg_ah` to signal the seamless mouse integration - but since real mouse drivers never set this bit, there is a slight risk of incompatibility with a badly written software; this PR prevents the possible problem.

2. The 2-byte variable to store the mouse driver language is no longer stored in the UMB memory; it is now shared among all the mouse driver instances (a new driver instance is created by the Windows 3.1x when the user starts the MS-DOS prompt). No sane mouse software changes this value nevertheless.


# Manual testing

Checked that the seamless mouse integration still works with the Warcraft game.
Checked that Windows 3.11 MS-DOS Prompt can still be used (in both fullscreen and windowed mode), and that Norton Commander launched under this prompt still has a properly working mouse support.
Checked that the VBADOS package Int33 Windows mouse driver still works as before (just please don't try to launch MS-DOS prompt in windowed mode with this driver; this use case requires some additional code, which is not yet written).

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [x] Linux


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

