### PR TITLE
Fix Output label in debugger

### DIFF
--- a/src/debugger/debugger_gui.cpp
+++ b/src/debugger/debugger_gui.cpp
@@ -197,7 +197,7 @@ static void DrawBars(void)
 	         0,
 	         "-----(Variable Overview                   )-----                                ");
 	/* Show the Output OverView */
-	outy += dbg.rows_output + 1;
+	outy += dbg.rows_variables + 1;
 	mvaddstr(outy - 1,
 	         0,
 	         "-----(Output          Scroll: home/end    )-----                                ");


### PR DESCRIPTION
# Description

#4691 caused incorrect placement of the Output label in the debugger.

# Manual testing

Screenshots before:
<img width="1280" height="1664" alt="CleanShot 2026-01-27 at 17 29 29@2x" src="https://github.com/user-attachments/assets/12ec59f0-af3e-4673-9f5f-4e92ae0565a6" />
<img width="1280" height="1664" alt="CleanShot 2026-01-27 at 17 29 46@2x" src="https://github.com/user-attachments/assets/1fba27ac-44db-4ceb-a0a7-baabacd2e8d5" />

after:
<img width="1280" height="1664" alt="CleanShot 2026-01-27 at 17 30 24@2x" src="https://github.com/user-attachments/assets/5b077bb7-5115-4b0c-91f8-c91297d08174" />
<img width="1280" height="1664" alt="CleanShot 2026-01-27 at 17 30 42@2x" src="https://github.com/user-attachments/assets/ce8b8848-b883-40e7-9655-51667206cf2c" />


The change has been manually tested on:

- [ ] Windows
- [x] macOS
- [ ] Linux


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

