### PR TITLE
Bump external DOSBox Staging deps version

### DIFF
--- a/.github/actions/set-common-vars/action.yml
+++ b/.github/actions/set-common-vars/action.yml
@@ -13,5 +13,5 @@ runs:
         DOSBOX_VERSION_AND_HASH=$(./scripts/ci/get-version.sh version-and-hash)
         echo "DOSBOX_VERSION_AND_HASH=$DOSBOX_VERSION_AND_HASH" >> $GITHUB_ENV
 
-        echo "VCPKG_EXT_DEPS_VERSION=v0.83.0-3" >> $GITHUB_ENV
+        echo "VCPKG_EXT_DEPS_VERSION=v0.83.0-4" >> $GITHUB_ENV
         echo "NUKED_SC55_CLAP_VERSION=v0.11.0" >> $GITHUB_ENV


### PR DESCRIPTION
# Description

No library updated, just keeping the vcpkg baseline in sync with Staging.

# Manual testing

Tested slirp networking can be enabled.

The change has been manually tested on:

- [ ] Windows
- [x] macOS
- [ ] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

