### PR TITLE
Fix closest video mode calculation in showpic command

### DIFF
--- a/src/dos/programs/showpic.cpp
+++ b/src/dos/programs/showpic.cpp
@@ -190,6 +190,7 @@ std::optional<VideoModeBlock> SHOWPIC::GetClosestVideoMode(const int width,
 
 		if (new_distance < best_distance) {
 			best_mode = mode;
+			best_distance = new_distance;
 		}
 	}
 


### PR DESCRIPTION
# Description

Didn't get a chance to review #4632 so now I have and I found a bug. `best_distance` variable was never updated so when picking the closest mode, it used the last one in the list, not necessarily the best.


# Manual testing

Went through several pictures in the test pack: https://github.com/user-attachments/files/24126446/test-pics.zip

Not sure if there's an observable bug but it looks like an obvious oversight in the code so I'm fixing it anyway.

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [x] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

