### PR TITLE
Destroy the renderer in GFX_Quit()

### DIFF
--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -1152,14 +1152,6 @@ static void gui_destroy()
 	if (sdl.draw.callback) {
 		(sdl.draw.callback)(GFX_CallbackStop);
 	}
-
-	// Let SDL cleanup up after itself (exit fullscreen, restore mouse
-	// state, etc.) instead of us attempting to do it manually. That is
-	// unnecessary and a moving target with each SDL library upgrade.
-	//
-	// Similarly, all GPU resources (textures, compiled shaders, etc.) will
-	// be cleaned up by the driver automatically. That's the best way, we
-	// don't need to attempt to do a manual cleanup.
 }
 
 void GFX_Destroy()
@@ -2869,6 +2861,11 @@ void GFX_AddConfigSection()
 void GFX_Quit()
 {
 #if !C_DEBUGGER
+	// Renderer must be destoryed before SDL_Quit() is called.
+	// Otherwise we can get segfaults and sadness.
+	sdl.renderer = {};
+	sdl.window = nullptr;
+
 	SDL_Quit();
 #endif
 }


### PR DESCRIPTION
# Description

Fixes a segfault by avoiding the global destructor


## Related issues

Fixes #4559

# Manual testing

I could not reproduce the segfault on my machine. I used GDB to confirm the destructor is now being run before `SDL_Quit()`. The Staging debugger build still launches.

The change has been manually tested on:

- [ ] Windows
- [x] macOS
- [x] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

