### PR TITLE
Implement auto config option for file_locking

### DIFF
--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -1993,12 +1993,18 @@ static void init_dos_settings(SectionProp& section)
 	        "tab-separated format, used by SETVER.EXE as a persistent storage (empty by\n"
 	        "default).");
 
-	pbool = section.AddBool("file_locking", WhenIdle, true);
-	pbool->SetHelp(
-	        "Enable file locking via emulating SHARE.EXE ('on' by default). This is required\n"
+	pstring = section.AddString("file_locking", WhenIdle, "auto");
+	pstring->SetValues({"auto", "on", "off"});
+	pstring->SetHelp(
+	        "Enable file locking via emulating SHARE.EXE ('auto' by default). This is required\n"
 	        "for some Windows 3.1x applications to work properly. It generally does not cause\n"
 	        "problems for DOS games except in rare cases (e.g., Astral Blur demo). If you\n"
-	        "experience crashes related to file permissions, you can try disabling this.");
+	        "experience crashes related to file permissions, you can try disabling this.\n"
+	        "Possible values:\n"
+	        "\n"
+	        "  auto:  Enable file locking only when Windows 3.1 is running.\n"
+	        "  on:    Always enable file locking.\n"
+	        "  off:   Always disable file locking.");
 }
 
 void DOS_AddConfigSection([[maybe_unused]] const ConfigPtr& conf)


### PR DESCRIPTION
# Description

Auto will enable file locking only when Windows 3.1 is running.  It is the new default option.

## Related issues

#4702

# Release notes

file_locking has a new default setting of "auto" which will only enable the feature when Windows 3.1 is running. The games we have tested that require this features are all Windows games. A few rare DOS games have been broken by this feature so it is now disabled by default when not running Windows.

# Manual testing

- Set `file_locking = auto`
- Launch Windows 3.1
- Confirmed Microsoft Word launches (requires file locking)
- Exited Windows
- Tested Falcon 3 Expansion: Operation Fighting Tiger from issue #4702 to confirm file locking automatically turned off
- Relaunched Windows
- Confirmed Microsoft Word still launches to confirm file locking turned back on

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [x] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [x] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

