### PR TITLE
Fix OpenGL uniform errors/warnings when using a debug context

### DIFF
--- a/src/gui/render/opengl_renderer.cpp
+++ b/src/gui/render/opengl_renderer.cpp
@@ -417,23 +417,38 @@ void OpenGlRenderer::GetUniformLocations()
 
 	uniform.frame_count = glGetUniformLocation(current_shader.program_object,
 	                                           "rubyFrameCount");
+
+	uniform.input_texture = glGetUniformLocation(current_shader.program_object,
+	                                             "rubyTexture");
 }
 
 void OpenGlRenderer::UpdateUniforms() const
 {
-	glUniform2f(uniform.texture_size,
-	            static_cast<GLfloat>(render_width_px),
-	            static_cast<GLfloat>(render_height_px));
+	if (uniform.texture_size > -1) {
+		glUniform2f(uniform.texture_size,
+		            static_cast<GLfloat>(render_width_px),
+		            static_cast<GLfloat>(render_height_px));
+	}
 
-	glUniform2f(uniform.input_size,
-	            static_cast<GLfloat>(render_width_px),
-	            static_cast<GLfloat>(render_height_px));
+	if (uniform.input_size > -1) {
+		glUniform2f(uniform.input_size,
+		            static_cast<GLfloat>(render_width_px),
+		            static_cast<GLfloat>(render_height_px));
+	}
 
-	glUniform2f(uniform.output_size,
-	            static_cast<GLfloat>(draw_rect_px.w),
-	            static_cast<GLfloat>(draw_rect_px.h));
+	if (uniform.output_size > -1) {
+		glUniform2f(uniform.output_size,
+		            static_cast<GLfloat>(draw_rect_px.w),
+		            static_cast<GLfloat>(draw_rect_px.h));
+	}
 
-	glUniform1i(uniform.frame_count, frame_count);
+	if (uniform.frame_count > -1) {
+		glUniform1i(uniform.frame_count, frame_count);
+	}
+
+	if (uniform.input_texture > -1) {
+		glUniform1i(uniform.input_texture, 0);
+	}
 }
 
 std::optional<GLuint> OpenGlRenderer::BuildShader(const GLenum type,
@@ -617,12 +632,6 @@ std::optional<GLuint> OpenGlRenderer::BuildShaderProgram(const std::string& sour
 	                      vertex_data);
 
 	glEnableVertexAttribArray(static_cast<GLuint>(vertex_attrib_location));
-
-	// Set texture slot
-	const GLint texture_uniform = glGetUniformLocation(shader_program,
-	                                                   "rubyTexture");
-
-	glUniform1i(texture_uniform, 0);
 
 	return shader_program;
 }

--- a/src/gui/render/opengl_renderer.h
+++ b/src/gui/render/opengl_renderer.h
@@ -119,10 +119,11 @@ private:
 	bool is_framebuffer_srgb_capable = false;
 
 	struct {
-		GLint texture_size = 0;
-		GLint input_size   = 0;
-		GLint output_size  = 0;
-		GLint frame_count  = 0;
+		GLint texture_size  = -1;
+		GLint input_size    = -1;
+		GLint output_size   = -1;
+		GLint frame_count   = -1;
+		GLint input_texture = -1;
 	} uniform = {};
 
 	GLuint frame_count         = 0;


### PR DESCRIPTION
# Description

These are harmless errors/warnings raised when the uniform we're trying to set does not exist in the compiled shader, but it's easy to do things properly, so I figured why not.

## Related issues

Fixes https://github.com/dosbox-staging/dosbox-staging/issues/4593


# Manual testing

Trivial change, Staging starts up on Windows and the shaders work.

The change has been manually tested on:

- [x] Windows
- [ ] macOS
- [ ] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [ ] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

