### PR TITLE
Exclude debugger-related files from non-debugger builds

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,7 +2,11 @@ add_subdirectory(audio)
 add_subdirectory(capture)
 add_subdirectory(config)
 add_subdirectory(cpu)
-add_subdirectory(debugger)
+
+if (OPT_DEBUGGER)
+  add_subdirectory(debugger)
+endif()
+
 add_subdirectory(dos)
 add_subdirectory(fpu)
 add_subdirectory(gui)

--- a/src/libs/CMakeLists.txt
+++ b/src/libs/CMakeLists.txt
@@ -4,7 +4,11 @@ add_subdirectory(ESFMu)
 add_subdirectory(loguru)
 add_subdirectory(manymouse)
 add_subdirectory(nuked)
-add_subdirectory(PDCurses)
+
+if (OPT_DEBUGGER)
+  add_subdirectory(PDCurses)
+endif()
+
 add_subdirectory(residfp)
 add_subdirectory(simde)
 add_subdirectory(tal-chorus)


### PR DESCRIPTION
# Description

As I was working on SDL3 migration, I got tripped up by the PDcurses SDL2 code, even when I wasn't compiling a debugger-enabled build, so I got rid of debugger-related code at the CMake level for non-debugger builds.

# Manual testing

Downloaded and ran the Windows debugger build artifact.

The change has been manually tested on:

- [x] Windows
- [x] macOS
- [ ] Linux


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

