### PR TITLE
Add mouse hack for 'Joan of Arc: Siege & the Sword' game on Hercules machine

### DIFF
--- a/src/hardware/input/mouse_config.cpp
+++ b/src/hardware/input/mouse_config.cpp
@@ -213,8 +213,9 @@ static void set_serial_mouse_model(const std::string_view model_str)
 
 static void set_dos_driver_options(const std::string_view options_str)
 {
-	const std::string OptionImmediate = "immediate";
-	const std::string OptionModern    = "modern";
+	const std::string OptionImmediate     = "immediate";
+	const std::string OptionModern        = "modern";
+	const std::string OptionNoGranularity = "no-granularity";
 
 	auto& last_options_str = mouse_config.dos_driver_last_options_str;
 	if (last_options_str == options_str) {
@@ -222,14 +223,17 @@ static void set_dos_driver_options(const std::string_view options_str)
 	}
 	last_options_str = options_str;
 
-	mouse_config.dos_driver_immediate = false;
-	mouse_config.dos_driver_modern    = false;
+	mouse_config.dos_driver_immediate      = false;
+	mouse_config.dos_driver_modern         = false;
+	mouse_config.dos_driver_no_granularity = false;
 
 	for (const auto& token : split(options_str, " ,")) {
 		if (token == OptionImmediate) {
 			mouse_config.dos_driver_immediate = true;
 		} else if (token == OptionModern) {
 			mouse_config.dos_driver_modern = true;
+		} else if (token == OptionNoGranularity) {
+			mouse_config.dos_driver_no_granularity = true;
 		} else {
 			LOG_WARNING(
 			        "MOUSE: Invalid 'builtin_dos_mouse_driver_options' "
@@ -592,18 +596,25 @@ static void init_mouse_config_settings(SectionProp& secprop)
 	        "Additional built-in DOS mouse driver settings as a list of space or comma\n"
 	        "separated options (unset by default). Possible values:\n"
 	        "\n"
-	        "  immediate:  Update mouse movement counters immediately, without waiting for\n"
-	        "              interrupt. May improve mouse latency in fast-paced games (arcade,\n"
-	        "              FPS, etc.), but might cause issues in some titles.\n"
-	        "              List of known incompatible games:\n"
-	        "                - Ultima Underworld: The Stygian Abyss\n"
-	        "                - Ultima Underworld II: Labyrinth of Worlds\n"
-	        "              Please report other incompatible games so we can update this list.\n"
+	        "  immediate:       Update mouse movement counters immediately, without waiting\n"
+	        "                   for interrupt. May improve mouse latency in fast-paced games\n"
+	        "                   (arcade, FPS, etc.), but might cause issues in some titles.\n"
+	        "                   List of known incompatible games:\n"
+	        "                     - Ultima Underworld: The Stygian Abyss\n"
+	        "                     - Ultima Underworld II: Labyrinth of Worlds\n"
+	        "                   Please report other incompatible games so we can update this\n"
+	        "                   list.\n"
 	        "\n"
-	        "  modern:     If provided, v7.0+ Microsoft mouse driver behaviour is emulated,\n"
-	        "              otherwise the v6.0 and earlier behaviour (the two are slightly\n"
-	        "              incompatible). Only Descent II with the official Voodoo patch has\n"
-	        "              been found to require the v7.0+ behaviour so far.");
+	        "  modern:          If provided, v7.0+ Microsoft mouse driver behaviour is\n"
+	        "                   emulated, otherwise the v6.0 and earlier behaviour (the two\n"
+	        "                   are slightly incompatible). Only 'Descent II' with the\n"
+	        "                   official Voodoo patch has been found to require the v7.0+\n"
+	        "                   behaviour so far.\n"
+	        "\n"
+	        "  no-granularity:  Disables the mouse position granularity. Only enable if the\n"
+	        "                   game needs it. Only 'Joan of Arc: Siege & the Sword' in\n"
+	        "                   Hercules mode has been found to require disabled granularity\n"
+	        "                   so far.");
 
 	prop_bool = secprop.AddBool("dos_mouse_immediate", Deprecated, false);
 	prop_bool->SetHelp("Configure using [color=light-green]'builtin_dos_mouse_driver_options'[reset].");

--- a/src/hardware/input/mouse_config.h
+++ b/src/hardware/input/mouse_config.h
@@ -79,8 +79,9 @@ struct MouseConfig {
 	bool dos_driver_autoexec = false;
 	bool dos_driver_no_tsr   = false;
 
-	bool dos_driver_modern    = false;
-	bool dos_driver_immediate = false;
+	bool dos_driver_modern         = false;
+	bool dos_driver_immediate      = false;
+	bool dos_driver_no_granularity = false;
 
 	std::string dos_driver_last_options_str = {};
 

--- a/src/hardware/input/mouseif_dos_driver.cpp
+++ b/src/hardware/input/mouseif_dos_driver.cpp
@@ -310,6 +310,9 @@ static uint16_t get_pos_x()
 	MouseDriverState state(*state_segment);
 
 	const auto pos_x = static_cast<uint16_t>(std::lround(state.GetPosX()));
+	if (mouse_config.dos_driver_no_granularity) {
+		return pos_x;
+	}
 	return pos_x & state.GetGranularityX();
 }
 
@@ -318,6 +321,9 @@ static uint16_t get_pos_y()
 	MouseDriverState state(*state_segment);
 
 	const auto pos_y = static_cast<uint16_t>(std::lround(state.GetPosY()));
+	if (mouse_config.dos_driver_no_granularity) {
+		return pos_y;
+	}
 	return pos_y & state.GetGranularityY();
 }
 


### PR DESCRIPTION
# Description

Adds a mouse driver hack, allowing to run Joan of Arc game on Hercules machine with a properly functioning mouse.

It is based on experimentation and observation of the game behavior; I have found no mouse driver compatible with this game (they cause the same problems as the current DOSBox Staging main branch) , so I was forced to guess what the game needs.


## Related issues

Fixes https://github.com/dosbox-staging/dosbox-staging/issues/4263


# Release notes

Added a mouse driver hack, allowing to run 'Joan of Arc: Siege & the Sword' game on Hercules machine with a properly functioning mouse (without constant mouse cursor drift upwards). Enable it by setting `builtin_dos_mouse_driver_options = no-granularity`.


# Manual testing

Set `builtin_dos_mouse_driver_options = no-granularity` and `machine = hercules`, start Joan of Arc game - the mouse pointer should work.

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [x] Linux


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [x] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

