### PR TITLE
Unpause the emulator with a remapped pause key

### DIFF
--- a/src/gui/mapper.cpp
+++ b/src/gui/mapper.cpp
@@ -88,6 +88,8 @@ static std::vector<CHandlerEvent *> handlergroup;
 static std::list<CBind *> all_binds;
 static std::queue<std::string> auto_type_queue = {};
 
+static SDL_Keysym last_key_pressed = {};
+
 typedef std::list<CBind *> CBindList;
 typedef std::list<CBind *>::iterator CBindList_it;
 typedef std::vector<CBindGroup *>::iterator CBindGroup_it;
@@ -2644,6 +2646,9 @@ void MAPPER_CheckEvent(SDL_Event *event)
 	case SDL_JOYDEVICEADDED:
 		MAPPER_HandleJoyDeviceEvent(&event->jdevice);
 		return;
+	case SDL_KEYDOWN:
+		last_key_pressed = event->key.keysym;
+		break;
 	default: break;
 	}
 
@@ -2652,6 +2657,11 @@ void MAPPER_CheckEvent(SDL_Event *event)
 			return;
 		}
 	}
+}
+
+SDL_Keysym MAPPER_GetLastKeyPressed()
+{
+	return last_key_pressed;
 }
 
 void MAPPER_HandleJoyDeviceEvent(SDL_JoyDeviceEvent* event)

--- a/src/gui/mapper.h
+++ b/src/gui/mapper.h
@@ -88,4 +88,6 @@ constexpr int MaxBindNameLength = 100;
  */
 void MAPPER_HandleJoyDeviceEvent(SDL_JoyDeviceEvent* event);
 
+SDL_Keysym MAPPER_GetLastKeyPressed();
+
 #endif // DOSBOX_MAPPER_H

--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -294,19 +294,45 @@ void GFX_RequestExit(const bool pressed)
 	}
 }
 
-#if defined(MACOSX)
-static bool is_command_pressed(const SDL_Event event)
+static bool is_unpause_event(const SDL_Event event, const SDL_Keysym unpause_key)
 {
-	return (event.key.keysym.mod == KMOD_RGUI ||
-	        event.key.keysym.mod == KMOD_LGUI);
+	if (event.type != SDL_KEYDOWN) {
+		return false;
+	}
+
+	if (event.key.keysym.sym == unpause_key.sym) {
+		// These are the only mods we're going to care about.
+		// Others mods include caps lock and num lock which we should not look at.
+		constexpr uint16_t ModMask = KMOD_CTRL | KMOD_SHIFT | KMOD_ALT | KMOD_GUI;
+		const uint16_t unpause_mod = unpause_key.mod & ModMask;
+		if ((event.key.keysym.mod & unpause_mod) == unpause_mod) {
+			return true;
+		}
+	}
+
+	// Also check previously hard-coded Alt+Pause on Windows/Linux
+	// and Command+P on Mac to ensure we don't have regressions.
+	#if defined(MACOSX)
+	constexpr uint16_t DefaultMod = KMOD_GUI;
+	constexpr int32_t DefaultKey = SDLK_p;
+	#else
+	constexpr uint16_t DefaultMod = KMOD_ALT;
+	constexpr int32_t DefaultKey = SDLK_PAUSE;
+	#endif
+	return event.key.keysym.sym == DefaultKey && (event.key.keysym.mod & DefaultMod);
 }
-#endif
 
 [[maybe_unused]] static void pause_emulation(bool pressed)
 {
 	if (!pressed) {
 		return;
 	}
+
+	// Bit of a hack but this is the key that was used to pause so let's also check it to unpause.
+	// We should really be relying on MAPPER_CheckEvent() but that is not possible inside this janky pause loop.
+	// TODO: In the future, re-work pause logic so we use the main event loop all the time.
+	const auto unpause_key = MAPPER_GetLastKeyPressed();
+
 	const auto inkeymod = static_cast<uint16_t>(SDL_GetModState());
 
 	sdl.is_paused = true;
@@ -341,15 +367,7 @@ static bool is_command_pressed(const SDL_Event event)
 			break;
 
 		case SDL_KEYDOWN:
-#if defined(MACOSX)
-			// Pause/unpause is hardcoded to Command+P on macOS
-			if (is_command_pressed(event) &&
-			    event.key.keysym.sym == SDLK_p) {
-#else
-			// Pause/unpause is hardcoded to Alt+Pause on Window &
-			// Linux
-			if (event.key.keysym.sym == SDLK_PAUSE) {
-#endif
+			if (is_unpause_event(event, unpause_key)) {
 				const uint16_t outkeymod = event.key.keysym.mod;
 				if (inkeymod != outkeymod) {
 					KEYBOARD_ClrBuffer();


### PR DESCRIPTION
# Description

We now look at the key that was used to pause and allow the same key to unpause.

Also fixes a bug on Windows/Linux where we were ignoring the Alt key in Alt+Pause.

Had to do this in a hackish way because of the way the mapper works but it should work for nearly all usecases. Under normal operation, the mapper keeps track of Mod keys as internal state. Those Mod keys can also themselves be remapped. I tried to write some code to deal with all that but it was getting very ugly and the proper solution is to re-write pause logic.

This just adds a quick line into the mapper to save the last key event before we jump into the pause loop and then unpause when we see that key again.

# Release notes

Unpausing now works if the pause hotkey has been remapped.

# Manual testing

- Launch `dosbox --startmapper`
- Remap "Pause Emu"
- Confirmed I can now unpause with the same pause key, including with Ctrl+Alt, etc mods.
- Previously hard-coded Alt+Pause or Command+P (Mac) will always unpause.

The change has been manually tested on:

- [x] Windows
- [x] macOS
- [x] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

