### PR TITLE
Improve unit testing instructions

### DIFF
--- a/docs/build-linux.md
+++ b/docs/build-linux.md
@@ -209,18 +209,58 @@ available in these old versions can be used (choose one for your compiler):
 
 ## Unit tests
 
-Unit tests are built by default, you can start them with the command:
-
-```bash
-./build/release-linux/tests/dosbox_tests
-```
-
-To disable building unit tests, pass the `-DOPT_TESTS=OFF` option when
-configuring the project, for example:
+Unit tests are built by default. To disable building unit tests, pass the
+`-DOPT_TESTS=OFF` option when configuring the project, for example:
 
 ```bash
 cmake --preset=release-linux -DOPT_TESTS=OFF
 ```
+
+To run the entire test suite, execute the following (use the same CMake preset
+you used for building):
+
+```bash
+ctest --preset debug-linux
+```
+
+To run all test cases in a single test suite, pass in the name of the suite
+with the `-R` option:
+
+```bash
+ctest --preset debug-linux -R DOS_FilesTest
+```
+
+You can narrow this down to run a single test case only:
+
+```bash
+ctest --preset debug-linux -R DOS_FilesTest.DOS_MakeName_Basic_Failures
+```
+
+To run a group of tests, you can use wildcards and regexes. E.g. to run all
+test cases in the `DOS_FilesTest` suite with names starting with
+`DOS_MakeName_`:
+
+```bash
+ctest --preset debug-linux -R "DOS_FilesTest.DOS_MakeName_*"
+```
+
+Pass in the `-V` option to see the DOSBox Staging log output:
+
+```bash
+ctest --preset debug-linux -R DOS_FilesTest.DOS_MakeName_Basic_Failures -V
+```
+
+You might want to run the test executable directly to get coloured output, and
+the option to start an interactive `gdb` session if a test crashes. For
+example:
+
+```
+build/debug-linux/tests/dosbox_tests --gtest_filter=DOS_FilesTest.DOS_MakeName_Basic_Failures
+```
+
+See the [ctest documentation](https://cmake.org/cmake/help/v3.31/manual/ctest.1.html)
+for the full list of available options.
+
 
 ## Sanitizer build
 


### PR DESCRIPTION
# Description

Only doing it for the Linux instructions for now. The Windows and macOS build instructions need a full rewrite first.

Probably I'll move the unit testing instructions into a separate `testing.md` file later.

## Related issues

- https://github.com/dosbox-staging/dosbox-staging/issues/4658


# Manual testing

N/A

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [ ] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

