### PR TITLE
Remove Wine support from DOS to host filesystem code

### DIFF
--- a/src/dos/drive_cache.cpp
+++ b/src/dos/drive_cache.cpp
@@ -464,86 +464,6 @@ bool DOS_Drive_Cache::RemoveTrailingDot(char* shortname) {
 	return false;
 }
 
-#define WINE_DRIVE_SUPPORT 1
-#if WINE_DRIVE_SUPPORT
-//Changes to interact with WINE by supporting their namemangling.
-//The code is rather slow, because orglist is unordered, so it needs to be avoided if possible.
-//Hence the tests in GetLongFileName
-
-
-// From the Wine project
-static Bits wine_hash_short_file_name( char* name, char* buffer )
-{
-	constexpr char hash_chars[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ012345";
-
-	// returns '_' if invalid or upper case if valid.
-	auto replace_invalid = [](char c) -> char {
-		constexpr char invalid_chars[] = {'*',
-		                                  '?',
-		                                  '<',
-		                                  '>',
-		                                  '|',
-		                                  '"',
-		                                  '+',
-		                                  '=',
-		                                  ',',
-		                                  ';',
-		                                  '[',
-		                                  ']',
-		                                  ' ',
-		                                  '\345',
-		                                  '~',
-		                                  '.',
-		                                  '\0'};
-		const auto is_invalid = char_is_negative(c) ||
-		                        strchr(invalid_chars, c);
-		return is_invalid ? '_' : toupper(c);
-	};
-
-	char *p = nullptr;
-	char *ext = nullptr;
-	char *end = name + strlen(name);
-	char *dst = nullptr;
-	uint16_t hash = 0;
-	int i = 0;
-
-	// Compute the hash code of the file name
-	for (p = name, hash = 0xbeef; p < end - 1; p++)
-		hash = (hash<<3) ^ (hash>>5) ^ tolower(*p) ^ (tolower(p[1]) << 8);
-	hash = (hash<<3) ^ (hash>>5) ^ tolower(*p); // Last character
-
-	// Find last dot for start of the extension
-	for (p = name + 1, ext = nullptr; p < end - 1; p++) if (*p == '.') ext = p;
-
-	// Copy first 4 chars, replacing invalid chars with '_'
-	for (i = 4, p = name, dst = buffer; i > 0; i--, p++)
-	{
-		if (p == end || p == ext) {
-			break;
-		}
-		*dst++ = replace_invalid(*p);
-	}
-	// Pad to 5 chars with '~'
-	while (i-- >= 0)
-		*dst++ = '~';
-
-	// Insert hash code converted to 3 ASCII chars
-	*dst++ = hash_chars[(hash >> 10) & 0x1f];
-	*dst++ = hash_chars[(hash >> 5) & 0x1f];
-	*dst++ = hash_chars[hash & 0x1f];
-
-	// Copy the first 3 chars of the extension (if any)
-	if (ext) {
-		*dst++ = '.';
-		for (i = 3, ext++; (i > 0) && ext < end; i--, ext++) {
-			*dst++ = replace_invalid(*ext);
-		}
-	}
-
-	return dst - buffer;
-}
-#endif
-
 Bits DOS_Drive_Cache::GetLongName(CFileInfo* curDir, char* shortName, const size_t shortName_len) {
 	std::vector<CFileInfo*>::size_type filelist_size = curDir->fileList.size();
 	if (filelist_size <= 0) {
@@ -566,21 +486,6 @@ Bits DOS_Drive_Cache::GetLongName(CFileInfo* curDir, char* shortName, const size
 			return mid;
 		};
 	}
-#ifdef WINE_DRIVE_SUPPORT
-	if (strlen(shortName) < 8 || shortName[4] != '~' || shortName[5] == '.' || shortName[6] == '.' || shortName[7] == '.') return -1; // not available
-	// else it's most likely a Wine style short name ABCD~###, # = not dot  (length at least 8) 
-	// The above test is rather strict as the following loop can be really slow if filelist_size is large.
-	char buff[CROSS_LEN];
-	for (Bitu i = 0; i < filelist_size; i++) {
-		res = wine_hash_short_file_name(curDir->fileList[i]->orgname,buff);
-		buff[res] = 0;
-		if (!strcmp(shortName,buff)) {	
-			// Found
-			safe_strncpy(shortName, curDir->fileList[i]->orgname, shortName_len);
-			return (Bits)i;
-		}
-	}
-#endif
 	// not available
 	return -1;
 }


### PR DESCRIPTION
# Description

Wine integration has long been broken in Staging.
We've already explicitly removed part of it.
This remaining filesystem code is a legacy maintenance burden at this point.

## Related issues

Fixes #4742

# Release notes

Removed remaining Wine integration support (maybe just not mention it in release notes since it was already broken).

# Manual testing

Gave it a quick smoke test with a couple games and it seems fine. I think this is a pretty low risk change.

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [x] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

