### PR TITLE
Enable additional warnings for Clang and GCC 13+

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,15 +30,6 @@ if (MSVC)
 
 else()
 
-  # TODO: GCC 12 (still used in our CI workflow) complains about unrecognized
-  # command line options; after switching to a newer release, enable the
-  # following warning flags:
-  #     -Winvalid-utf8
-  #     -Wtrivial-auto-var-init
-  #     -Wdeprecated-non-prototype (C only)
-  #     -Wflex-array-member-not-at-end (C only)
-  #     -Wfree-labels (C only)
-
   # Warning flags common to C and C++ code
   set(WARNING_FLAGS_COMMON
       "-Wall" "-Wextra" "-Wdeprecated"
@@ -65,6 +56,30 @@ else()
       "-Weffc++"
       "-Wextra-semi"
   )
+
+  # GCC 12 (still used in our CI workflow) complains about unrecognized
+  # command line options; after switching to a newer release, enable the
+  # following warning flags:
+  if ((CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND
+       CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 13)
+       OR
+       (CMAKE_CXX_COMPILER_ID STREQUAL "Clang"))
+
+    set(WARNING_FLAGS_C
+        ${WARNING_FLAGS_C}
+        "-Winvalid-utf8"
+        "-Wtrivial-auto-var-init"
+        "-Wdeprecated-non-prototype"
+        "-Wflex-array-member-not-at-end"
+        "-Wfree-labels"
+    )
+    set(WARNING_FLAGS_CXX
+        ${WARNING_FLAGS_CXX}
+        "-Winvalid-utf8"
+        "-Wtrivial-auto-var-init"
+    )
+  endif()
+
 
   add_compile_options(
     "$<$<COMPILE_LANGUAGE:C>:${WARNING_FLAGS_C}>"


### PR DESCRIPTION
# Description

As per title. It was a TODO item the the main CMake script.

## Related issues

- https://github.com/dosbox-staging/dosbox-staging/issues/4196

# Manual testing

N/A

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [ ] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

