### PR TITLE
Update Linux build instructions

### DIFF
--- a/docs/build-linux.md
+++ b/docs/build-linux.md
@@ -60,16 +60,19 @@ These are generic, distro-independent building instructions.
 
 ### Install the dependencies (development packages are needed, too)
 
-- SDL 2.x
-- SDL2_net
-- IIR
-- OpusFile
-- MT32Emu
-- FluidSynth
 - ALSA
-- libpng
-- OpenGL headers
+- FluidSynth
 - GTest
+- IIR
+- libpng
+- MT32Emu
+- OpenGL headers
+- OpusFile
+- SDL 2.x
+- SDL2_image
+- SDL2_net
+- SpeexDSP
+- zlib-nG
 
 ### Clone DOSBox Staging
 
@@ -101,7 +104,8 @@ You can now launch DOSBox Staging with the command:
 
 ```bash
 sudo apt-get install git build-essential pkg-config cmake curl ninja-build \
-             autoconf bison libtool libgl1-mesa-dev libsdl2-dev
+             autoconf autoconf-archive automake bison libtool libgl1-mesa-dev \
+             libsdl2-dev
 ```
 
 ### Install the vcpkg tool


### PR DESCRIPTION
# Description

Adding some missing dependencies to the Linux build doco, and the prerequisites for the lates libxcrypt we're using. I had to change the Linux deps installed on CI to make it work again, see df74b35504b0eb7b9b39d83a787b55904fd0245a

I've also raised an issue ticket for the [vcpkg package](https://github.com/microsoft/vcpkg/issues/48617). Not sure if this is an actual bug, but it seems like a regression to me. Anyway, zero movement in the last 3 weeks since I've raised it.


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

