### PR TITLE
Fix 'expand_shell_variable' description

### DIFF
--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -1978,9 +1978,9 @@ static void init_dos_settings(SectionProp& section)
 	        "('auto' by default). FreeDOS and MS-DOS 7.0+ COMMAND.COM supports this behavior.\n"
 	        "Possible values:\n"
 	        "\n"
-	        "  auto:   Enabled if DOS version is 7.0 or above (default).\n"
-	        "  on:     Disable expansion of environment variables.\n"
-	        "  off:    Enable expansion of environment variables.");
+	        "  auto:  Enabled if DOS version is 7.0 or above (default).\n"
+	        "  on:    Enable expansion of environment variables.\n"
+	        "  off:   Disable expansion of environment variables.");
 
 	pstring = section.AddPath("shell_history_file", OnlyAtStart, "shell_history.txt");
 


### PR DESCRIPTION
# Description

Fix description of `expand_shell_variable` config option - as found by @Kappa971, on/off descriptions were reversed.


# Manual testing

Tested on Linux that the new `expand_shell_variable` description reflects the actual behavior.

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [x] Linux


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

