### PR TITLE
Abort mounting drives if parameters are invalid

### DIFF
--- a/src/dos/programs/mount.cpp
+++ b/src/dos/programs/mount.cpp
@@ -517,7 +517,7 @@ bool MOUNT::HandleUnmount()
 	return false;
 }
 
-void MOUNT::ParseArguments(MountParameters& params, bool& explicit_fs,
+bool MOUNT::ParseArguments(MountParameters& params, bool& explicit_fs,
                            bool& path_relative_to_last_config)
 {
 	if (cmd->FindExist("-pr", true)) {
@@ -531,6 +531,18 @@ void MOUNT::ParseArguments(MountParameters& params, bool& explicit_fs,
 	}
 	if (params.type == "fdd") {
 		params.type = "floppy";
+	}
+
+	// Validate the requested mount type
+	if (params.type != "floppy" && params.type != "dir" &&
+	    params.type != "overlay" && params.type != "iso" &&
+	    params.type != "hdd") {
+
+		NOTIFY_DisplayWarning(Notification::Source::Console,
+		                      "MOUNT",
+		                      "PROGRAM_MOUNT_ILL_TYPE",
+		                      params.type.c_str());
+		return false;
 	}
 
 	params.roflag = cmd->FindExist("-ro", true);
@@ -552,6 +564,8 @@ void MOUNT::ParseArguments(MountParameters& params, bool& explicit_fs,
 
 	// Label
 	cmd->FindString("-label", params.label, true);
+
+	return true;
 }
 
 bool MOUNT::ParseGeometry(MountParameters& params)
@@ -582,14 +596,9 @@ bool MOUNT::ParseGeometry(MountParameters& params)
 		}
 	} else if (params.type == "iso") {
 		str_size = "2048,1,65535,0";
-	} else if (params.type != "hdd") {
-		// If it is 'hdd', we leave sizes 0 to trigger detection or
-		// parsing below. If it is unknown, we error out later.
-		NOTIFY_DisplayWarning(Notification::Source::Console,
-		                      "MOUNT",
-		                      "PROGRAM_MOUNT_ILL_TYPE",
-		                      params.type.c_str());
-		return false;
+	} else {
+		// Type parameter validation should prevent this from happening
+		assert(params.type == "hdd");
 	}
 
 	// Parse the free space in mb (kb for floppies)
@@ -1130,7 +1139,9 @@ void MOUNT::Run(void)
 	bool path_relative_to_last_config = false;
 
 	// Parse command line arguments
-	ParseArguments(params, explicit_fs, path_relative_to_last_config);
+	if (!ParseArguments(params, explicit_fs, path_relative_to_last_config)) {
+		return;
+	}
 
 	// Check drive geometry and types, abort if not valid
 	if (!ParseGeometry(params)) {

--- a/src/dos/programs/mount.h
+++ b/src/dos/programs/mount.h
@@ -52,7 +52,7 @@ private:
 	void ShowUsage();
 
 	bool HandleUnmount();
-	void ParseArguments(MountParameters& params, bool& explicit_fs,
+	bool ParseArguments(MountParameters& params, bool& explicit_fs,
 	                    bool& path_relative_to_last_config);
 	bool ParseGeometry(MountParameters& params);
 	bool ParseDrive(MountParameters& params, bool explicit_fs);


### PR DESCRIPTION
# Description

The mount command now does not continue if parameters like type or geometry are invalid.

## Related issues

#4786

# Manual testing

```mount a floppy.img -t optolythic_datarod```

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [X] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [X] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [X] performed a self-review of my code.
- [X] commented on the particularly hard-to-understand areas of my code.
- [X] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [X] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [X] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

