### PR TITLE
Fix vcpkg compilation on Linux for newer compilers

### DIFF
--- a/vcpkg-ports/libsystemd/disable-warning-nonnull.patch
+++ b/vcpkg-ports/libsystemd/disable-warning-nonnull.patch
@@ -1,0 +1,14 @@
+diff --git a/src/basic/memory-util.h b/src/basic/memory-util.h
+index 1179513..fc39e06 100644
+--- a/src/basic/memory-util.h
++++ b/src/basic/memory-util.h
+@@ -41,7 +41,9 @@ static inline int memcmp_safe(const void *s1, const void *s2, size_t n) {
+                 return 0;
+         assert(s1);
+         assert(s2);
++DISABLE_WARNING_NONNULL
+         return memcmp(s1, s2, n);
++REENABLE_WARNING
+ }
+ 
+ /* Compare s1 (length n1) with s2 (length n2) in lexicographic order. */

--- a/vcpkg-ports/libsystemd/glibc-const.patch
+++ b/vcpkg-ports/libsystemd/glibc-const.patch
@@ -1,0 +1,177 @@
+commit 0bc360a7ee9c9c258354a85a0fdd66a91bdead03
+Author: Daniel Bomar <dbdaniel42@gmail.com>
+Date:   Fri Apr 3 11:40:43 2026 -0500
+
+    Fix compiling on newer versions of Clang
+
+diff --git a/src/basic/sort-util.h b/src/basic/sort-util.h
+index 9c818bd747..b19fba4ac1 100644
+--- a/src/basic/sort-util.h
++++ b/src/basic/sort-util.h
+@@ -31,7 +31,7 @@ static inline void* bsearch_safe(const void *key, const void *base,
+                 return NULL;
+ 
+         assert(base);
+-        return bsearch(key, base, nmemb, size, compar);
++        return (void *)bsearch(key, base, nmemb, size, compar);
+ }
+ 
+ #define typesafe_bsearch(k, b, n, func)                                 \
+diff --git a/src/basic/string-util.c b/src/basic/string-util.c
+index 171a368059..ca77898f4e 100644
+--- a/src/basic/string-util.c
++++ b/src/basic/string-util.c
+@@ -1055,7 +1055,7 @@ int split_pair(const char *s, const char *sep, char **l, char **r) {
+         if (isempty(sep))
+                 return -EINVAL;
+ 
+-        x = strstr(s, sep);
++        x = (char *)strstr(s, sep);
+         if (!x)
+                 return -EINVAL;
+ 
+@@ -1402,7 +1402,7 @@ char* find_line_startswith(const char *haystack, const char *needle) {
+         /* Finds the first line in 'haystack' that starts with the specified string. Returns a pointer to the
+          * first character after it */
+ 
+-        p = strstr(haystack, needle);
++        p = (char *)strstr(haystack, needle);
+         if (!p)
+                 return NULL;
+ 
+@@ -1513,7 +1513,7 @@ char* strrstr(const char *haystack, const char *needle) {
+         /* Special case: for the empty string we return the very last possible occurrence, i.e. *after* the
+          * last char, not before. */
+         if (*needle == 0)
+-                return strchr(haystack, 0);
++                return (char *)strchr(haystack, 0);
+ 
+         for (const char *p = strstr(haystack, needle), *q; p; p = q) {
+                 q = strstr(p + 1, needle);
+diff --git a/src/basic/string-util.h b/src/basic/string-util.h
+index cc6aa183c0..f578c869f8 100644
+--- a/src/basic/string-util.h
++++ b/src/basic/string-util.h
+@@ -30,7 +30,7 @@
+ static inline char* strstr_ptr(const char *haystack, const char *needle) {
+         if (!haystack || !needle)
+                 return NULL;
+-        return strstr(haystack, needle);
++        return (char *)strstr(haystack, needle);
+ }
+ 
+ static inline char* strstrafter(const char *haystack, const char *needle) {
+diff --git a/src/basic/unit-name.c b/src/basic/unit-name.c
+index 43c15213ef..2eb0676566 100644
+--- a/src/basic/unit-name.c
++++ b/src/basic/unit-name.c
+@@ -230,7 +230,7 @@ int unit_name_change_suffix(const char *n, const char *suffix, char **ret) {
+         if (!unit_suffix_is_valid(suffix))
+                 return -EINVAL;
+ 
+-        assert_se(e = strrchr(n, '.'));
++        assert_se(e = (char *)strrchr(n, '.'));
+ 
+         a = e - n;
+         b = strlen(suffix);
+@@ -531,7 +531,7 @@ bool unit_name_is_hashed(const char *name) {
+         if (!unit_name_is_valid(name, UNIT_NAME_PLAIN))
+                 return false;
+ 
+-        assert_se(s = strrchr(name, '.'));
++        assert_se(s = (char *)strrchr(name, '.'));
+ 
+         if (s - name < UNIT_NAME_HASH_LENGTH_CHARS + 1)
+                 return false;
+@@ -556,7 +556,7 @@ int unit_name_hash_long(const char *name, char **ret) {
+         if (strlen(name) < UNIT_NAME_MAX)
+                 return -EMSGSIZE;
+ 
+-        suffix = strrchr(name, '.');
++        suffix = (char *)strrchr(name, '.');
+         if (!suffix)
+                 return -EINVAL;
+ 
+diff --git a/src/libsystemd/sd-bus/sd-bus.c b/src/libsystemd/sd-bus/sd-bus.c
+index 3ea12fc371..b6f4a9fada 100644
+--- a/src/libsystemd/sd-bus/sd-bus.c
++++ b/src/libsystemd/sd-bus/sd-bus.c
+@@ -1446,14 +1446,14 @@ int bus_set_address_system_remote(sd_bus *b, const char *host) {
+         if (*host == '[') {
+                 char *t;
+ 
+-                rbracket = strchr(host, ']');
++                rbracket = (char *)strchr(host, ']');
+                 if (!rbracket)
+                         return -EINVAL;
+                 t = strndupa_safe(host + 1, rbracket - host - 1);
+                 e = bus_address_escape(t);
+                 if (!e)
+                         return -ENOMEM;
+-        } else if ((a = strchr(host, '@'))) {
++        } else if ((a = (char *)strchr(host, '@'))) {
+                 if (*(a + 1) == '[') {
+                         _cleanup_free_ char *t = NULL;
+ 
+@@ -1473,7 +1473,7 @@ int bus_set_address_system_remote(sd_bus *b, const char *host) {
+         }
+ 
+         /* Let's see if a port was given */
+-        m = strchr(rbracket ? rbracket + 1 : host, ':');
++        m = (char *)strchr(rbracket ? rbracket + 1 : host, ':');
+         if (m) {
+                 char *t;
+                 bool got_forward_slash = false;
+@@ -1496,7 +1496,7 @@ int bus_set_address_system_remote(sd_bus *b, const char *host) {
+         }
+ 
+         /* Let's see if a machine was given */
+-        m = strchr(rbracket ? rbracket + 1 : host, '/');
++        m = (char *)strchr(rbracket ? rbracket + 1 : host, '/');
+         if (m) {
+                 m++;
+ interpret_port_as_machine_old_syntax:
+diff --git a/src/libsystemd/sd-hwdb/sd-hwdb.c b/src/libsystemd/sd-hwdb/sd-hwdb.c
+index 588fb0313b..df01346f1d 100644
+--- a/src/libsystemd/sd-hwdb/sd-hwdb.c
++++ b/src/libsystemd/sd-hwdb/sd-hwdb.c
+@@ -101,7 +101,7 @@ static const struct trie_node_f *node_lookup_f(sd_hwdb *hwdb, const struct trie_
+         struct trie_child_entry_f search;
+ 
+         search.c = c;
+-        child = bsearch(&search, (const char *)node + le64toh(hwdb->head->node_size), node->children_count,
++        child = (void *)bsearch(&search, (const char *)node + le64toh(hwdb->head->node_size), node->children_count,
+                         le64toh(hwdb->head->child_entry_size), trie_children_cmp_f);
+         if (child)
+                 return trie_node_from_off(hwdb, child->child_off);
+diff --git a/src/libsystemd/sd-journal/catalog.c b/src/libsystemd/sd-journal/catalog.c
+index 7dcc35d8d5..519debb1bb 100644
+--- a/src/libsystemd/sd-journal/catalog.c
++++ b/src/libsystemd/sd-journal/catalog.c
+@@ -541,7 +541,7 @@ static const char *find_id(void *p, sd_id128_t id) {
+                         strncpy(key.language, loc, len);
+                         key.language[len] = '\0';
+ 
+-                        f = bsearch(&key,
++                        f = (void *)bsearch(&key,
+                                     (const uint8_t*) p + le64toh(h->header_size),
+                                     le64toh(h->n_items),
+                                     le64toh(h->catalog_item_size),
+@@ -552,7 +552,7 @@ static const char *find_id(void *p, sd_id128_t id) {
+                                 e = strchr(key.language, '_');
+                                 if (e) {
+                                         *e = 0;
+-                                        f = bsearch(&key,
++                                        f = (void *)bsearch(&key,
+                                                     (const uint8_t*) p + le64toh(h->header_size),
+                                                     le64toh(h->n_items),
+                                                     le64toh(h->catalog_item_size),
+@@ -564,7 +564,7 @@ static const char *find_id(void *p, sd_id128_t id) {
+ 
+         if (!f) {
+                 zero(key.language);
+-                f = bsearch(&key,
++                f = (void *)bsearch(&key,
+                             (const uint8_t*) p + le64toh(h->header_size),
+                             le64toh(h->n_items),
+                             le64toh(h->catalog_item_size),

--- a/vcpkg-ports/libsystemd/only-libsystemd.patch
+++ b/vcpkg-ports/libsystemd/only-libsystemd.patch
@@ -1,0 +1,56 @@
+diff --git a/meson.build b/meson.build
+index a4730f0..32ec825 100644
+--- a/meson.build
++++ b/meson.build
+@@ -2148,12 +2148,11 @@ libsystemd_includes = [basic_includes, include_directories(
+ includes = [libsystemd_includes, include_directories('src/shared')]
+ 
+ subdir('po')
+-subdir('catalog')
++support_url='https://github.com/microsoft/vcpkg/issues'
+ subdir('src/fundamental')
+ subdir('src/basic')
+ subdir('src/libsystemd')
+-subdir('src/shared')
+-subdir('src/libudev')
++static_libudev='unused'
+ 
+ libsystemd = shared_library(
+         'systemd',
+@@ -2169,7 +2168,8 @@ libsystemd = shared_library(
+                         threads,
+                         userspace],
+         link_depends : libsystemd_sym,
+-        install : true,
++        build_by_default : static_libsystemd == 'false',
++        install : static_libsystemd == 'false',
+         install_tag: 'libsystemd',
+         install_dir : libdir)
+ 
+@@ -2205,6 +2205,8 @@ else
+         alias_target('libsystemd', libsystemd)
+ endif
+ 
++if false
++
+ libudev = shared_library(
+         'udev',
+         version : libudev_version,
+@@ -2940,6 +2942,17 @@ custom_target(
+         install_dir : testdata_dir,
+         command : [meson_extract_unit_files, meson.project_build_root()])
+ 
++else
++  # headers
++  subdir('src/systemd')
++  # subdir man
++  want_html=false
++  want_man=false
++  # subdir shell-completion/*
++  bashcompletiondir='no'
++  zshcompletiondir='no'
++endif
++
+ #####################################################################
+ 
+ alt_time_epoch = run_command('date', '-Is', '-u', '-d', '@@0@'.format(time_epoch),

--- a/vcpkg-ports/libsystemd/pkgconfig.patch
+++ b/vcpkg-ports/libsystemd/pkgconfig.patch
@@ -1,0 +1,25 @@
+diff --git a/meson.build b/meson.build
+index 687450e..ee4460b 100644
+--- a/meson.build
++++ b/meson.build
+@@ -1011,6 +1011,9 @@ threads = dependency('threads')
+ librt = cc.find_library('rt')
+ libm = cc.find_library('m')
+ libdl = cc.find_library('dl')
++conf.set_quoted('PC_RT', librt.found() ? '-lrt' : '')
++conf.set_quoted('PC_M',  libm.found()  ? '-lm'  : '')
++conf.set_quoted('PC_DL', libdl.found() ? '-ldl' : '')
+ libcrypt = dependency('libcrypt', 'libxcrypt', required : false)
+ if not libcrypt.found()
+         # fallback to use find_library() if libcrypt is provided by glibc, e.g. for LibreELEC.
+diff --git a/src/libsystemd/libsystemd.pc.in b/src/libsystemd/libsystemd.pc.in
+index 3a43ef6..930f16a 100644
+--- a/src/libsystemd/libsystemd.pc.in
++++ b/src/libsystemd/libsystemd.pc.in
+@@ -17,4 +17,6 @@ Description: systemd Library
+ URL: {{PROJECT_URL}}
+ Version: {{PROJECT_VERSION}}
+ Libs: -L${libdir} -lsystemd
++Libs.private: {{PC_DL}} {{PC_M}} {{PC_RT}}
++Requires.private: libcap libcrypt liblz4 liblzma libzstd mount
+ Cflags: -I${includedir}

--- a/vcpkg-ports/libsystemd/portfile.cmake
+++ b/vcpkg-ports/libsystemd/portfile.cmake
@@ -1,0 +1,89 @@
+vcpkg_from_github(
+  OUT_SOURCE_PATH SOURCE_PATH
+  REPO systemd/systemd
+  REF "v${VERSION}"
+  SHA512 30331df5eb7a1556da8c017a0e6c07b8b99f0cb31da055c1b86c9b9e6fd7074f7c6746efa3e69711b73af48a15d61a84f35ad6e554d32a23441ba910398f7f65
+  PATCHES
+    disable-warning-nonnull.patch
+    only-libsystemd.patch
+    pkgconfig.patch
+    # This is fixed upstream but commit would not cleanly apply.
+    # Remove when vcpkg finally updates this port.
+    # Latest version is 260.1 vcpkg is about a year behind on 257.8.
+    glibc-const.patch
+)
+
+set(static false)
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+  set(static pic)
+endif()
+
+vcpkg_find_acquire_program(PYTHON3)
+x_vcpkg_get_python_packages(
+    PYTHON_VERSION 3
+    PYTHON_EXECUTABLE "${PYTHON3}"
+    PACKAGES "jinja2"
+)
+
+vcpkg_configure_meson(
+  SOURCE_PATH "${SOURCE_PATH}"
+  OPTIONS
+    -Dmode=release
+    -Dstatic-libsystemd=${static}
+    -Dtests=false
+    # disabled capabilites
+    -Ddns-over-tls=false
+    -Dtranslations=false
+    # disabled dependencies
+    -Dacl=disabled
+    -Dapparmor=disabled
+    -Daudit=disabled
+    -Dblkid=disabled
+    -Dbpf-framework=disabled
+    -Dbzip2=disabled
+    -Ddbus=disabled # tests only
+    -Delfutils=disabled
+    -Dfdisk=disabled
+    -Dgcrypt=disabled
+    -Dglib=disabled # tests only
+    -Dgnutls=disabled
+    -Dkmod=disabled
+    -Dlibcurl=disabled
+    -Dlibcryptsetup=disabled
+    -Dlibfido2=disabled
+    -Dlibidn=disabled
+    -Dlibidn2=disabled
+    -Dlibiptc=disabled
+    -Dmicrohttpd=disabled
+    -Dopenssl=disabled
+    -Dp11kit=disabled
+    -Dpam=disabled
+    -Dpcre2=disabled
+    -Dpolkit=disabled
+    -Dpwquality=disabled
+    -Dpasswdqc=disabled
+    -Dseccomp=disabled
+    -Dselinux=disabled
+    -Dtpm2=disabled
+    -Dxenctrl=disabled
+    -Dxkbcommon=disabled
+    -Dzlib=disabled
+    # enabled dependencies
+    -Dlz4=enabled
+    -Dxz=enabled
+    -Dzstd=enabled
+  ADDITIONAL_BINARIES
+    "gperf = ['${CURRENT_HOST_INSTALLED_DIR}/tools/gperf/gperf${HOST_EXECUTABLE_SUFFIX}']"
+)
+
+vcpkg_install_meson()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+vcpkg_fixup_pkgconfig()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSES/README.md" "${SOURCE_PATH}/LICENSE.LGPL2.1"
+  COMMENT [[
+This port provides libsystemd.so/.a, which is based on sources in
+src/basic, src/fundamental, src/systemd and src/libsystemd.
+]])

--- a/vcpkg-ports/libsystemd/vcpkg.json
+++ b/vcpkg-ports/libsystemd/vcpkg.json
@@ -1,0 +1,29 @@
+{
+  "name": "libsystemd",
+  "version": "257.8",
+  "port-version": 1,
+  "description": "Libsystemd",
+  "homepage": "https://github.com/systemd/systemd",
+  "license": null,
+  "supports": "linux",
+  "dependencies": [
+    {
+      "name": "gperf",
+      "host": true
+    },
+    "libcap",
+    "liblzma",
+    "libmount",
+    "libxcrypt",
+    "lz4",
+    {
+      "name": "vcpkg-get-python-packages",
+      "host": true
+    },
+    {
+      "name": "vcpkg-tool-meson",
+      "host": true
+    },
+    "zstd"
+  ]
+}

--- a/vcpkg-ports/sdl2/alsa-sig.patch
+++ b/vcpkg-ports/sdl2/alsa-sig.patch
@@ -1,0 +1,21 @@
+commit 05c9b16183743925e59a489c4348141c8a050603
+Author: Ozkan Sezer <sezeroz@gmail.com>
+Date:   Tue Sep 2 17:02:28 2025 +0300
+
+    alsa: fix signature of snd_pcm_info_free
+    
+    Reference issue: https://github.com/libsdl-org/SDL/issues/13845.
+
+diff --git a/src/audio/alsa/SDL_alsa_audio.c b/src/audio/alsa/SDL_alsa_audio.c
+index 8f3a49c81..7af711411 100644
+--- a/src/audio/alsa/SDL_alsa_audio.c
++++ b/src/audio/alsa/SDL_alsa_audio.c
+@@ -88,7 +88,7 @@ static const char *(*ALSA_snd_pcm_info_get_name)(const snd_pcm_info_t *);
+ static int (*ALSA_snd_pcm_info_get_card)(const snd_pcm_info_t *);
+ static int (*ALSA_snd_card_get_name)(int, char **);
+ static int (*ALSA_snd_pcm_info_malloc)(snd_pcm_info_t **);
+-static int (*ALSA_snd_pcm_info_free)(snd_pcm_info_t *);
++static void (*ALSA_snd_pcm_info_free)(snd_pcm_info_t *);
+ #ifdef SND_CHMAP_API_VERSION
+ static snd_pcm_chmap_t *(*ALSA_snd_pcm_get_chmap)(snd_pcm_t *);
+ static int (*ALSA_snd_pcm_chmap_print)(const snd_pcm_chmap_t *map, size_t maxlen, char *buf);

--- a/vcpkg-ports/sdl2/portfile.cmake
+++ b/vcpkg-ports/sdl2/portfile.cmake
@@ -8,6 +8,8 @@ vcpkg_from_github(
         deps.patch
         alsa-dep-fix.patch
         cxx-linkage-pkgconfig.diff
+        # Upstream commit 05c9b16183743925e59a489c4348141c8a050603, remove this patch on next SDL release.
+        alsa-sig.patch
 )
 
 if (VCPKG_TARGET_IS_OSX)


### PR DESCRIPTION
# Description

I had to patch both libsystemd (for Clang) and sdl2 (for GCC) in order to get a working vcpkg build on my system. Both are Linux specific and pretty trivial changes.

SDL 2: Had an incorrect function pointer declaration for an ALSA function. One line patch taken directly from upstream that just hasn't made it into a numbered release yet.

libsystemd: `strstr` and friends are returning const pointers in newer Linux toolchains. This one has been fixed upstream (and in a numbered release) but vcpkg has an outdated version in the repo. Upstream patch would not apply cleanly so I patched it myself by adding casts to remove the const until it compiled.

# Manual testing

Did a quick smoke test on my system and all looks good.

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [x] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

