### PR TITLE
meson: Fix a bad relative resource path on macOS

### DIFF
--- a/resources/meson.build
+++ b/resources/meson.build
@@ -46,7 +46,7 @@ resources = [
 #         - https://github.com/mesonbuild/meson/issues/7067
 #
 relative_resources = (
-    target_machine.system() == 'darwin' ? '../../Resources' : '../resources'
+    target_machine.system() == 'darwin' ? '../../../Resources' : '../resources'
 )
 
 # Top-level resources directory for the build and installation area


### PR DESCRIPTION
It appears to me that a recent fix[1] may have made things worse.

When I followed the build instructions from the readme I got this:

    > meson setup build
    The Meson build system
    Version: 1.10.0
    Source dir: /Users/kuba/projects/dosbox-staging
    Build dir: /Users/kuba/projects/dosbox-staging/build
    Build type: native build
    Project name: dosbox-staging
    Project version: 0.83.0-alpha
    C compiler for the host machine: /opt/homebrew/bin/ccache cc (clang 16.0.0 "Apple clang version 16.0.0 (clang-1600.0.26.6)")
    C linker for the host machine: cc ld64 1115.7.3
    C++ compiler for the host machine: /opt/homebrew/bin/ccache c++ (clang 16.0.0 "Apple clang version 16.0.0 (clang-1600.0.26.6)")
    C++ linker for the host machine: c++ ld64 1115.7.3
    Host machine cpu family: aarch64
    Host machine cpu: aarch64
    Configuring disk-noises with command
    Configuring fdd_seek1.flac with command

    resources/meson.build:72:8: ERROR: Command `/usr/bin/install -m 644 /Users/kuba/projects/dosbox-staging/resources/disk-noises/fdd_seek1.flac /Users/kuba/projects/dosbox-staging/build/resources/../../Resources/disk-noises/fdd_seek1.flac` failed with status 64.

This is because a non-existent file was attempted to be copied (and to its own location too).

With this patch the build works.

[1] d2a14f52407c ("build: Fix Meson build")


# Manual testing

...

The change has been manually tested on:

- [ ] Windows
- [x] macOS
- [ ] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [ ] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

