### PR TITLE
User manual related fixes

### DIFF
--- a/.github/workflows/pvs-studio.yml
+++ b/.github/workflows/pvs-studio.yml
@@ -62,7 +62,7 @@ jobs:
           set -x
           export CC=clang
           export CXX=clang++
-          cmake --preset debug-linux-vcpkg -DOPT_TESTS=OFF -DOPT_DOCUMENTATION=ON
+          cmake --preset debug-linux-vcpkg -DOPT_TESTS=OFF
 
           # TODO Consider using the the PV-Studio CMake integration instead
           # of calling the `pvs-studio-analyzer` directly. That might be a

--- a/cmake/add_build_documentation.cmake
+++ b/cmake/add_build_documentation.cmake
@@ -248,6 +248,11 @@ function(add_build_documentation)
             --config-file "${MKDOCS_CONFIG}"
             --site-dir "${MKDOCS_OUTPUT_DIR}"
 
+    COMMAND "${CMAKE_COMMAND}" -E remove
+            "${MKDOCS_OUTPUT_DIR}/404.html"
+            "${MKDOCS_OUTPUT_DIR}/sitemap.xml"
+            "${MKDOCS_OUTPUT_DIR}/sitemap.xml.gz"
+
     COMMAND "${CMAKE_COMMAND}" -E touch "${MKDOCS_BUILD_STAMP}"
 
     WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/website"

--- a/src/dos/programs/guide.cpp
+++ b/src/dos/programs/guide.cpp
@@ -3,6 +3,8 @@
 
 #include "guide.h"
 
+#include <filesystem>
+
 #include "misc/support.h"
 #include "more_output.h"
 #include "utils/checks.h"
@@ -23,11 +25,13 @@ void GUIDE::Run(void)
 		return;
 	}
 
-	const auto url =
-	        std::string{"file://"} +
-	        get_resource_path("docs/getting-started/introduction.html").string();
+	const auto path = get_resource_path("docs/getting-started/introduction.html");
 
-	if (SDL_OpenURL(url.c_str()) == -1) {
+	if (std::filesystem::exists(path)) {
+		const auto url = std::string{"file://"} + path.string();
+		SDL_OpenURL(url.c_str());
+
+	} else {
 		SDL_OpenURL("https://www.dosbox-staging.org/getting-started/");
 	}
 }

--- a/src/dos/programs/guide.cpp
+++ b/src/dos/programs/guide.cpp
@@ -46,7 +46,13 @@ void GUIDE::AddMessages()
 	        "  [color=light-green]guide[reset]\n"
 	        "\n"
 	        "Notes:\n"
-	        "  - This will open an offline copy of the Getting Started guide bundled with\n"
-	        "    your DOSBox Staging installation; you don't need an internet connection to\n"
-	        "    read the guide.\n");
+	        "  - This will open a local offline copy of the Getting Started guide bundled\n"
+	        "    with your DOSBox Staging installation; you don't need an internet connection\n"
+	        "    to read the bundled guide.\n"
+	        "\n"
+	        "  - The offline documentation is located in the 'docs' subfolder of your\n"
+	        "    DOSBox Staging 'resources' folder.\n"
+	        "\n"
+	        "  - If the offline documentation cannot be found, the command will open the\n"
+	        "    guide on the project website (requires internet connection).");
 }

--- a/src/dos/programs/manual.cpp
+++ b/src/dos/programs/manual.cpp
@@ -3,6 +3,8 @@
 
 #include "manual.h"
 
+#include <filesystem>
+
 #include "misc/support.h"
 #include "more_output.h"
 #include "utils/checks.h"
@@ -23,11 +25,13 @@ void MANUAL::Run(void)
 		return;
 	}
 
-	const auto url =
-	        std::string{"file://"} +
-	        get_resource_path("docs/manual/about-this-manual.html").string();
+	const auto path = get_resource_path("docs/manual/about-this-manual.html");
 
-	if (SDL_OpenURL(url.c_str()) == -1) {
+	if (std::filesystem::exists(path)) {
+		const auto url = std::string{"file://"} + path.string();
+		SDL_OpenURL(url.c_str());
+
+	} else {
 		SDL_OpenURL("https://www.dosbox-staging.org/manual/");
 	}
 }

--- a/src/dos/programs/manual.cpp
+++ b/src/dos/programs/manual.cpp
@@ -46,7 +46,13 @@ void MANUAL::AddMessages()
 	        "  [color=light-green]manual[reset]\n"
 	        "\n"
 	        "Notes:\n"
-	        "  - This will open an offline copy of the user manual bundled with your DOSBox\n"
-	        "    Staging installation; you don't need an internet connection to read the\n"
-	        "    manual.\n");
+	        "  - This will open a local offline copy of the user manual guide bundled with\n"
+	        "    your DOSBox Staging installation; you don't need an internet connection to\n"
+	        "    read the bundled manual.\n"
+	        "\n"
+	        "  - The offline documentation is located in the 'docs' subfolder of your\n"
+	        "    DOSBox Staging 'resources' folder.\n"
+	        "\n"
+	        "  - If the offline documentation cannot be found, the command will open the\n"
+	        "    guide on the project website (requires internet connection).");
 }


### PR DESCRIPTION
# Description

Somehow these extra commits fell off my user manual PR somehow... I was working on it on 3 different machines; probably I screwed something up when syncing/force-pushing branches...

There's nothing new here, just stuff we already discussed.

# Manual testing

Compiled with `-DOPT_DOCUMENTATION=ON`, online fallback works, extra notes are there.

The change has been manually tested on:

- [ ] Windows
- [x] macOS
- [ ] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [x] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

