### PR TITLE
Fix false positive key check in Windows console read multitasking subroutine

### DIFF
--- a/src/dos/dev_con.h
+++ b/src/dos/dev_con.h
@@ -89,7 +89,7 @@ bool device_CON::Read(uint8_t* data, uint16_t* size)
 			while (true) {
 				reg_ah = is_machine_ega_or_better() ? 0x11 : 0x1;
 				CALLBACK_RunRealInt(0x16);
-				if (reg_ax != 0) {
+				if (!(cpu_regs.flags & FLAG_ZF)) {
 					break;
 				}
 				WINDOWS_ReleaseTimeSlice();


### PR DESCRIPTION
# Description

This Windows specific loop was written by @FeralChild64  in 516cb5a542

This code is entirely untested but while working on #4716 using this same INT16 function, I had a lot of false positives when I tried checking the AX register so I'm fairly certain this code will have the same problems. The only observable problem here would be not releasing the time slice as often as you should and I have no idea how to test that and really don't use Windows at all.

The INT16 handler in `bios_keyboard.cpp` sticks whatever was in the head of the keyboard buffer into AX and it may or may not be zero. I'm not sure if this behavior is accurate to real DOS or not but we do accurately clear the zero flag when a key has been pressed.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [ ] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [ ] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

