### PR TITLE
Add support for Microprose's 'The Entertainer' variant of the Innovation SSI-2001

### DIFF
--- a/src/hardware/audio/innovation.cpp
+++ b/src/hardware/audio/innovation.cpp
@@ -12,50 +12,44 @@
 #include "misc/notifications.h"
 #include "misc/support.h"
 #include "utils/checks.h"
+#include "utils/string_utils.h"
 
 CHECK_NARROWING();
 
-Innovation::Innovation(const std::string_view model_choice,
-                       const std::string_view clock_choice,
-                       const int filter_strength_6581,
-                       const int filter_strength_8580, const int port_choice,
+// The Innovation SSI-2001 and Microprose's "The Entertainer" used a SID 6581
+// clocked at 14.318180 MHz from the ISA bus. This clock signal is
+// divided by the counter and flip flops on the board by 16 to produce a base
+// frequency of .89488625 MHz. The cards default to listening on ports
+// 0x280-0x29D. The Entertainer also used I/O address 0x200 for identification,
+// which always return the magic value 0xA5.
+// https://forum.vcfed.org/index.php?threads/the-entertainer-sound-card-exposed.41255/
+// https://nerdlypleasures.blogspot.com/2014/01/sid-and-dos-unlikely-but-true-bedfellows.html
+
+constexpr auto BasePort = io_port_t{0x280};
+
+constexpr auto ChipModel   = reSIDfp::MOS6581;
+constexpr auto ChipClockHz = 14318180.0 / 16;
+
+constexpr auto EntertainerIdPort  = io_port_t{0x200};
+constexpr auto EntertainerIdValue = uint8_t{0xA5};
+
+Innovation::Innovation(const int sid_filter_strength,
                        const std::string& channel_filter_choice)
+        : ms_per_clock{MillisInSecond / ChipClockHz}
 {
 	using namespace std::placeholders;
 
-	int filter_strength = 0;
-	auto sid_service    = std::make_unique<reSIDfp::SID>();
+	assert(ms_per_clock > 0);
+
+	auto sid_service = std::make_unique<reSIDfp::SID>();
 
 	// Setup the model and filter
-	if (model_choice == "8580") {
-		sid_service->setChipModel(reSIDfp::MOS8580);
-		filter_strength = filter_strength_8580;
-		if (filter_strength > 0) {
-			sid_service->enableFilter(true);
-			sid_service->setFilter8580Curve(filter_strength / 100.0);
-		}
-	} else {
-		sid_service->setChipModel(reSIDfp::MOS6581);
-		filter_strength = filter_strength_6581;
-		if (filter_strength > 0) {
-			sid_service->enableFilter(true);
-			sid_service->setFilter6581Curve(filter_strength / 100.0);
-		}
-	}
+	sid_service->setChipModel(ChipModel);
 
-	// Determine chip clock frequency
-	if (clock_choice == "default") {
-		chip_clock = 894886.25;
-	} else if (clock_choice == "c64ntsc") {
-		chip_clock = 1022727.14;
-	} else if (clock_choice == "c64pal") {
-		chip_clock = 985250.0;
-	} else if (clock_choice == "hardsid") {
-		chip_clock = 1000000.0;
+	if (sid_filter_strength > 0) {
+		sid_service->enableFilter(true);
+		sid_service->setFilter6581Curve(sid_filter_strength / 100.0);
 	}
-	assert(chip_clock);
-
-	ms_per_clock = MillisInSecond / chip_clock;
 
 	MIXER_LockMixerThread();
 
@@ -95,39 +89,24 @@ Innovation::Innovation(const std::string_view model_choice,
 	const double passband = 0.9 * sample_rate_hz / 2;
 
 	// Assign the sampling parameters
-	sid_service->setSamplingParameters(chip_clock,
+	sid_service->setSamplingParameters(ChipClockHz,
 	                                   reSIDfp::RESAMPLE,
 	                                   sample_rate_hz,
 	                                   passband);
 
-	if (model_choice == "auto") {
-		// Both the Innovation and Microprose's The Entertainer used a
-		// SID 6581 on default ports 0x280-0x29D. The Entertainer also
-		// used I/O address 0x200 for identification, which always
-		// return the magic value 0xA5.
-		// https://forum.vcfed.org/index.php?threads/the-entertainer-sound-card-exposed.41255/
-		// https://nerdlypleasures.blogspot.com/2014/01/sid-and-dos-unlikely-but-true-bedfellows.html
-
-		constexpr io_port_t DefaultBasePort   = 0x280;
-		constexpr io_port_t EntertainerIdPort = 0x200;
-		constexpr uint8_t EntertainerIdValue  = 0xA5;
-
-		base_port = DefaultBasePort;
-
-		read_entertainer_id_handler.Install(
-		        EntertainerIdPort,
-		        [](io_port_t, io_width_t) { return EntertainerIdValue; },
-		        io_width_t::byte,
-		        1);
-	} else {
-		base_port = check_cast<io_port_t>(port_choice);
-	}
-
 	// Setup and assign the port address
 	const auto read_from = std::bind(&Innovation::ReadFromPort, this, _1, _2);
 	const auto write_to = std::bind(&Innovation::WriteToPort, this, _1, _2, _3);
-	read_handler.Install(base_port, read_from, io_width_t::byte, 0x20);
-	write_handler.Install(base_port, write_to, io_width_t::byte, 0x20);
+
+	read_handler.Install(BasePort, read_from, io_width_t::byte, 0x20);
+
+	read_entertainer_id_handler.Install(
+	        EntertainerIdPort,
+	        [](io_port_t, io_width_t) { return EntertainerIdValue; },
+	        io_width_t::byte,
+	        1);
+
+	write_handler.Install(BasePort, write_to, io_width_t::byte, 0x20);
 
 	// Move the locals into members
 	service = std::move(sid_service);
@@ -136,21 +115,9 @@ Innovation::Innovation(const std::string_view model_choice,
 	// Ready state-values for rendering
 	last_rendered_ms = 0.0;
 
-	// Variable model_name is only used for logging, so use a const char* here
-	const char* model_name  = model_choice == "8580" ? "8580" : "6581";
-	constexpr auto us_per_s = 1'000'000.0;
-	if (filter_strength == 0) {
-		LOG_MSG("INNOVATION: Running on port %xh with a SID %s at %0.3f MHz",
-		        base_port,
-		        model_name,
-		        chip_clock / us_per_s);
-	} else {
-		LOG_MSG("INNOVATION: Running on port %xh with a SID %s at %0.3f MHz filtering at %d%%",
-		        base_port,
-		        model_name,
-		        chip_clock / us_per_s,
-		        filter_strength);
-	}
+	LOG_MSG("INNOVATION: Running on port %xh with filtering at %d%%",
+	        BasePort,
+	        sid_filter_strength);
 
 	MIXER_UnlockMixerThread();
 }
@@ -186,7 +153,7 @@ Innovation::~Innovation()
 uint8_t Innovation::ReadFromPort(io_port_t port, io_width_t)
 {
 	std::lock_guard lock(mutex);
-	const auto sid_port = static_cast<io_port_t>(port - base_port);
+	const auto sid_port = static_cast<io_port_t>(port - BasePort);
 	return service->read(sid_port);
 }
 
@@ -197,7 +164,7 @@ void Innovation::WriteToPort(io_port_t port, io_val_t value, io_width_t)
 	RenderUpToNow();
 
 	const auto data     = check_cast<uint8_t>(value);
-	const auto sid_port = static_cast<io_port_t>(port - base_port);
+	const auto sid_port = static_cast<io_port_t>(port - BasePort);
 	service->write(sid_port, data);
 }
 
@@ -270,23 +237,11 @@ void INNOVATION_Init()
 {
 	const auto section = get_section("innovation");
 
-	const auto model_choice         = section->GetString("sidmodel");
-	const auto clock_choice         = section->GetString("sidclock");
-	const auto port_choice          = section->GetHex("sidport");
-	const auto filter_strength_6581 = section->GetInt("6581filter");
-	const auto filter_strength_8580 = section->GetInt("8580filter");
-	const auto channel_filter_choice = section->GetString("innovation_filter");
-
-	if (has_false(model_choice)) {
-		return;
+	if (section->GetBool("innovation")) {
+		innovation = std::make_unique<Innovation>(
+		        section->GetInt("innovation_sid_filter"),
+		        section->GetString("innovation_filter"));
 	}
-
-	innovation = std::make_unique<Innovation>(model_choice,
-	                                          clock_choice,
-	                                          filter_strength_6581,
-	                                          filter_strength_8580,
-	                                          port_choice,
-	                                          channel_filter_choice);
 }
 
 void INNOVATION_Destroy()
@@ -305,58 +260,24 @@ static void init_innovation_config_settings(SectionProp& sec_prop)
 {
 	constexpr auto when_idle = Property::Changeable::WhenIdle;
 
-	// Chip type
-	auto* str_prop = sec_prop.AddString("sidmodel", when_idle, "none");
-	str_prop->SetValues({"auto", "6581", "8580", "none"});
-	str_prop->SetHelp(
-	        "Model of chip to emulate in the Innovation SSI-2001 card ('none' by default).\n"
-	        "Possible values:\n"
-	        "\n"
-	        "  auto:  Emulates the default Innovation SSI-2001 configuration and\n"
-	        "         Microprose's The Entertainer variant using the standard 6581\n"
-	        "         chip on IO port 280. This is compatible with all SID-based games.\n"
-	        "\n"
-	        "  6581:  The original chip, known for its bassy and rich character.\n"
-	        "\n"
-	        "  8580:  A later revision that more closely matched the SID specification.\n"
-	        "         It fixed the 6581's DC bias and is less prone to distortion.\n"
-	        "         The 8580 is an option on reproduction cards, like the DuoSID.\n"
-	        "\n"
-	        "  none:  Disable the card (default).");
-
-	// Chip clock frequency
-	str_prop = sec_prop.AddString("sidclock", when_idle, "default");
-	str_prop->SetValues({"default", "c64ntsc", "c64pal", "hardsid"});
-	str_prop->SetHelp(
-	        "The SID chip's clock frequency, which is jumperable on reproduction cards\n"
-	        "('default' by default). Possible values:\n"
-	        "\n"
-	        "  default:  0.895 MHz, per the original SSI-2001 card (default).\n"
-	        "  c64ntsc:  1.023 MHz, per NTSC Commodore PCs and the DuoSID.\n"
-	        "  c64pal:   0.985 MHz, per PAL Commodore PCs and the DuoSID.\n"
-	        "  hardsid:  1.000 MHz, available on the DuoSID.");
-
-	// IO Address
-	auto* hex_prop = sec_prop.AddHex("sidport", when_idle, 0x280);
-	hex_prop->SetValues({"240", "260", "280", "2a0", "2c0"});
-	hex_prop->SetHelp(
-	        "The IO port address of the Innovation SSI-2001 (280 by default).\n"
-	        "Possible values: 240, 260, 280, 2a0, 2c0");
+	// Card state
+	auto* bool_prop = sec_prop.AddBool("innovation", when_idle, false);
+	assert(bool_prop);
+	bool_prop->SetHelp(
+	        "Enable emulation of the Innovation SSI-2001 and Microprose's \"The Entertainer\"\n"
+	        "sound cards on base port of 280. These use the iconic MOS 6581 SID chip of the\n"
+	        "Commodore 64 personal computer from the 1980s. Only 15 games are known to\n"
+	        "support these cards.");
 
 	// Filter strengths
-	auto* int_prop = sec_prop.AddInt("6581filter", when_idle, 50);
+	auto* int_prop = sec_prop.AddInt("innovation_sid_filter", when_idle, 50);
+	assert(int_prop);
 	int_prop->SetMinMax(0, 100);
 	int_prop->SetHelp(
 	        "Adjusts the 6581's filtering strength as a percentage from 0 to 100 (50 by\n"
 	        "default). The SID's analog filtering meant that each chip was physically unique.");
 
-	int_prop = sec_prop.AddInt("8580filter", when_idle, 50);
-	int_prop->SetMinMax(0, 100);
-	int_prop->SetHelp(
-	        "Adjusts the 8580's filtering strength as a percentage from 0 to 100 (50 by\n"
-	        "default).");
-
-	str_prop = sec_prop.AddString("innovation_filter", when_idle, "off");
+	auto* str_prop = sec_prop.AddString("innovation_filter", when_idle, "off");
 	assert(str_prop);
 	str_prop->SetHelp(
 	        "Filter for the Innovation audio output ('off' by default). Possible values:\n"

--- a/src/hardware/audio/innovation.cpp
+++ b/src/hardware/audio/innovation.cpp
@@ -100,10 +100,32 @@ Innovation::Innovation(const std::string_view model_choice,
 	                                   sample_rate_hz,
 	                                   passband);
 
+	if (model_choice == "auto") {
+		// Both the Innovation and Microprose's The Entertainer used a
+		// SID 6581 on default ports 0x280-0x29D. The Entertainer also
+		// used I/O address 0x200 for identification, which always
+		// return the magic value 0xA5.
+		// https://forum.vcfed.org/index.php?threads/the-entertainer-sound-card-exposed.41255/
+		// https://nerdlypleasures.blogspot.com/2014/01/sid-and-dos-unlikely-but-true-bedfellows.html
+
+		constexpr io_port_t DefaultBasePort   = 0x280;
+		constexpr io_port_t EntertainerIdPort = 0x200;
+		constexpr uint8_t EntertainerIdValue  = 0xA5;
+
+		base_port = DefaultBasePort;
+
+		read_entertainer_id_handler.Install(
+		        EntertainerIdPort,
+		        [](io_port_t, io_width_t) { return EntertainerIdValue; },
+		        io_width_t::byte,
+		        1);
+	} else {
+		base_port = check_cast<io_port_t>(port_choice);
+	}
+
 	// Setup and assign the port address
 	const auto read_from = std::bind(&Innovation::ReadFromPort, this, _1, _2);
 	const auto write_to = std::bind(&Innovation::WriteToPort, this, _1, _2, _3);
-	base_port = check_cast<io_port_t>(port_choice);
 	read_handler.Install(base_port, read_from, io_width_t::byte, 0x20);
 	write_handler.Install(base_port, write_to, io_width_t::byte, 0x20);
 
@@ -146,6 +168,7 @@ Innovation::~Innovation()
 
 	// Remove the IO handlers before removing the SID device
 	read_handler.Uninstall();
+	read_entertainer_id_handler.Uninstall();
 	write_handler.Uninstall();
 
 	// Deregister the mixer channel and remove it
@@ -289,7 +312,9 @@ static void init_innovation_config_settings(SectionProp& sec_prop)
 	        "Model of chip to emulate in the Innovation SSI-2001 card ('none' by default).\n"
 	        "Possible values:\n"
 	        "\n"
-	        "  auto:  Use the 6581 chip.\n"
+	        "  auto:  Emulates the default Innovation SSI-2001 configuration and\n"
+	        "         Microprose's The Entertainer variant using the standard 6581\n"
+	        "         chip on IO port 280. This is compatible with all SID-based games.\n"
 	        "\n"
 	        "  6581:  The original chip, known for its bassy and rich character.\n"
 	        "\n"

--- a/src/hardware/audio/private/innovation.h
+++ b/src/hardware/audio/private/innovation.h
@@ -37,8 +37,11 @@ private:
 
 	// Managed objects
 	MixerChannelPtr channel               = nullptr;
+
 	IO_ReadHandleObject read_handler      = {};
+	IO_ReadHandleObject read_entertainer_id_handler = {};
 	IO_WriteHandleObject write_handler    = {};
+
 	std::unique_ptr<reSIDfp::SID> service = {};
 	std::queue<float> fifo                = {};
 	std::mutex mutex                      = {};

--- a/src/hardware/audio/private/innovation.h
+++ b/src/hardware/audio/private/innovation.h
@@ -17,10 +17,8 @@
 
 class Innovation {
 public:
-	Innovation(const std::string_view model_choice,
-	           const std::string_view clock_choice,
-	           int filter_strength_6581, int filter_strength_8580,
-	           int port_choice, const std::string& channel_filter_choice);
+	Innovation(const int sid_filter_strength,
+	           const std::string& channel_filter_choice);
 
 	~Innovation();
 
@@ -47,9 +45,7 @@ private:
 	std::mutex mutex                      = {};
 
 	// Initial configuration
-	double chip_clock            = 0.0;
-	double ms_per_clock          = 0.0;
-	io_port_t base_port          = 0;
+	const double ms_per_clock    = 0.0;
 	int idle_after_silent_frames = 0;
 
 	// Runtime states

--- a/website/docs/0.83/manual/sound/sound-devices/innovation.md
+++ b/website/docs/0.83/manual/sound/sound-devices/innovation.md
@@ -2,9 +2,10 @@
 
 The ultra-rare **Innovation SSI-2001** card was released in April 1989 by
 Innovation Computer Corporation, utilizing the MOS 6581 (aka SID) chip, as
-found in the Commodore 64.
+found in the Commodore 64. Microprose later released its own variant,
+called "The Entertainer".
 
-Only a small handful of games support this truly unique sound option.
+Only 15 games are known to support this truly unique sound option.
 
 ??? note "Games with Innovation SS-2001 support"
 
@@ -16,16 +17,17 @@ Only a small handful of games support this truly unique sound option.
     - [BattleTech: The Crescent Hawks' Revenge](https://www.mobygames.com/game/233/battletech-the-crescent-hawks-revenge/)
     - [F-19 Stealth Fighter](https://www.mobygames.com/game/512/f-19-stealth-fighter/)
     - [Falcon A.T.](https://www.mobygames.com/game/1628/falcon-at/)
+    - [Gunship versions 429.04 and 429.05](https://www.mobygames.com/game/335/gunship/)
     - [Harpoon](https://www.mobygames.com/game/8308/harpoon/)
     - [Joe Montana Football](https://www.mobygames.com/game/21183/joe-montana-football/)
     - [J.R.R. Tolkien's The Lord of the Rings, Vol. I](https://www.mobygames.com/game/3870/jrr-tolkiens-the-lord-of-the-rings-vol-i/)
+    - [Pirates! versions 432.1, 432.2, and 432.3](https://www.mobygames.com/game/214/sid-meiers-pirates/)
     - [Red Storm Rising](https://www.mobygames.com/game/1655/red-storm-rising/)
     - [Super Jeopardy!](https://www.mobygames.com/game/33449/super-jeopardy/)
     - [Ultima VI: The False Prophet](https://www.mobygames.com/game/104/ultima-vi-the-false-prophet/)
     - [Windwalker](https://www.mobygames.com/game/1636/windwalker/)
 
     </div>
-
 
 ## Mixer channel
 
@@ -39,44 +41,19 @@ You can set the parameters of the Innovation SSI-2001 card in the
 `[innovation]` configuration section.
 
 
-##### sidmodel
+##### innovation
 
-:   Model of chip to emulate in the Innovation SSI-2001 card:
-
-    - `none` *default*{ .default } --  Disables the card.
-    - `auto` --  Selects the 6581 chip.
-    - `6581` --  The original chip, known for its bassy and rich character.
-    - `8580` --  A later revision that more closely matched the SID specification.
-               It fixed the 6581's DC bias and is less prone to distortion.
-               The 8580 is an option on reproduction cards, like the DuoSID.
-
-##### sidport
-
-:   The IO port address of the Innovation SSI-2001.
-
-    Possible values: `240`, `260`, `280` *default*{ .default }, `2a0`, `2c0`.
+:   Enable emulation of the Innovation SSI-2001 and Microprose's "The
+Entertainer" sound cards on base port of 280. These use the iconic MOS 6581 SID
+chip of the Commodore 64 personal computer from the 1980s. Only 15 games are
+known to support these cards.
 
 
-##### sidclock
-
-:   The SID chip's clock frequency, which is jumperable on reproduction cards:
-
-    - `default` *default*{ .default } -- Uses 0.895 MHz, per the original SSI-2001 card.
-    - `c64ntsc` -- Uses 1.023 MHz, per NTSC Commodore PCs and the DuoSID.
-    - `c64pal` --  Uses 0.985 MHz, per PAL Commodore PCs and the DuoSID.
-    - `hardsid` -- Uses 1.000 MHz, available on the DuoSID.
-
-
-##### 6581filter
+##### innovation_sid_filter
 
 :   The SID's analog filtering meant that each chip was physically unique.
 
     Adjusts the 6581's filtering strength as a percent from 0 to 100 (defaults to 50).
-
-
-##### 8580filter
-
-:   Adjusts the 8580's filtering strength as a percent from 0 to 100 (defaults to 50).
 
 
 ##### innovation_filter


### PR DESCRIPTION
# Description

Add support for Microprose's 'The Entertainer' variant of the Innovation SSI-2001 card. 

This turned out to be straight forward to add given the simplicity of the code and thanks to the reference posted by merkur on Discord.

# Release notes

## Configuration changes

The Innovation SSI-2001's configuration has been simplified to the following:

```ini
[innovation]
innovation = on/off
innovation_sid_filter = [0 to 100]
innovation_filter = (existing mixer filter settings)
```
The chip type, base port, and frequency settings have been eliminated in favor of a fixed configuration using the standard SID 6581 chip running at 0.89488625 MHz on the card's default base port 280h.

## Feature additions

Microprose's 'The Entertainer' variant of the Innovation SSI-2001 is now supported when the innovation card is enabled. This is used by Microprose's Gunship versions 429.04 and 429.05 and Pirates! versions 432.1, 432.2, and 432.3. 

https://github.com/user-attachments/assets/8157b44d-09d9-420e-8e47-2d2058dce298


https://github.com/user-attachments/assets/d917afb7-ba89-49a0-8dab-f0f810ee01a9


# Manual testing

Tested cmake sanitizer build with Gunship and Pirates and confirmed these are using the card instead of the PC speaker. No errors or crashes occured.

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [x] Linux

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [ ] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [x] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

