### PR TITLE
Translation handling improvements

### DIFF
--- a/src/misc/CMakeLists.txt
+++ b/src/misc/CMakeLists.txt
@@ -12,6 +12,7 @@ target_sources(libdosboxcommon PRIVATE
   host_locale_posix.cpp
   host_locale_win32.cpp
   iso_locale_codes.cpp
+  messages_adjust.cpp
   messages_po_entry.cpp
   rwqueue.cpp
   support.cpp

--- a/src/misc/meson.build
+++ b/src/misc/meson.build
@@ -13,6 +13,7 @@ libmisc_nomsg_sources = [
     'host_locale_posix.cpp',
     'host_locale_win32.cpp',
     'iso_locale_codes.cpp',
+    'messages_adjust.cpp',
     'messages_po_entry.cpp',
     'rwqueue.cpp',
     'support.cpp',

--- a/src/misc/messages_adjust.cpp
+++ b/src/misc/messages_adjust.cpp
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText:  2025-2025 The DOSBox Staging Team
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "private/messages_adjust.h"
+
+#include "utils/checks.h"
+#include "utils/string_utils.h"
+
+CHECK_NARROWING();
+
+
+void adjust_newlines(const std::string &current,
+                     std::string &previous,
+                     std::string &translated)
+{
+	auto count_leading_newlines = [](const std::string& message) {
+		const auto position = message.find_first_not_of('\n');
+		if (position == std::string::npos) {
+			return message.size();
+		} else {
+			return position;
+		}
+	};
+
+	auto count_trailing_newlines = [](const std::string& message) {
+		const auto position = message.find_last_not_of('\n');
+		if (position == std::string::npos) {
+			return message.size();
+		} else {
+			return message.size() - position - 1;
+		}
+	};
+
+	// Count the number of leading and trailing newlines in the translated
+	// message, the current English message, and the English message
+	// which was the base for the translation (the previous English)
+
+	const auto num_leading_translated  = count_leading_newlines(translated);
+	const auto num_trailing_translated = count_trailing_newlines(translated);
+
+	const auto num_leading_previous  = count_leading_newlines(previous);
+	const auto num_trailing_previous = count_trailing_newlines(previous);
+
+	const auto num_leading_current  = count_leading_newlines(current);
+	const auto num_trailing_current = count_trailing_newlines(current);
+
+	// Skip auto-adjusting if any of the strings is empty or consists only
+	// of newline characters
+	if (num_leading_translated == translated.size() || translated.empty() ||
+	    num_leading_previous == previous.size() || previous.empty() ||
+	    num_leading_current == current.size() || current.empty()) {
+		return;
+	}
+
+	// Safety check - do not auto-adjust the translation if the translated
+	// message has a different
+	if (num_leading_translated  != num_leading_previous ||
+	    num_trailing_translated != num_trailing_previous) {
+		return;
+	}
+
+	const auto translated_stripped = translated.substr(
+	        num_leading_translated,
+	        translated.size() - num_leading_translated - num_trailing_translated);
+	const auto previous_stripped = previous.substr(
+	        num_leading_previous,
+	        previous.size() - num_leading_previous - num_trailing_previous);
+	const auto current_stripped = current.substr(
+	        num_leading_current,
+                current.size() - num_leading_current - num_trailing_current);
+
+	// We can only auto-adjust the translated message if the previous and
+	// current English strings only differ by the number of leading/trailing
+	// newlines
+	if (current_stripped != previous_stripped) {
+		return;
+	}
+
+	// Override the previous English string, adjust the translation
+	previous   = current;
+	translated = std::string(num_leading_current, '\n') +
+	             translated_stripped +
+	             std::string(num_trailing_current, '\n');
+}

--- a/src/misc/private/messages_adjust.h
+++ b/src/misc/private/messages_adjust.h
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText:  2025-2025 The DOSBox Staging Team
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#ifndef DOSBOX_PRIVATE_MESSAGES_H
+#define DOSBOX_PRIVATE_MESSAGES_H
+
+#include <string>
+
+void adjust_newlines(const std::string& current,
+                     std::string& previous,
+                     std::string& translated);
+
+#endif // DOSBOX_PRIVATE_MESSAGES_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ add_executable(dosbox_tests
     int10_modes_tests.cpp
     language_territory_tests.cpp
     math_utils_tests.cpp
+    messages_adjust_tests.cpp
     mixer_tests.cpp
     port_containers_tests.cpp
     program_mixer_tests.cpp

--- a/tests/messages_adjust_tests.cpp
+++ b/tests/messages_adjust_tests.cpp
@@ -1,0 +1,128 @@
+// SPDX-FileCopyrightText:  2025-2025 The DOSBox Staging Team
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "misc/private/messages_adjust.h"
+
+#include <cstdint>
+#include <gtest/gtest.h>
+
+#include <string>
+#include <sys/types.h>
+
+// The Tragedy of Romeo and Juliet, by William Shakespeare
+
+static const std::string TestStringNewlineAfter =
+        "Two households, both alike in dignity,\n"
+        "In fair Verona, where we lay our scene,\n"
+        "From ancient grudge break to new mutiny,\n"
+        "Where civil blood makes civil hands unclean.\n";
+
+static const std::string TestStringNewlineBefore =
+        "\n"
+        "From forth the fatal loins of these two foes\n"
+        "A pair of star-cross'd lovers take their life;\n"
+        "Whose misadventured piteous overthrows\n"
+        "Do with their death bury their parents' strife.";
+
+static const std::string TestStringNewlineBeforeAfter =
+        "\n"
+        "The fearful passage of their death-mark'd love,\n"
+        "And the continuance of their parents' rage,\n"
+        "Which, but their children's end, nought could remove,\n"
+        "Is now the two hours' traffic of our stage;\n";
+
+namespace {
+
+TEST(Messages, Adjust_Newlines_1)
+{
+	const std::string& current = TestStringNewlineAfter;
+	auto previous = std::string("\n\n") + current + std::string("\n");
+
+	std::string translated = "\n\nLorem ipsum dolor sit amet\n\n";
+
+	adjust_newlines(current, previous, translated);
+
+	EXPECT_EQ(previous, current);
+	EXPECT_EQ(translated, "Lorem ipsum dolor sit amet\n");
+}
+
+TEST(Messages, Adjust_Newlines_2)
+{
+	const std::string& current = TestStringNewlineBefore;
+	auto previous = std::string("\n\n") + current + std::string("\n");
+
+	std::string translated = "\n\n\nLorem ipsum dolor sit amet\n";
+
+	adjust_newlines(current, previous, translated);
+
+	EXPECT_EQ(previous, current);
+	EXPECT_EQ(translated, "\nLorem ipsum dolor sit amet");
+}
+
+TEST(Messages, Adjust_Newlines_3)
+{
+	const std::string& current = TestStringNewlineBeforeAfter;
+	auto previous = std::string("\n\n") + current + std::string("\n");
+
+	std::string translated = "\n\n\nLorem ipsum dolor sit amet\n\n";
+
+	adjust_newlines(current, previous, translated);
+
+	EXPECT_EQ(previous, current);
+	EXPECT_EQ(translated, "\nLorem ipsum dolor sit amet\n");
+}
+
+TEST(Messages, Skip_Adjust_Newlines_1)
+{
+	// Here we expect the newline adjustment won't be performed due to
+	// English string changed beyond just leading/trailing newlines
+
+	const std::string& current = TestStringNewlineBefore;
+	auto previous = std::string("\n") + "FooBar" + std::string("\n");
+
+	const std::string previous_original = previous;
+	std::string translated = "\nLorem ipsum dolor sit amet\n";
+
+	adjust_newlines(current, previous, translated);
+
+	EXPECT_EQ(previous, previous_original);
+	EXPECT_EQ(translated, "\nLorem ipsum dolor sit amet\n");
+}
+
+TEST(Messages, Skip_Adjust_Newlines_2)
+{
+	// Here we expect the newline adjustment won't be performed due to
+	// translated message having different number of leading newlines
+	// than the original English string
+
+	const std::string& current = TestStringNewlineBeforeAfter;
+	auto previous = std::string("\n") + current + std::string("\n");
+
+	const std::string previous_original = previous;
+	std::string translated = "Lorem ipsum dolor sit amet\n\n";
+
+	adjust_newlines(current, previous, translated);
+
+	EXPECT_EQ(previous, previous_original);
+	EXPECT_EQ(translated, "Lorem ipsum dolor sit amet\n\n");
+}
+
+TEST(Messages, Skip_Adjust_Newlines_3)
+{
+	// Here we expect the newline adjustment won't be performed due to
+	// translated message having different number of trailing newlines
+	// than the original English string
+
+	const std::string& current = TestStringNewlineBeforeAfter;
+	auto previous = std::string("\n") + current + std::string("\n");
+
+	const std::string previous_original = previous;
+	std::string translated = "\n\nLorem ipsum dolor sit amet";
+
+	adjust_newlines(current, previous, translated);
+
+	EXPECT_EQ(previous, previous_original);
+	EXPECT_EQ(translated, "\n\nLorem ipsum dolor sit amet");
+}
+
+} // namespace


### PR DESCRIPTION
# Description

Two translation handling improvements:
- if the English string change is limited to newlines at the start/end of the string, the translated string (if it was up to date and correct according to other checks) is auto-adapted
- translated strings containing certain known helper patterns (like `-` repeated 80 times, or `01234567890123...`) are marked as invalid and warning is printed for them in the log (see fix PR https://github.com/dosbox-staging/dosbox-staging/pull/4650 by @rderooy)


# Manual testing

1. Insert a 80-character helper line consisting of `-` characters into any translated string, load the PO file using command `config -set language (file)` - a warning log should appear (like in the example below) and the string should not be used:
`LOCALE: Translated message 'SHELL_CMD_CHDIR_HELP_LONG' contains a leftover helper line`

2. Modify any command help text (change the command source code) by adding newlines at the start/end of the message. Compile, start DOSBox Staging, run command:
`config set language=nl` (this translation is currently up-to-date)
and display the help message of the modified command (for example execute `more /?` inside DOSBox Staging) - the added newline characters should be visible in the output despite the help displayed in Dutch.


The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [x] Linux


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

