### PR TITLE
ci: Bump Windows runner to VS2026

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -56,7 +56,7 @@ jobs:
     name:  Release ${{ matrix.conf.debugger && 'w/ debugger' || '' }} (${{ matrix.conf.arch }})
     if:    github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     needs: generate_release_notes
-    runs-on: windows-2022
+    runs-on: windows-2025-vs2026
     strategy:
       matrix:
         conf:
@@ -132,8 +132,8 @@ jobs:
         run: |
           set -x
           # Construct VC_REDIST_DIR
-          readonly VC_REDIST_BASE="C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Redist/MSVC"
-          readonly VC_REDIST_CRT_VERSION="Microsoft.VC143.CRT"
+          readonly VC_REDIST_BASE="C:/Program Files/Microsoft Visual Studio/18/Enterprise/VC/Redist/MSVC"
+          readonly VC_REDIST_CRT_VERSION="Microsoft.VC145.CRT"
 
           for ENTRY in "$VC_REDIST_BASE"/*
           do
@@ -245,7 +245,7 @@ jobs:
   build_installer:
     name:    Build installer (${{ matrix.arch }} )
     needs:   merge_artifacts
-    runs-on: windows-2022
+    runs-on: windows-2025-vs2026
     strategy:
       matrix:
         # We only provide x64 installers as ARM64 support is experimental

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -136,10 +136,46 @@
       }
     },
     {
+      "name": "debug-windows-vs2022",
+      "displayName": "Debug (Windows host CPU with VS2022)",
+      "description": "Configure for Debug build",
+      "generator": "Visual Studio 17 2022",
+      "binaryDir": "${sourceDir}/build/debug-windows-vs2022",
+      "cacheVariables": {
+        "CMAKE_GENERATOR_TOOLSET": "ClangCL",
+        "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
+        "CMAKE_FIND_PACKAGE_PREFER_CONFIG" : "ON",
+        "CMAKE_BUILD_TYPE": "Debug",
+        "RESOURCE_COPY_PATH": "/Resources"
+      },
+      "environment": {
+        "UseMultiToolTask": "true",
+        "EnforceProcessCountAcrossBuilds": "true"
+      }
+    },
+    {
+      "name": "release-windows-vs2022",
+      "displayName": "Release (Windows host CPU with VS2022)",
+      "description": "Configure for Release build",
+      "generator": "Visual Studio 17 2022",
+      "binaryDir": "${sourceDir}/build/release-windows-vs2022",
+      "cacheVariables": {
+        "CMAKE_GENERATOR_TOOLSET": "ClangCL",
+        "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
+        "CMAKE_FIND_PACKAGE_PREFER_CONFIG" : "ON",
+        "CMAKE_BUILD_TYPE": "Release",
+        "RESOURCE_COPY_PATH": "/Resources"
+      },
+      "environment": {
+        "UseMultiToolTask": "true",
+        "EnforceProcessCountAcrossBuilds": "true"
+      }
+    },
+    {
       "name": "debug-windows",
       "displayName": "Debug (Windows host CPU)",
       "description": "Configure for Debug build",
-      "generator": "Visual Studio 17 2022",
+      "generator": "Visual Studio 18 2026",
       "binaryDir": "${sourceDir}/build/debug-windows",
       "cacheVariables": {
         "IS_PRESET_USED" : "TRUE",
@@ -159,7 +195,7 @@
       "name": "release-windows",
       "displayName": "Release (Windows host CPU)",
       "description": "Configure for Release build",
-      "generator": "Visual Studio 17 2022",
+      "generator": "Visual Studio 18 2026",
       "binaryDir": "${sourceDir}/build/release-windows",
       "cacheVariables": {
         "IS_PRESET_USED" : "TRUE",
@@ -340,6 +376,22 @@
     {
       "name": "release-macos-x86_64",
       "configurePreset" : "release-macos-x86_64",
+      "configuration": "Release",
+      "output": {
+        "outputOnFailure": true
+      }
+    },
+    {
+      "name": "debug-windows-vs2022",
+      "configurePreset" : "debug-windows-vs2022",
+      "configuration": "Debug",
+      "output": {
+        "outputOnFailure": true
+      }
+    },
+    {
+      "name": "release-windows-vs2022",
+      "configurePreset" : "release-windows-vs2022",
       "configuration": "Release",
       "output": {
         "outputOnFailure": true


### PR DESCRIPTION
# Description

Bump the Windows runner and default CMake Windows presets to use VS 2026.

Created VS 2022 presets for those who haven't updated yet.

Since this isn't urgent and doesn't fix any issues, happy to wait to merge this post-0.83.

# Manual testing

Downloaded and ran the build artifacts on Windows 11.

The change has been manually tested on:

- [x] Windows
- [ ] macOS
- [ ] Linux


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

