### PR TITLE
Reset OpenGL attributes before creating the mapper's renderer

### DIFF
--- a/src/gui/mapper.cpp
+++ b/src/gui/mapper.cpp
@@ -3053,6 +3053,16 @@ void MAPPER_DisplayUI() {
 			E_Exit("MAPPER: OpenGL support in SDL renderer is unavailable but required for OpenGL output");
 		}
 
+		// Since our OpenGL renderer started requesting a version 3.3 context,
+		// the call to SDL_GL_MakeCurrent() when exiting the mapper started failing.
+		//
+		// This is a bit of hack (but so is a lot of this mapper code).
+		// Resetting attributes to default before creating the mapper's render fixes the problem.
+		//
+		// As far as I know, attributes are only evalutated before window and/or context creation
+		// so this should not affect our regular (non-mapper) OpenGL renderer.
+		SDL_GL_ResetAttributes();
+
 		constexpr uint32_t renderer_flags = 0;
 
 		mapper.renderer = SDL_CreateRenderer(mapper.window,


### PR DESCRIPTION
# Description

This fixes an issue where the mapper would fail to exit due to failing to restore our regular renderer's OpenGL context.

## Related issues

Fixes #4627

# Manual testing

Mapper now closes correctly

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [x] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

