### PR TITLE
fix: use reg_dx for INT 33h function 13h double-speed threshold

### DIFF
--- a/src/hardware/input/mouseif_dos_driver.cpp
+++ b/src/hardware/input/mouseif_dos_driver.cpp
@@ -2010,7 +2010,7 @@ static Bitu int33_handler()
 		break;
 	case 0x13:
 		// MS MOUSE v5.0+ - set double-speed threshold
-		set_double_speed_threshold(reg_bx);
+		set_double_speed_threshold(reg_dx);
 		break;
 	case 0x14:
 		// MS MOUSE v3.0+ - exchange event-handler


### PR DESCRIPTION
Fixes #4837

Function 13h reads from reg_bx but the Microsoft Mouse Programmer's Reference says it should be reg_dx. Ralph Brown confirms the same. @FeralChild64 checked the PC Sourcebook too.

Pretty harmless since nothing reads this value back but its still wrong per spec. @sduensin tested on real MS-DOS hardware with actual mouse drivers and confirmed dx is correct.

One line change:
```diff
- set_double_speed_threshold(reg_bx);
+ set_double_speed_threshold(reg_dx);
```