### PR TITLE
Enforce using Unix EOL marks in the translation subsystem

### DIFF
--- a/src/misc/messages.cpp
+++ b/src/misc/messages.cpp
@@ -106,14 +106,14 @@ private:
 
 Message::Message(const std::string& message_english)
         : is_english(true),
-          message_raw(message_english)
+          message_raw(replace_eol(message_english, "\n"))
 {}
 
 Message::Message(const std::string& message_english,
                  const std::string& message_translated)
         : is_english(false),
-          message_raw(message_translated),
-          message_previous_english(message_english)
+          message_raw(replace_eol(message_translated, "\n")),
+          message_previous_english(replace_eol(message_english, "\n"))
 {}
 
 bool Message::IsFuzzy() const


### PR DESCRIPTION
# Description

Always use Unix EOL in the translation subsystem - all the strings are converted to Unix EOL when added/loaded.
This fixes the problem @rderooy reported in PR https://github.com/dosbox-staging/dosbox-staging/pull/4650.


# Manual testing

1. Make sure you nl.po is from before PR https://github.com/dosbox-staging/dosbox-staging/pull/4653
2. Start DOSBox Staging, execute command `config -set language=nl`, check the logs - there should be no warnings about invalid characters in the translation file
3. Execute command `showpic /?` - Dutch language help should be displayed

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [x] Linux


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

