### PR TITLE
fix: add cd/dvd aliases for -t type parameter

### DIFF
--- a/src/dos/programs/mount.cpp
+++ b/src/dos/programs/mount.cpp
@@ -526,7 +526,7 @@ void MOUNT::ParseArguments(MountParameters& params, bool& explicit_fs,
 
 	cmd->FindString("-t", params.type, true);
 	// Allow aliases or standard image types to pass through
-	if (params.type == "cdrom") {
+	if (params.type == "cdrom" || params.type == "cd" || params.type == "dvd") {
 		params.type = "iso";
 	}
 	if (params.type == "fdd") {


### PR DESCRIPTION
## Description

Add 'cd' and 'dvd' as aliases for 'iso' type in MOUNT command. This allows users to use MOUNT with  or  instead of only  or .

This fixes issue #4786 where using unsupported type strings like  could result in a silent crash. The  alias already exists, but this adds the commonly expected  and  aliases.

## Changes

- Modified  to add  and  as aliases for  type

## Testing

Users can now use:
```
MOUNT D path/to/iso -t cd
MOUNT D path/to/iso -t dvd
```

Instead of only:
```
MOUNT D path/to/iso -t cdrom
MOUNT D path/to/iso -t iso
```

## Related Issues

Fixes #4786