### PR TITLE
Fixed debugger command IV truncating addresses to 16-bit (issue #4515)

### DIFF
--- a/src/debugger/debugger.cpp
+++ b/src/debugger/debugger.cpp
@@ -1535,7 +1535,7 @@ bool ParseCommand(char* str)
 	if (command == "IV") { // Insert variable
 		auto seg = (uint16_t)GetHexValue(found, found);
 		found++;
-		uint32_t ofs = (uint16_t)GetHexValue(found, found);
+		uint32_t ofs = GetHexValue(found, found); // Do not truncate; IV must support 32-bit addresses like SV/LV.
 		found++;
 		char name[16];
 		for (int i = 0; i < 16; i++) {
@@ -1551,7 +1551,7 @@ bool ParseCommand(char* str)
 		if (!name[0]) {
 			return false;
 		}
-		DEBUG_ShowMsg("DEBUG: Created debug var %s at %04X:%04X\n", name, seg, ofs);
+		DEBUG_ShowMsg("DEBUG: Created debug var %s at %04X:%08X\n", name, seg, ofs);
 		CDebugVar::InsertVariable(name, GetAddress(seg, ofs));
 		return true;
 	}


### PR DESCRIPTION
# Description

bug fix for issue #4515.
Followed the exact fix suggested by issue reporter.
Removed unnecessary casting of 32-bit offset to 16-bit.

## Related issues

Also fixed corresponding debug message to show full 32-bit offset rather than a truncated 16-bit one.

# Release notes

bug fix #4515: 32-bit segment offsets can now be referenced when creating variables using the IV command in the debugger.

# Manual testing

Tested issue before and after change.
Before a 32-bit offset would be truncated to 16-bit.
After a 32-bit offset would work just fine.

The change has been manually tested on:

- [x] Windows
- [ ] macOS
- [ ] Linux

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [x] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

