### PR TITLE
The `GUIDE` and `MANUAL` commands open a versioned URL now

### DIFF
--- a/src/dos/programs/guide.cpp
+++ b/src/dos/programs/guide.cpp
@@ -32,7 +32,7 @@ void GUIDE::Run(void)
 		SDL_OpenURL(url.c_str());
 
 	} else {
-		SDL_OpenURL("https://www.dosbox-staging.org/getting-started/");
+		SDL_OpenURL("https://www.dosbox-staging.org/0.83/getting-started/");
 	}
 }
 

--- a/src/dos/programs/manual.cpp
+++ b/src/dos/programs/manual.cpp
@@ -32,7 +32,7 @@ void MANUAL::Run(void)
 		SDL_OpenURL(url.c_str());
 
 	} else {
-		SDL_OpenURL("https://www.dosbox-staging.org/manual/");
+		SDL_OpenURL("https://www.dosbox-staging.org/0.83/manual/");
 	}
 }
 

--- a/website/docs/getting-started/introduction.md
+++ b/website/docs/getting-started/introduction.md
@@ -2,7 +2,7 @@
 
 ## Foreword
 
-Welcome to the **DOSBox Staging v0.83.0 Getting Started guide**!
+Welcome to the **DOSBox Staging v0.83 Getting Started guide**!
 
 This guide will gently introduce you to the wonderful world of DOSBox by
 setting up a few example games from scratch. Although it's primarily intended

--- a/website/docs/manual/about-this-manual.md
+++ b/website/docs/manual/about-this-manual.md
@@ -1,6 +1,6 @@
 # About this manual
 
-Welcome to the **DOSBox Staging v0.83.0 user manual** --- your complete guide
+Welcome to the **DOSBox Staging v0.83 user manual** --- your complete guide
 to getting the most out of the emulator. It covers everything from basic
 concepts to the detailed configuration of every emulated device. You don't
 need to read it cover to cover --- most people dip in when they need to

--- a/website/mkdocs.yml
+++ b/website/mkdocs.yml
@@ -94,6 +94,10 @@ plugins:
           'manual/index.md':          'manual/about-this-manual.md'
           'getting-started/index.md': 'getting-started/introduction.md'
 
+          # Version redirects
+          '0.83/manual/index.md':          'manual/about-this-manual.md'
+          '0.83/getting-started/index.md': 'getting-started/introduction.md'
+
           # Redirect RC release notes to the final notes
           'releases/release-notes/0.82.0-rc.md': 'releases/release-notes/0.82.0.md'
           'releases/release-notes/0.81.0-rc.md': 'releases/release-notes/0.81.0.md'


### PR DESCRIPTION
# Description

As discussed with @FeralChild64, versioning the documentation is a good idea going forward, then the `GUIDE` and `MANUAL` commands will open the appropriate doco version for the online fallback path.

No change to the bundled documentation — we bundle the appropriate version at release package build time.

No change to the website yet — we'll only need a version selector when 0.84 goes out. I'll deal with it then. For now, `0.83/manual` just redirects to `manual`, and `0.83/getting-started` to `getting-started`.

No change to the links in the documentation — we can add any prefixes (e.g. `0.84/manual` or `fr/0.84/manual`) and the links will still work as we only use relative paths for cross-links within the manual, and also between the Getting Started guide and the manual.

Eventually, the URL scheme will look like this:

### Unversioned

- `/` (front page; offline doco always points to the URL on the website)
- `/about/` 
- `/get-involed/`
- `/releases/...` (offline doco always points to the URL on the website)

### Versioned URLs (e.g., for version 0.84.x)

- `0.84/manual`
- `0.84/getting-started`

Later we could append a language prefix as well if we get manual translations from the community:

- `jp/0.84/manual`
- `jp/0.84/getting-started`


# Manual testing


The change has been manually tested on:

- [ ] Windows
- [x] macOS
- [ ] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [x] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

