### PR TITLE
Upgrade download-artifact action manually

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -123,7 +123,7 @@ jobs:
         run: HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 brew install --overwrite librsvg
 
       - name: Download binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
 
       - name: Package
         run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -223,9 +223,6 @@ jobs:
         with:
           submodules: false
 
-      - name: Download artifacts
-        uses: actions/download-artifact@v4
-
       - name: Set common vars
         uses: ./.github/actions/set-common-vars
 
@@ -235,6 +232,12 @@ jobs:
         run: |
           set -x
           echo "PACKAGE_DIR=dosbox-staging-windows-${{ matrix.arch }}-$DOSBOX_VERSION_AND_HASH" >> $GITHUB_ENV
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v6
+        with:
+          name: ${{ env.PACKAGE_DIR }}
+          path: ${{ env.PACKAGE_DIR }}          
 
       - name: Dump workspace contents
         shell: bash


### PR DESCRIPTION
# Description

download-artifact@v6 broke the Windows CI and needed a path fix. This PR overrides #4574.

# Manual testing

Verified Windows and macOS CI builds completed successfully and downloaded both artifacts.

The change has been manually tested on:

- [x] Windows
- [x] macOS
- [ ] Linux

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

