### PR TITLE
Fix choice /t repeatedly pressing default key

### DIFF
--- a/src/gui/mapper.cpp
+++ b/src/gui/mapper.cpp
@@ -1238,7 +1238,7 @@ void MAPPER_AutoType(std::vector<std::string>& buttons, uint32_t wait_ms,
 	}
 }
 
-void MAPPER_StopAutoTyping()
+static void stop_auto_typing()
 {
 	auto_type_queue = {};
 	PIC_RemoveEvents(auto_type_queued_button);
@@ -2479,7 +2479,7 @@ static struct {
 
 static void ClearAllBinds()
 {
-	MAPPER_StopAutoTyping();
+	stop_auto_typing();
 
 	for (const auto& event : events) {
 		event->ClearBinds();
@@ -3158,7 +3158,7 @@ void MAPPER_DisplayUI() {
 
 void MAPPER_Destroy() {
 	// Stop any ongoing typing as soon as possible (because it access events)
-	MAPPER_StopAutoTyping();
+	stop_auto_typing();
 
 	// Release all the accumulated allocations by the mapper
 	events.clear();


### PR DESCRIPTION
# Description

It's a regression from 393e3923bb6af6a89f83692de23b5e91e18a4bfd but I think that commit is solid overall for Autotype's intended usecase.

Autotype leaves the key pressed for 50ms before releasing the key but `CMD_CHOICE` calls `MAPPER_StopAutoTyping()` immediately after reading the key which stops the key from ever being released.

I could write some extra logic into `MAPPER_StopAutoTyping()` or introduce a 50ms delay in `CMD_CHOICE` but I think the use of Autotype here is really just a hack.

Instead I'm using INT16 in a loop to check if a key has been pressed and break out early if a timeout is requested.

## Related issues

Fixes #4708

# Release notes

Fix choice /t repeating the default key if timeout is reached.

# Manual testing

`choice /t:n,2` and wait 2 seconds. The N key no longer goes on repeat.

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [x] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [x] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

