### PR TITLE
Docs: update Fedora build dep's in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ _¹ You can use plain old zlib instead._
 **Slirp** is built separately as a dynamic library (via
 vcpkg) and is loaded on-demand at runtime if available. Please refer to the
 [dosbox-staging-ext](https://github.com/dosbox-staging/dosbox-staging-ext)
-project for further details. To check the version of this dependency 
+project for further details. To check the version of this dependency
 included in our stable and dev build packages, check out the comments of the
 [releases packages](https://github.com/dosbox-staging/dosbox-staging-ext/releases) of
 the [dosbox-staging-ext](https://github.com/dosbox-staging/dosbox-staging-ext)
@@ -143,10 +143,10 @@ Install build dependencies appropriate for your OS:
 
 ``` shell
 # Fedora
-sudo dnf install ccache gcc-c++ meson alsa-lib-devel libatomic libpng-devel \
-                 SDL2-devel asio-devel opusfile-devel \
-                 fluidsynth-devel iir1-devel mt32emu-devel libslirp-devel \
-                 speexdsp-devel libXi-devel zlib-ng-devel
+sudo dnf install SDL2_image-devel alsa-lib-devel asio-devel ccache \
+                 fluidsynth-devel gcc-c++ gmock-devel iir1-devel libXi-devel \
+                 libatomic libpng-devel libslirp-devel meson mt32emu-devel \
+                 opusfile-devel speexdsp-devel zlib-ng-devel
 ```
 
 ``` shell


### PR DESCRIPTION
# Description

Update Fedora build dependencies in README.md

- `SDL2-devel` -> `SDL2_image-devel`
- add `gmock-devel`

## Related issues

See issue [4767](https://github.com/dosbox-staging/dosbox-staging/issues/4767)

# Manual testing

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [X ] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [X] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [X] performed a self-review of my code.
- [] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [ ] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [X] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [X] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

