### PR TITLE
Fix VGA double scanning when setting a shader preset at startup

### DIFF
--- a/src/hardware/video/vga.cpp
+++ b/src/hardware/video/vga.cpp
@@ -291,9 +291,6 @@ void VGA_SetCGA4Table(uint8_t val0,uint8_t val1,uint8_t val2,uint8_t val3) {
 
 void VGA_AllowVgaScanDoubling(const bool allow)
 {
-	if (!is_machine_vga_or_better()) {
-		return;
-	}
 	if (allow && !vga.draw.scan_doubling_allowed) {
 		LOG_MSG("VGA: Double scanning VGA video modes enabled");
 	}


### PR DESCRIPTION
# Description

VGA double scanning was broken when setting a preset that allows scan-doubling in the config or at the command line.

E.g., setting `shader = crt/crt-hyllian:vga-4k` in the config resulted in forced single scanning in the 320x200 VGA mode.

# Manual testing

- Start a 320x200 VGA game with `--set "shader crt/crt-hyllian:vga-4k"`
- On `main`, this would result in single-scanned output (wrong)
- With the fix, the output is double-scanned (correct)

The change has been manually tested on:

- [ ] Windows
- [x] macOS
- [ ] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

