### PR TITLE
Fix handling of LOCK combined with other prefixes

### DIFF
--- a/src/cpu/core_dynrec/decoder.h
+++ b/src/cpu/core_dynrec/decoder.h
@@ -707,8 +707,9 @@ static CacheBlock *CreateCacheBlock(CodePageHandler *codepage, PhysPt start, Bit
 
 		case 0x90:	// nop
 		case 0x9b:	// wait
-		case 0xf0:	// lock
 			break;
+		case 0xf0:	// lock
+			goto restart_prefix;
 
 		case 0x91:case 0x92:case 0x93:case 0x94:case 0x95:case 0x96:case 0x97:
 			dyn_xchg_ax(opcode&7);

--- a/src/cpu/core_full/load.h
+++ b/src/cpu/core_full/load.h
@@ -474,7 +474,7 @@ l_M_Ed:
 	case D_LOCK: /* FIXME: according to intel, LOCK should raise an exception if it's not followed by one of a small set of instructions;
 			probably doesn't matter for our purposes as it is a pentium prefix anyhow */
 		LOG(LOG_CPU,LOG_NORMAL)("CPU:LOCK");
-		goto nextopcode;
+		goto restartopcode;
 	case D_ENTERw:
 		{
 			Bitu bytes=Fetchw();

--- a/src/cpu/core_normal/prefix_none.h
+++ b/src/cpu/core_normal/prefix_none.h
@@ -943,7 +943,7 @@
 		break;
 	CASE_B(0xf0)												/* LOCK */
 		LOG(LOG_CPU,LOG_NORMAL)("CPU:LOCK"); /* FIXME: see case D_LOCK in core_full/load.h */
-		break;
+        goto restart_opcode;
 	CASE_B(0xf1)												/* ICEBP */
 		CPU_SW_Interrupt_NoIOPLCheck(1,GETIP);
 #if CPU_TRAP_CHECK

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -30,6 +30,7 @@ add_executable(dosbox_tests
     # stubs.cpp
     support_tests.cpp
     unicode_tests.cpp
+    multi_prefix_tests.cpp
 )
 
 # Disable some warnings for deliberately flawed test cases

--- a/tests/cpu_config_param.h
+++ b/tests/cpu_config_param.h
@@ -1,0 +1,39 @@
+#ifndef DOSBOX_CPU_CONFIG_PARAM_H
+#define DOSBOX_CPU_CONFIG_PARAM_H
+
+#include <string>
+#include <iostream>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+typedef Bits (*CpuRunner)(void);
+
+struct CpuConfig {
+	CpuRunner runner;
+	std::string test_name;
+	std::string config_cpu;
+	std::string config_cpu_type = "auto";
+};
+
+std::ostream& operator<<(std::ostream& os, const CpuConfig& cfg)
+{
+	return os << cfg.test_name;
+}
+
+const auto AllCpuConfigs = testing::Values(
+#if (C_DYNREC)
+        CpuConfig{CPU_Core_Dynrec_Run, "Dynrec", "dynamic"},
+#endif
+#if (C_DYNAMIC_X86)
+        CpuConfig{CPU_Core_Dyn_X86_Run, "Dyn_X86", "dynamic"},
+#endif
+        CpuConfig{CPU_Core_Normal_Run, "Normal", "normal"},
+        CpuConfig{CPU_Core_Simple_Run, "Simple", "simple"},
+        CpuConfig{CPU_Core_Full_Run, "Full", "full"},
+        CpuConfig{CPU_Core_Prefetch_Run, "Prefetch", "normal", "386_prefetch"});
+
+} // namespace tests
+
+#endif

--- a/tests/multi_prefix_tests.cpp
+++ b/tests/multi_prefix_tests.cpp
@@ -1,0 +1,103 @@
+#include <gtest/gtest.h>
+
+#include "config/config.h"
+#include "cpu/cpu.h"
+#include "cpu/registers.h"
+#include "cpu_config_param.h"
+#include "dosbox_test_fixture.h"
+#include "memory.h"
+
+namespace {
+
+class MultiPrefixTest : public DOSBoxTestFixture,
+                        public testing::WithParamInterface<CpuConfig> {
+public:
+	void SetUp() override
+	{
+		const auto& cfg = GetParam();
+
+		DOSBoxTestFixture::SetUp();
+
+		set_section_property_value("cpu", "core", cfg.config_cpu);
+		set_section_property_value("cpu", "cputype", cfg.config_cpu_type);
+		CPU_Init();
+
+		reg_eip = 0x100;
+		clear_code_mem(reg_eip);
+	}
+
+private:
+	static constexpr uint32_t TestMemSize = 0x100;
+
+	void clear_code_mem(PhysPt start_addr)
+	{
+		for (PhysPt addr = start_addr; addr < start_addr + TestMemSize;
+		     ++addr) {
+			mem_writeb(addr, 0x90); // NOP
+		}
+	}
+};
+
+template <typename... Bytes>
+void mem_write(PhysPt addr, Bytes... bytes)
+{
+	(mem_writeb(addr++, static_cast<uint8_t>(bytes)), ...);
+}
+
+TEST_P(MultiPrefixTest, LockPrefixGcc)
+{
+	reg_eax = 0x10000;
+
+	// gcc -m16 -march=i386 generates this for prefix-increment on an
+	// _Atomic var 67 66 f0 ff 80 00 00 00 00  lock inc DWORD PTR [eax]
+	mem_write(reg_eip, 0x67, 0x66, 0xf0, 0xff, 0x80, 0x00, 0x00, 0x00, 0x00);
+	mem_writed(reg_eax, 0xDEADBEEF);
+	// Incorrect implementations will see this as multiple instructions
+	CPU_Cycles = 2;
+	GetParam().runner();
+
+	EXPECT_EQ(mem_readd(reg_eax), 0xDEADBEEF + 1);
+}
+
+TEST_P(MultiPrefixTest, LockPrefixReordered)
+{
+	reg_eax = 0x10000;
+
+	// lock inc DWORD PTR [eax] as assembled by Keystone, different prefix
+	// order
+	mem_write(reg_eip, 0xf0, 0x67, 0x66, 0xff, 0x80, 0x00, 0x00, 0x00, 0x00);
+	mem_writed(reg_eax, 0xDEADBEEF);
+
+	CPU_Cycles = 2;
+	GetParam().runner();
+
+	EXPECT_EQ(mem_readd(reg_eax), 0xDEADBEEF + 1);
+}
+
+TEST_P(MultiPrefixTest, AllPrefixes)
+{
+	if (GetParam().test_name == "Prefetch") {
+		GTEST_SKIP() << "Not supported on prefetch core (386 doesn't have CMPXCHG)";
+	}
+
+	reg_eax = 0xDEADBEEF;
+	reg_ebx = 0x10000;
+	reg_ecx = 0x12345678;
+	CPU_SetSegGeneral(SegNames::fs, 0x1);
+	PhysPt test_addr = SegPhys(SegNames::fs) + reg_ebx;
+
+	// Valid instruction, but unlikely to exist in any real old code
+	// 64 67 66 f0 0f b1 0b lock cmpxchg DWORD PTR fs:[ebx], ecx
+	mem_write(reg_eip, 0x64, 0x67, 0x66, 0xf0, 0x0f, 0xb1, 0x0b);
+	mem_writed(test_addr, reg_eax);
+
+	CPU_Cycles = 2;
+	GetParam().runner();
+
+	EXPECT_EQ(reg_eax, 0xDEADBEEF);
+	EXPECT_EQ(mem_readd(test_addr), reg_ecx);
+}
+
+INSTANTIATE_TEST_SUITE_P(CpuVariations, MultiPrefixTest, AllCpuConfigs);
+
+} // namespace


### PR DESCRIPTION
LOCK was handled as NOP but should be handled as a prefix. Example instruction that was emulated incorrectly:

67 F0 0F B0 08  lock cmpxchg BYTE PTR [eax], cl


