### PR TITLE
API: Add more control over allocation strategy

### DIFF
--- a/extras/api/api.d.ts
+++ b/extras/api/api.d.ts
@@ -49,7 +49,7 @@ export class DOSBoxApi {
 	writeMem(offset: string | number, data: Uint8Array): Promise<void>;
 	compareAndSwap(segment: string | number, offset: string | number, data: Uint8Array, expected: Uint8Array): Promise<Uint8Array?>;
 	compareAndSwap(offset: string | number, data: Uint8Array, expected: Uint8Array): Promise<Uint8Array?>;
-    alloc(sizeBytes: number, area?: 'conv' | 'UMA' | 'XMS'): Promise<AllocateResponse>;
+    alloc(sizeBytes: number, area?: 'conv' | 'UMA' | 'XMS', strategy?: 'best_fit' | 'first_fit' | 'last_fit'): Promise<AllocateResponse>;
     free(physicalAddress: number): Promise<void>;
     getDosInfo(): Promise<DosInfo>;
 }

--- a/extras/api/api.js
+++ b/extras/api/api.js
@@ -92,11 +92,11 @@ export class DOSBoxApi {
         return null;
     }
 
-    async alloc(sizeBytes, area = 'conv') {
+    async alloc(sizeBytes, area = 'conv', strategy = 'best_fit') {
         const res = await this._request('memory/allocate', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ size: sizeBytes, area: area })
+            body: JSON.stringify({ size: sizeBytes, area: area,  strategy: strategy })
         });
         return await res.json();
     }

--- a/resources/webserver/index.html
+++ b/resources/webserver/index.html
@@ -58,6 +58,7 @@
             <pre><code>{
     "size": size_bytes,
     "area": "conv"|"UMA"|"XMS
+    "strategy": "best_fit"|"first_fit"|"last_fit"
 }</code></pre>
             <p><strong>Response</strong></p>
             <pre><code>{
@@ -66,6 +67,10 @@
 
             <code>conv</code> and <code>UMA</code> allocate memory from DOS.
             <code>XMS</code> allocates raw pages and marks them as reserved for EMS and XMS.
+
+            <p><code>strategy</code> controls the allocator behavior, the default is <code>best_fit</code> which is almost always the best setting.
+            The other options will prefer lower/higer addresses in the selected area.</p>
+            <p>The XMS allocator only supports <code>best_fit</code>.</p>
 
             <h2 class="single">POST /api/memory/free</h2>
             <p>Frees allocated memory at the given address.</p>

--- a/src/webserver/dos.h
+++ b/src/webserver/dos.h
@@ -28,20 +28,25 @@ public:
 
 enum class MemoryArea { Conv, Uma, Xms };
 
+enum class AllocStrategy { FirstFit, BestFit, LastFit };
+
 class AllocMemoryCommand : public DebugCommand {
 public:
-	AllocMemoryCommand(const uint16_t bytes, const MemoryArea area)
+	AllocMemoryCommand(const uint16_t bytes, const MemoryArea area, const AllocStrategy strategy)
 	        : area(area),
+	          strategy(strategy),
 	          bytes(bytes)
+	          
 	{}
 
 	void Execute() override;
 	static void Post(const httplib::Request& req, httplib::Response& res);
 
 private:
-	MemoryArea area = {};
-	uint32_t addr   = 0;
-	uint16_t bytes  = 0;
+	MemoryArea area        = {};
+	AllocStrategy strategy = AllocStrategy::BestFit;
+	uint32_t addr          = 0;
+	uint16_t bytes         = 0;
 
 	void AllocDos();
 	void AllocXms();


### PR DESCRIPTION
# Description

The old version basically always acquired memory in the upper memory area which made the option rather pointless.

For weird reasons I need to allocate some memory in the first 64 KiB which turned out to be impossible with my first API.

# Manual testing

`http -v POST localhost:8080/api/memory/allocate size:=123 area=conv strategy=last_fit`
I have:

- [X] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [X] performed a self-review of my code.
- [X] commented on the particularly hard-to-understand areas of my code.
- [X] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [X] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [X] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [X] my change has been manually tested on Windows, macOS, and Linux.
- [X] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [X] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [X] provided the release notes draft (for significant user-facing changes).
- [X] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [X] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

