### PR TITLE
Add more metadata to the macOS executable for better observabilty

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,10 +92,22 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   add_compile_options("--param" "max-gcse-memory=250000")
 endif()
 
-# TODO: These are sprintf deprecated warnings.
-# We probably do want to remove sprintf usage at some point.
 if (APPLE)
+  # TODO: These are sprintf deprecated warnings. We probably do want to remove
+  # sprintf usage at some point.
   add_compile_options("-Wno-deprecated-declarations")
+
+  # This adds more metadata to the executable (about ~500KB) which is handy
+  # for profiling. It also results in better crash dumps. This does not affect
+  # performance at all.
+  add_compile_options("-g")
+
+  if (C_TARGETCPU STREQUAL "ARMV8LE")
+    # This has virtually zero performance impact on ARM and it gives us deep
+    # observability on release mode builds at full speed (e.g., when using a
+    # profiler).
+    add_compile_options("-fno-omit-frame-pointer")
+  endif()
 endif()
 
 option(OPT_DEBUGGER "Enable debugger" OFF)


### PR DESCRIPTION
# Description

Based on @kklobe 's tips; see commit message for details.

This is pretty amazing because we can connect the XCode Instruments profiler to the running release executable and get various stats using dtrace, _even_ on inlined functions! Best of all, if you don't attach the profiler, the performance hit is virtually non-existent (double-checked with the Quake benchmark), and with the profiler active it's just a few percents.

You can see on this screenshot that we get profiler info even on inlined functions (note the `inlined` badges next to some items). Pretty handy and it's for free! 🚀 

<img width="2032" height="1167" alt="image" src="https://github.com/user-attachments/assets/b6eb67b6-7b7c-47e8-8fbd-3830c71cf90a" />


# Manual testing

- Ran Quake bench on `main` and this branch — no performance regressions with the profiler _not_ attached
- With the profiler attached, there's a small preformance hit (a few percentages, e.g., 65 FPS on average instead of 69)
- We gets stats on all inlined functions in the profiler with the release executable


The change has been manually tested on:

- [ ] Windows
- [x] macOS
- [ ] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

