### PR TITLE
Address PVS warnings

### DIFF
--- a/src/misc/rwqueue.cpp
+++ b/src/misc/rwqueue.cpp
@@ -172,10 +172,9 @@ size_t RWQueue<T>::BulkEnqueue(std::vector<T>& from_source, const size_t num_req
 		if (is_running) {
 			const auto source_end = source_start +
 			                        static_cast<difference_t>(num_items);
-			queue.insert(queue.end(),
-			             std::move_iterator(source_start),
-			             std::move_iterator(source_end));
-
+			for (auto it = source_start; it != source_end; ++it) {
+				queue.emplace_back(std::move(*it));
+			}
 			// notify the first waiting thread that we have an item
 			lock.unlock();
 			has_items.notify_one();
@@ -219,7 +218,9 @@ size_t RWQueue<T>::NonblockingBulkEnqueue(std::vector<T>& from_source,
 	const auto source_start = from_source.begin();
 	const auto source_end = from_source.begin() + num_items;
 
-	queue.insert(queue.end(), std::move_iterator(source_start), std::move_iterator(source_end));
+	for (auto it = source_start; it != source_end; ++it) {
+		queue.emplace_back(std::move(*it));
+	}
 	from_source.erase(source_start, source_end);
 	lock.unlock();
 	has_items.notify_one();


### PR DESCRIPTION
# Description

Something recently increased the PVS warnings; two of my branches started erroring out after nothing but a main rebase. These two changes were very small, simple, should result in identical generated code, and removed two "high" warnings from PVS.

# Manual testing

Checked audio on several games with no issues.

Ran ASAN build.

The change has been manually tested on:

- [ ] Windows
- [x] macOS
- [ ] Linux


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

