### PR TITLE
Allow shutdown via POST /api/v1/dosbox/shutdown

### DIFF
--- a/extras/api/api.d.ts
+++ b/extras/api/api.d.ts
@@ -47,8 +47,8 @@ export class DOSBoxApi {
 	readMemAndCpu(offset: string | number, len: string | number): Promise<MemoryResponse>;
     writeMem(segment: string | number, offset: string | number, data: Uint8Array): Promise<void>;
 	writeMem(offset: string | number, data: Uint8Array): Promise<void>;
-	compareAndSwap(segment: string | number, offset: string | number, data: Uint8Array, expected: Uint8Array): Promise<Uint8Array?>;
-	compareAndSwap(offset: string | number, data: Uint8Array, expected: Uint8Array): Promise<Uint8Array?>;
+	compareAndSwap(segment: string | number, offset: string | number, data: Uint8Array, expected: Uint8Array): Promise<Uint8Array | null>;
+	compareAndSwap(offset: string | number, data: Uint8Array, expected: Uint8Array): Promise<Uint8Array | null>;
     alloc(sizeBytes: number, area?: 'conv' | 'UMA' | 'XMS', strategy?: 'best_fit' | 'first_fit' | 'last_fit'): Promise<AllocateResponse>;
     free(physicalAddress: number): Promise<void>;
 	shutdown(): Promise<void>;

--- a/extras/api/api.d.ts
+++ b/extras/api/api.d.ts
@@ -51,5 +51,6 @@ export class DOSBoxApi {
 	compareAndSwap(offset: string | number, data: Uint8Array, expected: Uint8Array): Promise<Uint8Array?>;
     alloc(sizeBytes: number, area?: 'conv' | 'UMA' | 'XMS', strategy?: 'best_fit' | 'first_fit' | 'last_fit'): Promise<AllocateResponse>;
     free(physicalAddress: number): Promise<void>;
+	shutdown(): Promise<void>;
     getDosInfo(): Promise<DosInfo>;
 }

--- a/extras/api/api.js
+++ b/extras/api/api.js
@@ -113,4 +113,10 @@ export class DOSBoxApi {
         const res = await this._request('dos/internals');
         return await res.json();
     }
+
+    async shutdown()  {
+        await this._request('dosbox/shutdown', {
+            method: 'POST'
+        });
+    }
 }

--- a/extras/api/memory.html
+++ b/extras/api/memory.html
@@ -58,7 +58,7 @@
 		<form class="nav-group" id="disasm-nav" onsubmit="renderDisasmManual(); return false;">
 			<label>Start:</label>
 			<input type="text" id="disasm-start" value="">
-			<button type="submit"">Disassemble</button>
+			<button type="submit">Disassemble</button>
 		</form>
         <div id="disasm-content"></div>
     </div>

--- a/resources/webserver/index.html
+++ b/resources/webserver/index.html
@@ -120,6 +120,9 @@
 
             <h2 class="single">GET /api/v1/dosbox/info</h2>
             <p>Retrieve DOSBox version and relevant paths.</p>
+
+            <h2 class="single">POST /api/v1/dosbox/shutdown</h2>
+            <p>Request a graceful shutdown of DOSBox Staging.</p>
         </section>
     </div>
 

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -417,22 +417,23 @@ void DOSBOX_SetNormalLoop()
 	loop = normal_loop;
 }
 
-static bool is_shutdown_requested = false;
+static std::atomic<bool> is_shutdown_requested = false;
 
 void DOSBOX_RunMachine()
 {
-	while ((*loop)() == 0 && !is_shutdown_requested)
-		;
+	while ((*loop)() == 0 &&
+	       !is_shutdown_requested.load(std::memory_order_relaxed)) {
+	};
 }
 
 void DOSBOX_RequestShutdown()
 {
-	is_shutdown_requested = true;
+	is_shutdown_requested.store(true, std::memory_order_relaxed);
 }
 
 bool DOSBOX_IsShutdownRequested()
 {
-	return is_shutdown_requested;
+	return is_shutdown_requested.load(std::memory_order_relaxed);
 }
 
 static void DOSBOX_UnlockSpeed(bool pressed)

--- a/src/webserver/CMakeLists.txt
+++ b/src/webserver/CMakeLists.txt
@@ -3,6 +3,7 @@ target_sources(dosboxcommon PRIVATE
   webserver.cpp
   cpu.cpp
   memory.cpp
-  dos.cpp)
+  dos.cpp
+  dosbox.cpp)
 
 target_link_libraries(dosboxcommon PRIVATE simde base64 httplib json)

--- a/src/webserver/cpu.cpp
+++ b/src/webserver/cpu.cpp
@@ -1,9 +1,9 @@
 // SPDX-FileCopyrightText:  2026-2026 The DOSBox Staging Team
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-#include "cpu.h"
-#include "bridge.h"
 #include "webserver.h"
+#include "bridge.h"
+#include "private/cpu.h"
 
 #include "base64/base64.h"
 #include "http/http.h"

--- a/src/webserver/dos.cpp
+++ b/src/webserver/dos.cpp
@@ -1,9 +1,9 @@
 // SPDX-FileCopyrightText:  2026-2026 The DOSBox Staging Team
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-#include "dos.h"
-#include "bridge.h"
 #include "webserver.h"
+#include "bridge.h"
+#include "private/dos.h"
 
 #include "http/http.h"
 #include "json/json.h"

--- a/src/webserver/dosbox.cpp
+++ b/src/webserver/dosbox.cpp
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText:  2026-2026 The DOSBox Staging Team
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "private/dosbox.h"
+
+#include "dosbox.h"
+
+namespace Webserver {
+
+void ShutdownCommand::Execute()
+{
+	DOSBOX_RequestShutdown();
+}
+
+void ShutdownCommand::Post(const httplib::Request&, httplib::Response&)
+{
+	ShutdownCommand cmd;
+	cmd.WaitForCompletion();
+}
+
+} // namespace Webserver

--- a/src/webserver/memory.cpp
+++ b/src/webserver/memory.cpp
@@ -1,9 +1,9 @@
 // SPDX-FileCopyrightText:  2026-2026 The DOSBox Staging Team
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-#include "webserver/memory.h"
-#include "webserver/bridge.h"
-#include "webserver/webserver.h"
+#include "webserver.h"
+#include "bridge.h"
+#include "private/memory.h"
 
 #include "base64/base64.h"
 #include "http/http.h"

--- a/src/webserver/private/cpu.h
+++ b/src/webserver/private/cpu.h
@@ -4,7 +4,7 @@
 #ifndef DOSBOX_WEBSERVER_CPU_H
 #define DOSBOX_WEBSERVER_CPU_H
 
-#include "bridge.h"
+#include "webserver/bridge.h"
 
 #include "http/http.h"
 #include "json/json.h"

--- a/src/webserver/private/dos.h
+++ b/src/webserver/private/dos.h
@@ -3,7 +3,8 @@
 
 #ifndef DOSBOX_WEBSERVER_DOS_H
 #define DOSBOX_WEBSERVER_DOS_H
-#include "bridge.h"
+
+#include "webserver/bridge.h"
 
 #include "http/http.h"
 

--- a/src/webserver/private/dosbox.h
+++ b/src/webserver/private/dosbox.h
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText:  2026-2026 The DOSBox Staging Team
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#ifndef DOSBOX_WEBSERVER_DOSBOX_H
+#define DOSBOX_WEBSERVER_DOSBOX_H
+
+#include "webserver/bridge.h"
+
+#include "http/http.h"
+
+namespace Webserver {
+
+class ShutdownCommand : public Command {
+public:
+	void Execute() override;
+	static void Post(const httplib::Request& req, httplib::Response& res);
+};
+
+} // namespace Webserver
+
+#endif // DOSBOX_WEBSERVER_DOSBOX_H

--- a/src/webserver/private/memory.h
+++ b/src/webserver/private/memory.h
@@ -4,7 +4,7 @@
 #ifndef DOSBOX_WEBSERVER_MEMORY_H
 #define DOSBOX_WEBSERVER_MEMORY_H
 
-#include "bridge.h"
+#include "webserver/bridge.h"
 #include "cpu.h"
 
 #include <limits>

--- a/src/webserver/webserver.cpp
+++ b/src/webserver/webserver.cpp
@@ -3,9 +3,9 @@
 
 #include "webserver.h"
 #include "bridge.h"
-#include "cpu.h"
-#include "dos.h"
-#include "memory.h"
+#include "private/cpu.h"
+#include "private/dos.h"
+#include "private/memory.h"
 
 #include <set>
 #include <string>

--- a/src/webserver/webserver.cpp
+++ b/src/webserver/webserver.cpp
@@ -5,6 +5,7 @@
 #include "bridge.h"
 #include "private/cpu.h"
 #include "private/dos.h"
+#include "private/dosbox.h"
 #include "private/memory.h"
 
 #include <set>
@@ -58,6 +59,8 @@ static void setup_api_handlers()
 	server.Get("/api/v1/cpu/state", CpuStateCommand::Get);
 
 	server.Get("/api/v1/dos/internals", DosInternalsCommand::Get);
+
+	server.Post("/api/v1/dosbox/shutdown", ShutdownCommand::Post);
 
 	server.Post("/api/v1/memory/allocate", AllocMemoryCommand::Post);
 	server.Post("/api/v1/memory/free", FreeMemoryCommand::Post);

--- a/website/docs/0.83/manual/http-api.md
+++ b/website/docs/0.83/manual/http-api.md
@@ -152,6 +152,11 @@ see the built-in API documentation.
 
 :   Returns DOSBox Staging version and relevant filesystem paths.
 
+### Shutdown
+
+`POST /api/v1/dosbox/shutdown`
+
+:   Request a graceful shutdown of DOSBox Staging.
 
 ## Example tools
 

--- a/website/docs/0.83/manual/http-api.md
+++ b/website/docs/0.83/manual/http-api.md
@@ -42,7 +42,7 @@ see the built-in API documentation.
 
 ### CPU registers
 
-`GET /api/cpu`
+`GET /api/v1/cpu/state`
 
 :   Returns all x86 CPU registers: `eax`, `ebx`, `ecx`, `edx`, `esi`,
     `edi`, `esp`, `ebp`, `eip`, `flags`, `cs`, `ds`, `es`, `ss`, `fs`,
@@ -51,8 +51,8 @@ see the built-in API documentation.
 
 ### Reading memory
 
-`GET /api/memory/:offset/:len`
-`GET /api/memory/:segment/:offset/:len`
+`GET /api/v1/memory/:offset/:len`
+`GET /api/v1/memory/:segment/:offset/:len`
 
 :   Read memory at the given address. The optional segment parameter can be
     the name of a segment register (`CS`, `SS`, `DS`, `ES`, `FS`, `GS`) or a
@@ -67,14 +67,14 @@ see the built-in API documentation.
     Example --- download the entire conventional memory area:
 
     ```
-    GET /api/memory/0/0x100000
+    GET /api/v1/memory/0/0x100000
     ```
 
 
 ### Writing memory
 
-`PUT /api/memory/:offset`
-`PUT /api/memory/:segment/:offset`
+`PUT /api/v1/memory/:offset`
+`PUT /api/v1/memory/:segment/:offset`
 
 :   Write memory to the given address. Path parameters work the same as for
     reading.
@@ -90,7 +90,7 @@ see the built-in API documentation.
 
 ### Memory allocation
 
-`POST /api/memory/allocate`
+`POST /api/v1/memory/allocate`
 
 :   Allocate memory from the emulated machine.
 
@@ -119,7 +119,7 @@ see the built-in API documentation.
     Returns HTTP 503 if allocation fails.
 
 
-`POST /api/memory/free`
+`POST /api/v1/memory/free`
 
 :   Free previously allocated memory.
 
@@ -136,7 +136,7 @@ see the built-in API documentation.
 
 ### DOS information
 
-`GET /api/dos`
+`GET /api/v1/dos/internals`
 
 :   Returns pointers to internal DOS data structures:
 
@@ -148,7 +148,7 @@ see the built-in API documentation.
 
 ### System information
 
-`GET /api/info`
+`GET /api/v1/dosbox/info`
 
 :   Returns DOSBox Staging version and relevant filesystem paths.
 


### PR DESCRIPTION
# Description

This PR adds an endpoint to the webserver (POST `/api/v1/dosbox/shutdown`) to shutdown DOSBox externally. I will keep this in draft until 0.83 is done.

Now that we accept remote shutdown requests, I changed the `is_shutdown_requested` type to `std::atomic` to improve thread safety.

# Release notes

- You can now shutdown DOSBox via the webserver by sending a POST request with an empty body to the `/api/v1/dosbox/shutdown` endpoint.

# Manual testing

Sent a `cURL` request to the webserver:

```
curl -X POST http://127.0.0.1:8090/api/v1/dosbox/shutdown
```

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [x] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [ ] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [x] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

