### PR TITLE
Defer SDL audio subsystem init until mixer init

### DIFF
--- a/src/audio/mixer.cpp
+++ b/src/audio/mixer.cpp
@@ -2786,6 +2786,11 @@ static bool init_sdl_sound(const int requested_sample_rate_hz,
 	// Non-zero is the device is to be opened for recording as well
 	constexpr auto IsCapture = 0;
 
+	if (SDL_InitSubSystem(SDL_INIT_AUDIO) < 0) {
+		LOG_ERR("SDL: Failed to init SDL audio subsystem: %s", SDL_GetError());
+		return false;
+	}
+
 	if ((mixer.sdl_device = SDL_OpenAudioDevice(
 	             DeviceName, IsCapture, &desired, &obtained, sdl_allow_flags)) ==
 	    SdlError) {
@@ -2795,6 +2800,8 @@ static bool init_sdl_sound(const int requested_sample_rate_hz,
 		set_section_property_value("mixer", "nosound", "off");
 		return false;
 	}
+
+	LOG_MSG("SDL: %s audio initialised", SDL_GetCurrentAudioDriver());
 
 	// Opening SDL audio device succeeded
 	//

--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -1714,8 +1714,8 @@ void GFX_InitSdl()
 	set_sdl_hints();
 
 	// Initialise SDL (timer is needed for title bar animations)
-	if (SDL_InitSubSystem(SDL_INIT_AUDIO | SDL_INIT_VIDEO | SDL_INIT_TIMER) < 0) {
-		E_Exit("SDL: Can't init SDL %s", SDL_GetError());
+	if (SDL_InitSubSystem(SDL_INIT_VIDEO | SDL_INIT_TIMER) < 0) {
+		E_Exit("SDL: Failed to init SDL video and timer: %s", SDL_GetError());
 	}
 
 	if (is_using_kmsdrm_driver() && !check_kmsdrm_setting()) {
@@ -1733,12 +1733,11 @@ void GFX_InitSdl()
 	SDL_version sdl_version = {};
 	SDL_GetVersion(&sdl_version);
 
-	LOG_MSG("SDL: Version %d.%d.%d initialised (%s video and %s audio)",
+	LOG_MSG("SDL: Version %d.%d.%d initialised",
 	        sdl_version.major,
 	        sdl_version.minor,
-	        sdl_version.patch,
-	        SDL_GetCurrentVideoDriver(),
-	        SDL_GetCurrentAudioDriver());
+	        sdl_version.patch);
+	LOG_MSG("SDL: %s video initialised", SDL_GetCurrentVideoDriver());
 
 #ifdef MACOSX
 	// Check for .dosbox document packages dropped from Finder


### PR DESCRIPTION
# Description

Advantage of this is failing to init the audio subsystem is no longer a fatal error. We also don't attempt to init it at all if nosound = on.

# Manual testing

- nosound = on
- SDL_AUDIODRIVER=pipewire
- SDL_AUDIODRIVER=pulseaudio
- SDL_AUDIODRIVER=alsa

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [x] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

