### PR TITLE
Restrict usage of warning flags only with compatible compilers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,9 +69,6 @@ else()
         ${WARNING_FLAGS_C}
         "-Winvalid-utf8"
         "-Wtrivial-auto-var-init"
-        "-Wdeprecated-non-prototype"
-        "-Wflex-array-member-not-at-end"
-        "-Wfree-labels"
     )
     set(WARNING_FLAGS_CXX
         ${WARNING_FLAGS_CXX}
@@ -80,6 +77,18 @@ else()
     )
   endif()
 
+  if ((CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND
+       CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 15)
+       OR
+       (CMAKE_CXX_COMPILER_ID STREQUAL "Clang"))
+
+    set(WARNING_FLAGS_C
+            ${WARNING_FLAGS_C}
+            "-Wdeprecated-non-prototype"
+            "-Wflex-array-member-not-at-end"
+            "-Wfree-labels"
+    )
+  endif()
 
   add_compile_options(
     "$<$<COMPILE_LANGUAGE:C>:${WARNING_FLAGS_C}>"


### PR DESCRIPTION
# Description

This PR fixes the build files so that they use certain warning flags only when building with supported compilers. This was noticed when building with gcc 13 (the default compiler of Ubuntu 24.04), as loading the project produces the following warnings:

```
Problems were encountered while collecting compiler information:
	cc: error: unrecognized command-line option '-Wdeprecated-non-prototype'
	cc: error: unrecognized command-line option '-Wflex-array-member-not-at-end'
	cc: error: unrecognized command-line option '-Wfree-labels'
```

If building the main executable is attempted, it fails complaining about those flags:

```
/home/farsil/.local/share/JetBrains/Toolbox/apps/clion/bin/cmake/linux/x64/bin/cmake --build /home/farsil/Development/dosbox-staging/build/debug-linux --target dosbox -j 18
[222/336] Building C object src/libs/decoders/CMakeFiles/libdecoders.dir/flac.c.o
FAILED: src/libs/decoders/CMakeFiles/libdecoders.dir/flac.c.o 
/usr/bin/cc  -I/home/farsil/Development/dosbox-staging/src -I/home/farsil/Development/dosbox-staging/src/libs -I/home/farsil/Development/dosbox-staging/build/debug-linux/include -I/home/farsil/Development/dosbox-staging/src/libs/decoders/.. -isystem /home/farsil/Development/dosbox-staging/build/debug-linux/vcpkg_installed/x64-linux/include/opus -isystem /home/farsil/Development/dosbox-staging/build/debug-linux/vcpkg_installed/x64-linux/include -isystem /home/farsil/Development/dosbox-staging/build/debug-linux/vcpkg_installed/x64-linux/include/SDL2 -g -fdiagnostics-color=always -Wall -Wextra -Wdeprecated -Wno-unknown-warning-option -Wno-unknown-pragmas -Wno-conversion -Wno-narrowing -Wdisabled-optimization -Wduplicated-branches -Wtrampolines -Wvla -Wlogical-op -Wduplicated-cond -Wpointer-arith -Wredundant-decls -Wfloat-conversion -Wjump-misses-init -Wnested-externs -Wold-style-definition -Wstrict-prototypes -Wvariadic-macros -Winvalid-utf8 -Wtrivial-auto-var-init -Wdeprecated-non-prototype -Wflex-array-member-not-at-end -Wfree-labels --param max-gcse-memory=250000 -MD -MT src/libs/decoders/CMakeFiles/libdecoders.dir/flac.c.o -MF src/libs/decoders/CMakeFiles/libdecoders.dir/flac.c.o.d -o src/libs/decoders/CMakeFiles/libdecoders.dir/flac.c.o -c /home/farsil/Development/dosbox-staging/src/libs/decoders/flac.c
cc: error: unrecognized command-line option ‘-Wdeprecated-non-prototype’
cc: error: unrecognized command-line option ‘-Wflex-array-member-not-at-end’
cc: error: unrecognized command-line option ‘-Wfree-labels’
[239/336] Building CXX object CMakeFiles/libdosboxcommon.dir/src/shell/shell.cpp.o
ninja: build stopped: subcommand failed.
```

# Manual testing

I configured CLion with two different sets of presets, one with gcc 13 (default) and one with CLang 20. No problems with either set after the change.

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [x] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

