### PR TITLE
Put all custom shader pragmas in multi-line comment blocks

### DIFF
--- a/resources/shaders/crt/crt-hyllian.glsl
+++ b/resources/shaders/crt/crt-hyllian.glsl
@@ -10,6 +10,8 @@
 // Ported from Libretro's GLSL shader crt-hyllian.glslp to DOSBox-compatible
 // format by Tyrells.
 
+/*
+
 #pragma parameter BEAM_PROFILE "BEAM PROFILE (BP)" 0.0 0.0 2.0 1.0
 #pragma parameter HFILTER_PROFILE "HORIZONTAL FILTER PROFILE [ HERMITE | CATMULL-ROM ]" 0.0 0.0 1.0 1.0
 #pragma parameter BEAM_MIN_WIDTH "Custom [If BP=0.00] MIN BEAM WIDTH" 0.95 0.0 1.0 0.01
@@ -23,6 +25,8 @@
 #pragma parameter INPUT_GAMMA "INPUT GAMMA" 2.4 0.0 5.0 0.1
 #pragma parameter OUTPUT_GAMMA "OUTPUT GAMMA" 2. 0.0 5.0 0.1
 #pragma parameter VSCANLINES "VERTICAL SCANLINES [ OFF | ON ]" 0.0 0.0 1.0 1.0
+
+*/
 
 /////////////////////////////////////////////////////////////////////////////
 

--- a/resources/shaders/crt/vga-1080p-fake-double-scan.glsl
+++ b/resources/shaders/crt/vga-1080p-fake-double-scan.glsl
@@ -3,6 +3,8 @@
 // SPDX-FileCopyrightText:  2020-2025 The DOSBox Staging Team
 // SPDX-License-Identifier: MIT
 
+/*
+
 #pragma force_single_scan
 
 #pragma parameter PHOSPHOR_LAYOUT "Phosphor Layout" 2.0 0.0 19.0 1.0
@@ -13,6 +15,8 @@
 #pragma parameter MASK_STRENGTH "Mask Strength" 0.10 0.0 1.0 0.1
 #pragma parameter GAMMA_INPUT "Gamma Input" 2.4 0.0 5.0 0.1
 #pragma parameter GAMMA_OUTPUT "Gamma Output" 2.62 0.0 5.0 0.1
+
+*/
 
 /////////////////////////////////////////////////////////////////////////////
 

--- a/resources/shaders/crt/vga-1080p.glsl
+++ b/resources/shaders/crt/vga-1080p.glsl
@@ -3,6 +3,8 @@
 // SPDX-FileCopyrightText:  2020-2025 The DOSBox Staging Team
 // SPDX-License-Identifier: MIT
 
+/*
+
 #pragma parameter SPOT_WIDTH "Spot Width" 0.85 0.0 1.0 0.05
 #pragma parameter SPOT_HEIGHT "Spot Height" 0.80 0.0 1.0 0.05
 #pragma parameter PHOSPHOR_LAYOUT "Phosphor Layout" 2.0 0.0 19.0 1.0
@@ -13,6 +15,8 @@
 #pragma parameter MASK_STRENGTH "Mask Strength" 0.10 0.0 1.0 0.1
 #pragma parameter GAMMA_INPUT "Gamma Input" 2.4 0.0 5.0 0.1
 #pragma parameter GAMMA_OUTPUT "Gamma Output" 2.62 0.0 5.0 0.1
+
+*/
 
 /////////////////////////////////////////////////////////////////////////////
 

--- a/resources/shaders/interpolation/catmull-rom.glsl
+++ b/resources/shaders/interpolation/catmull-rom.glsl
@@ -18,8 +18,12 @@
  *	more details
  */
 
+/*
+
 #pragma force_single_scan
 #pragma force_no_pixel_doubling
+
+*/
 
 #if defined(VERTEX)
 

--- a/resources/shaders/interpolation/jinc2.glsl
+++ b/resources/shaders/interpolation/jinc2.glsl
@@ -9,8 +9,12 @@
 // Ported from Libretro's GLSL shader jinc2.glsl to DOSBox-compatible
 // format by Tyrells.
 
+/*
+
 #pragma force_single_scan
 #pragma force_no_pixel_doubling
+
+*/
 
 #define JINC2_WINDOW_SINC 0.44
 #define JINC2_SINC 0.82

--- a/resources/shaders/interpolation/nearest.glsl
+++ b/resources/shaders/interpolation/nearest.glsl
@@ -5,9 +5,13 @@
 // SPDX-FileCopyrightText:  2020-2020 jmarsh <jmarsh@vogons.org>
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+/*
+
 #pragma use_nearest_texture_filter
 #pragma force_single_scan
 #pragma force_no_pixel_doubling
+
+*/
 
 #if defined(VERTEX)
 

--- a/resources/shaders/interpolation/sharp.glsl
+++ b/resources/shaders/interpolation/sharp.glsl
@@ -5,8 +5,12 @@
 // SPDX-FileCopyrightText:  2020-2020 jmarsh <jmarsh@vogons.org>
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+/*
+
 #pragma force_single_scan
 #pragma force_no_pixel_doubling
+
+*/
 
 #if defined(VERTEX)
 

--- a/resources/shaders/scaler/advinterp2x.glsl
+++ b/resources/shaders/scaler/advinterp2x.glsl
@@ -4,8 +4,12 @@
 // SPDX-FileCopyrightText:  2004-2020 The DOSBox Team
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+/*
+
 #pragma force_single_scan
 #pragma force_no_pixel_doubling
+
+*/
 
 #if defined(VERTEX)
 

--- a/resources/shaders/scaler/advinterp3x.glsl
+++ b/resources/shaders/scaler/advinterp3x.glsl
@@ -4,8 +4,12 @@
 // SPDX-FileCopyrightText:  2004-2020 The DOSBox Team
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+/*
+
 #pragma force_single_scan
 #pragma force_no_pixel_doubling
+
+*/
 
 #if defined(VERTEX)
 

--- a/resources/shaders/scaler/advmame2x.glsl
+++ b/resources/shaders/scaler/advmame2x.glsl
@@ -4,8 +4,12 @@
 // SPDX-FileCopyrightText:  2003-2020 The DOSBox Team
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+/*
+
 #pragma force_single_scan
 #pragma force_no_pixel_doubling
+
+*/
 
 #if defined(VERTEX)
 

--- a/resources/shaders/scaler/advmame3x.glsl
+++ b/resources/shaders/scaler/advmame3x.glsl
@@ -4,8 +4,12 @@
 // SPDX-FileCopyrightText:  2004-2020 The DOSBox Team
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+/*
+
 #pragma force_single_scan
 #pragma force_no_pixel_doubling
+
+*/
 
 #if defined(VERTEX)
 

--- a/resources/shaders/scaler/xbr-lv2-3d.glsl
+++ b/resources/shaders/scaler/xbr-lv2-3d.glsl
@@ -9,6 +9,8 @@
 // Note from Hyllian:
 //   Incorporates some of the ideas from SABR shader. Thanks to Joshua Street.
 
+/*
+
 #pragma use_nearest_texture_filter
 #pragma force_single_scan
 #pragma force_no_pixel_doubling
@@ -19,6 +21,8 @@
 #pragma parameter XBR_RES "Internal Res Multiplier" 1.0 1.0 8.0 1.0
 #pragma parameter XBR_SCALE "xBR Scale" 3.0 1.0 5.0 1.0
 #pragma parameter XBR_CORNER_TYPE "Corner Calculation" 3.0 1.0 4.0 1.0
+
+*/
 
 #define mul(a,b) (b*a)
 #define saturate(c) clamp(c, 0.0, 1.0)

--- a/resources/shaders/scaler/xbr-lv2-noblend.glsl
+++ b/resources/shaders/scaler/xbr-lv2-noblend.glsl
@@ -6,6 +6,8 @@
 
 // Hyllian's xBR-lv2-noblend Shader
 
+/*
+
 #pragma use_nearest_texture_filter
 #pragma force_single_scan
 #pragma force_no_pixel_doubling
@@ -13,6 +15,8 @@
 #pragma parameter XBR_EQ_THRESHOLD "Eq Threshold" 0.6 0.0 2.0 0.1
 #pragma parameter XBR_LV2_COEFFICIENT "Lv2 Coefficient" 2.0 1.0 3.0 0.1
 #pragma parameter XBR_CORNER_TYPE "Corner Calculation" 1.0 1.0 4.0 1.0
+
+*/
 
 #define mul(a,b) (b*a)
 

--- a/resources/shaders/scaler/xbr-lv3.glsl
+++ b/resources/shaders/scaler/xbr-lv3.glsl
@@ -9,6 +9,8 @@
 // Note from Hyllian:
 //   Incorporates some of the ideas from SABR shader. Thanks to Joshua Street.
 
+/*
+
 #pragma use_nearest_texture_filter
 #pragma force_single_scan
 #pragma force_no_pixel_doubling
@@ -18,6 +20,8 @@
 #pragma parameter XBR_EQ_THRESHOLD2 "EQ Threshold 2" 2.0 0.0 4.0 1.0
 #pragma parameter XBR_LV2_COEFFICIENT "Lv2 Coefficient" 2.0 1.0 3.0 1.0
 #pragma parameter XBR_CORNER_TYPE "Corner Calculation" 3.0 1.0 3.0 1.0
+
+*/
 
 #if defined(VERTEX)
 


### PR DESCRIPTION
# Description

_Issue reported by **exmensa** on our Discord. The problem manifested on a Surface Pro 3 tablet running Windows with the old 2016 Intel OpenGL drivers._

GLSL compiler implementations should ignore unknown pragmas, but certain old Intel drivers seem to fail the shader compilation stage with an error if they encounter double-quote characters in custom pragma values.

Relevant part of the [GLSL 3.30 spec](https://registry.khronos.org/OpenGL/specs/gl/GLSLangSpec.3.30.pdf):

<img width="720" height="76" alt="image" src="https://github.com/user-attachments/assets/bedf97c5-8b74-4214-bc39-dec8079431c2" />

---

For example, pragmas like this that we use for encoding uniform parameters and their default values cause compilation errors on these buggy drivers:

    #pragma parameter BEAM_PROFILE "BEAM PROFILE (BP)" 0.0 0.0 2.0 1.0

The workaround is to enclose all custom pragmas in multi-line comment blocks (`/* ... */`) to make the driver ignore them.

# Manual testing

Fix confirmed by **exmensa**:

> Seems good- I renamed the appdata subfolder and uninstalled yesterday's build, made sure the folder was completely gone in program files, installed the new build - no errors and CRT shader looks intact.

The change has been manually tested on:

- [x] Windows
- [x] macOS
- [ ] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

