### PR TITLE
Fix wrong 640x200 mode ID in SHOWPIC.EXE

### DIFF
--- a/src/dos/programs/showpic.cpp
+++ b/src/dos/programs/showpic.cpp
@@ -139,7 +139,7 @@ std::optional<VideoModeBlock> SHOWPIC::GetClosestVideoMode(const int width,
 
 	for (auto& mode : ModeList_VGA) {
 		// Disallow 2-color monochrome modes
-		constexpr auto Monochrome_640x200 = 0x0f;
+		constexpr auto Monochrome_640x200 = 0x06;
 		constexpr auto Monochrome_640x350 = 0x0f;
 		constexpr auto Monochrome_640x480 = 0x11;
 


### PR DESCRIPTION
# Description

I have noticed a mistake in the 640x200 mode ID in the newly added SHOWPIC.EXE tool - this is fixed now.


# Manual testing

Checked that the viewer still works.

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [x] Linux


# Checklist


I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

