### PR TITLE
Implement DOS STACKS-type feature for keyboard and timer interrupts

### DIFF
--- a/src/dos/CMakeLists.txt
+++ b/src/dos/CMakeLists.txt
@@ -16,6 +16,7 @@ target_sources(dosboxcommon PRIVATE
   dos_misc.cpp
   dos_mscdex.cpp
   dos_programs.cpp
+  dos_stacks.cpp
   dos_tables.cpp
   dos_windows.cpp
   drive_cache.cpp

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -61,6 +61,7 @@ constexpr auto EstimatedFileSeekIoOverheadInBytes     = 512;
 
 void DOS_NotifyBooting()
 {
+	DOS_UninstallInterruptStacks();
 	is_guest_booted = true;
 	DOS_ClearLaunchedProgramNames();
 }
@@ -1779,6 +1780,8 @@ private:
 public:
 	DOS(Section* sec)
 	{
+		const auto section = static_cast<SectionProp*>(sec);
+
 		callback[0].Install(DOS_20Handler, CB_IRET, "DOS Int 20");
 		callback[0].Set_RealVec(0x20);
 
@@ -1818,6 +1821,9 @@ public:
 		DOS_SetupMemory();								/* Setup first MCB */
 		DOS_SetupPrograms();
 		DOS_SetupMisc();							/* Some additional dos interrupts */
+		if (DOS_ShouldUseInterruptStacks(*section)) {
+			DOS_InstallInterruptStacks(*section);
+		}
 		DOS_SDA(DOS_SDA_SEG,DOS_SDA_OFS).SetDrive(25); /* Else the next call gives a warning. */
 		DOS_SetDefaultDrive(25);
 
@@ -1826,7 +1832,6 @@ public:
 		dos.direct_output=false;
 		dos.internal_output=false;
 
-		const SectionProp* section = static_cast<SectionProp*>(sec);
 		std::string args = section->GetString("ver");
 		std::string word = strip_word(args);
 		const auto new_version = DOS_ParseVersion(word.c_str(), args.c_str());
@@ -1853,6 +1858,8 @@ public:
 		// without throwing an inevitable `DOS: Too many devices added`
 		// exception
 		DOS_ShutDownDevices();
+
+		DOS_UninstallInterruptStacks();
 
 		DOS_FreeTableMemory();
 	}
@@ -1937,6 +1944,28 @@ static void init_dos_settings(SectionProp& section)
 
 	pbool = section.AddBool("umb", WhenIdle, true);
 	pbool->SetHelp("Enable UMB memory support ('on' by default).");
+
+	pstring = section.AddString("stacks", OnlyAtStart, "auto");
+	pstring->SetHelp(
+	        "Use DOS-style private stacks for hardware interrupts ('auto' by default).\n"
+	        "When a wrapped hardware interrupt fires, DOSBox Staging switches to one\n"
+	        "stack from a private pool before invoking the previous handler. Disabling\n"
+	        "this means each running program must have enough stack space for hardware\n"
+	        "interrupts (and any chained handlers) itself. Most programs work correctly\n"
+	        "without it; a few legacy programs depend on it to avoid corrupting their\n"
+	        "own stack.\n"
+	        "\n"
+	        "Note: the current implementation wraps the timer interrupt (INT 08h, IRQ0)\n"
+	        "and the keyboard interrupt (INT 09h, IRQ1). MS-DOS's STACKS feature wraps\n"
+	        "additional hardware-IRQ vectors; coverage may be expanded in future versions.\n"
+	        "\n"
+	        "  auto:        Enable on AT-class machine types with the MS-DOS defaults\n"
+	        "               (9 stacks of 128 bytes each). Disable on PC/XT-class machine\n"
+			"               types (e.g., cga, pcjr, tandy).\n"
+	        "  count,size:  Allocate `count` private stacks of `size` bytes each, e.g.\n"
+	        "               'stacks = 9,128'. Equivalent to the DOS 'STACKS=count,size'\n"
+	        "               setting; 'count' must be 8-64, 'size' must be 32-512.\n"
+	        "  0,0:         Disable; use the interrupted program's stack.");
 
 	pstring = section.AddString("pcjr_memory_config", OnlyAtStart, "expanded");
 	pstring->SetValues({"expanded", "standard"});

--- a/src/dos/dos.h
+++ b/src/dos/dos.h
@@ -306,6 +306,10 @@ bool DOS_FreeMemory(uint16_t segment);
 void DOS_FreeProcessMemory(uint16_t pspseg);
 uint16_t DOS_GetMemory(uint16_t pages);
 void DOS_FreeTableMemory();
+
+bool DOS_ShouldUseInterruptStacks(const SectionProp& section);
+void DOS_InstallInterruptStacks(const SectionProp& section);
+void DOS_UninstallInterruptStacks();
 bool DOS_SetMemAllocStrategy(uint16_t strat);
 void DOS_SetMcbFaultStrategy(const char *mcb_fault_strategy_pref);
 uint16_t DOS_GetMemAllocStrategy(void);

--- a/src/dos/dos_stacks.cpp
+++ b/src/dos/dos_stacks.cpp
@@ -1,0 +1,501 @@
+// SPDX-FileCopyrightText:  2026-2026 The DOSBox Staging Team
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+// DOS-style private stacks for hardware interrupts (MS-DOS 3.2+ STACKS=count,size).
+//
+// When a wrapped hardware IRQ fires, a small real-mode wrapper switches SS:SP
+// to a stack drawn from a private pool, calls the previous handler, and
+// restores SS:SP on the way out. This protects programs whose own stacks are
+// too tight to absorb BIOS ISRs plus any chained handlers.
+//
+// The current implementation wraps the timer interrupt (INT 08h, IRQ0) and
+// the keyboard interrupt (INT 09h, IRQ1). MS-DOS additionally wraps INT 02h
+// and several other hardware-IRQ vectors; coverage may be expanded later with
+// no change to the public surface.
+//
+// The wrapper, entry table, and stack pool live in a single conventional-
+// memory segment owned by MCB_DOS so the block survives program exits.
+
+#include "dos/dos.h"
+
+#include <vector>
+
+#include "cpu/callback.h"
+#include "cpu/registers.h"
+#include "dosbox.h"
+#include "hardware/memory.h"
+#include "ints/bios.h"
+#include "misc/support.h"
+#include "utils/math_utils.h"
+#include "utils/string_utils.h"
+
+namespace {
+
+constexpr uint8_t Irq0Vector = 0x08;
+constexpr uint8_t Irq1Vector = 0x09;
+
+// Match the MS-DOS defaults used when STACKS is active. Min/Max bounds are
+// validated when parsing the 'stacks' setting; MaxNestedInterrupts must track
+// MaxStackCount because each nested interrupt consumes one entry in the
+// active-LIFO.
+constexpr uint8_t DefaultStackCount = 9;
+constexpr uint16_t DefaultStackSize = 128;
+constexpr uint8_t MinStackCount     = 8;
+constexpr uint8_t MaxStackCount     = 64;
+constexpr uint16_t MinStackSize     = 32;
+constexpr uint16_t MaxStackSize     = 512;
+
+constexpr uint16_t EntrySize          = 8;
+constexpr uint16_t WrapperSize        = 0x20;
+constexpr uint16_t NumWrappedVectors  = 2;
+constexpr uint16_t TableOffset        = NumWrappedVectors * WrapperSize;
+constexpr uint8_t MaxNestedInterrupts = 64;
+
+// One slot in the stack pool. `allocated` tracks whether the slot is in use;
+// `saved_ss`/`saved_sp` hold the interrupted program's SS:SP so leave_irq_stack
+// can restore it; `new_sp` is the precomputed top of this slot's stack within
+// the pool segment.
+struct StackEntry {
+	bool allocated    = false;
+	uint16_t saved_ss = 0;
+	uint16_t saved_sp = 0;
+	uint16_t new_sp   = 0;
+};
+
+// Runtime state for the interrupt-stack wrapper. The wrapper code, the per-slot
+// table, and the stack pool all live in `segment` at offsets 0, TableOffset,
+// and get_stack_area_offset() respectively.
+//
+// `active_depth` counts nested interrupts that have an entry in `active_entries`
+// (which may itself be -1 if the pool was exhausted at entry); `untracked_depth`
+// counts nested interrupts that arrived after `active_entries` was already full.
+// Their sum is the true nesting depth, and both must be unwound on the way out.
+struct InterruptStacks {
+	bool installed                = false;
+	bool exhausted_warning_logged = false;
+
+	uint16_t segment       = 0;
+	RealPt old_irq0_vector = 0;
+	RealPt irq0_wrapper    = 0;
+	RealPt old_irq1_vector = 0;
+	RealPt irq1_wrapper    = 0;
+
+	CALLBACK_HandlerObject enter_callback = {};
+	CALLBACK_HandlerObject leave_callback = {};
+
+	std::vector<StackEntry> entries        = {};
+	std::vector<int16_t> active_entries    = {};
+
+	uint8_t stack_count     = DefaultStackCount;
+	uint16_t stack_size     = DefaultStackSize;
+	uint8_t active_depth    = 0;
+	uint8_t untracked_depth = 0;
+	uint8_t next_entry      = DefaultStackCount - 1;
+};
+
+InterruptStacks stacks = {}; //-V1076
+
+// Segment layout: [IRQ0 wrapper | IRQ1 wrapper | per-slot table | stack pool].
+// Each wrapper occupies WrapperSize bytes; the table follows at TableOffset
+// (= NumWrappedVectors * WrapperSize) with `stack_count` entries of EntrySize
+// bytes; the stack pool fills the rest, each slot sized `stack_size`. The
+// helpers below derive offsets and sizes from those constants and the runtime
+// configuration.
+uint16_t get_stack_area_offset()
+{
+	return check_cast<uint16_t>(TableOffset + stacks.stack_count * EntrySize);
+}
+
+uint16_t get_stack_top(const uint8_t index)
+{
+	return check_cast<uint16_t>(get_stack_area_offset() +
+	                           (index + 1) * stacks.stack_size - 2);
+}
+
+uint16_t get_required_bytes()
+{
+	return check_cast<uint16_t>(get_stack_area_offset() +
+	                           stacks.stack_count * stacks.stack_size);
+}
+
+uint16_t get_required_paragraphs()
+{
+	return ceil_udivide(get_required_bytes(), uint16_t{16});
+}
+
+void write_callback_instruction(PhysPt& address, const callback_number_t callback)
+{
+	phys_writeb(address++, 0xfe); // GRP 4
+	phys_writeb(address++, 0x38); // DOSBox callback instruction
+	phys_writew(address, callback);
+	address += 2;
+}
+
+void write_far_call(PhysPt& address, const RealPt target)
+{
+	phys_writeb(address++, 0x9a); // call far ptr16:16
+	phys_writew(address, RealOffset(target));
+	address += 2;
+	phys_writew(address, RealSegment(target));
+	address += 2;
+}
+
+// Lay down an IRQ wrapper at `wrapper_address` that chains to `old_vector`.
+// The wrapper runs on the interrupted program's stack on entry; the enter
+// callback then switches SS:SP to a private slot. We push flags and far-call
+// the previous handler so its iret unwinds correctly back to the instruction
+// after the call. The leave callback restores the original SS:SP before our
+// own iret returns to the interrupted program. The same enter/leave callbacks
+// serve all wrapped vectors — they simply allocate/free from the shared pool.
+void write_irq_wrapper(const RealPt wrapper_address, const RealPt old_vector)
+{
+	auto address = RealToPhysical(wrapper_address);
+
+	phys_writeb(address++, 0x55); // push bp
+	write_callback_instruction(address, stacks.enter_callback.Get_callback());
+	phys_writeb(address++, 0x9c); // pushf
+	write_far_call(address, old_vector);
+	write_callback_instruction(address, stacks.leave_callback.Get_callback());
+	phys_writeb(address++, 0x5d); // pop bp
+	phys_writeb(address++, 0xcf); // iret
+}
+
+// Zero the segment and populate the per-slot table. Each table entry holds the
+// alloc flag and (filled in at runtime) the saved SS:SP; each stack slot has
+// its table-entry offset written into the top word. The latter mirrors the
+// MS-DOS layout and helps both DOSBox-side debugging and any DOS code that
+// inspects the stack area directly.
+void initialise_stack_pool()
+{
+	const auto base = PhysicalMake(stacks.segment, 0);
+
+	for (uint16_t offset = 0; offset < get_required_bytes(); ++offset) {
+		mem_writeb(base + offset, 0);
+	}
+
+	stacks.entries.assign(stacks.stack_count, {});
+	stacks.active_entries.assign(MaxNestedInterrupts, -1);
+
+	for (uint8_t i = 0; i < stacks.stack_count; ++i) {
+		const auto entry_offset = check_cast<uint16_t>(TableOffset +
+		                                               i * EntrySize);
+		const auto stack_top    = get_stack_top(i);
+
+		stacks.entries[i]        = {};
+		stacks.entries[i].new_sp = stack_top;
+
+		// MS-DOS leaves the table-entry offset in the word at the top
+		// of each interrupt stack. Keep the same layout for
+		// debuggability and for code that inspects the stack area
+		// directly.
+		real_writew(stacks.segment, stack_top, entry_offset);
+		real_writeb(stacks.segment, entry_offset + 0, 0); // free
+		real_writew(stacks.segment, entry_offset + 6, stack_top);
+	}
+
+	stacks.active_depth    = 0;
+	stacks.untracked_depth = 0;
+	stacks.next_entry      = check_cast<uint8_t>(stacks.stack_count - 1);
+}
+
+void reset_runtime_state()
+{
+	stacks.entries.clear();
+	stacks.active_entries.clear();
+
+	stacks.installed                = false;
+	stacks.exhausted_warning_logged = false;
+	stacks.segment                  = 0;
+	stacks.old_irq0_vector          = 0;
+	stacks.irq0_wrapper             = 0;
+	stacks.old_irq1_vector          = 0;
+	stacks.irq1_wrapper             = 0;
+	stacks.stack_count     = DefaultStackCount;
+	stacks.stack_size      = DefaultStackSize;
+	stacks.active_depth    = 0;
+	stacks.untracked_depth = 0;
+	stacks.next_entry      = DefaultStackCount - 1;
+}
+
+// Pick the next free slot, or return -1 if the pool is exhausted. We start
+// at `next_entry` and walk downwards (wrapping at zero), which matches the
+// MS-DOS "hi-mem first" allocation order: the deepest-nested interrupt gets
+// the lowest-addressed slot. The intent is that if a slot does overflow, it
+// clobbers another pool slot rather than the interrupted program's stack.
+int16_t allocate_stack_entry()
+{
+	for (uint8_t i = 0; i < stacks.stack_count; ++i) {
+		const auto index = check_cast<uint8_t>(
+		        (stacks.next_entry + stacks.stack_count - i) %
+		        stacks.stack_count);
+
+		if (stacks.entries[index].allocated) {
+			continue;
+		}
+
+		stacks.entries[index].allocated = true;
+		stacks.next_entry = (index == 0) ? check_cast<uint8_t>(stacks.stack_count - 1)
+		                                 : index - 1;
+		real_writeb(stacks.segment, TableOffset + index * EntrySize, 1);
+		return check_cast<int16_t>(index);
+	}
+
+	if (!stacks.exhausted_warning_logged) {
+		LOG_WARNING("DOS: Interrupt stack pool exhausted; using interrupted stack");
+		stacks.exhausted_warning_logged = true;
+	}
+	return -1;
+}
+
+// Callback fired by the wrapper before chaining to the previous IRQ0 handler.
+// Allocates a slot, saves the interrupted SS:SP into both the runtime entry
+// and its mirror in the in-segment table, then switches SS:SP to the top of
+// the slot. If allocation fails (pool exhausted, or `active_entries` LIFO
+// already full), the previous handler runs on the interrupted stack — the
+// same fallback MS-DOS uses. BP is also pointed at the new top, matching the
+// real MS-DOS wrapper's behaviour.
+Bitu enter_irq_stack()
+{
+	if (!stacks.installed) {
+		return CBRET_NONE;
+	}
+
+	if (stacks.active_depth >= stacks.active_entries.size()) {
+		++stacks.untracked_depth;
+		return CBRET_NONE;
+	}
+
+	const auto index                             = allocate_stack_entry();
+	stacks.active_entries[stacks.active_depth++] = index;
+
+	if (index < 0) {
+		return CBRET_NONE;
+	}
+
+	auto& entry    = stacks.entries[static_cast<size_t>(index)];
+	entry.saved_ss = SegValue(ss);
+	entry.saved_sp = reg_sp;
+
+	const auto entry_offset = check_cast<uint16_t>(
+	        TableOffset + static_cast<uint8_t>(index) * EntrySize);
+	real_writew(stacks.segment, entry_offset + 2, entry.saved_sp);
+	real_writew(stacks.segment, entry_offset + 4, entry.saved_ss);
+
+	SegSet16(ss, stacks.segment);
+	reg_sp = entry.new_sp;
+
+	// The real MS-DOS stack wrapper uses BP while selecting and switching
+	// stacks. This keeps the interrupted program's BP out of BIOS INT 1Ch.
+	reg_bp = entry.new_sp;
+	return CBRET_NONE;
+}
+
+// Counterpart to enter_irq_stack: pop the most recent slot off the LIFO,
+// restore SS:SP from the saved entry, free the slot, and clear the in-segment
+// mirror. The `untracked_depth` branch unwinds the pathological case where
+// the LIFO overflowed on entry; in that case there was no slot to switch to,
+// so there is nothing to restore here either.
+Bitu leave_irq_stack()
+{
+	if (!stacks.installed) {
+		return CBRET_NONE;
+	}
+
+	if (stacks.untracked_depth > 0) {
+		--stacks.untracked_depth;
+		return CBRET_NONE;
+	}
+
+	if (stacks.active_depth == 0) {
+		return CBRET_NONE;
+	}
+
+	const auto index = stacks.active_entries[--stacks.active_depth];
+	stacks.active_entries[stacks.active_depth] = -1;
+
+	if (index < 0) {
+		return CBRET_NONE;
+	}
+
+	auto& entry = stacks.entries[static_cast<size_t>(index)];
+
+	SegSet16(ss, entry.saved_ss);
+	reg_sp = entry.saved_sp;
+
+	entry.allocated   = false;
+	stacks.next_entry = static_cast<uint8_t>(index);
+
+	const auto entry_offset = check_cast<uint16_t>(
+	        TableOffset + static_cast<uint8_t>(index) * EntrySize);
+	real_writeb(stacks.segment, entry_offset + 0, 0);
+	real_writew(stacks.segment, entry_offset + 2, 0);
+	real_writew(stacks.segment, entry_offset + 4, 0);
+
+	return CBRET_NONE;
+}
+
+// Parse the `stacks` setting into a usable configuration. The setting is
+// either the literal `auto` (use defaults, gated on AT-class machine type) or
+// a `count,size` pair where `0,0` disables the feature and any other pair
+// must lie within [Min,Max]StackCount and [Min,Max]StackSize. On invalid
+// input the feature is treated as disabled; warnings are logged only when
+// `log_warnings` is true so the parser can be invoked twice without
+// double-reporting the same problem.
+struct StacksConfig {
+	bool enabled    = false;
+	uint8_t count   = DefaultStackCount;
+	uint16_t size   = DefaultStackSize;
+};
+
+StacksConfig parse_stacks_setting(const std::string& setting, const bool log_warnings)
+{
+	if (setting == "auto") {
+		StacksConfig config = {};
+		config.enabled = is_machine_ega_or_better();
+		return config;
+	}
+
+	auto warn_invalid = [&]() {
+		if (log_warnings) {
+			LOG_WARNING("DOS: Invalid 'stacks' value '%s'; expected 'auto' or "
+			            "'count,size'. Disabling.",
+			            setting.c_str());
+		}
+	};
+
+	const auto parts = split_with_empties(setting, ',');
+	if (parts.size() != 2) {
+		warn_invalid();
+		return {};
+	}
+
+	const auto count_opt = parse_int(parts[0]);
+	const auto size_opt  = parse_int(parts[1]);
+	if (!count_opt.has_value() || !size_opt.has_value()) {
+		warn_invalid();
+		return {};
+	}
+
+	const int count = *count_opt;
+	const int size  = *size_opt;
+
+	if (count == 0 && size == 0) {
+		return {}; // explicitly disabled
+	}
+
+	if (count < MinStackCount || count > MaxStackCount ||
+	    size < MinStackSize || size > MaxStackSize) {
+		if (log_warnings) {
+			LOG_WARNING("DOS: 'stacks=%s' values out of range; count must be "
+			            "%u-%u and size must be %u-%u. Disabling.",
+			            setting.c_str(), MinStackCount, MaxStackCount,
+			            MinStackSize, MaxStackSize);
+		}
+		return {};
+	}
+
+	StacksConfig config = {};
+	config.enabled      = true;
+	config.count        = check_cast<uint8_t>(count);
+	config.size         = check_cast<uint16_t>(size);
+	return config;
+}
+
+} // namespace
+
+// Decide whether to install the wrapper based on the `stacks` setting. `auto`
+// is treated as a proxy for "modern enough to plausibly run software that
+// needs this": EGA-or-better machines roughly correlate with the MS-DOS 3.2+
+// era where games started to assume STACKS= was available, and we explicitly
+// match MS-DOS in not installing on PCjr-class hardware. This is also where
+// invalid `stacks` values are reported, since we are guaranteed to run once
+// at startup.
+bool DOS_ShouldUseInterruptStacks(const SectionProp& section)
+{
+	return parse_stacks_setting(section.GetString("stacks"),
+	                            /*log_warnings=*/true)
+	        .enabled;
+}
+
+void DOS_InstallInterruptStacks(const SectionProp& section)
+{
+	if (stacks.installed) {
+		return;
+	}
+
+	const auto config = parse_stacks_setting(section.GetString("stacks"),
+	                                         /*log_warnings=*/false);
+	if (!config.enabled) {
+		return;
+	}
+
+	stacks.stack_count = config.count;
+	stacks.stack_size  = config.size;
+
+	// Allocate the wrapper, table and stack pool from conventional memory
+	// via the DOS MCB chain, matching MS-DOS's STACKS layout. Mark the
+	// owning PSP as MCB_DOS so the block is treated as kernel-owned and is
+	// not freed when programs exit.
+	uint16_t segment            = 0;
+	const uint16_t requested    = get_required_paragraphs();
+	uint16_t blocks             = requested;
+	const uint16_t saved_psp    = dos.psp();
+	dos.psp(MCB_DOS);
+	const bool allocated = DOS_AllocateMemory(&segment, &blocks);
+	dos.psp(saved_psp);
+
+	if (!allocated) {
+		LOG_WARNING("DOS: Could not allocate %u paragraphs for interrupt stacks "
+		            "(largest free block: %u paragraphs); feature disabled",
+		            requested, blocks);
+		return;
+	}
+
+	DOS_MCB(check_cast<uint16_t>(segment - 1)).SetFileName("SD      ");
+
+	stacks.segment         = segment;
+	stacks.irq0_wrapper    = RealMake(stacks.segment, 0);
+	stacks.old_irq0_vector = RealGetVec(Irq0Vector);
+	stacks.irq1_wrapper    = RealMake(stacks.segment, WrapperSize);
+	stacks.old_irq1_vector = RealGetVec(Irq1Vector);
+
+	stacks.enter_callback.Allocate(enter_irq_stack, "DOS IRQ stack enter");
+	stacks.leave_callback.Allocate(leave_irq_stack, "DOS IRQ stack leave");
+
+	initialise_stack_pool();
+	write_irq_wrapper(stacks.irq0_wrapper, stacks.old_irq0_vector);
+	write_irq_wrapper(stacks.irq1_wrapper, stacks.old_irq1_vector);
+
+	RealSetVec(Irq0Vector, stacks.irq0_wrapper);
+	RealSetVec(Irq1Vector, stacks.irq1_wrapper);
+	stacks.installed = true;
+}
+
+// Reverse the install sequence at shutdown. We restore the IVT only if we
+// still own the vector; if a TSR has hooked over us, unhooking would corrupt
+// its chain, so we leave the vector alone and log a warning. The conventional-
+// memory segment itself is not freed here — it is owned by MCB_DOS and will
+// be reclaimed when the DOS kernel tears down.
+void DOS_UninstallInterruptStacks()
+{
+	if (!stacks.installed) {
+		return;
+	}
+
+	if (RealGetVec(Irq0Vector) == stacks.irq0_wrapper) {
+		RealSetVec(Irq0Vector, stacks.old_irq0_vector);
+	} else {
+		LOG_INFO("DOS: IRQ0 vector changed while interrupt stacks were installed");
+	}
+
+	if (RealGetVec(Irq1Vector) == stacks.irq1_wrapper) {
+		RealSetVec(Irq1Vector, stacks.old_irq1_vector);
+	} else {
+		LOG_INFO("DOS: IRQ1 vector changed while interrupt stacks were installed");
+	}
+
+	stacks.enter_callback.Uninstall();
+	stacks.leave_callback.Uninstall();
+
+	reset_runtime_state();
+}

--- a/src/dos/meson.build
+++ b/src/dos/meson.build
@@ -17,6 +17,7 @@ libdos_sources = files(
     'dos_misc.cpp',
     'dos_mscdex.cpp',
     'dos_programs.cpp',
+    'dos_stacks.cpp',
     'dos_tables.cpp',
     'dos_windows.cpp',
     'drive_cache.cpp',

--- a/website/docs/0.83/manual/system/dos.md
+++ b/website/docs/0.83/manual/system/dos.md
@@ -70,6 +70,31 @@ on the emulated PCjr. The default `expanded` provides 640 KB and is compatible
 with most games. A few very old PCjr titles ([Jumpman](https://www.mobygames.com/game/80/jumpman/), [Troll](https://www.mobygames.com/game/14214/troll/)) require the
 `standard` 128 KB layout.
 
+## Interrupt stacks
+
+The [`stacks`](#stacks) setting replicates the `STACKS=count,size` directive
+that MS-DOS 3.2 introduced in `CONFIG.SYS`. It maintains a small private pool
+of stacks; whenever a hardware interrupt fires, DOSBox Staging switches to a
+free slot before invoking the handler, then restores the original stack on the
+way out.
+
+The default `auto` enables the feature on AT-class [`machine`](general.md#machine) types, using the
+same defaults MS-DOS used --- 9 stacks of 128 bytes each. It is disabled
+automatically on PC/XT-class machines (e.g., `cga`, `pcjr`, `tandy`), since this
+was the default under DOS. You will rarely need to change this; it exists for
+the edge case where a specific program misbehaves with interrupt stacks
+enabled, or needs a different stack count or size.
+
+!!! note
+
+    When a hardware interrupt fires --- a timer tick, a key press, and so on ---
+    the CPU briefly pauses the running program and executes the interrupt
+    handler, using the program's own stack for that purpose. Most programs leave
+    enough stack space for this to work without issue. A small number of older
+    programs allocate a very tight stack, however, and can crash or corrupt
+    their own data if an interrupt handler (and any handlers it triggers in
+    turn) together need more space than the program left available.
+
 ## Configuration settings
 
 You can set the DOS parameters in the `[dos]` configuration section.
@@ -174,3 +199,34 @@ You can set the DOS parameters in the `[dos]` configuration section.
 :   File containing persistent command line history (`shell_history.txt` by
     default). Setting it to empty disables persistent shell history.
 
+
+### Interrupt stacks
+
+##### stacks
+
+:   Use DOS-style private stacks for hardware interrupts ('auto' by default).
+    When a wrapped hardware interrupt fires, DOSBox Staging switches to one
+    stack from a private pool before invoking the previous handler. Disabling
+    this means each running program must have enough stack space for hardware
+    interrupts (and any chained handlers) itself. Most programs work correctly
+    without it; a few legacy programs depend on it to avoid corrupting their
+    own stack.
+
+    Note: the current implementation wraps the timer interrupt (INT 08h, IRQ0)
+    and the keyboard interrupt (INT 09h, IRQ1). MS-DOS's STACKS feature wraps
+    additional hardware-IRQ vectors; coverage may be expanded in future
+    versions.
+
+    Possible values:
+
+    <div class="compact" markdown>
+
+    - `auto` *default*{ .default } -- Enable on AT-class machine types with
+      the MS-DOS defaults (9 stacks of 128 bytes each). Disable on PC/XT-class
+      machine types (e.g., `cga`, `pcjr`, `tandy`).
+    - `count,size` -- Allocate `count` private stacks of `size` bytes each,
+      e.g. 'stacks = 9,128'. Equivalent to the DOS 'STACKS=count,size' setting;
+      'count' must be 8-64, 'size' must be 32-512.
+    - `0,0` -- Disable; use the interrupted program's stack.
+
+    </div>


### PR DESCRIPTION
# Description

Adds a private-stack mechanism for the timer (INT 08h, IRQ0) and keyboard (INT 09h, IRQ1) interrupts , modeled on the timer and keyboard interrupt portion of the DOS `STACKS=count,size` CONFIG.SYS feature.

Potential for backwards compatibility issues, needs thorough testing.

Adds new config file options.

## Related issues

Fixes #4850 #4045 #4884

# Release notes

We've added an experimental private-stack mechanism for the timer (INT 08h, IRQ0) and keyboard ((INT 09h, IRQ1) interrupts , inspired by the MS-DOS `STACKS=count,size` CONFIG.SYS feature. When enabled, DOSBox Staging switches to a private stack from a small pool before invoking the BIOS timer handler, so timer ISRs (and any chained INT 1Ch handlers) don't consume stack from whatever program happened to be running. This fixes a class of crashes in legacy games whose own stacks are too tight to absorb timer-tick interrupts — for example:

- Rules of Engagement 2 (v1.08)
- StarFight III - Within the Darkness (1997)
- Duke Nukem 3D Atomic Edition

This is narrower than MS-DOS's STACKS feature, which also wraps several other hardware-IRQ vectors. Only the timer and keyboard are wrapped here.

The behaviour is controlled by a new option in the `[dos]` section:

```ini
# Use DOS-style private stacks for hardware interrupts ('auto' by default).
# When a wrapped hardware interrupt fires, DOSBox Staging switches to one
# stack from a private pool before invoking the previous handler. Disabling
# this means each running program must have enough stack space for hardware
# interrupts (and any chained handlers) itself. Most programs work correctly
# without it; a few legacy programs depend on it to avoid corrupting their
# own stack.
#
# Note: the current implementation wraps the timer interrupt (INT 08h, IRQ0)
# and the keyboard interrupt (INT 09h, IRQ1). MS-DOS's STACKS feature wraps
# additional hardware-IRQ vectors; coverage may be expanded in future versions.
#
#   auto:        Enable on AT-class machine types with the MS-DOS defaults
#                (9 stacks of 128 bytes each). Disable on PC/XT-class machine
#                types (e.g., cga, pcjr, tandy).
#   count,size:  Allocate `count` private stacks of `size` bytes each, e.g.
#                'stacks = 9,128'. Equivalent to the DOS 'STACKS=count,size'
#                setting; 'count' must be 8-64, 'size' must be 32-512.
#   0,0:         Disable; use the interrupted program's stack.
#
stacks = auto
```

The pool is allocated from conventional memory (visible with the `MEM /D` command, matching MS-DOS's layout) and is freed automatically when the guest boots a real OS via `BOOT.COM` or when the emulator shuts down.

More technical information is available from https://jeffpar.github.io/kbarchive/kb/084/Q84300/

# Manual testing

Tested Rules of Engagement 2 v1.08 as per #4850

The change has been manually tested on:

- [ ] Windows
- [x] macOS
- [ ] Linux


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

