### PR TITLE
Always raise the window after startup on macOS (SDL workaround)

### DIFF
--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -1479,6 +1479,17 @@ static void create_window_and_renderer()
 	}
 
 	sdl.window = sdl.renderer->GetWindow();
+
+#ifdef MACOSX
+	// The window is not always brought to the foreground after startup with
+	// SDL 2.32.10 on macOS, hence this workaround. Both the OpenGL and SDL
+	// texture renderers are affected.
+	//
+	// SDL on Windows and Linux seems to always raise the window after
+	// creation.
+	//
+	SDL_RaiseWindow(sdl.window);
+#endif
 }
 
 static void configure_keyboard_capture()


### PR DESCRIPTION
# Description

The window is not always brought to the foreground after startup with SDL 2.32.10 on macOS, hence this workaround. Both the OpenGL and SDL texture renderers are affected.

SDL on Windows and Linux seems to always raise the window after creation.

@kklobe has identified this SDL 2.32.10 change as a potential reason:

https://github.com/libsdl-org/SDL/commit/d98087a0c3c2e218793badfaf5da24332254798b

Raised an SDL issue ticket, too:
https://github.com/libsdl-org/SDL/issues/14701

## Related issues

- https://github.com/libsdl-org/SDL/issues/14701

# Manual testing

The window always appears in the foreground on macOS (this gets tested extensively during local dev on my Mac Mini).

The change has been manually tested on:

- [ ] Windows
- [x] macOS
- [ ] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

