### PR TITLE
Fix non UTF-8 characters in ManyMouse library

### DIFF
--- a/src/libs/manymouse/macosx_hidutilities.c
+++ b/src/libs/manymouse/macosx_hidutilities.c
@@ -6,6 +6,8 @@
  * Please see the file LICENSE.txt in the source's root directory.
  *
  *  This file written by Ryan C. Gordon.
+ *  Altered by the DOSBox Staging team to:
+ *   - fix non UTF-8 characters GCC compiler warning
  */
 
 #include "manymouse.h"
@@ -949,7 +951,7 @@ static unsigned long HIDCreateOpenDeviceInterface (UInt32 hidDevice, pRecDevice 
 			plugInResult = (*ppPlugInInterface)->QueryInterface (ppPlugInInterface,
 														CFUUIDGetUUIDBytes (kIOHIDDeviceInterfaceID), (void *) &(pDevice->interface));
 			if (S_OK != plugInResult)
-				HIDReportErrorNum ("CouldnÕt query HID class device interface from plugInInterface", plugInResult);
+				HIDReportErrorNum ("Couldn't query HID class device interface from plugInInterface", plugInResult);
 			IODestroyPlugInInterface (ppPlugInInterface); // replace (*ppPlugInInterface)->Release (ppPlugInInterface)
 		}
 		else
@@ -1434,7 +1436,7 @@ static unsigned long  HIDQueueDevice (pRecDevice pDevice)
 			HIDREPORTERRORNUM ("HIDQueueDevice - Failed to stop queue.", result);
 
 		// queue element
-  //¥ pElement = HIDGetFirstDeviceElement (pDevice, kHIDElementTypeIO);
+		// pElement = HIDGetFirstDeviceElement (pDevice, kHIDElementTypeIO);
 		pElement = HIDGetFirstDeviceElement (pDevice, kHIDElementTypeInput | kHIDElementTypeFeature);
 
 		while (pElement)
@@ -1445,7 +1447,7 @@ static unsigned long  HIDQueueDevice (pRecDevice pDevice)
 				if (kIOReturnSuccess != result)
 					HIDREPORTERRORNUM ("HIDQueueDevice - Failed to add element to queue.", result);
 			}
-			//¥ pElement = HIDGetNextDeviceElement (pElement, kHIDElementTypeIO);
+			// pElement = HIDGetNextDeviceElement (pElement, kHIDElementTypeIO);
 			pElement = HIDGetNextDeviceElement (pElement, kHIDElementTypeInput | kHIDElementTypeFeature);
 		}
 


### PR DESCRIPTION
# Description

There are some non UTF-8 characters in the ManyMouse library - let's fix them, otherwise after merging https://github.com/dosbox-staging/dosbox-staging/pull/4647 some devs are going to see compiler warnings.

## Related issues

https://github.com/dosbox-staging/dosbox-staging/issues/4196


# Manual testing

Compiled with GCC 15.1 with `-Winvalid-utf8` flag, no UTF-8 warnings are visible.

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [x] Linux


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

