### PR TITLE
Fix setting `shader = crt-auto-machine` causing a crash at startup

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -671,10 +671,10 @@ int main(int argc, char* argv[])
 
 		maybe_create_resource_directories();
 
+		DOSBOX_InitModules();
+
 		// Initialise the GUI
 		GFX_Init();
-
-		DOSBOX_InitModules();
 
 		// All subsystems' hotkeys need to be registered at this point
 		// to ensure their hotkeys appear in the graphical mapper.
@@ -688,8 +688,8 @@ int main(int argc, char* argv[])
 		SHELL_InitAndRun();
 
 		// Shutdown and release
-		GFX_Destroy();
 		DOSBOX_DestroyModules();
+		GFX_Destroy();
 
 	} catch (char* error) {
 		// TODO Maybe show popup dialog with the error in addition to


### PR DESCRIPTION
# Description

This fixes the crash at startup when setting `shader = crt-auto-machine` in the config and setting `machine = cga` or `ega` or `hercules` (pretty much anything else than the default), and it's the more correct init order anyway.

# Manual testing

- `dosbox --set "shader crt-auto-machine" --noprimaryconf` works
- `dosbox --set "machine ega" --set "shader crt-auto-machine" --noprimaryconf` works
- `dosbox --set "machine cga" --set "shader crt-auto-machine" --noprimaryconf` works
- `dosbox --set "machine hercules" --set "shader crt-auto-machine" --noprimaryconf` works

The change has been manually tested on:

- [x] Windows
- [x] macOS
- [x] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

