### PR TITLE
Website release notes draft generation

### DIFF
--- a/.github/actions/generate-release-notes/action.yml
+++ b/.github/actions/generate-release-notes/action.yml
@@ -28,7 +28,7 @@ runs:
         GITHUB_ACCESS_TOKEN: ${{ inputs.github_token }}
       run: |
         ./scripts/tools/release-notes-drafter.py \
-            query \
+            summary.query \
             --start_time            $RELEASE_START_TIME \
             --out_pull_requests_csv pull-requests.csv
 
@@ -40,7 +40,7 @@ runs:
         mkdir -p "$(dirname "${{ inputs.output_path }}")"
 
         ./scripts/tools/release-notes-drafter.py \
-            process \
+            summary.process \
             --input_csv_file   pull-requests.csv \
             --html_version_tag $DOSBOX_VERSION_AND_HASH \
             --out_html_file    "${{ inputs.output_path }}"

--- a/.github/actions/generate-release-notes/action.yml
+++ b/.github/actions/generate-release-notes/action.yml
@@ -29,8 +29,7 @@ runs:
       run: |
         ./scripts/tools/release-notes-drafter.py \
             summary.query \
-            --start_time            $RELEASE_START_TIME \
-            --out_pull_requests_csv pull-requests.csv
+            --start_time $RELEASE_START_TIME pull-requests.csv
 
     - name: Generate HTML release notes
       shell: bash
@@ -40,7 +39,5 @@ runs:
         mkdir -p "$(dirname "${{ inputs.output_path }}")"
 
         ./scripts/tools/release-notes-drafter.py \
-            summary.process \
-            --input_csv_file   pull-requests.csv \
-            --html_version_tag $DOSBOX_VERSION_AND_HASH \
-            --out_html_file    "${{ inputs.output_path }}"
+            summary.process_html \
+            pull-requests.csv $DOSBOX_VERSION_AND_HASH "${{ inputs.output_path }}"

--- a/.github/workflows/release-notes-preview.yml
+++ b/.github/workflows/release-notes-preview.yml
@@ -32,20 +32,17 @@ jobs:
         run: |
           ./scripts/tools/release-notes-drafter.py \
               summary.query \
-              --start_time            $RELEASE_START_TIME \
-              --out_pull_requests_csv pull-requests.csv
+              --start_time $RELEASE_START_TIME pull-requests.csv
 
       - name: Generate release notes
         run: |
           ./scripts/tools/release-notes-drafter.py \
-              summary.process \
-              --input_csv_file    pull-requests.csv \
-              --out_markdown_file release-notes.md
+              summary.process_markdown \
+              pull-requests.csv release-notes.md
 
       - name: Publish release notes preview
         run: |
           ./scripts/tools/release-notes-drafter.py \
               summary.publish \
-              --release_notes_file  release-notes.md \
-              --publish_version_tag $PRE_RELEASE_TAG
+              release-notes.md $PRE_RELEASE_TAG
 

--- a/.github/workflows/release-notes-preview.yml
+++ b/.github/workflows/release-notes-preview.yml
@@ -31,21 +31,21 @@ jobs:
       - name: Query pull requests
         run: |
           ./scripts/tools/release-notes-drafter.py \
-              query \
+              summary.query \
               --start_time            $RELEASE_START_TIME \
               --out_pull_requests_csv pull-requests.csv
 
       - name: Generate release notes
         run: |
           ./scripts/tools/release-notes-drafter.py \
-              process \
+              summary.process \
               --input_csv_file    pull-requests.csv \
               --out_markdown_file release-notes.md
 
       - name: Publish release notes preview
         run: |
           ./scripts/tools/release-notes-drafter.py \
-              publish \
+              summary.publish \
               --release_notes_file  release-notes.md \
               --publish_version_tag $PRE_RELEASE_TAG
 

--- a/.pylint
+++ b/.pylint
@@ -494,4 +494,4 @@ valid-metaclass-classmethod-first-arg=cls
 # Exceptions that will emit a warning when being caught. Defaults to
 # "BaseException, Exception".
 overgeneral-exceptions=builtins.BaseException,
-                       Exception
+                       builtins.Exception

--- a/scripts/tools/release-notes-drafter.py
+++ b/scripts/tools/release-notes-drafter.py
@@ -101,7 +101,8 @@ FILTERS = [
 def setup_arg_parser(parser):
     parser.add_argument(
         "ACTION",
-        choices=["summary.query", "summary.process", "summary.publish"],
+        choices=["summary.query", "summary.process", "summary.publish",
+                 "website.query", "website.process"],
         help="""summary.query
   Queries information about all pull requests merged to the 'main'
   branch since the last public DOSBox Staging release and writes
@@ -113,6 +114,15 @@ summary.process
 
 summary.publish
   Publishes (creates or updates) the release notes draft.
+
+website.query
+  Queries all pull requests merged to 'main' since the last public
+  release, including their full descriptions, and writes the results
+  to a JSON file.
+
+website.process
+  Processes the JSON output of the 'website.query' action and generates
+  a detailed release notes draft for the website.
 """
     )
 
@@ -174,6 +184,23 @@ summary.publish
     publish_args.add_argument(
         "--publish_version_tag",
         help="the release notes will be published under this tag (e.g., v0.83.0-alpha)"
+    )
+
+    website_args = parser.add_argument_group(title="website.query / website.process arguments")
+
+    website_args.add_argument(
+        "--out_json_file",
+        help="output JSON file containing pull requests with descriptions"
+    )
+
+    website_args.add_argument(
+        "--input_json_file",
+        help="input JSON file from 'website.query'"
+    )
+
+    website_args.add_argument(
+        "--version",
+        help="release version number (e.g., 0.83.0)"
     )
 
 
@@ -251,12 +278,14 @@ def get_prerelease_id_by_tag(tag):
     return None
 
 
-def get_pull_requests(start, end, cursor=None):
+def get_pull_requests(start, end, cursor=None, include_body=False):
     after = f'"{cursor}"' if cursor else "null"
 
     search_query = ("repo:dosbox-staging/dosbox-staging is:pr "
                     "is:merged base:main "
                     f"merged:{start}..{end} sort:updated")
+
+    body_field = "body" if include_body else ""
 
     query = """
       {
@@ -278,6 +307,7 @@ def get_pull_requests(start, end, cursor=None):
               createdAt
               updatedAt
               mergedAt
+              """ + body_field + """
               labels(first: 20) {
                 nodes {
                   name
@@ -308,7 +338,7 @@ def pull_requests_response_to_dict(response):
     result = []
 
     for item in nodes:
-        result.append({
+        pr = {
             "title":     item["title"],
             "number":    item["number"],
             "author":    get_author(item),
@@ -317,12 +347,16 @@ def pull_requests_response_to_dict(response):
             "updatedAt": item["updatedAt"],
             "mergedAt":  item["mergedAt"],
             "labels":    ", ".join([l["name"] for l in item["labels"]["nodes"]])
-        })
+        }
+        if "body" in item:
+            pr["body"] = item["body"]
+
+        result.append(pr)
 
     return result
 
 
-def fetch_all_pull_requests_since(start_time):
+def fetch_all_pull_requests_since(start_time, include_body=False):
     all_items = []
     cursor = None
     item_offset = 0
@@ -331,7 +365,9 @@ def fetch_all_pull_requests_since(start_time):
 
     while True:
         print(f"Fetching next page of pull requests, item offset: {item_offset}")
-        response = get_pull_requests(start=start_time, end=now, cursor=cursor)
+        response = get_pull_requests(start=start_time, end=now,
+                                     cursor=cursor,
+                                     include_body=include_body)
         items = pull_requests_response_to_dict(response)
 
         all_items.extend(items)
@@ -558,16 +594,25 @@ def process_pull_requests_html(items, html_fname, version_tag):
         f.write(html)
 
 
+def write_json(items, output_json):
+    with open(output_json, "w", encoding="UTF-8") as f:
+        json.dump(items, f, indent=2, ensure_ascii=False)
+
+
+def read_json(fname):
+    with open(fname, encoding="UTF-8") as f:
+        return json.load(f)
+
+
 def query_pull_requests(csv_fname, start_time):
-#    latest_release = get_latest_public_release()
-
-#    latest_release_name = latest_release["name"]
-#    start_time = latest_release["publishedAt"]
-#    print(f"Latest release name: {latest_release_name}, published at: {start_time}")
-
     items = fetch_all_pull_requests_since(start_time)
     write_csv(items, csv_fname)
+    print(f"{len(items)} pull requests written")
 
+
+def website_query_pull_requests(json_fname, start_time):
+    items = fetch_all_pull_requests_since(start_time, include_body=True)
+    write_json(items, json_fname)
     print(f"{len(items)} pull requests written")
 
 
@@ -683,6 +728,15 @@ def main():
                 parser.error("--publish_version_tag must be specified")
 
             publish_prerelease(args.release_notes_file, args.publish_version_tag)
+
+        case "website.query":
+            if not args.start_time:
+                parser.error("--start_time must be specified")
+
+            if not args.out_json_file:
+                parser.error("--out_json_file must be specified")
+
+            website_query_pull_requests(args.out_json_file, args.start_time)
 
 
 if __name__ == "__main__":

--- a/scripts/tools/release-notes-drafter.py
+++ b/scripts/tools/release-notes-drafter.py
@@ -7,9 +7,7 @@
 Create release notes draft for DOSBox Staging.
 
 The GitHub access token must be set in the GITHUB_ACCESS_TOKEN env var.
-
-The token must have the following scopes:
-  repo, workflow, write:packages, delete:packages
+You must use a classic personal access token with 'repo' scope.
 
 """
 

--- a/scripts/tools/release-notes-drafter.py
+++ b/scripts/tools/release-notes-drafter.py
@@ -101,22 +101,22 @@ FILTERS = [
 def setup_arg_parser(parser):
     parser.add_argument(
         "ACTION",
-        choices=["query", "process", "publish"],
-        help="""query
+        choices=["summary.query", "summary.process", "summary.publish"],
+        help="""summary.query
   Queries information about all pull requests merged to the 'main'
   branch since the last public DOSBox Staging release and writes
   the results to a CSV file.
 
-process
-  Processes the CSV output of the 'query' action and generates the
+summary.process
+  Processes the CSV output of the 'summary.query' action and generates the
   release notes draft either in Markdown or CSV format.
 
-publish
+summary.publish
   Publishes (creates or updates) the release notes draft.
 """
     )
 
-    query_args = parser.add_argument_group(title="query arguments")
+    query_args = parser.add_argument_group(title="summary.query arguments")
     query_args.add_argument(
         "--start_time",
         help="""include pull requests after this datetime
@@ -127,7 +127,7 @@ publish
         help="output CSV file containing the pull requests"
     )
 
-    process_args = parser.add_argument_group(title="process arguments")
+    process_args = parser.add_argument_group(title="summary.process arguments")
 
     process_args.add_argument(
         "--input_csv_file",
@@ -162,7 +162,7 @@ publish
         help="version tag of the release notes draft (e.g., v0.83.0-alpha)"
     )
 
-    publish_args = parser.add_argument_group(title="publish arguments")
+    publish_args = parser.add_argument_group(title="summary.publish arguments")
 
     publish_args.add_argument(
         "--release_notes_file",
@@ -642,7 +642,7 @@ def main():
         sys.exit(1)
 
     match args.ACTION:
-        case "query":
+        case "summary.query":
             if not args.start_time:
                 parser.error("--start_time must be specified")
 
@@ -651,7 +651,7 @@ def main():
 
             query_pull_requests(args.out_pull_requests_csv, args.start_time)
 
-        case "process":
+        case "summary.process":
             if not args.input_csv_file:
                 parser.error("--input_csv_file must be specified")
 
@@ -675,7 +675,7 @@ def main():
             if args.out_csv_file:
                 process_pull_requests_csv(items, args.out_csv_file)
 
-        case "publish":
+        case "summary.publish":
             if not args.release_notes_file:
                 parser.error("--release_notes_file must be specified")
 

--- a/scripts/tools/release-notes-drafter.py
+++ b/scripts/tools/release-notes-drafter.py
@@ -466,47 +466,10 @@ def get_contributor_list(items):
     return sorted(authors, key=str.casefold)
 
 
-def append_contributor_list(markdown, items):
-    markdown = f'{markdown}## Commit authors\n\n<div class="authors">\n<ul>\n'
-
-    for i in get_contributor_list(items):
-        markdown = f"{markdown}  <li>{i}</li>\n"
-
-    return f"{markdown}</ul>\n</div>\n"
-
-
-def summary_process_pull_requests_csv(items, csv_fname):
-    remaining = items
-    result = []
-
-    for filter_def in FILTERS:
-        [filtered, remaining] = filter_category(remaining, filter_def)
-
-        for item in filtered:
-            item["category"] = filter_def["category"]
-            result.append(item)
-
-    sort_items(remaining)
-
-    for item in remaining:
-        item["category"] = "other"
-        result.append(item)
-
-    write_csv(result, csv_fname)
-
-
-def append_category_markdown(markdown, items, category_name):
-    markdown = f"{markdown}## Full PR list of {category_name}\n\n"
-
-    for i in items:
-        pr_link = f"[#{i['number']}]({i['url']})"
-        item_md = f"  - {i['title']} ({pr_link})"
-        if "backport" in i["labels"]:
-            item_md += " _[backport]_"
-
-        markdown += item_md + "\n"
-
-    return f"{markdown}\n\n"
+def summary_query_pull_requests(csv_fname, start_time):
+    items = fetch_all_pull_requests_since(start_time)
+    write_csv(items, csv_fname)
+    print(f"{len(items)} pull requests written to '{csv_fname}'")
 
 
 MARKDOWN_HEADER = """> [!WARNING]
@@ -575,6 +538,36 @@ HTML_TEMPLATE = """<!DOCTYPE html>
 """
 
 
+def summary_process_pull_requests_markdown(items, markdown_fname):
+    markdown = generate_markdown(items, MARKDOWN_HEADER)
+
+    with open(markdown_fname, "w", newline="", encoding="UTF-8") as f:
+        f.write(markdown)
+
+
+def append_category_markdown(markdown, items, category_name):
+    markdown = f"{markdown}## Full PR list of {category_name}\n\n"
+
+    for i in items:
+        pr_link = f"[#{i['number']}]({i['url']})"
+        item_md = f"  - {i['title']} ({pr_link})"
+        if "backport" in i["labels"]:
+            item_md += " _[backport]_"
+
+        markdown += item_md + "\n"
+
+    return f"{markdown}\n\n"
+
+
+def append_contributor_list(markdown, items):
+    markdown = f'{markdown}## Commit authors\n\n<div class="authors">\n<ul>\n'
+
+    for i in get_contributor_list(items):
+        markdown = f"{markdown}  <li>{i}</li>\n"
+
+    return f"{markdown}</ul>\n</div>\n"
+
+
 def generate_markdown(items, header):
     remaining = items
     markdown = header
@@ -595,11 +588,24 @@ def generate_markdown(items, header):
     return markdown
 
 
-def summary_process_pull_requests_markdown(items, markdown_fname):
-    markdown = generate_markdown(items, MARKDOWN_HEADER)
+def summary_process_pull_requests_csv(items, csv_fname):
+    remaining = items
+    result = []
 
-    with open(markdown_fname, "w", newline="", encoding="UTF-8") as f:
-        f.write(markdown)
+    for filter_def in FILTERS:
+        [filtered, remaining] = filter_category(remaining, filter_def)
+
+        for item in filtered:
+            item["category"] = filter_def["category"]
+            result.append(item)
+
+    sort_items(remaining)
+
+    for item in remaining:
+        item["category"] = "other"
+        result.append(item)
+
+    write_csv(result, csv_fname)
 
 
 def summary_process_pull_requests_html(items, html_fname, version_tag):
@@ -618,20 +624,58 @@ def summary_process_pull_requests_html(items, html_fname, version_tag):
         f.write(html)
 
 
-def write_json(items, output_json):
-    with open(output_json, "w", encoding="UTF-8") as f:
-        json.dump(items, f, indent=2, ensure_ascii=False)
+def make_upsert_release_payload(tag, name, description):
+    return json.dumps({
+        "tag_name": tag,
+        "target_commitish": "main",
+        "name": name,
+        "body": description,
+        "draft": False,
+        "prerelease": True,
+        "generate_release_notes": False
+    })
 
 
-def read_json(fname):
-    with open(fname, encoding="UTF-8") as f:
-        return json.load(f)
+def update_release(release_id, tag, name, description):
+    url = f"{RELEASES_BASE_URL}/{release_id}"
+    data = make_upsert_release_payload(tag, name, description)
+
+    r = requests.patch(url, headers=create_headers(), data=data,
+                       timeout=HTTP_TIMEOUT_SEC)
+
+    if r.status_code != 200:
+        print_api_error(data, r)
+        sys.exit(1)
+
+    return json.loads(r.text)
 
 
-def summary_query_pull_requests(csv_fname, start_time):
-    items = fetch_all_pull_requests_since(start_time)
-    write_csv(items, csv_fname)
-    print(f"{len(items)} pull requests written to '{csv_fname}'")
+def create_release(tag, name, description):
+    url = RELEASES_BASE_URL
+    data = make_upsert_release_payload(tag, name, description)
+
+    r = requests.post(url, headers=create_headers(), data=data,
+                      timeout=HTTP_TIMEOUT_SEC)
+
+    if r.status_code != 201:
+        print_api_error(data, r)
+        sys.exit(1)
+
+    return json.loads(r.text)
+
+
+def summary_publish_prerelease(markdown_file, tag):
+    release_id = get_prerelease_id_by_tag(tag)
+
+    with open(markdown_file, encoding="UTF-8") as f:
+        description = f.read()
+
+    name = f"{tag} release notes preview"
+
+    if release_id:
+        update_release(release_id, tag, name, description)
+    else:
+        create_release(tag, name, description)
 
 
 def website_query_pull_requests(json_fname, start_time):
@@ -640,36 +684,22 @@ def website_query_pull_requests(json_fname, start_time):
     print(f"{len(items)} pull requests written to '{json_fname}'")
 
 
+def website_process_pull_requests(json_fname, version, markdown_fname):
+    items = read_json(json_fname)
+    items = [i for i in items if "backport" not in i["labels"]]
+
+    markdown = website_generate_markdown(items, version)
+
+    with open(markdown_fname, "w", encoding="UTF-8") as f:
+        f.write(markdown)
+
+    print(f"Website release notes draft written to '{markdown_fname}'")
+
+
 TEMPLATE_PLACEHOLDER_PHRASES = [
     "If this is a user-facing change",
     "Remove the section if no notes are needed",
 ]
-
-
-def extract_release_notes(body):
-    """Extract the 'Release notes' section from a PR description."""
-    if not body:
-        return None
-
-    match = re.search(r"^#\s+Release notes\s*$", body, re.MULTILINE | re.IGNORECASE)
-    if not match:
-        return None
-
-    rest = body[match.end():]
-
-    # Find the next first level heading or end of string
-    next_heading = re.search(r"^#\s+\w", rest, re.MULTILINE)
-    content = rest[:next_heading.start()] if next_heading else rest
-    content = normalise_newlines(content.strip())
-
-    if not content:
-        return None
-
-    for phrase in TEMPLATE_PLACEHOLDER_PHRASES:
-        if phrase in content:
-            return None
-
-    return content
 
 
 def categorize_pull_requests(items):
@@ -696,6 +726,32 @@ def append_collapsible_pr_list(md, items, title):
         md += f"    - {item['title']} (#{item['number']})\n"
     md += "\n\n"
     return md
+
+
+def extract_release_notes(body):
+    """Extract the 'Release notes' section from a PR description."""
+    if not body:
+        return None
+
+    match = re.search(r"^#\s+Release notes\s*$", body, re.MULTILINE | re.IGNORECASE)
+    if not match:
+        return None
+
+    rest = body[match.end():]
+
+    # Find the next first level heading or end of string
+    next_heading = re.search(r"^#\s+\w", rest, re.MULTILINE)
+    content = rest[:next_heading.start()] if next_heading else rest
+    content = normalise_newlines(content.strip())
+
+    if not content:
+        return None
+
+    for phrase in TEMPLATE_PLACEHOLDER_PHRASES:
+        if phrase in content:
+            return None
+
+    return content
 
 
 def append_narrative_prs(md, items):
@@ -806,70 +862,14 @@ project, on which DOSBox Staging is based.
     return md
 
 
-def website_process_pull_requests(json_fname, version, markdown_fname):
-    items = read_json(json_fname)
-    items = [i for i in items if "backport" not in i["labels"]]
-
-    markdown = website_generate_markdown(items, version)
-
-    with open(markdown_fname, "w", encoding="UTF-8") as f:
-        f.write(markdown)
-
-    print(f"Website release notes draft written to '{markdown_fname}'")
+def read_json(fname):
+    with open(fname, encoding="UTF-8") as f:
+        return json.load(f)
 
 
-def make_upsert_release_payload(tag, name, description):
-    return json.dumps({
-        "tag_name": tag,
-        "target_commitish": "main",
-        "name": name,
-        "body": description,
-        "draft": False,
-        "prerelease": True,
-        "generate_release_notes": False
-    })
-
-
-def create_release(tag, name, description):
-    url = RELEASES_BASE_URL
-    data = make_upsert_release_payload(tag, name, description)
-
-    r = requests.post(url, headers=create_headers(), data=data,
-                      timeout=HTTP_TIMEOUT_SEC)
-
-    if r.status_code != 201:
-        print_api_error(data, r)
-        sys.exit(1)
-
-    return json.loads(r.text)
-
-
-def update_release(release_id, tag, name, description):
-    url = f"{RELEASES_BASE_URL}/{release_id}"
-    data = make_upsert_release_payload(tag, name, description)
-
-    r = requests.patch(url, headers=create_headers(), data=data,
-                       timeout=HTTP_TIMEOUT_SEC)
-
-    if r.status_code != 200:
-        print_api_error(data, r)
-        sys.exit(1)
-
-    return json.loads(r.text)
-
-
-def summary_publish_prerelease(markdown_file, tag):
-    release_id = get_prerelease_id_by_tag(tag)
-
-    with open(markdown_file, encoding="UTF-8") as f:
-        description = f.read()
-
-    name = f"{tag} release notes preview"
-
-    if release_id:
-        update_release(release_id, tag, name, description)
-    else:
-        create_release(tag, name, description)
+def write_json(items, output_json):
+    with open(output_json, "w", encoding="UTF-8") as f:
+        json.dump(items, f, indent=2, ensure_ascii=False)
 
 
 # pylint: disable=too-many-branches

--- a/scripts/tools/release-notes-drafter.py
+++ b/scripts/tools/release-notes-drafter.py
@@ -544,6 +544,8 @@ def summary_process_pull_requests_markdown(items, markdown_fname):
     with open(markdown_fname, "w", newline="", encoding="UTF-8") as f:
         f.write(markdown)
 
+    print(f"Release notes draft Markdown written to '{markdown_fname}'")
+
 
 def append_category_markdown(markdown, items, category_name):
     markdown = f"{markdown}## Full PR list of {category_name}\n\n"
@@ -606,6 +608,7 @@ def summary_process_pull_requests_csv(items, csv_fname):
         result.append(item)
 
     write_csv(result, csv_fname)
+    print(f"Categorised pull requests CSV written to '{csv_fname}'")
 
 
 def summary_process_pull_requests_html(items, html_fname, version_tag):
@@ -622,6 +625,8 @@ def summary_process_pull_requests_html(items, html_fname, version_tag):
 
     with open(html_fname, "w", newline="", encoding="UTF-8") as f:
         f.write(html)
+
+    print(f"Release notes draft HTML written to '{html_fname}'")
 
 
 def make_upsert_release_payload(tag, name, description):

--- a/scripts/tools/release-notes-drafter.py
+++ b/scripts/tools/release-notes-drafter.py
@@ -4,10 +4,11 @@
 # SPDX-License-Identifier: MIT
 
 """
-Create release notes draft for DOSBox Staging.
+Create and publish DOSBox Staging release notes.
 
 The GitHub access token must be set in the GITHUB_ACCESS_TOKEN env var.
-The token must have the following scopes: repo, workflow, write:packages, delete:packages
+The token must have 'repo' scope.
+
 """
 
 # pylint: disable=invalid-name
@@ -20,6 +21,7 @@ import csv
 import datetime
 import json
 import os
+import re
 import sys
 
 import markdown2
@@ -32,6 +34,9 @@ GITHUB_API_URL      = "https://api.github.com"
 GITHUB_ACCESS_TOKEN = ""
 
 RELEASES_BASE_URL = f"{GITHUB_API_URL}/repos/{GITHUB_ORG}/{GITHUB_REPO}/releases"
+
+COMMON_VARS_PATH = os.path.join(os.path.dirname(__file__),
+                                "../../.github/actions/set-common-vars/action.yml")
 
 FETCH_PAGE_SIZE = 50
 
@@ -126,40 +131,45 @@ website.process
 """
     )
 
-    query_args = parser.add_argument_group(title="summary.query arguments")
+    query_args = parser.add_argument_group(title="common query arguments")
+
     query_args.add_argument(
         "--start_time",
         help="""include pull requests after this datetime
-        """
+(defaults to RELEASE_START_TIME from set-common-vars/action.yml)
+"""
     )
-    query_args.add_argument(
+
+    process_args = parser.add_argument_group(title="common process arguments")
+
+    process_args.add_argument(
+        "--out_markdown_file",
+        help="""write output to a Markdown file
+"""
+    )
+
+    summary_query_args = parser.add_argument_group(title="summary.query arguments")
+
+    summary_query_args.add_argument(
         "--out_pull_requests_csv",
         help="output CSV file containing the pull requests"
     )
 
-    process_args = parser.add_argument_group(title="summary.process arguments")
+    summary_process_args = parser.add_argument_group(title="summary.process arguments")
 
-    process_args.add_argument(
+    summary_process_args.add_argument(
         "--input_csv_file",
         help="""input CSV file containing the pull requests
         """
     )
 
-    process_args.add_argument(
+    summary_process_args.add_argument(
         "--out_csv_file",
         help="""write categorised PRs to a CSV file
         """
     )
 
-    process_args.add_argument(
-        "--out_markdown_file",
-        help="""write categorised PRs to a Markdown file
-(to be published as pre-release notes on GitHub)
-
-"""
-    )
-
-    process_args.add_argument(
+    summary_process_args.add_argument(
         "--out_html_file",
         help="""write release notes to an HTML file
 (to be included in the development build artifacts)
@@ -167,41 +177,54 @@ website.process
 """
     )
 
-    process_args.add_argument(
+    summary_process_args.add_argument(
         "--html_version_tag",
         help="version tag of the release notes draft (e.g., v0.83.0-alpha)"
     )
 
-    publish_args = parser.add_argument_group(title="summary.publish arguments")
+    summary_publish_args = parser.add_argument_group(title="summary.publish arguments")
 
-    publish_args.add_argument(
+    summary_publish_args.add_argument(
         "--release_notes_file",
         help="""release notes Markdown file
 
 """
     )
 
-    publish_args.add_argument(
+    summary_publish_args.add_argument(
         "--publish_version_tag",
         help="the release notes will be published under this tag (e.g., v0.83.0-alpha)"
     )
 
-    website_args = parser.add_argument_group(title="website.query / website.process arguments")
+    website_query_args = parser.add_argument_group(title="website.query arguments")
 
-    website_args.add_argument(
+    website_query_args.add_argument(
         "--out_json_file",
         help="output JSON file containing pull requests with descriptions"
     )
 
-    website_args.add_argument(
+    website_process_args = parser.add_argument_group(title="website.process arguments")
+
+    website_process_args.add_argument(
         "--input_json_file",
         help="input JSON file from 'website.query'"
     )
 
-    website_args.add_argument(
+    website_process_args.add_argument(
         "--version",
         help="release version number (e.g., 0.83.0)"
     )
+
+
+def get_default_start_time():
+    """Read RELEASE_START_TIME from the CI common vars file."""
+    path = os.path.normpath(COMMON_VARS_PATH)
+    with open(path, encoding="UTF-8") as f:
+        for line in f:
+            m = re.search(r'RELEASE_START_TIME=(\S+)', line)
+            if m:
+                return m.group(1).strip('"\'')
+    return None
 
 
 def create_headers():
@@ -402,6 +425,11 @@ def sort_items(items):
     items.sort(key=lambda x: (x["title"].lower()))
 
 
+def normalise_newlines(text):
+    """ Replace Window-style newlines (CRLF) with Unix style (just LF) """
+    return text.replace('\r\n', '\n').replace('\r', '\n')
+
+
 def filter_category(items, filter_def):
     """ `filter_def` is an entry from FILTERS """
 
@@ -433,11 +461,9 @@ def filter_category(items, filter_def):
 
 
 def get_contributor_list(items):
-    res = map(lambda i: i["author"], items)
-    res = filter(lambda s: s not in ["-", "", "dependabot"], res)
-    res = list(set(res))
-    res.sort(key=str.casefold)
-    return res
+    excluded = {"-", "", "dependabot"}
+    authors = {i["author"] for i in items if i["author"] not in excluded}
+    return sorted(authors, key=str.casefold)
 
 
 def append_contributor_list(markdown, items):
@@ -449,7 +475,7 @@ def append_contributor_list(markdown, items):
     return f"{markdown}</ul>\n</div>\n"
 
 
-def process_pull_requests_csv(items, csv_fname):
+def summary_process_pull_requests_csv(items, csv_fname):
     remaining = items
     result = []
 
@@ -484,9 +510,7 @@ def append_category_markdown(markdown, items, category_name):
 
 
 MARKDOWN_HEADER = """> [!WARNING]
-> **These are the automatically generated release notes of the latest
-> development snapshot builds!** This is not a stable release; things
-> might blow up! 💣 🔥 💀
+> **These are the automatically generated release notes of the latest development snapshot builds!** This is not a stable release; things might blow up! 💣 🔥 💀
 >
 > You can download the latest development builds from here:
 > https://www.dosbox-staging.org/releases/development-builds/
@@ -571,14 +595,14 @@ def generate_markdown(items, header):
     return markdown
 
 
-def process_pull_requests_markdown(items, markdown_fname):
+def summary_process_pull_requests_markdown(items, markdown_fname):
     markdown = generate_markdown(items, MARKDOWN_HEADER)
 
     with open(markdown_fname, "w", newline="", encoding="UTF-8") as f:
         f.write(markdown)
 
 
-def process_pull_requests_html(items, html_fname, version_tag):
+def summary_process_pull_requests_html(items, html_fname, version_tag):
     markdown = generate_markdown(items, HTML_HEADER)
 
     # Convert markdown to HTML
@@ -604,16 +628,194 @@ def read_json(fname):
         return json.load(f)
 
 
-def query_pull_requests(csv_fname, start_time):
+def summary_query_pull_requests(csv_fname, start_time):
     items = fetch_all_pull_requests_since(start_time)
     write_csv(items, csv_fname)
-    print(f"{len(items)} pull requests written")
+    print(f"{len(items)} pull requests written to '{csv_fname}'")
 
 
 def website_query_pull_requests(json_fname, start_time):
     items = fetch_all_pull_requests_since(start_time, include_body=True)
     write_json(items, json_fname)
-    print(f"{len(items)} pull requests written")
+    print(f"{len(items)} pull requests written to '{json_fname}'")
+
+
+TEMPLATE_PLACEHOLDER_PHRASES = [
+    "If this is a user-facing change",
+    "Remove the section if no notes are needed",
+]
+
+
+def extract_release_notes(body):
+    """Extract the 'Release notes' section from a PR description."""
+    if not body:
+        return None
+
+    match = re.search(r"^#\s+Release notes\s*$", body, re.MULTILINE | re.IGNORECASE)
+    if not match:
+        return None
+
+    rest = body[match.end():]
+
+    # Find the next first level heading or end of string
+    next_heading = re.search(r"^#\s+\w", rest, re.MULTILINE)
+    content = rest[:next_heading.start()] if next_heading else rest
+    content = normalise_newlines(content.strip())
+
+    if not content:
+        return None
+
+    for phrase in TEMPLATE_PLACEHOLDER_PHRASES:
+        if phrase in content:
+            return None
+
+    return content
+
+
+def categorize_pull_requests(items):
+    """Categorize PRs using FILTERS, returning a dict of category → PR list."""
+    categories = {}
+    remaining = items
+
+    for filter_def in FILTERS:
+        [filtered, remaining] = filter_category(remaining, filter_def)
+        if filtered:
+            categories[filter_def["category"]] = filtered
+
+    sort_items(remaining)
+    if remaining:
+        categories["other"] = remaining
+
+    return categories
+
+
+def append_collapsible_pr_list(md, items, title):
+    """Append a collapsible PR list section."""
+    md += f'??? note "Full PR list of {title}"\n\n'
+    for item in items:
+        md += f"    - {item['title']} (#{item['number']})\n"
+    md += "\n\n"
+    return md
+
+
+def append_narrative_prs(md, items):
+    """Append release notes extracted from PR descriptions."""
+    for item in items:
+        notes = extract_release_notes(item.get("body", ""))
+        if notes:
+            md += f"## {item['title']} (#{item['number']})\n\n"
+            md += f"{notes}\n\n\n"
+    return md
+
+
+# pylint: disable=too-many-locals
+def website_generate_markdown(items, version):
+    categories = categorize_pull_requests(items)
+    filter_titles = {f["category"]: f["title"] for f in FILTERS}
+    short_version = version.rsplit(".", 1)[0] if "." in version else version
+
+    md = f"""\
+# {version} release notes
+
+**Release date:** YYYY-MM-DD
+
+## Summary
+
+TODO: Write summary of highlights
+
+
+## Downloads
+
+Start by downloading the latest version:
+
+<div class="compact" markdown>
+
+- [Windows](../windows.md)
+- [macOS](../macos.md)
+- [Linux](../linux.md)
+
+</div>
+
+TODO: Add upgrade instructions
+
+
+"""
+
+    # Standard sections
+    standard_sections = [
+        ("game-compatibility", "Game compatibility fixes"),
+        ("graphics",           "Graphics"),
+        ("sound",              "Sound"),
+        ("input-handling",     "Input"),
+        ("dos-integration",    "DOS integration"),
+    ]
+
+    for category, heading in standard_sections:
+        prs = categories.get(category, [])
+        if prs:
+            md += f"## {heading}\n\n"
+            md = append_narrative_prs(md, prs)
+            md = append_collapsible_pr_list(md, prs, filter_titles[category])
+
+    # General section: narrative from misc-enhancements/misc-fixes,
+    # collapsible lists for all "general" sub-categories
+    general_narrative = ["misc-enhancements", "misc-fixes"]
+    general_collapsible_only = ["documentation", "project-maintenance", "other"]
+    all_general = general_narrative + general_collapsible_only
+
+    if any(categories.get(cat) for cat in all_general):
+        md += "## General\n\n"
+
+        for cat in general_narrative:
+            md = append_narrative_prs(md, categories.get(cat, []))
+
+        for cat in all_general:
+            prs = categories.get(cat, [])
+            if prs:
+                title = filter_titles.get(cat, "other changes")
+                md = append_collapsible_pr_list(md, prs, title)
+
+    # Localisation
+    loc_prs = categories.get("localisation", [])
+    if loc_prs:
+        md += "## Localisation\n\n"
+        md = append_narrative_prs(md, loc_prs)
+        md = append_collapsible_pr_list(md, loc_prs, filter_titles["localisation"])
+
+    # Contributors & Thank you
+    contributors = "\n".join(f"- {a}" for a in get_contributor_list(items))
+
+    md += f"""\
+## Contributors
+
+### {short_version} commit authors
+
+<div class="compact" markdown>
+
+{contributors}
+
+</div>
+
+
+## Thank you
+
+We are grateful for all the community contributions and the original DOSBox
+project, on which DOSBox Staging is based.
+"""
+
+    return md
+
+
+def website_process_pull_requests(json_fname, version, markdown_fname):
+    items = read_json(json_fname)
+    items = [i for i in items if "backport" not in i["labels"]]
+
+    markdown = website_generate_markdown(items, version)
+
+    with open(markdown_fname, "w", encoding="UTF-8") as f:
+        f.write(markdown)
+
+    print(f"Website release notes draft written to '{markdown_fname}'")
 
 
 def make_upsert_release_payload(tag, name, description):
@@ -656,7 +858,7 @@ def update_release(release_id, tag, name, description):
     return json.loads(r.text)
 
 
-def publish_prerelease(markdown_file, tag):
+def summary_publish_prerelease(markdown_file, tag):
     release_id = get_prerelease_id_by_tag(tag)
 
     with open(markdown_file, encoding="UTF-8") as f:
@@ -679,22 +881,28 @@ def main():
     setup_arg_parser(parser)
     args = parser.parse_args()
 
+    actions_requiring_token = [
+        "summary.query", "summary.process", "summary.publish",
+        "website.query"
+    ]
+
     global GITHUB_ACCESS_TOKEN
     GITHUB_ACCESS_TOKEN = os.getenv("GITHUB_ACCESS_TOKEN")
 
-    if not GITHUB_ACCESS_TOKEN:
+    if args.ACTION in actions_requiring_token and not GITHUB_ACCESS_TOKEN:
         print("Error: GITHUB_ACCESS_TOKEN env var is empty")
         sys.exit(1)
 
     match args.ACTION:
         case "summary.query":
-            if not args.start_time:
+            start_time = args.start_time or get_default_start_time()
+            if not start_time:
                 parser.error("--start_time must be specified")
 
             if not args.out_pull_requests_csv:
                 parser.error("--out_pull_requests_csv must be specified")
 
-            query_pull_requests(args.out_pull_requests_csv, args.start_time)
+            summary_query_pull_requests(args.out_pull_requests_csv, start_time)
 
         case "summary.process":
             if not args.input_csv_file:
@@ -707,18 +915,18 @@ def main():
             items = read_csv(args.input_csv_file)
 
             if args.out_markdown_file:
-                process_pull_requests_markdown(items, args.out_markdown_file)
+                summary_process_pull_requests_markdown(items, args.out_markdown_file)
 
             if args.out_html_file:
                 if not args.html_version_tag:
                     parser.error("--html_version_tag of the release notes draft must "
                                  "be specified")
 
-                process_pull_requests_html(items, args.out_html_file,
+                summary_process_pull_requests_html(items, args.out_html_file,
                                            args.html_version_tag)
 
             if args.out_csv_file:
-                process_pull_requests_csv(items, args.out_csv_file)
+                summary_process_pull_requests_csv(items, args.out_csv_file)
 
         case "summary.publish":
             if not args.release_notes_file:
@@ -727,16 +935,31 @@ def main():
             if not args.publish_version_tag:
                 parser.error("--publish_version_tag must be specified")
 
-            publish_prerelease(args.release_notes_file, args.publish_version_tag)
+            summary_publish_prerelease(args.release_notes_file, args.publish_version_tag)
 
         case "website.query":
-            if not args.start_time:
+            start_time = args.start_time or get_default_start_time()
+            if not start_time:
                 parser.error("--start_time must be specified")
 
             if not args.out_json_file:
                 parser.error("--out_json_file must be specified")
 
-            website_query_pull_requests(args.out_json_file, args.start_time)
+            website_query_pull_requests(args.out_json_file, start_time)
+
+        case "website.process":
+            if not args.input_json_file:
+                parser.error("--input_json_file must be specified")
+
+            if not args.version:
+                parser.error("--version must be specified")
+
+            if not args.out_markdown_file:
+                parser.error("--out_markdown_file must be specified")
+
+            website_process_pull_requests(args.input_json_file,
+                                          args.version,
+                                          args.out_markdown_file)
 
 
 if __name__ == "__main__":

--- a/scripts/tools/release-notes-drafter.py
+++ b/scripts/tools/release-notes-drafter.py
@@ -4,10 +4,12 @@
 # SPDX-License-Identifier: MIT
 
 """
-Create and publish DOSBox Staging release notes.
+Create release notes draft for DOSBox Staging.
 
 The GitHub access token must be set in the GITHUB_ACCESS_TOKEN env var.
-The token must have 'repo' scope.
+
+The token must have the following scopes:
+  repo, workflow, write:packages, delete:packages
 
 """
 
@@ -103,117 +105,153 @@ FILTERS = [
 ]
 
 
+# ANSI colour helpers — automatically disabled when stdout is not a TTY
+# (e.g. when output is piped or redirected).
+def _ansi(code):
+    def apply(text):
+        if sys.stdout.isatty():
+            return f"\033[{code}m{text}\033[0m"
+        return text
+    return apply
+
+_BOLD  = _ansi("1")
+_GREEN = _ansi("32")
+_CYAN  = _ansi("36")
+_YELLOW = _ansi("33")
+_DIM   = _ansi("2")
+
+
+class CustomFormatter(argparse.RawDescriptionHelpFormatter):
+    """Coloured, grouped help for both the top-level and subcommand parsers."""
+
+    # Top-level: render subcommand list
+    def _format_action(self, action):
+        if action.nargs == argparse.PARSER:
+            rows = [(name, sub.description or "")
+                    for name, sub in action.choices.items()]
+
+            lines = []
+            last_prefix = None
+            col = 30
+
+            for name, help_text in rows:
+                prefix = name.split(".")[0]
+                if prefix != last_prefix:
+                    if lines:
+                        lines.append("")
+                    last_prefix = prefix
+
+                styled_name = _GREEN(f"{name:<{col}}")
+                lines.append(f"  {styled_name}{help_text}")
+
+            lines.append(
+                f"\n{_DIM('Run')} "
+                f"{_CYAN('./release-notes-drafter.py <command> --help')} "
+                f"{_DIM('for command-specific usage.')}"
+            )
+            return "\n".join(lines) + "\n"
+
+        # Subcommand: colour option names and positional arg names
+        result = super()._format_action(action)
+        if action.option_strings:
+            for opt in action.option_strings:
+                result = result.replace(opt, _CYAN(opt), 1)
+        elif action.dest != argparse.SUPPRESS:
+            result = result.replace(action.dest, _GREEN(action.dest), 1)
+        return result
+
+    # Colour section headers (e.g. "positional arguments:")
+    def start_section(self, heading):
+        super().start_section(_BOLD(_YELLOW(heading)) if heading else heading)
+
+    # Colour the "usage:" prefix
+    def _format_usage(self, usage, actions, groups, prefix):
+        if prefix is None:
+            prefix = _BOLD("usage: ")
+        return super()._format_usage(usage, actions, groups, prefix)
+
+
 def setup_arg_parser(parser):
-    parser.add_argument(
-        "ACTION",
-        choices=["summary.query", "summary.process", "summary.publish",
-                 "website.query", "website.process"],
-        help="""summary.query
-  Queries information about all pull requests merged to the 'main'
-  branch since the last public DOSBox Staging release and writes
-  the results to a CSV file.
+    fmt = CustomFormatter
+    subparsers = parser.add_subparsers(dest="ACTION", required=True,
+                                       metavar="<command>")
 
-summary.process
-  Processes the CSV output of the 'summary.query' action and generates the
-  release notes draft either in Markdown or CSV format.
-
-summary.publish
-  Publishes (creates or updates) the release notes draft.
-
-website.query
-  Queries all pull requests merged to 'main' since the last public
-  release, including their full descriptions, and writes the results
-  to a JSON file.
-
-website.process
-  Processes the JSON output of the 'website.query' action and generates
-  a detailed release notes draft for the website.
-"""
+    # summary.query
+    # -----------------------------------------------------------------
+    p = subparsers.add_parser(
+        "summary.query",
+        description="Fetch merged PRs and write to CSV.",
+        formatter_class=fmt,
     )
+    p.add_argument("out_pull_requests_csv",
+                   help="output CSV file for pull requests")
+    p.add_argument("--start_time",
+                   help="include PRs after this datetime "
+                        "(defaults to RELEASE_START_TIME from set-common-vars/action.yml)")
 
-    query_args = parser.add_argument_group(title="common query arguments")
-
-    query_args.add_argument(
-        "--start_time",
-        help="""include pull requests after this datetime
-(defaults to RELEASE_START_TIME from set-common-vars/action.yml)
-"""
+    # summary.process_markdown
+    # -----------------------------------------------------------------
+    p = subparsers.add_parser(
+        "summary.process_markdown",
+        description="Generate release notes Markdown from CSV.",
+        formatter_class=fmt,
     )
+    p.add_argument("in_pull_requests_csv", help="input CSV file")
+    p.add_argument("out_markdown",         help="output Markdown file")
 
-    process_args = parser.add_argument_group(title="common process arguments")
-
-    process_args.add_argument(
-        "--out_markdown_file",
-        help="""write output to a Markdown file
-"""
+    # summary.process_html
+    # -----------------------------------------------------------------
+    p = subparsers.add_parser(
+        "summary.process_html",
+        description="Generate release notes HTML from CSV.",
+        formatter_class=fmt,
     )
+    p.add_argument("in_pull_requests_csv", help="input CSV file")
+    p.add_argument("process_version_tag",  help="version tag (e.g. v0.83.0-alpha)")
+    p.add_argument("out_html",             help="output HTML file")
 
-    summary_query_args = parser.add_argument_group(title="summary.query arguments")
-
-    summary_query_args.add_argument(
-        "--out_pull_requests_csv",
-        help="output CSV file containing the pull requests"
+    # summary.process_csv
+    # -----------------------------------------------------------------
+    p = subparsers.add_parser(
+        "summary.process_csv",
+        description="Generate categorised CSV from input CSV.",
+        formatter_class=fmt,
     )
+    p.add_argument("in_pull_requests_csv", help="input CSV file")
+    p.add_argument("out_categorised_csv",  help="output categorised CSV file")
 
-    summary_process_args = parser.add_argument_group(title="summary.process arguments")
-
-    summary_process_args.add_argument(
-        "--input_csv_file",
-        help="""input CSV file containing the pull requests
-        """
+    # summary.publish
+    # -----------------------------------------------------------------
+    p = subparsers.add_parser(
+        "summary.publish",
+        description="Publish (create or update) the release notes draft.",
+        formatter_class=fmt,
     )
+    p.add_argument("in_markdown",          help="input Markdown file")
+    p.add_argument("publish_version_tag",  help="version tag (e.g. v0.83.0-alpha)")
 
-    summary_process_args.add_argument(
-        "--out_csv_file",
-        help="""write categorised PRs to a CSV file
-        """
+    # website.query
+    # -----------------------------------------------------------------
+    p = subparsers.add_parser(
+        "website.query",
+        description="Fetch merged PRs with descriptions and write to JSON.",
+        formatter_class=fmt,
     )
+    p.add_argument("out_pull_requests_json", help="output JSON file")
+    p.add_argument("--start_time",
+                   help="include PRs after this datetime "
+                        "(defaults to RELEASE_START_TIME from set-common-vars/action.yml)")
 
-    summary_process_args.add_argument(
-        "--out_html_file",
-        help="""write release notes to an HTML file
-(to be included in the development build artifacts)
-
-"""
+    # website.process_markdown
+    # -----------------------------------------------------------------
+    p = subparsers.add_parser(
+        "website.process_markdown",
+        description="Generate detailed website release notes from JSON.",
+        formatter_class=fmt,
     )
-
-    summary_process_args.add_argument(
-        "--html_version_tag",
-        help="version tag of the release notes draft (e.g., v0.83.0-alpha)"
-    )
-
-    summary_publish_args = parser.add_argument_group(title="summary.publish arguments")
-
-    summary_publish_args.add_argument(
-        "--release_notes_file",
-        help="""release notes Markdown file
-
-"""
-    )
-
-    summary_publish_args.add_argument(
-        "--publish_version_tag",
-        help="the release notes will be published under this tag (e.g., v0.83.0-alpha)"
-    )
-
-    website_query_args = parser.add_argument_group(title="website.query arguments")
-
-    website_query_args.add_argument(
-        "--out_json_file",
-        help="output JSON file containing pull requests with descriptions"
-    )
-
-    website_process_args = parser.add_argument_group(title="website.process arguments")
-
-    website_process_args.add_argument(
-        "--input_json_file",
-        help="input JSON file from 'website.query'"
-    )
-
-    website_process_args.add_argument(
-        "--version",
-        help="release version number (e.g., 0.83.0)"
-    )
+    p.add_argument("in_pull_requests_json", help="input JSON file from website.query")
+    p.add_argument("process_version_tag",   help="version tag (e.g. v0.83.0-alpha)")
+    p.add_argument("out_markdown",          help="output Markdown file")
 
 
 def get_default_start_time():
@@ -611,7 +649,7 @@ def summary_process_pull_requests_csv(items, csv_fname):
     print(f"Categorised pull requests CSV written to '{csv_fname}'")
 
 
-def summary_process_pull_requests_html(items, html_fname, version_tag):
+def summary_process_pull_requests_html(items, version_tag, html_fname):
     markdown = generate_markdown(items, HTML_HEADER)
 
     # Convert markdown to HTML
@@ -738,14 +776,17 @@ def extract_release_notes(body):
     if not body:
         return None
 
-    match = re.search(r"^#\s+Release notes\s*$", body, re.MULTILINE | re.IGNORECASE)
+    body = normalise_newlines(body)
+
+    match = re.search(r"^#\s+Release notes\s*$", body, re.MULTILINE |
+                      re.IGNORECASE)
     if not match:
         return None
 
     rest = body[match.end():]
 
     # Find the next first level heading or end of string
-    next_heading = re.search(r"^#\s+\w", rest, re.MULTILINE)
+    next_heading = re.search(r"^#\sManual testing\s*$", rest, re.MULTILINE)
     content = rest[:next_heading.start()] if next_heading else rest
     content = normalise_newlines(content.strip())
 
@@ -816,12 +857,16 @@ TODO: Add upgrade instructions
         if prs:
             md += f"## {heading}\n\n"
             md = append_narrative_prs(md, prs)
-            md = append_collapsible_pr_list(md, prs, filter_titles[category])
+            md = append_collapsible_pr_list(md, prs,
+                                            filter_titles[category])
 
     # General section: narrative from misc-enhancements/misc-fixes,
     # collapsible lists for all "general" sub-categories
     general_narrative = ["misc-enhancements", "misc-fixes"]
-    general_collapsible_only = ["documentation", "project-maintenance", "other"]
+
+    general_collapsible_only = ["documentation", "project-maintenance",
+                                "other"]
+
     all_general = general_narrative + general_collapsible_only
 
     if any(categories.get(cat) for cat in all_general):
@@ -841,10 +886,12 @@ TODO: Add upgrade instructions
     if loc_prs:
         md += "## Localisation\n\n"
         md = append_narrative_prs(md, loc_prs)
-        md = append_collapsible_pr_list(md, loc_prs, filter_titles["localisation"])
+        md = append_collapsible_pr_list(md, loc_prs,
+                                        filter_titles["localisation"])
 
     # Contributors & Thank you
-    contributors = "\n".join(f"- {a}" for a in get_contributor_list(items))
+    contributors = "\n".join(f"- {a}" for a in
+                             get_contributor_list(items))
 
     md += f"""\
 ## Contributors
@@ -877,18 +924,17 @@ def write_json(items, output_json):
         json.dump(items, f, indent=2, ensure_ascii=False)
 
 
-# pylint: disable=too-many-branches
 def main():
     parser = argparse.ArgumentParser(
-        formatter_class=argparse.RawTextHelpFormatter,
+        formatter_class=CustomFormatter,
         description=__doc__
     )
     setup_arg_parser(parser)
     args = parser.parse_args()
 
     actions_requiring_token = [
-        "summary.query", "summary.process", "summary.publish",
-        "website.query"
+        "summary.query", "summary.process_markdown", "summary.process_html",
+        "summary.process_csv", "summary.publish", "website.query"
     ]
 
     global GITHUB_ACCESS_TOKEN
@@ -903,68 +949,40 @@ def main():
             start_time = args.start_time or get_default_start_time()
             if not start_time:
                 parser.error("--start_time must be specified")
+            summary_query_pull_requests(args.out_pull_requests_csv,
+                                        start_time)
 
-            if not args.out_pull_requests_csv:
-                parser.error("--out_pull_requests_csv must be specified")
+        case "summary.process_markdown":
+            items = read_csv(args.in_pull_requests_csv)
+            summary_process_pull_requests_markdown(items,
+                                                   args.out_markdown)
 
-            summary_query_pull_requests(args.out_pull_requests_csv, start_time)
+        case "summary.process_html":
+            items = read_csv(args.in_pull_requests_csv)
+            summary_process_pull_requests_html(items,
+                                               args.process_version_tag,
+                                               args.out_html)
 
-        case "summary.process":
-            if not args.input_csv_file:
-                parser.error("--input_csv_file must be specified")
-
-            if not args.out_markdown_file and not args.out_csv_file and not args.out_html_file:
-                parser.error("one of --out_markdown_file, --out_csv_file, or "
-                             "--out_html_file must be specified")
-
-            items = read_csv(args.input_csv_file)
-
-            if args.out_markdown_file:
-                summary_process_pull_requests_markdown(items, args.out_markdown_file)
-
-            if args.out_html_file:
-                if not args.html_version_tag:
-                    parser.error("--html_version_tag of the release notes draft must "
-                                 "be specified")
-
-                summary_process_pull_requests_html(items, args.out_html_file,
-                                           args.html_version_tag)
-
-            if args.out_csv_file:
-                summary_process_pull_requests_csv(items, args.out_csv_file)
+        case "summary.process_csv":
+            items = read_csv(args.in_pull_requests_csv)
+            summary_process_pull_requests_csv(items,
+                                              args.out_categorised_csv)
 
         case "summary.publish":
-            if not args.release_notes_file:
-                parser.error("--release_notes_file must be specified")
-
-            if not args.publish_version_tag:
-                parser.error("--publish_version_tag must be specified")
-
-            summary_publish_prerelease(args.release_notes_file, args.publish_version_tag)
+            summary_publish_prerelease(args.in_markdown,
+                                       args.publish_version_tag)
 
         case "website.query":
             start_time = args.start_time or get_default_start_time()
             if not start_time:
                 parser.error("--start_time must be specified")
+            website_query_pull_requests(args.out_pull_requests_json,
+                                        start_time)
 
-            if not args.out_json_file:
-                parser.error("--out_json_file must be specified")
-
-            website_query_pull_requests(args.out_json_file, start_time)
-
-        case "website.process":
-            if not args.input_json_file:
-                parser.error("--input_json_file must be specified")
-
-            if not args.version:
-                parser.error("--version must be specified")
-
-            if not args.out_markdown_file:
-                parser.error("--out_markdown_file must be specified")
-
-            website_process_pull_requests(args.input_json_file,
-                                          args.version,
-                                          args.out_markdown_file)
+        case "website.process_markdown":
+            website_process_pull_requests(args.in_pull_requests_json,
+                                          args.process_version_tag,
+                                          args.out_markdown)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description

This refactors the release drafter script to add a new mode that generates a draft of the detailed version of the notes that we publish on our website. The new mode goes through all the PRs in the current alpha release and copies the content from the "Release notes" section into the draft.

This will help me automate this tedious and mechanical part of the release process so I can focus on the important bit, which is editing and refining the notes. I will only use this locally to generate a 70-80% starting point that I will then edit manually.

I didn't write a single line of this — the whole thing was generated by Claude based on my high-level task description and successive refinements until we reached this final form. Time taken: less than 2 hours. This could've easily eaten up an entire day (if not more) if I did it manually.

I instructed it to document the changes extensively in the commit descriptions; read them for additional details.

Use the help to find out how to use it — the commands & options are very well documented, and the invocation is much more logical than before.

<img width="983" height="628" alt="image" src="https://github.com/user-attachments/assets/058e3a24-9c95-42e8-94d7-a465420e9d18" />


# Manual testing

Claude & myself ran it locally a few times, then I ran all the actions locally and inspected the output. Also ran the "Update release notes preview" GitHub action manually.

The change has been manually tested on:

- [ ] Windows
- [x] macOS
- [ ] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

