### PR TITLE
Fix for default config file created without using translations

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -348,9 +348,9 @@ static void maybe_write_primary_config(const CommandLineArguments& args)
 		const auto primary_config_path = get_primary_config_path();
 
 		if (!config_file_is_valid(primary_config_path)) {
-			// No config is loaded at this point, so we're
-			// writing the default settings to the primary
-			// config.
+			// No config is loaded at this point, so we're writing
+			// the default settings to the primary config.
+			MSG_LoadMessages();
 			if (control->WriteConfig(primary_config_path)) {
 				LOG_MSG("CONFIG: Created primary config file '%s'",
 				        primary_config_path.string().c_str());


### PR DESCRIPTION
# Description

Fix for the problems noticed by @Kappa971, where the default config file is always created in English, without using translations.


# Manual testing

1. Delete the DOSBox Staging default config file, start the emulator with `dosbox -lang it` command - DOSBox Staging should start in Italian language and create a default config file with Italian comments.
2. Delete the DOSBox Staging default config file, start the emulator with `LANGUAGE="it_IT" dosbox` command - result should be the same as above (this point only works with Linux; if using Windows or macOS you would need to change the OS language and - most likely - re-login).


The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [x] Linux


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

