### PR TITLE
Update macOS notarize script

### DIFF
--- a/docs/build-macos.md
+++ b/docs/build-macos.md
@@ -334,6 +334,7 @@ As sanitizer availability and performance are highly dependent on the concrete
 platform (CPU, OS, compiler), you might need to manually adapt the
 `SANITIZER_FLAGS` variable in the `CMakeLists.txt` file to suit your needs.
 
+
 ## Using FluidSynth and Slirp during local development
 
 FluidSynth and Slirp are difficult and time-consuming to build, therefore they
@@ -376,3 +377,72 @@ to the FluidSynth MIDI synth or NE2000 networking via Slirp.
 
 You'll only need to do this once after a successful build. If you delete the
 CMake build folder, redo step 4.
+
+
+## Setting up local dev environment for code signing
+
+The prerequisite for code signing is an Apple Developer membership. The
+following steps describe how to set up the necessary certificates and
+credentials in the Keychain for the [notarizer
+script](/scripts/packaging/macos/notarize-macos-dmg.sh) for local code
+signing.
+
+### Import the dev certificates into the Keychain
+
+1. Start XCode, then go to **Settings / Accounts**.
+
+2. Click on the **+** button in the bottom left corner and select **Apple
+   Account**.
+
+3. Select the newly added account and click on **Manage Certificates** in the
+   bottom right corner.
+
+4. Click on the **+** button and add all available certificates (probably
+   **Apple Development Certificates** is only one needed, but it doesn't hurt
+   to add them all). 
+
+5. Quit XCode, then open Keychain Access and verify the new certificates and
+   keys have been imported. Search for "developer" --- you should see a bunch
+   of entries, including **Developer ID Application: <Your Name>
+   (_<TEAM_ID>_)**. You might need to wait a minute or two for the entries to
+   show up in the Keychain.
+
+Your Team ID is the 10-character alphanumeric code in parentheses on your
+certificate, e.g. **Developer ID Application: Your Name (X4MF6H9XZ6)**
+
+
+### Store the authentication credentials in the Keychain
+
+These instructions are adapted from [here](https://github.com/electron/notarize/blob/main/README.md).
+
+1. Generate an app-specific password for your Apple ID [as described here](https://support.apple.com/en-us/102654).
+
+2. Run the following command to store your credentials securely in the
+   Keychain (you can change the new keychain profile name from
+   `notary-tool-profile` to anything else you like):
+
+       xcrun notarytool store-credentials "notary-tool-profile" \
+           --apple-id "<your-apple-id>" \
+           --team-id "<10-char-team-id>" 
+           --password "<app-specific-pw>"
+
+   You should get the following input if all went well:
+
+       Validating your credentials...
+       Success. Credentials validated.
+       Credentials saved to Keychain.
+       To use them, specify `--keychain-profile "notary-tool-profile"`
+
+3. **[Optional]** Create a new script to set the env vars required by the
+   [notarizer script](/scripts/packaging/macos/notarize-macos-dmg.sh) script:
+
+       export DEVELOPER_IDENTITY="Developer ID Application: Your Name (X4MF6H9XZ6)"
+       export KEYCHAIN_PROFILE="notary-tool-profile"
+
+
+## Code signing the application bundle
+
+Once the the local dev environment for code signing is set up, you can sign
+the application bundle built on GitHub CI with the [notarizer
+script](/scripts/packaging/macos/notarize-macos-dmg.sh).
+

--- a/scripts/packaging/macos/notarize-macos-dmg.sh
+++ b/scripts/packaging/macos/notarize-macos-dmg.sh
@@ -1,63 +1,147 @@
 #!/bin/bash
 
-# SPDX-FileCopyrightText:  2024-2024 The DOSBox Staging Team
+# SPDX-FileCopyrightText:  2024-2026 The DOSBox Staging Team
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-# This script notarizes a macOS DMG produced from the CI builds by
-# extracting the DMG, signing the app bundle, using the rest of the files
-# and the newly-signed app bundle to create a new DMG, then signing and 
-# notarizing the entire new DMG. Xcode must be installed.
-
-# Ensure developer identity and keychain profile name are set as environment variables
-# For example:
-# export DEVELOPER_IDENTITY="Developer ID Application: Valued Developer (xxxxxxxxxxx)"
-# export KEYCHAIN_PROFILE="Valued Developer Personal"
+# This script takes an unsigned DOSBox Staging DMG from the GitHub CI build,
+# signs all binaries inside it with a Developer ID certificate, notarizes it
+# with Apple, and staples the notarization ticket to the final DMG.
 #
-# Apple's notarization documentation: 
-# https://developer.apple.com/documentation/security/notarizing_macos_software_before_distribution
+# See docs/build-macos.dmg for instructions on setting up the certificates for
+# code signing on your development machine.
+#
+# Required environment variables:
+#
+#   DEVELOPER_IDENTITY - Your Developer ID cert, e.g:
+#                        "Developer ID Application: John Novak (944SS92GAH)"
+#
+#   KEYCHAIN_PROFILE   - The notarytool keychain profile name created via:
+#                        xcrun notarytool store-credentials <profile-name> ...
+#
+# Usage:
+#   ./notarize-macos-dmg.sh INPUT_DMG OUTPUT_DMG
+
+set -e
 
 if [[ -z "$DEVELOPER_IDENTITY" || -z "$KEYCHAIN_PROFILE" ]]; then
     echo "Error: DEVELOPER_IDENTITY and KEYCHAIN_PROFILE environment variables must be set."
     exit 1
 fi
 
-if [ "$#" -ne 2 ]; then
+if [[ "$#" -ne 2 ]]; then
     echo "Usage: $0 INPUT_DMG OUTPUT_DMG"
     exit 1
 fi
 
 SCRIPT_DIR=$(pwd)
 INPUT_DMG="$1"
-OUTPUT_DMG="$2"
+
+# Resolve OUTPUT_DMG to an absolute path before we cd into TEMP_DIR,
+# otherwise the relative path will point inside TEMP_DIR and get deleted
+# during cleanup.
+OUTPUT_DMG="$(cd "$(dirname "$2")" && pwd)/$(basename "$2")"
+
 TEMP_DIR=$(mktemp -d)
 
+# Mount the input DMG and capture the volume path
 ATTACHED_VOLUME_PATH=$(hdiutil attach "$INPUT_DMG" | grep "Volumes" | awk 'BEGIN {FS="\t"}; {print $NF}')
 ATTACHED_VOLUME_NAME=$(basename "$ATTACHED_VOLUME_PATH")
 
-if [ -z "$ATTACHED_VOLUME_NAME" ]; then
+if [[ -z "$ATTACHED_VOLUME_NAME" ]]; then
     echo "Error attaching DMG."
     exit 1
 fi
 
+# Copy the mounted volume's contents into a temp directory so we can modify
+# them.
 ditto "$ATTACHED_VOLUME_PATH" "$TEMP_DIR"
-
 cd "$TEMP_DIR" || { echo "Failed to change to $TEMP_DIR"; exit 1; }
 
-# Remove accidental sed backup files from older DMGs. These will cause
-# verification failures, e.g.:
-# spctl -a -vvv -t install "/Volumes/DOSBox Staging/DOSBox Staging.app"
-rm "DOSBox Staging.app/Contents/Info.plist-e"
-rm "DOSBox Staging.app/Contents/SharedSupport/README-e"
+APP="DOSBox Staging.app"
+CERT="$DEVELOPER_IDENTITY"
 
-codesign -s "$DEVELOPER_IDENTITY" -fv --timestamp -o runtime --entitlements "${SCRIPT_DIR}/extras/macos/Entitlements.plist" "DOSBox Staging.app"
+# Remove accidental sed backup files left over from older DMG builds.
+# These corrupt the app bundle signature and cause spctl verification to fail.
+#
+rm -f "$APP/Contents/Info.plist-e"
+rm -f "$APP/Contents/SharedSupport/README-e"
 
-hdiutil create -volname "$ATTACHED_VOLUME_NAME" -srcfolder "$TEMP_DIR" -ov -format UDZO "$OUTPUT_DMG"
+# -------------------------------------------------------------------
+# IMPORTANT!
+# ===================================================================
+# Signing must be done inside-out: every binary inside the app bundle
+# must be signed *before* the bundle itself is signed. This is because
+# the app bundle signature is a hash of its contents — if anything
+# inside is signed or modified after the bundle is signed, the bundle
+# signature becomes invalid.
+# -------------------------------------------------------------------
 
-codesign -s "$DEVELOPER_IDENTITY" -fv --timestamp "$OUTPUT_DMG"
+# Sign all bundled dylibs individually. These are third-party libraries
+# (glib, slirp, etc.) that we inject at CI-build time, so they are not signed
+# by their upstream sources. Therefore, we must sign them ourselves with our
+# Developer ID.
+#
+find "$APP/Contents/MacOS/lib" -name "*.dylib" | while read -r dylib; do
+    echo "Signing dylib: $dylib"
+    codesign -s "$CERT" -fv --timestamp -o runtime "$dylib"
+done
 
-xcrun notarytool submit "$OUTPUT_DMG" --keychain-profile "$KEYCHAIN_PROFILE" --wait
+# Sign the bundled Nuked-SC55 CLAP plugin. CLAP plugins are bundles, so we
+# must sign the inner binary first, then the outer bundle.
+#
+if [[ -f "$APP/Contents/PlugIns/Nuked-SC55.clap/Contents/MacOS/Nuked-SC55" ]]; then
+    echo "Signing Nuked-SC55 binary..."
+    codesign -s "$CERT" -fv --timestamp -o runtime \
+        "$APP/Contents/PlugIns/Nuked-SC55.clap/Contents/MacOS/Nuked-SC55"
+
+    echo "Signing Nuked-SC55.clap bundle..."
+    codesign -s "$CERT" -fv --timestamp -o runtime \
+        "$APP/Contents/PlugIns/Nuked-SC55.clap"
+fi
+
+# Catch-all: sign any other executable files in PlugIns that aren't
+# part of a .clap bundle (future-proofing for additional plugins).
+#
+find "$APP/Contents/PlugIns" -name "*.clap" -prune -o -type f -perm +111 -print | while read -r bin; do
+    echo "Signing plugin binary: $bin"
+    codesign -s "$CERT" -fv --timestamp -o runtime "$bin"
+done
+
+# Sign the app bundle last, with our entitlements. The entitlements file
+# declares capabilities the app needs (e.g., hardened runtime exceptions).
+echo "Signing app bundle..."
+
+codesign -s "$CERT" -fv --timestamp -o runtime \
+    --entitlements "${SCRIPT_DIR}/extras/macos/Entitlements.plist" "$APP"
+
+# Verify the signature is valid before we bother packaging and uploading.
+# Catches problems early and saves a wasted notarization submission.
+echo "Verifying signature..."
+codesign --verify --deep --strict --verbose=2 "$APP"
+
+# Repackage the signed app into a new DMG using UDZO (zlib) compression.
+echo "Creating output DMG..."
+hdiutil create -volname "$ATTACHED_VOLUME_NAME" -srcfolder "$TEMP_DIR" \
+	-ov -format UDZO "$OUTPUT_DMG"
+
+# The DMG itself must also be signed — Apple requires all submitted
+# files to be signed, not just the app inside them.
+echo "Signing DMG..."
+codesign -s "$CERT" -fv --timestamp "$OUTPUT_DMG"
+
+# Submit the DMG to Apple's notary service. --wait blocks until Apple
+# returns a result rather than requiring a separate polling step.
+echo "Submitting for notarization..."
+xcrun notarytool submit "$OUTPUT_DMG" \
+	--keychain-profile "$KEYCHAIN_PROFILE" --wait
+
+# Staple the notarization ticket to the DMG. This embeds the ticket
+# so Gatekeeper can verify it offline, without contacting Apple's servers.
+echo "Stapling notarization ticket..."
 xcrun stapler staple "$OUTPUT_DMG"
 
+# Cleanup: detach the original mounted volume and delete the temp directory.
 hdiutil detach "$ATTACHED_VOLUME_PATH"
 rm -rf "$TEMP_DIR"
 
+echo "Done: $OUTPUT_DMG"


### PR DESCRIPTION
# Description

Update the macOS notarise script to correctly sign all the external deps and the CLAP plugin we inject at CI-build time:

> Signing must be done inside-out: every binary inside the app bundle must be signed *before* the bundle itself is signed. This is because the app bundle signature is a hash of its contents — if anything inside is signed or modified after the bundle is signed, the bundle signature becomes invalid.

I've also updated the macOS build instructions with detailed info about setting up code signing on your dev machine.

## Manual testing

Notarise script runs without errors, and macOS doesn't prevent starting Staging when installed from the signed DMG.

The change has been manually tested on:

- [ ] Windows
- [x] macOS
- [ ] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

