### PR TITLE
Fix 'lpf' acronym in help text messages

### DIFF
--- a/src/audio/mixer.cpp
+++ b/src/audio/mixer.cpp
@@ -3242,7 +3242,7 @@ static void register_mixer_text_messages()
 	MSG_Add("MIXER_INVALID_CUSTOM_FILTER",
 	        "Invalid custom filter definition: [color=white]'%s'[reset].\n"
 	        "Must be specified in [color=light-cyan]"
-	        "'lfp|hpf ORDER CUTOFF_FREQUENCY'[reset] format.");
+	        "'lpf|hpf ORDER CUTOFF_FREQUENCY'[reset] format.");
 
 	MSG_Add("MIXER_INVALID_CUSTOM_FILTER_ORDER",
 	        "Invalid %s filter order: [color=white]'%s'[reset]. "

--- a/src/hardware/audio/soundblaster.cpp
+++ b/src/hardware/audio/soundblaster.cpp
@@ -3845,7 +3845,7 @@ void init_sblaster_config_settings(SectionProp& secprop)
 	        "             (1st order = 6dB/oct slope, 2nd order = 12dB/oct, etc.),\n"
 	        "             and FREQ is the cutoff frequency in Hz. Examples:\n"
 	        "                lpf 2 12000\n"
-	        "                hpf 3 120 lfp 1 6500");
+	        "                hpf 3 120 lpf 1 6500");
 
 	pbool = secprop.AddBool("sb_filter_always_on", when_idle, false);
 	pbool->SetHelp(


### PR DESCRIPTION
# Description

Fixes https://github.com/dosbox-staging/dosbox-staging/issues/4614


## Related issues

- https://github.com/dosbox-staging/dosbox-staging/issues/4614

# Manual testing

Trivial change.

The change has been manually tested on:

- [ ] Windows
- [x] macOS
- [ ] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

