### PR TITLE
Fix segfault on exit for some Linux systems

### DIFF
--- a/src/gui/render/opengl_renderer.cpp
+++ b/src/gui/render/opengl_renderer.cpp
@@ -199,6 +199,10 @@ OpenGlRenderer::~OpenGlRenderer()
 		input_texture.texture = 0;
 	}
 
+	// ShaderPipeline destructor makes some gl calls.
+	// Do that here before we delete the context.
+	shader_pipeline = {};
+
 	if (context) {
 		SDL_GL_DeleteContext(context);
 		context = {};

--- a/src/gui/render/private/shader_manager.h
+++ b/src/gui/render/private/shader_manager.h
@@ -49,7 +49,7 @@ public:
 
 private:
 	ShaderManager() = default;
-	~ShaderManager();
+	~ShaderManager() = default;
 
 	// prevent copying
 	ShaderManager(const ShaderManager&) = delete;

--- a/src/gui/render/shader_manager.cpp
+++ b/src/gui/render/shader_manager.cpp
@@ -69,14 +69,6 @@ bool ShaderDescriptor::EnforceAutoIntegerScaling() const
 	return (shader_name != ShaderName::Sharp);
 }
 
-ShaderManager::~ShaderManager()
-{
-	for (const auto& [_, shader] : shader_cache) {
-		glDeleteProgram(shader.program_object);
-	}
-	shader_cache.clear();
-}
-
 std::optional<Shader> ShaderManager::LoadShader(const std::string& shader_name)
 {
 	if (!shader_cache.contains(shader_name)) {


### PR DESCRIPTION
# Description

A user on Discord found this crash. At first I could only reproduce it with CI artifacts. Took me a while to be able to reproduce it on a local build. Turns out it's not related to SDL version or vcpkg.

My local builds were linking to `libOpenGL` and `libGLX` at build time. CI builds were not (probably because they don't have X11 and/or GL drivers installed). Instead, the GL drivers must be dynamically loaded at runtime and that is what's needed to trigger the crash.

I was able to reproduce it locally by making the following change to build files (this is not being committed here, only used it locally for testing):

```
diff --git a/src/gui/CMakeLists.txt b/src/gui/CMakeLists.txt
index a1813a0d5..b96df1e93 100644
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -17,5 +17,4 @@ target_sources(libdosboxcommon PRIVATE
 )
 
 target_link_libraries(libdosboxcommon PRIVATE
-  OpenGL::GL
-  $<IF:$<BOOL:${C_OPENGL}>,libglad,>)
+  libglad)
```

# Manual testing

No more crashes  on exit. Doom still works.

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [x] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

