### PR TITLE
Re-enable portamento handling for FluidSynth

### DIFF
--- a/src/midi/fluidsynth.cpp
+++ b/src/midi/fluidsynth.cpp
@@ -380,25 +380,15 @@ void MidiDeviceFluidSynth::SetChorusParams(const ChorusParameters& params)
 	// Apply setting to all groups
 	constexpr int FxGroup = -1;
 
-	fluid_synth_set_chorus_group_nr(synth.get(),
-									FxGroup,
-									params.voice_count);
+	fluid_synth_set_chorus_group_nr(synth.get(), FxGroup, params.voice_count);
 
-	fluid_synth_set_chorus_group_level(synth.get(),
-									   FxGroup,
-									   params.level);
+	fluid_synth_set_chorus_group_level(synth.get(), FxGroup, params.level);
 
-	fluid_synth_set_chorus_group_speed(synth.get(),
-									   FxGroup,
-									   params.speed);
+	fluid_synth_set_chorus_group_speed(synth.get(), FxGroup, params.speed);
 
-	fluid_synth_set_chorus_group_depth(synth.get(),
-	                                   FxGroup,
-	                                   params.depth);
+	fluid_synth_set_chorus_group_depth(synth.get(), FxGroup, params.depth);
 
-	fluid_synth_set_chorus_group_type(synth.get(),
-	                                  FxGroup,
-	                                  params.mod_wave);
+	fluid_synth_set_chorus_group_type(synth.get(), FxGroup, params.mod_wave);
 
 	LOG_MSG("FSYNTH: Chorus enabled with %d voices at level %.2f, "
 	        "%.2f Hz speed, %.2f depth, and %s-wave modulation",
@@ -519,21 +509,13 @@ void MidiDeviceFluidSynth::SetReverbParams(const ReverbParameters& params)
 	// Apply setting to all groups
 	constexpr int FxGroup = -1;
 
-	fluid_synth_set_reverb_group_roomsize(synth.get(),
-	                                      FxGroup,
-	                                      params.room_size);
+	fluid_synth_set_reverb_group_roomsize(synth.get(), FxGroup, params.room_size);
 
-	fluid_synth_set_reverb_group_damp(synth.get(),
-	                                  FxGroup,
-	                                  params.damping);
+	fluid_synth_set_reverb_group_damp(synth.get(), FxGroup, params.damping);
 
-	fluid_synth_set_reverb_group_width(synth.get(),
-	                                   FxGroup,
-	                                   params.width);
+	fluid_synth_set_reverb_group_width(synth.get(), FxGroup, params.width);
 
-	fluid_synth_set_reverb_group_level(synth.get(),
-	                                   FxGroup,
-	                                   params.level);
+	fluid_synth_set_reverb_group_level(synth.get(), FxGroup, params.level);
 
 	LOG_MSG("FSYNTH: Reverb enabled with a %.2f room size, "
 	        "%.2f damping, %.2f width, and level %.2f",
@@ -626,9 +608,7 @@ MidiDeviceFluidSynth::MidiDeviceFluidSynth()
 	const auto sample_rate_hz = MIXER_GetSampleRate();
 	ms_per_audio_frame        = MillisInSecond / sample_rate_hz;
 
-	fluid_settings_setnum(fluid_settings.get(),
-						  "synth.sample-rate",
-						  sample_rate_hz);
+	fluid_settings_setnum(fluid_settings.get(), "synth.sample-rate", sample_rate_hz);
 
 	FluidSynthPtr fluid_synth(new_fluid_synth(fluid_settings.get()),
 	                          delete_fluid_synth);
@@ -644,8 +624,8 @@ MidiDeviceFluidSynth::MidiDeviceFluidSynth()
 
 	constexpr auto ResetPresets = true;
 	if (fluid_synth_sfload(fluid_synth.get(),
-						   sf_path.string().c_str(),
-						   ResetPresets) == FLUID_FAILED) {
+	                       sf_path.string().c_str(),
+	                       ResetPresets) == FLUID_FAILED) {
 
 		const auto msg = format_str("FSYNTH: Error loading SoundFont '%s'",
 		                            sf_name.c_str());
@@ -678,9 +658,8 @@ MidiDeviceFluidSynth::MidiDeviceFluidSynth()
 
 	// Use a 7th-order (highest) polynomial to generate MIDI channel
 	// waveforms
-	fluid_synth_set_interp_method(fluid_synth.get(),
-								  FxGroup,
-								  FLUID_INTERP_HIGHEST);
+	fluid_synth_set_interp_method(fluid_synth.get(), FxGroup, FLUID_INTERP_HIGHEST);
+
 	// Always use XG/GS mode which emulates the concave curve specific to
 	// the Roland Sound Canvas family of sound modules. In this mode the
 	// portamento time is 7 bits wide, using only CC5, and the concave curve
@@ -688,7 +667,6 @@ MidiDeviceFluidSynth::MidiDeviceFluidSynth()
 	// Roland SC-55 v1.21 hardware unit.
 	fluid_synth_set_portamento_time_mode(fluid_synth.get(),
 	                                     FLUID_PORTAMENTO_TIME_MODE_XG_GS);
-
 
 	SetChorus();
 	SetReverb();
@@ -925,13 +903,13 @@ void MidiDeviceFluidSynth::RenderAudioFramesToFifo(const int num_audio_frames)
 	}
 
 	fluid_synth_write_float(synth.get(),
-							num_audio_frames,
-							&audio_frames[0][0],
-							0,
-							2,
-							&audio_frames[0][0],
-							1,
-							2);
+	                        num_audio_frames,
+	                        &audio_frames[0][0],
+	                        0,
+	                        2,
+	                        &audio_frames[0][0],
+	                        1,
+	                        2);
 
 	audio_frame_fifo.BulkEnqueue(audio_frames, num_audio_frames);
 }

--- a/src/midi/private/fluidsynth.h
+++ b/src/midi/private/fluidsynth.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText:  2020-2025 The DOSBox Staging Team
+// SPDX-FileCopyrightText:  2020-2026 The DOSBox Staging Team
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #ifndef DOSBOX_FLUIDSYNTH_H


### PR DESCRIPTION
# Description

Addresses https://github.com/dosbox-staging/dosbox-staging/issues/4540

## Related issues

- https://github.com/dosbox-staging/dosbox-staging/pull/2705
- https://github.com/dosbox-staging/dosbox-staging/issues/2701

# Release notes

Previously, we did not send portamento MIDI messages (CC 5, 64 & 84) to FluidSynth because it was not able to emulate the special concave portamento curve used on the Roland Sound Canvas family of sound modules. The linear portameno of FluidSynth made certain tunes sound way out of tune (e.g., Descent Level 08), so this was the best overall option.

FluidSynth 2.5.0 introduced a special `xg-gs` portamento time mode which faithfully emulates Sound Canvas style portamento (based on reverse-engineering the behaviour of real hardware), so with that enabled we we're sending the portamento messages again.


# Manual testing

1. Start Descent
2. Enter cheat mode by typing `gabbagabbahey`
3. Enter level select dialog by typing `farmerjoe`, then jump to level 8 by typing `8` followed by `Enter`.
4. Wait until the main synth instrument starts playing -- it should not be out-of-tune, and there's a subtle portamento at the start of the notes.

The change has been manually tested on:

- [x] Windows
- [ ] macOS
- [ ] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

