### PR TITLE
PDCurses: Always convert font surface to 8-bit indexed

### DIFF
--- a/src/libs/PDCurses/sdl2_queue/pdcscrn.cpp
+++ b/src/libs/PDCurses/sdl2_queue/pdcscrn.cpp
@@ -214,14 +214,25 @@ int PDC_scr_open(void)
 
     SP->mono = FALSE;
 #else
+    SDL_PixelFormat *format = SDL_AllocFormat(SDL_PIXELFORMAT_INDEX8);
     if (!pdc_font)
     {
         const char *fname = getenv("PDC_FONT");
-        pdc_font = SDL_LoadBMP(fname ? fname : "pdcfont.bmp");
+        SDL_Surface *temp = SDL_LoadBMP(fname ? fname : "pdcfont.bmp");
+        if (temp) {
+            pdc_font = SDL_ConvertSurface(temp, format, 0);
+            SDL_FreeSurface(temp);
+        }
     }
 
-    if (!pdc_font)
-        pdc_font = SDL_LoadBMP_RW(SDL_RWFromMem(font437, sizeof(font437)), 0);
+    if (!pdc_font) {
+        SDL_Surface *temp = SDL_LoadBMP_RW(SDL_RWFromMem(font437, sizeof(font437)), 0);
+        if (temp) {
+            pdc_font = SDL_ConvertSurface(temp, format, 0);
+            SDL_FreeSurface(temp);
+        }
+    }
+    SDL_FreeFormat(format);
 
     if (!pdc_font)
     {


### PR DESCRIPTION
# Description
There seems to be an issue when rendering the default font in the debugger; when loading the embedded 1bpp font bitmap, PDCurses trusts SDL_BlitSurface to be able to convert the surface on the fly to the target format. This no longer seems to be the case; under Arch Linux (SDL2-compat 2.32.58 backed by SDL3 3.2.26), the x-coordinate of the source rectangle is effectively multiplied by 8, leading to overflow of the data area and garbled fonts on the screen. The y coordinate data offset is calculated using the surface's pitch and is unaffected.

Fix is to pre-convert the font surface to SDL_PIXELFORMAT_INDEX8.

This is a copy of upstream patch https://github.com/wmcbrine/PDCurses/pull/177

# Manual testing

Tested on Arch Linux, with sdl2-compat 2.32.58-1 and sdl3 3.2.26-1.
Built dosbox-staging with `-Dbuildtype=debug -Ddebug=true -Denable_debugger=heavy -Dunit_tests=disabled`. Open the debugger pane with Alt-Pause.

Before:
<img width="640" height="828" alt="image" src="https://github.com/user-attachments/assets/5806e3e8-8301-4b43-8217-ebe8bcec39ee" />

After:
<img width="640" height="828" alt="image" src="https://github.com/user-attachments/assets/d80ae3f7-c727-4c29-b05e-21f1a99b38be" />


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [ ] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

