### PR TITLE
Always use SDL_PIXELFORMAT_ARGB8888 for the SDL texture renderer

### DIFF
--- a/src/gui/render/opengl_renderer.cpp
+++ b/src/gui/render/opengl_renderer.cpp
@@ -161,6 +161,8 @@ bool OpenGlRenderer::InitRenderer()
 	         safe_gl_get_string(GL_SHADING_LANGUAGE_VERSION, "unknown"),
 	         safe_gl_get_string(GL_VENDOR, "unknown"));
 
+	// TODO: GFX_CAN_32 | GFX_CAN_RANDOM is always set for both SDL and OpenGL backends.
+	// Opportunity to remove dead code from render.cpp.
 	gfx_flags = GFX_CAN_32 | GFX_CAN_RANDOM;
 
 	return true;

--- a/src/gui/render/sdl_renderer.h
+++ b/src/gui/render/sdl_renderer.h
@@ -79,7 +79,6 @@ private:
 	// True if the last framebuffer has been updated since the last present
 	bool last_framebuf_dirty = false;
 
-	SDL_PixelFormat* pixel_format = {};
 	SDL_Texture* texture          = {};
 
 	TextureFilterMode texture_filter_mode = TextureFilterMode::Bilinear;


### PR DESCRIPTION
# Description

We were previously just using the first supported format reported by the renderer. This doesn't always work though. I found that if we get BGRA our colors get messed up.

Most GPUs should support this format.
If not, SDL will take a slow path and the code should still work.

This is also the format the OpenGL renderer always uses.

The `GFX_CAN_RANDOM` check didn't make any sense. We're drawing to a software surface so we always have random access to the framebuffer, same as we do in the OpenGL renderer.

## Related issues

https://github.com/libsdl-org/SDL/issues/14403

I initially reported this as an SDL regression as I found this bug by testing with the latest `main` build of SDL. It turns out the only relevant thing they changed was re-ordering the formats returned by `SDL_GetRendererInfo()` and we just weren't handling BGRA correctly.

# Release notes

Probably nothing user observable unless they're running a git build of SDL.

# Manual testing

Colors look correct in both the git and release builds of SDL.

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [x] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

