### PR TITLE
Mapper layout fixes

### DIFF
--- a/src/gui/mapper.cpp
+++ b/src/gui/mapper.cpp
@@ -2075,7 +2075,7 @@ static void CreateLayout() {
 		                  combo_4[i].entry,
 		                  combo_4[i].key);
 	}
-	AddKeyButtonEvent(pos_x(14), pos_y(4), button_width * 3, button_height, "SHIFT", "rshift", KBD_rightshift);
+	AddKeyButtonEvent(pos_x(14), pos_y(4), button_width * 2, button_height, "SHIFT", "rshift", KBD_rightshift);
 
 	/* Bottom Row */
 	AddKeyButtonEvent(pos_x(0), pos_y(5), button_width * 2, button_height, MMOD1_NAME, "lctrl", KBD_leftctrl);


### PR DESCRIPTION
# Description

This is how the mapper looks with `machine = cga` and `composite = on`. We have the highest number of hotkey buttons displayed in this mode because of the CGA composite adjustment hotkeys (Sel Knob, Inc Knob, Dec Knob, etc.)

<img width="2138" height="1660" alt="image" src="https://github.com/user-attachments/assets/ede32697-2639-4c40-886d-c4f61e7fcd69" />

### Problems

1. The joystick buttons are stuck to the virtual keyboard, there's no spacing, and the right Shift button is too wide (I screwed these up in 0.81.0, somehow 😊)
2. The hotkey bind buttons could be a bit wider.
3. The bind text is printed over the bottom hotkey button row. 

### After the fixes

I've fixed all that up by tweaking the button positions a bit. First screenshot is with `cga` and `composite = on`, second is with `svga_s3`:

<img width="2138" height="1660" alt="image" src="https://github.com/user-attachments/assets/fd52e58b-0bd0-4f51-bbe7-e57831eec914" />

<img width="2138" height="1660" alt="image" src="https://github.com/user-attachments/assets/0999e3e8-ea1c-4dcf-b3ee-f844b778155f" />

# Release notes

- The mapper layout has been improved (it has regressed a bit in 0.81.0).

# Manual testing

As per above.

The change has been manually tested on:

- [x] Windows
- [ ] macOS
- [x] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

