### PR TITLE
Optimize FPU code to set flags

### DIFF
--- a/src/fpu/fpu.h
+++ b/src/fpu/fpu.h
@@ -161,24 +161,24 @@ static inline void FPU_SET_TOP(const uint32_t val)
 void FPU_SetPRegsFrom(const uint8_t dyn_regs[8][10]);
 void FPU_GetPRegsTo(uint8_t dyn_regs[8][10]);
 
-static inline void FPU_SET_C0(Bitu C){
-	fpu.sw &= ~0x0100;
-	if(C) fpu.sw |=  0x0100;
+static inline void FPU_SET_C0(bool C)
+{
+	fpu.sw = (fpu.sw & ~0x0100u) | (C * 0x0100u);
 }
 
-static inline void FPU_SET_C1(Bitu C){
-	fpu.sw &= ~0x0200;
-	if(C) fpu.sw |=  0x0200;
+static inline void FPU_SET_C1(bool C)
+{
+	fpu.sw = (fpu.sw & ~0x0200u) | (C * 0x0200u);
 }
 
-static inline void FPU_SET_C2(Bitu C){
-	fpu.sw &= ~0x0400;
-	if(C) fpu.sw |=  0x0400;
+static inline void FPU_SET_C2(bool C)
+{
+	fpu.sw = (fpu.sw & ~0x0400u) | (C * 0x0400u);
 }
 
-static inline void FPU_SET_C3(Bitu C){
-	fpu.sw &= ~0x4000;
-	if(C) fpu.sw |= 0x4000;
+static inline void FPU_SET_C3(bool C)
+{
+	fpu.sw = (fpu.sw & ~0x4000u) | (C * 0x4000u);
 }
 
 static inline void FPU_LOG_WARN(unsigned tree, bool ea, uintptr_t group, uintptr_t sub)


### PR DESCRIPTION
# Description
This is a commit I had left out of PR #4534 by mistake. Very nit-picky micro optimization, but with the increased flag operations I added to that PR, every little bit helps.

Note, as with the original PR, this only affects non-x86.

# Manual testing

Ran the usual FPU suspects:
- Quake (QTD)
- MCPDIAG
- Sunflower
- multikolor
- Heaven 7
- moralhardcandy

The change has been manually tested on:

- [ ] Windows
- [x] macOS
- [ ] Linux


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

