### PR TITLE
Add release notes differ script

### DIFF
--- a/scripts/tools/release-notes-differ.py
+++ b/scripts/tools/release-notes-differ.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText:  2026-2026 The DOSBox Staging Team
+# SPDX-License-Identifier: MIT
+
+"""Find PRs in a draft release notes file that are missing from the
+current work-in-progress release notes. Both files must use the DOSBox
+Staging MkDocs release notes format with '??? note "Full PR list ..."'
+collapsible sections."""
+
+# pylint: disable=invalid-name
+
+import argparse
+import re
+
+SECTION_RE = re.compile(r'^\?\?\? note "Full PR list .+"')
+ITEM_RE    = re.compile(r"^ {4}- .+\(#(\d+)\)\s*$")
+
+
+def parse_pr_lists(path):
+    """Return list of (header, [(line_text, pr_number), ...]) for each
+    'Full PR list' section."""
+
+    sections = []
+    current_header = None
+    current_items = []
+
+    with open(path, encoding="UTF-8") as f:
+        for line in f:
+            if SECTION_RE.match(line):
+                if current_header:
+                    sections.append((current_header, current_items))
+
+                current_header = line.rstrip("\n")
+                current_items = []
+                continue
+
+            if current_header:
+                m = ITEM_RE.match(line)
+                if m:
+                    current_items.append((line.rstrip("\n"), m.group(1)))
+                elif line.strip() and not line.startswith("    "):
+                    # Left the indented block
+                    sections.append((current_header, current_items))
+
+                    current_header = None
+                    current_items = []
+
+    if current_header:
+        sections.append((current_header, current_items))
+
+    return sections
+
+
+# pylint: disable=missing-docstring
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+
+    parser.add_argument("current", help="work-in-progress release notes Markdown file")
+    parser.add_argument("draft", help="draft release notes Markdown file")
+    parser.add_argument("diff", help="output file containing the new PR items")
+
+    args = parser.parse_args()
+
+    # Collect all PR numbers from the current file
+    current_sections = parse_pr_lists(args.current)
+    current_prs = set()
+
+    for _, items in current_sections:
+        for _, pr in items:
+            current_prs.add(pr)
+
+    # Find new items in the draft
+    draft_sections = parse_pr_lists(args.draft)
+    output_sections = []
+
+    for header, items in draft_sections:
+        new_items = [(text, pr) for text, pr in items if pr not in current_prs]
+        if new_items:
+            output_sections.append((header, new_items))
+
+    # Write diff file
+    with open(args.diff, "w", encoding="UTF-8") as f:
+        for i, (header, items) in enumerate(output_sections):
+            if i > 0:
+                f.write("\n")
+            f.write(header + "\n\n")
+
+            for text, _ in items:
+                f.write(text + "\n")
+            f.write("\n")
+
+    total = sum(len(items) for _, items in output_sections)
+
+    print(f"{total} new PRs across {len(output_sections)} sections")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Description

This is just handy tool I generated for myself with Claude to compare two release notes drafts output by the release drafter script (`scripts/tools/release-notes-drafter.py`). I reviewed the whole file, tested it manually with real-world data and by instructing Claude to generate test data, plus I made some superficial stylistic improvements.

The use case is I usually start working on the release notes while there are still some in-flight PRs, and there's always some last minute fix or two finding their way into `main` before we finalise the release. Hunting for those last minute PR and finding their appropriate sections in the final notes is a bit of a pain in the sea of changes. This way I can generate a new draft again and use this tool to diff it against the work-in-progress notes and I get what's missing and from what section.

This is the help — very straightforward to use.

<img width="685" height="220" alt="image" src="https://github.com/user-attachments/assets/3de845f2-9e10-4795-afa2-14ad6b9a6794" />


# Manual testing

I used it a few time for my current release notes work — works well, no bugs found so far.

- [ ] Windows
- [x] macOS
- [ ] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

