### PR TITLE
BIOS: Preserve BP before calling INT 1Ch

### DIFF
--- a/src/cpu/callback.cpp
+++ b/src/cpu/callback.cpp
@@ -271,7 +271,10 @@ static uint8_t callback_setup_extra(const callback_number_t callback_number,
 		add_instruction_1(0x1e);                   // push ds
 		add_instruction_1(0x50);                   // push ax
 		add_instruction_1(0x52);                   // push dx
+		add_instruction_1(0x55);                   // push bp
+		add_instruction_2(0x31, 0xed);             // xor bp, bp
 		add_instruction_2(0xcd, 0x1c);             // int 0x1c
+		add_instruction_1(0x5d);                   // pop bp
 		add_instruction_1(0xfa);                   // cli
 		add_instruction_2(0xb0, 0x20);             // mov al, 0x20
 		add_instruction_2(0xe6, 0x20);             // out 0x20, al

--- a/src/ints/bios.cpp
+++ b/src/ints/bios.cpp
@@ -1264,8 +1264,10 @@ public:
 		// pseudocode for CB_IRQ0:
 		//	sti
 		//	callback INT8_Handler
-		//	push ds,ax,dx
+		//	push ds,ax,dx,bp
+		//	xor bp,bp
 		//	int 0x1c
+		//	pop bp
 		//	cli
 		//	mov al, 0x20
 		//	out 0x20, al


### PR DESCRIPTION
I got this idea from SeaBIOS which passes a fresh register frame to the INT 1Ch handler.

# Description

I wrote a detailed analysis about the bug that caused ROE2 to fail here: https://github.com/dosbox-staging/dosbox-staging/issues/4850#issuecomment-4331765547

After studying other implementations I saw that SeaBIOS creates a whole new register frame before handing over to the INT 1Ch handler:

<img width="990" height="865" alt="grafik" src="https://github.com/user-attachments/assets/166811e7-937b-4555-8d2b-207270f3bd2b" />

This fix replicates the way how ripsaw fixed it in his loader.

## Related issues

https://github.com/dosbox-staging/dosbox-staging/issues/4850

# Manual testing

I tested ROE2 with different cycles and normal/dynamic core as well as Quake, DUNE and several other titles.

The change has been manually tested on:

- [x] Windows
- [ ] macOS
- [ ] Linux


I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

