### PR TITLE
Unhardcode the layout of debugger windows

### DIFF
--- a/src/debugger/debugger_gui.cpp
+++ b/src/debugger/debugger_gui.cpp
@@ -179,23 +179,30 @@ static void DrawBars(void)
 		attrset(COLOR_PAIR(PAIR_BLACK_BLUE));
 	}
 	/* Show the Register bar */
-	mvaddstr(1 - 1, 0, "-----(Register Overview                   )-----                                ");
+	int outy = 1;
+	mvaddstr(outy - 1, 0, "-----(Register Overview                   )-----                                ");
 	/* Show the Data Overview bar perhaps with more special stuff in the end */
-	mvaddstr(6 - 1, 0, "-----(Data Overview   Scroll: page up/down)-----                                ");
+	outy += dbg.rows_registers + 1;
+	mvaddstr(outy - 1,
+	         0,
+	         "-----(Data Overview   Scroll: page up/down)-----                                ");
 	/* Show the Code Overview perhaps with special stuff in bar too */
-	mvaddstr(15 - 1,
+	outy += dbg.rows_data + 1;
+	mvaddstr(outy - 1,
 	         0,
 	         "-----(Code Overview   Scroll: up/down     )-----                                ");
 	/* Show the Variable Overview bar */
-	mvaddstr(27 - 1,
+	outy += dbg.rows_code + 1;
+	mvaddstr(outy - 1,
 	         0,
 	         "-----(Variable Overview                   )-----                                ");
 	/* Show the Output OverView */
-	mvaddstr(32 - 1,
+	outy += dbg.rows_output + 1;
+	mvaddstr(outy - 1,
 	         0,
 	         "-----(Output          Scroll: home/end    )-----                                ");
 	attrset(0);
-	// Match values with below. So we don't need to touch the internal
+	// Use height values in rows. So we don't need to touch the internal
 	// window structures
 }
 
@@ -205,21 +212,22 @@ static void MakeSubWindows(void)
 	/* Make all the subwindows */
 	int win_main_maxy, win_main_maxx;
 	getmaxyx(dbg.win_main, win_main_maxy, win_main_maxx);
-	int outy = 1; // Match values with above
+	int outy = 1;
 	/* The Register window  */
-	dbg.win_reg = subwin(dbg.win_main, 4, win_main_maxx, outy, 0);
-	outy += 5; // 6
+	dbg.win_reg = subwin(dbg.win_main, dbg.rows_registers, win_main_maxx, outy, 0);
+	outy += dbg.rows_registers + 1;
 	/* The Data Window */
-	dbg.win_data = subwin(dbg.win_main, 8, win_main_maxx, outy, 0);
-	outy += 9; // 15
+	dbg.win_data = subwin(dbg.win_main, dbg.rows_data, win_main_maxx, outy, 0);
+	outy += dbg.rows_data + 1;
 	/* The Code Window */
-	dbg.win_code = subwin(dbg.win_main, 11, win_main_maxx, outy, 0);
-	outy += 12; // 27
+	dbg.win_code = subwin(dbg.win_main, dbg.rows_code, win_main_maxx, outy, 0);
+	outy += dbg.rows_code + 1;
 	/* The Variable Window */
-	dbg.win_var = subwin(dbg.win_main, 4, win_main_maxx, outy, 0);
-	outy += 5; // 32
+	dbg.win_var = subwin(dbg.win_main, dbg.rows_variables, win_main_maxx, outy, 0);
+	outy += dbg.rows_variables + 1;
 	/* The Output Window */
-	dbg.win_out = subwin(dbg.win_main, win_main_maxy - outy, win_main_maxx, outy, 0);
+	dbg.rows_output = win_main_maxy - outy; /* Use the rest of window */
+	dbg.win_out = subwin(dbg.win_main, dbg.rows_output, win_main_maxx, outy, 0);
 	if (!dbg.win_reg || !dbg.win_data || !dbg.win_code || !dbg.win_var ||
 	    !dbg.win_out) {
 		E_Exit("Setting up windows failed");
@@ -347,6 +355,20 @@ void DBGUI_StartUp(void)
 	old_cursor_state = curs_set(0);
 	start_color();
 	cycle_count = 0;
+
+	// calculate minimum required size (in rows)
+	auto min_size = 1 + dbg.rows_registers
+	              + 1 + dbg.rows_data
+	              + 1 + dbg.rows_code
+	              + 1 + dbg.rows_variables
+	              + 1 + dbg.rows_output;
+
+	if (getmaxy(dbg.win_main) - min_size <= 0) {
+		LOG_ERR("DEBUG: Couldn't fit layout elements, screen size is too small");
+		dbg.win_main = NULL;
+		endwin();
+		return;
+	}
 
 	MakePairs();
 	MakeSubWindows();

--- a/src/debugger/debugger_inc.h
+++ b/src/debugger/debugger_inc.h
@@ -27,6 +27,12 @@ struct DBGBlock {
 	uint32_t active_win = 0;    /* Current active window */
 	uint32_t input_y = 0;
 	uint32_t global_mask = 0; /* Current msgmask */
+	/* Window height values in rows */
+	int32_t rows_registers = 4; /* Registers window height */
+	int32_t rows_data = 8;      /* Data Output window height */
+	int32_t rows_code = 11;     /* Disassembly/Debug point window height */
+	int32_t rows_variables = 4; /* Variable window height */
+	int32_t rows_output = 0;    /* Text Output window height, calculated dynamically */
 };
 
 struct DASMLine {


### PR DESCRIPTION
# Description

Currently the layout of debugger windows is hardcoded in several places.
Unhardcode it by using array of window sizes (in rows).

No behavior changes introduced, except an early quit when the screen size does not fit all windows.

This is preparation for a fix of bug reported in #4140.


## Related issues

- #4140


# Manual testing

- Run `dosbox_with_debugger` as usual, enter the debugger, no behavior changes were introduced

The change has been manually tested on:

- [x] Windows
- [ ] macOS
- [ ] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [ ] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

