### PR TITLE
Improve `window_size` and `window_position` help text

### DIFF
--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -2650,13 +2650,17 @@ static void init_sdl_config_settings(SectionProp& section)
 	        "resize the window after startup. Possible values:\n"
 	        "\n"
 	        "  default:   Select the best option based on your environment and other\n"
-	        "             settings (such as whether aspect ratio correction is enabled).\n"
+	        "             factors (such as whether aspect ratio correction is enabled).\n"
 	        "\n"
 	        "  small, medium, large (s, m, l):\n"
 	        "             Size the window relative to the desktop.\n"
 	        "\n"
-	        "  WxH:       Specify window size in WxH format in logical units\n"
-	        "             (e.g., 1024x768).");
+	        "  WxH:       Specify window size in WxH format in logical units (e.g.,\n"
+	        "             1024x768). The values be multiplied by the OS-level DPI scaling to\n"
+	        "             get the window size in pixels.\n"
+	        "\n"
+	        "Note: If you want to use pixel coordinates instead and ignore DPI scaling, set\n"
+	        "      the SDL_WINDOWS_DPI_SCALING environment variable to 0.");
 
 	pstring = section.AddString("window_position", Always, "auto");
 	pstring->SetHelp(
@@ -2666,7 +2670,12 @@ static void init_sdl_config_settings(SectionProp& section)
 	        "  auto:      Let the window manager decide the position (default).\n"
 	        "\n"
 	        "  X,Y:       Set window position in X,Y format in logical units (e.g., 250,100).\n"
-	        "             0,0 is the top-left corner of the screen.");
+	        "             0,0 is the top-left corner of the screen. The values will be\n"
+	        "             multiplied by the OS-level DPI scaling to get the window position\n"
+	        "             in pixels.\n"
+	        "\n"
+	        "Note: If you want to use pixel coordinates instead and ignore DPI scaling, set\n"
+	        "      the SDL_WINDOWS_DPI_SCALING environment variable to 0.");
 
 	pbool = section.AddBool("window_decorations", Always, true);
 	pbool->SetHelp("Enable window decorations in windowed mode ('on' by default).");


### PR DESCRIPTION
# Description

Added extra clarification about our use of logical units for the `window_size` & `window_position` settings.

## Related issues

- https://github.com/dosbox-staging/dosbox-staging/issues/4694

# Manual testing

- Tested `set SDL_WINDOWS_DPI_SCALING=0` before starting Staging then setting `window_size` & `window_setting (with 200% DPI scaling on a 4K monitor). 
- Updated help text:

<img width="2138" height="1660" alt="image" src="https://github.com/user-attachments/assets/694d5cd6-49d9-44c1-b7f1-cf00c3c37121" />




The change has been manually tested on:

- [x] Windows
- [ ] macOS
- [ ] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

