### PR TITLE
Use 'reg_dx' for the mouse double speed threshold, as stated in the Microsoft specification

### DIFF
--- a/src/hardware/input/mouseif_dos_driver.cpp
+++ b/src/hardware/input/mouseif_dos_driver.cpp
@@ -2010,7 +2010,7 @@ static Bitu int33_handler()
 		break;
 	case 0x13:
 		// MS MOUSE v5.0+ - set double-speed threshold
-		set_double_speed_threshold(reg_bx);
+		set_double_speed_threshold(reg_dx);
 		break;
 	case 0x14:
 		// MS MOUSE v3.0+ - exchange event-handler


### PR DESCRIPTION
# Description

According to both:
- _PC Sourcebook_
- _Microsoft Mouse Programmer's Reference_
the mouse driver function 13h should take the mouse double speed threshold from `dx`, not from `bx`. This fixes the problem.

## Related issues

Fixes https://github.com/dosbox-staging/dosbox-staging/issues/4837

# Manual testing

Only did some smoke test, checking that our mouse support still works. Our acceleration model does not use the threshold for anything, there is no getter function for this value.

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [x] Linux


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.
