### PR TITLE
Add OPT_SLOW_DYNREC option to CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -264,9 +264,15 @@ if (CMAKE_SYSTEM_PROCESSOR  STREQUAL "AMD64"  OR
     CMAKE_SYSTEM_PROCESSOR  STREQUAL "x86_64" OR
     CMAKE_OSX_ARCHITECTURES STREQUAL "x86_64")
 
+  option(OPT_SLOW_DYNREC "Disable dyn_x86 and use the slower dynrec" OFF)
+  if(OPT_SLOW_DYNREC)
+    set(C_DYNREC ON)
+    set(C_DYNAMIC_X86 OFF)
+  else()
+    set(C_DYNREC OFF)
+    set(C_DYNAMIC_X86 ON)
+  endif()
   set(C_TARGETCPU        "X86_64")
-  set(C_DYNAMIC_X86      ON)
-  set(C_DYNREC           OFF)
   set(C_FPU_X86          ON)
   set(C_UNALIGNED_MEMORY ON)
 


### PR DESCRIPTION
# Description

There was an option in Meson to set which dynrec to use. It can be useful to debug problems with the default x86 dynrec.



# Manual testing

Built and ran Doom with both option set and unset.

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [x] Linux

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

