### PR TITLE
build: Add meson build files for REST API.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1205,6 +1205,7 @@ subdir('src/ints')
 subdir('src/midi')
 subdir('src/shell')
 subdir('src/utils')
+subdir('src/webserver')
 
 # debugger-specific libs
 if get_option('enable_debugger') != 'none'

--- a/src/webserver/meson.build
+++ b/src/webserver/meson.build
@@ -1,0 +1,19 @@
+libwebserver_sources = [
+    'bridge.cpp',
+    'cpu.cpp',
+    'dos.cpp',
+    'memory.cpp',
+    'webserver.cpp',
+]
+
+libwebserver = static_library(
+    'webserver',
+    libwebserver_sources,
+    include_directories: incdir,
+    dependencies: [],
+    cpp_args: warnings,
+)
+
+libwebserver_dep = declare_dependency(link_with: libwebserver)
+
+internal_deps += libwebserver_dep


### PR DESCRIPTION
# Description

The meson build system lacks a build file for src/webservice. This adds this and thus makes dosbox-staging build with meson again.

## Related issues

Not known.

# Manual testing

I simply used meson for building:

meson setup ../build
meson compile -C ../build

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [x] Linux


# Checklist

Sorry for not doing all of this. But I thought this change is simple enough and might help people using meson instead of CMake.

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [ ] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [ ] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

