### PR TITLE
Fix PVS-Studio warnings

### DIFF
--- a/src/capture/capture_video.cpp
+++ b/src/capture/capture_video.cpp
@@ -463,9 +463,11 @@ void capture_video_add_frame(const RenderedImage& image, const float frames_per_
 	static uint8_t palette_data[NumVgaColors * 4] = {};
 
 	for (auto i = 0; i < NumVgaColors; ++i) {
-		palette_data[i * 4]     = image.palette[i].red;
-		palette_data[i * 4 + 1] = image.palette[i].green;
-		palette_data[i * 4 + 2] = image.palette[i].blue;
+		const auto color = image.palette[i];
+
+		palette_data[i * 4]     = color.red;
+		palette_data[i * 4 + 1] = color.green;
+		palette_data[i * 4 + 2] = color.blue;
 	}
 
 	if (!video.codec->PrepareCompressFrame(codec_flags,

--- a/src/gui/render/render.cpp
+++ b/src/gui/render/render.cpp
@@ -43,16 +43,13 @@ static void check_palette()
 	}
 
 	for (auto i = render.pal.first; i <= render.pal.last; i++) {
-		uint8_t r = render.pal.rgb[i].red;
-		uint8_t g = render.pal.rgb[i].green;
-		uint8_t b = render.pal.rgb[i].blue;
+		const auto color = render.pal.rgb[i];
+		const auto new_color = GFX_MakePixel(color.red, color.green, color.blue);
 
-		uint32_t new_pal = GFX_MakePixel(r, g, b);
-
-		if (new_pal != render.pal.lut[i]) {
+		if (new_color != render.pal.lut[i]) {
 			render.pal.changed     = true;
 			render.pal.modified[i] = 1;
-			render.pal.lut[i]      = new_pal;
+			render.pal.lut[i]      = new_color;
 		}
 	}
 
@@ -64,9 +61,11 @@ static void check_palette()
 void RENDER_SetPalette(const uint8_t entry, const uint8_t red,
                        const uint8_t green, const uint8_t blue)
 {
-	render.pal.rgb[entry].red   = red;
-	render.pal.rgb[entry].green = green;
-	render.pal.rgb[entry].blue  = blue;
+	auto& color = render.pal.rgb[entry];
+
+	color.red   = red;
+	color.green = green;
+	color.blue  = blue;
 
 	if (render.pal.first > entry) {
 		render.pal.first = entry;


### PR DESCRIPTION
# Description

Fix the 3 warnings the slipped through while PVS was down.

# Manual testing

N/A

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [ ] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

