### PR TITLE
Remove fullscreen_mode=original config option

### DIFF
--- a/src/gui/private/sdl_gui.h
+++ b/src/gui/private/sdl_gui.h
@@ -143,9 +143,6 @@ struct SDL_Block {
 	struct {
 		FullscreenMode mode = {};
 
-		int width  = 0;
-		int height = 0;
-
 		struct {
 			int width  = 0;
 			int height = 0;


### PR DESCRIPTION
# Description

As discussed in #4588 the feature is pretty broken so we're killing it. Also removed all calls to `SDL_SetWindowDisplayMode()` which only makes sense in exclusive fullscreen. Separated that into small commits on the off-chance there's regressions (I very much doubt there will be but still).

## Related issues

Fixes #4588

# Release notes

fullresolution is dead. Long live fullscreen_mode. You can have either standard or the Windows hack "forced-borderless".

# Manual testing

Doom runs.

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [x] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [x] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

