### PR TITLE
Use MOUNT command when auto-mounting CD images

### DIFF
--- a/src/shell/autoexec.cpp
+++ b/src/shell/autoexec.cpp
@@ -33,7 +33,6 @@ static const std::string CmdBoot          = "@Z:\\BOOT.COM ";
 static const std::string CmdConfig        = "@Z:\\CONFIG.COM ";
 static const std::string CmdMount         = "@Z:\\MOUNT.COM ";
 static const std::string CmdMouse         = "@Z:\\MOUSE.COM ";
-static const std::string CmdImgMount      = "@Z:\\IMGMOUNT.COM ";
 static const std::string CmdEchoOff       = "@ECHO OFF";
 static const std::string CmdSet           = "@SET ";
 static const std::string CmdSetPath       = "@SET PATH=";
@@ -644,7 +643,7 @@ std::string build_auto_mount_cd_images_cmd(const std::string_view dir_letter,
                                            const std::vector<std_fs::path>& image_paths,
                                            const std::optional<AutoMountSettings>& settings)
 {
-	auto command = CmdImgMount;
+	auto command = CmdMount;
 
 	if (!settings.has_value() || settings->override_drive.empty()) {
 		command += dir_letter;
@@ -724,7 +723,7 @@ void AutoExecModule::AutoMountDriveD(const std::string& cdrom_images,
                                      const Placement placement)
 {
 	AddLine(placement, CmdMount + "-u D" + ToNul);
-	AddLine(placement, CmdImgMount + "D " + cdrom_images + " -t iso" + ToNul);
+	AddLine(placement, CmdMount + "D " + cdrom_images + " -t iso" + ToNul);
 }
 
 void AutoExecModule::ReMountDirAsDriveC(const std::string& directory)


### PR DESCRIPTION
# Description

As per title.

@dividebysandwich forgot to update the internal mount command reference when we build the command sequence for the CD image auto-mounts. This resulted in the MOUNT deprecation warning always being raised for `drives/d`, etc. auto-mounts.

Example:

<img width="2023" height="111" alt="image" src="https://github.com/user-attachments/assets/4348718d-7817-4332-ab2c-0c287803e0c1" />


# Manual testing

1. Put some CD image into `drives/d` and start Staging from that directory.
2. The warning should be gone. 

The change has been manually tested on:

- [x] Windows
- [ ] macOS
- [ ] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

