### PR TITLE
Update PVS-Studio workflow for the latest version

### DIFF
--- a/.github/workflows/pvs-studio.yml
+++ b/.github/workflows/pvs-studio.yml
@@ -85,7 +85,7 @@ jobs:
           mkdir -p "${reportdir}"
 
           pvs-studio-analyzer analyze \
-            -a 63 \
+            -a '64;GA;OP;CS;MISRA' \
             -e subprojects -e src/libs \
             -s .pvs-suppress \
             -j "$(nproc)" \

--- a/.github/workflows/pvs-studio.yml
+++ b/.github/workflows/pvs-studio.yml
@@ -118,7 +118,7 @@ jobs:
 
       - name: Summarize report
         env:
-          MAX_BUGS: 171
+          MAX_BUGS: 162
         run: |
           echo "Full report is included in build Artifacts"
           echo

--- a/src/dos/dos_code_page.cpp
+++ b/src/dos/dos_code_page.cpp
@@ -1979,6 +1979,7 @@ static void set_screen_font(const ScreenFont& screen_font,
 	auto set_font_8x16 = [](const ScreenFont& screen_font) {
 		auto font = screen_font.font_8x16;
 		font.resize(ScreenFont::FullSize_8x16, 0);
+
 		const auto memory = RealToPhysical(int10.rom.font_16);
 		for (uint16_t idx = 0; idx < font.size(); ++idx) {
 			phys_writeb(memory + idx, font.at(idx));
@@ -1988,6 +1989,7 @@ static void set_screen_font(const ScreenFont& screen_font,
 	auto set_font_8x14 = [](const ScreenFont& screen_font) {
 		auto font = screen_font.font_8x14;
 		font.resize(ScreenFont::FullSize_8x14, 0);
+
 		const auto memory = RealToPhysical(int10.rom.font_14);
 		for (uint16_t idx = 0; idx < font.size(); ++idx) {
 			phys_writeb(memory + idx, font.at(idx));
@@ -1997,9 +1999,11 @@ static void set_screen_font(const ScreenFont& screen_font,
 	auto set_font_8x8 = [](const ScreenFont& screen_font) {
 		auto font = screen_font.font_8x8;
 		font.resize(ScreenFont::FullSize_8x8, 0);
+
 		const auto middle   = static_cast<uint16_t>(font.size() / 2);
 		const auto memory_1 = RealToPhysical(int10.rom.font_8_first);
 		const auto memory_2 = RealToPhysical(int10.rom.font_8_second);
+
 		for (uint16_t idx = 0; idx < middle; ++idx) {
 			phys_writeb(memory_1 + idx, font.at(idx));
 		}
@@ -2040,6 +2044,7 @@ static void set_screen_font(const ScreenFont& screen_font,
 	if (CurMode->type == M_TEXT) {
 		INT10_ReloadFont();
 	}
+
 	INT10_SetupRomMemoryChecksum();
 }
 

--- a/src/dos/dos_code_page.cpp
+++ b/src/dos/dos_code_page.cpp
@@ -1982,7 +1982,7 @@ static void set_screen_font(const ScreenFont& screen_font,
 
 		const auto memory = RealToPhysical(int10.rom.font_16);
 		for (uint16_t idx = 0; idx < font.size(); ++idx) {
-			phys_writeb(memory + idx, font.at(idx));
+			phys_writeb(memory + idx, font[idx]);
 		}
 	};
 
@@ -1992,7 +1992,7 @@ static void set_screen_font(const ScreenFont& screen_font,
 
 		const auto memory = RealToPhysical(int10.rom.font_14);
 		for (uint16_t idx = 0; idx < font.size(); ++idx) {
-			phys_writeb(memory + idx, font.at(idx));
+			phys_writeb(memory + idx, font[idx]);
 		}
 	};
 
@@ -2005,10 +2005,10 @@ static void set_screen_font(const ScreenFont& screen_font,
 		const auto memory_2 = RealToPhysical(int10.rom.font_8_second);
 
 		for (uint16_t idx = 0; idx < middle; ++idx) {
-			phys_writeb(memory_1 + idx, font.at(idx));
+			phys_writeb(memory_1 + idx, font[idx]);
 		}
 		for (uint16_t idx = middle; idx < font.size(); ++idx) {
-			phys_writeb(memory_2 - middle + idx, font.at(idx));
+			phys_writeb(memory_2 - middle + idx, font[idx]);
 		}
 	};
 

--- a/src/dos/dos_files.cpp
+++ b/src/dos/dos_files.cpp
@@ -1460,12 +1460,16 @@ bool DOS_FCBFindFirst(uint16_t seg, uint16_t offset)
 
 bool DOS_FCBFindNext(uint16_t seg, uint16_t offset)
 {
-	DOS_FCB fcb(seg, offset);
-	RealPt old_dta = dos.dta();
+	auto old_dta = dos.dta();
 	dos.dta(dos.tables.tempdta);
-	bool ret=DOS_FindNext();
+
+	bool ret = DOS_FindNext();
 	dos.dta(old_dta);
-	if (ret) SaveFindResult(fcb);
+
+	if (ret) {
+		DOS_FCB fcb(seg, offset);
+		SaveFindResult(fcb);
+	}
 	return ret;
 }
 
@@ -1852,13 +1856,16 @@ bool DOS_UnlockFile(const uint16_t entry, const uint32_t pos, const uint32_t len
 		return false;
 	}
 
-	const auto last = Files[handle]->region_locks.end();
-	for (auto it = Files[handle]->region_locks.begin(); it != last; ++it) {
+	auto& region_locks = Files[handle]->region_locks;
+	const auto last    = region_locks.end();
+
+	for (auto it = region_locks.begin(); it != last; ++it) {
 		if (it->pos == pos && it->len == len) {
-			Files[handle]->region_locks.erase(it);
+			region_locks.erase(it);
 			return true;
 		}
 	}
+
 	DOS_SetError(DOSERR_LOCK_VIOLATION);
 	return false;
 }

--- a/src/dos/programs/mem.cpp
+++ b/src/dos/programs/mem.cpp
@@ -909,11 +909,12 @@ MEM::McbChainInfo MEM::GetMcbChainInfo(const uint16_t start_segment)
 		}
 
 		chain_info.emplace_back();
-		chain_info.back().mcb_segment = mcb_segment;
+		auto& last_entry = chain_info.back();
 
-		chain_info.back().type        = mcb.GetType();
-		chain_info.back().size_bytes  = mcb.GetSize() * RealSegmentSize;
-		chain_info.back().psp_segment = mcb.GetPSPSeg();
+		last_entry.mcb_segment = mcb_segment;
+		last_entry.type        = mcb.GetType();
+		last_entry.size_bytes  = mcb.GetSize() * RealSegmentSize;
+		last_entry.psp_segment = mcb.GetPSPSeg();
 
 		char buffer[9];
 		mcb.GetFileName(&buffer[0]);
@@ -1232,9 +1233,11 @@ MEM::BiosMemoryMap MEM::GetBiosMemoryMap()
 		}
 
 		memory_map.emplace_back();
-		memory_map.back().base   = real_readq(segment, 0);
-		memory_map.back().length = real_readq(segment, 8);
-		memory_map.back().type   = real_readd(segment, 16);
+
+		auto& last_entry  = memory_map.back();
+		last_entry.base   = real_readq(segment, 0);
+		last_entry.length = real_readq(segment, 8);
+		last_entry.type   = real_readd(segment, 16);
 	}
 
 	DOS_FreeMemory(segment);

--- a/src/misc/fs_utils.cpp
+++ b/src/misc/fs_utils.cpp
@@ -101,18 +101,18 @@ std::string truncate_path(const std_fs::path& path, int max_length)
 		return ellipsis.substr(0, max_length_unsigned);
 	}
 
-	auto filename  = path.filename().string();
+	auto filename       = path.filename().string();
+	const auto path_str = path.string();
 
 	// Full path fits
-	if (path.string().size() <= max_length_unsigned) {
-		return path.string();
+	if (path_str.size() <= max_length_unsigned) {
+		return path_str;
 	}
 
 	// Shorten path while keeping the filename whole
 	if (max_length_unsigned > filename.size() + ellipsis.size()) {
 		auto keep_from_right = max_length_unsigned - ellipsis.size();
-		return ellipsis +
-		       path.string().substr(path.string().size() - keep_from_right);
+		return ellipsis + path_str.substr(path_str.size() - keep_from_right);
 	}
 
 	// Truncate the filename from the left if too long

--- a/src/misc/rendered_image.h
+++ b/src/misc/rendered_image.h
@@ -40,9 +40,11 @@ struct RenderedImage {
 
 	RenderedImage deep_copy() const
 	{
+		// Duplicate object; note this will only create a shallow copy
+		// of `image_data` as it's just a pointer
 		RenderedImage copy = *this;
 
-		// Deep-copy image and palette data
+		// Deep-copy image data
 		const auto image_data_num_bytes = static_cast<uint32_t>(
 		        params.height * pitch);
 
@@ -50,8 +52,6 @@ struct RenderedImage {
 
 		assert(image_data);
 		std::memcpy(copy.image_data, image_data, image_data_num_bytes);
-
-		copy.palette = palette;
 
 		return copy;
 	}

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -617,11 +617,14 @@ std::string shorten_path(const std::string& path, const size_t max_len)
 
 	// Extract parts of the path which can't be shortened
 
-	std::string path_prefix = {}; // part which has to stay untouched
-	std::string path_middle = path;
-	std::string path_suffix = {}; // part which has to stay untouched
+	// Parts which have to stay untouched
+	std::string path_prefix = {};
+	std::string path_suffix = {};
 
-	if (!path_middle.empty() && path_middle.back() == '\\') {
+	auto path_middle = path;
+	assert(!path_middle.empty());
+
+	if (path_middle.back() == '\\') {
 		// Input ends with backslash
 		path_suffix = "\\";
 		path_middle.pop_back();
@@ -630,6 +633,7 @@ std::string shorten_path(const std::string& path, const size_t max_len)
 	if (path_middle.size() >= 2 && path_middle[1] == ':' &&
 	    ((path_middle[0] >= 'a' && path_middle[0] <= 'z') ||
 	     (path_middle[0] >= 'A' && path_middle[0] <= 'Z'))) {
+
 		// Input starts with DRIVE:
 		if (path_middle.size() >= 3 && path_middle[2] == '\\') {
 			path_prefix = path_middle.substr(0, 3);


### PR DESCRIPTION
# Description

The PVS-Studio analyzer argument format has changed. Looks like when you download the latest version, that will get you to the current 7.42.x beta version. But they haven't released the change logs for that version yet, and it's supposed to be beta anyway? So probably a release process mistake on their end, but we gotta fix it.

I've also taken the opportunity to address a few PVS warnings.

Interestingly, the config file still accepts the numerical bitflags (search twice for `analysis-mode` here: https://pvs-studio.com/en/docs/manual/6615/):

<img width="710" height="385" alt="image" src="https://github.com/user-attachments/assets/5f82e7c2-3125-4687-a32b-fe0704c2a1d3" />

So the equivalent for 63 is (apparently 2 was some internal or reserved value, and yes, we had `MISRA` enabled):

`64;GA;OP;CS;MISRA`

# Manual testing

None.

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [ ] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

