### PR TITLE
Fix for setting the same shader twice in a row

### DIFF
--- a/src/gui/render/opengl_renderer.cpp
+++ b/src/gui/render/opengl_renderer.cpp
@@ -680,11 +680,13 @@ bool OpenGlRenderer::MaybeSwitchShaderAndPreset(const ShaderDescriptor& curr_des
 	                             new_descriptor.preset_name);
 
 	if (!changed_shader && !changed_preset) {
-		return false;
+		// No change; report success
+		return true;
 	}
 
 	if (changed_shader) {
 		if (!SwitchShader(new_descriptor.shader_name)) {
+			// Loading shader failed; report error
 			return false;
 		}
 	}
@@ -758,6 +760,7 @@ std::optional<ShaderPreset> OpenGlRenderer::GetOrLoadAndCacheShaderPreset(
 		        descriptor, default_preset);
 
 		if (!maybe_preset) {
+			// Error loading preset; report error
 			return {};
 		}
 


### PR DESCRIPTION
# Description

Setting the same shader twice in a row behaved erratically (e.g., setting `shader crt-auto` when `crt-auto` is the currently active shader). I broke this with my last "strictly refactoring changes on the renderer" PR. LOL 😂 

Also made a small tweak to explicitly raise the window to the foreground on startup. At least on macOS this seems to be necessary now; during debugging this the window did not appear in the foreground, had to click on the icon manually. Not sure what's going on, but explicitly raising the window certainly doesn't hurt.

## Related issues

- This guy broke it https://github.com/dosbox-staging/dosbox-staging/pull/4608

# Manual testing

- Setting the same shader twice should work.
- Setting `crt-auto` after startup should work when using the default config.
- Regression tested force reloading shaders, setting invalid shaders, invalid presets, and also the positive case of explicitly setting a concrete CRT auto shader preset.

The change has been manually tested on:

- [ ] Windows
- [x] macOS
- [ ] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

