### PR TITLE
Recommend and list cmake presets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,20 @@
 cmake_minimum_required(VERSION 3.25)
 
+# The project only tests preset build configurations, so we use
+# the IS_PRESET_USED variable to check and recommend using a preset.
+
+if (NOT IS_PRESET_USED)
+  message(WARNING
+    "\nPer docs/build-*.md, we recommend using a platform-specific preset.
+     cmake --preset <name>"
+  )
+  execute_process(
+    COMMAND ${CMAKE_COMMAND} --list-presets
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+  )
+  message("")
+endif()
+
 set(VCPKG_USE_HOST_TOOLS ON)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON CACHE BOOL

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -475,8 +475,15 @@ set(LICENSE_FILES
   licenses/Zlib.txt
 )
 
-# Set the directory with resources to bundle
+# The source of the resources, relative to the source root
 set(RESOURCES_PATH "resources")
+
+# The copy target of the resources, relative to the compiled binary
+if (APPLE OR WIN32)
+  set(RESOURCE_COPY_PATH "Resources" CACHE STRING "Resources copy target relative to binary")
+else()
+  set(RESOURCE_COPY_PATH "resources" CACHE STRING "Resources copy target relative to binary")
+endif()
 
 # Generate asset copy commands and add them as a dependency
 include(cmake/add_copy_assets.cmake)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -8,6 +8,7 @@
       "generator": "Ninja",
       "binaryDir": "${sourceDir}/build/debug",
       "cacheVariables": {
+        "IS_PRESET_USED" : "TRUE",
         "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
         "CMAKE_FIND_PACKAGE_PREFER_CONFIG" : "ON",
         "CMAKE_BUILD_TYPE": "Debug"
@@ -20,6 +21,7 @@
       "generator": "Ninja",
       "binaryDir": "${sourceDir}/build/release",
       "cacheVariables": {
+        "IS_PRESET_USED" : "TRUE",
         "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
         "CMAKE_FIND_PACKAGE_PREFER_CONFIG" : "ON",
         "CMAKE_BUILD_TYPE": "Release"
@@ -32,6 +34,7 @@
       "generator": "Ninja",
       "binaryDir": "${sourceDir}/build/debug-linux",
       "cacheVariables": {
+        "IS_PRESET_USED" : "TRUE",
         "CMAKE_BUILD_TYPE": "Debug",
         "USE_SYSTEM_LIBS": "ON"
       }
@@ -43,6 +46,7 @@
       "generator": "Ninja",
       "binaryDir": "${sourceDir}/build/release-linux",
       "cacheVariables": {
+        "IS_PRESET_USED" : "TRUE",
         "CMAKE_BUILD_TYPE": "Release",
         "USE_SYSTEM_LIBS": "ON"
       }
@@ -54,6 +58,7 @@
       "generator": "Ninja",
       "binaryDir": "${sourceDir}/build/debug-linux",
       "cacheVariables": {
+        "IS_PRESET_USED" : "TRUE",
         "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
         "CMAKE_FIND_PACKAGE_PREFER_CONFIG" : "ON",
         "CMAKE_BUILD_TYPE": "Debug"
@@ -66,6 +71,7 @@
       "generator": "Ninja",
       "binaryDir": "${sourceDir}/build/release-linux",
       "cacheVariables": {
+        "IS_PRESET_USED" : "TRUE",
         "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
         "CMAKE_FIND_PACKAGE_PREFER_CONFIG" : "ON",
         "CMAKE_BUILD_TYPE": "Release"
@@ -78,6 +84,7 @@
       "generator": "Xcode",
       "binaryDir": "${sourceDir}/build/debug-macos",
       "cacheVariables": {
+        "IS_PRESET_USED" : "TRUE",
         "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
         "CMAKE_OSX_DEPLOYMENT_TARGET": "12.0",
         "CMAKE_FIND_PACKAGE_PREFER_CONFIG" : "ON",
@@ -91,6 +98,7 @@
       "generator": "Xcode",
       "binaryDir": "${sourceDir}/build/release-macos",
       "cacheVariables": {
+        "IS_PRESET_USED" : "TRUE",
         "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
         "CMAKE_OSX_DEPLOYMENT_TARGET": "12.0",
         "CMAKE_FIND_PACKAGE_PREFER_CONFIG" : "ON",
@@ -104,6 +112,7 @@
       "generator": "Xcode",
       "binaryDir": "${sourceDir}/build/release-macos-arm64",
       "cacheVariables": {
+        "IS_PRESET_USED" : "TRUE",
         "CMAKE_OSX_ARCHITECTURES": "arm64",
         "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
         "CMAKE_OSX_DEPLOYMENT_TARGET": "12.0",
@@ -118,6 +127,7 @@
       "generator": "Xcode",
       "binaryDir": "${sourceDir}/build/release-macos-x86_64",
       "cacheVariables": {
+        "IS_PRESET_USED" : "TRUE",
         "CMAKE_OSX_ARCHITECTURES": "x86_64",
         "CMAKE_OSX_DEPLOYMENT_TARGET": "12.0",
         "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
@@ -132,6 +142,7 @@
       "generator": "Visual Studio 17 2022",
       "binaryDir": "${sourceDir}/build/debug-windows",
       "cacheVariables": {
+        "IS_PRESET_USED" : "TRUE",
         "CMAKE_GENERATOR_TOOLSET": "ClangCL",
         "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
         "CMAKE_FIND_PACKAGE_PREFER_CONFIG" : "ON",
@@ -149,6 +160,7 @@
       "generator": "Visual Studio 17 2022",
       "binaryDir": "${sourceDir}/build/release-windows",
       "cacheVariables": {
+        "IS_PRESET_USED" : "TRUE",
         "CMAKE_GENERATOR_TOOLSET": "ClangCL",
         "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
         "CMAKE_FIND_PACKAGE_PREFER_CONFIG" : "ON",

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -10,8 +10,7 @@
       "cacheVariables": {
         "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
         "CMAKE_FIND_PACKAGE_PREFER_CONFIG" : "ON",
-        "CMAKE_BUILD_TYPE": "Debug",
-        "RESOURCE_COPY_PATH": "/../resources"
+        "CMAKE_BUILD_TYPE": "Debug"
       }
     },
     {
@@ -23,8 +22,7 @@
       "cacheVariables": {
         "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
         "CMAKE_FIND_PACKAGE_PREFER_CONFIG" : "ON",
-        "CMAKE_BUILD_TYPE": "Release",
-        "RESOURCE_COPY_PATH": "/../resources"
+        "CMAKE_BUILD_TYPE": "Release"
       }
     },
     {
@@ -35,7 +33,6 @@
       "binaryDir": "${sourceDir}/build/debug-linux",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug",
-        "RESOURCE_COPY_PATH": "/resources",
         "USE_SYSTEM_LIBS": "ON"
       }
     },
@@ -47,7 +44,6 @@
       "binaryDir": "${sourceDir}/build/release-linux",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release",
-        "RESOURCE_COPY_PATH": "/resources",
         "USE_SYSTEM_LIBS": "ON"
       }
     },
@@ -60,8 +56,7 @@
       "cacheVariables": {
         "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
         "CMAKE_FIND_PACKAGE_PREFER_CONFIG" : "ON",
-        "CMAKE_BUILD_TYPE": "Debug",
-        "RESOURCE_COPY_PATH": "/resources"
+        "CMAKE_BUILD_TYPE": "Debug"
       }
     },
     {
@@ -73,8 +68,7 @@
       "cacheVariables": {
         "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
         "CMAKE_FIND_PACKAGE_PREFER_CONFIG" : "ON",
-        "CMAKE_BUILD_TYPE": "Release",
-        "RESOURCE_COPY_PATH": "/resources"
+        "CMAKE_BUILD_TYPE": "Release"
       }
     },
     {
@@ -87,8 +81,7 @@
         "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
         "CMAKE_OSX_DEPLOYMENT_TARGET": "12.0",
         "CMAKE_FIND_PACKAGE_PREFER_CONFIG" : "ON",
-        "CMAKE_BUILD_TYPE": "Debug",
-        "RESOURCE_COPY_PATH": "/Resources"
+        "CMAKE_BUILD_TYPE": "Debug"
       }
     },
     {
@@ -101,8 +94,7 @@
         "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
         "CMAKE_OSX_DEPLOYMENT_TARGET": "12.0",
         "CMAKE_FIND_PACKAGE_PREFER_CONFIG" : "ON",
-        "CMAKE_BUILD_TYPE": "Release",
-        "RESOURCE_COPY_PATH": "/Resources"
+        "CMAKE_BUILD_TYPE": "Release"
       }
     },
     {
@@ -116,8 +108,7 @@
         "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
         "CMAKE_OSX_DEPLOYMENT_TARGET": "12.0",
         "CMAKE_FIND_PACKAGE_PREFER_CONFIG" : "ON",
-        "CMAKE_BUILD_TYPE": "Release",
-        "RESOURCE_COPY_PATH": "/Resources"
+        "CMAKE_BUILD_TYPE": "Release"
       }
     },
     {
@@ -131,8 +122,7 @@
         "CMAKE_OSX_DEPLOYMENT_TARGET": "12.0",
         "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
         "CMAKE_FIND_PACKAGE_PREFER_CONFIG" : "ON",
-        "CMAKE_BUILD_TYPE": "Release",
-        "RESOURCE_COPY_PATH": "/Resources"
+        "CMAKE_BUILD_TYPE": "Release"
       }
     },
     {
@@ -145,8 +135,7 @@
         "CMAKE_GENERATOR_TOOLSET": "ClangCL",
         "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
         "CMAKE_FIND_PACKAGE_PREFER_CONFIG" : "ON",
-        "CMAKE_BUILD_TYPE": "Debug",
-        "RESOURCE_COPY_PATH": "/Resources"
+        "CMAKE_BUILD_TYPE": "Debug"
       },
       "environment": {
         "UseMultiToolTask": "true",
@@ -163,8 +152,7 @@
         "CMAKE_GENERATOR_TOOLSET": "ClangCL",
         "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
         "CMAKE_FIND_PACKAGE_PREFER_CONFIG" : "ON",
-        "CMAKE_BUILD_TYPE": "Release",
-        "RESOURCE_COPY_PATH": "/Resources"
+        "CMAKE_BUILD_TYPE": "Release"
       },
       "environment": {
         "UseMultiToolTask": "true",

--- a/cmake/add_build_documentation.cmake
+++ b/cmake/add_build_documentation.cmake
@@ -163,7 +163,7 @@ function(add_build_documentation)
   set(MKDOCS_VENV_DIR      "${CMAKE_BINARY_DIR}/_mkdocs_venv")
   set(MKDOCS_REQUIREMENTS  "${CMAKE_SOURCE_DIR}/extras/documentation/mkdocs-package-requirements.txt")
   set(MKDOCS_CONFIG        "${CMAKE_SOURCE_DIR}/website/mkdocs.yml")
-  set(MKDOCS_OUTPUT_DIR    "${CMAKE_CURRENT_BINARY_DIR}${RESOURCE_COPY_PATH}/docs")
+  set(MKDOCS_OUTPUT_DIR    "${CMAKE_CURRENT_BINARY_DIR}/${RESOURCE_COPY_PATH}/docs")
   set(MKDOCS_PIP_STAMP     "${MKDOCS_VENV_DIR}/.pip_install_stamp")
   set(MKDOCS_BUILD_STAMP   "${CMAKE_BINARY_DIR}/_mkdocs_build_stamp")
 

--- a/cmake/add_copy_assets.cmake
+++ b/cmake/add_copy_assets.cmake
@@ -22,7 +22,7 @@ function(add_copy_assets)
   # Generate list of resource files with destination paths
   foreach(RESOURCE_FILE ${RESOURCE_FILES})
     list(APPEND RESOURCE_DESTINATION_FILES
-         "${CMAKE_CURRENT_BINARY_DIR}${RESOURCE_COPY_PATH}/${RESOURCE_FILE}")
+         "${CMAKE_CURRENT_BINARY_DIR}/${RESOURCE_COPY_PATH}/${RESOURCE_FILE}")
   endforeach()
 
   # Generate list of license files with destination paths
@@ -41,8 +41,8 @@ function(add_copy_assets)
   # Add a copy command for each resource file
   foreach(RESOURCE_FILE ${RESOURCE_FILES})
     add_to_copy_command(
-      "${CMAKE_CURRENT_SOURCE_DIR}/resources/${RESOURCE_FILE}"
-      "${CMAKE_CURRENT_BINARY_DIR}${RESOURCE_COPY_PATH}/${RESOURCE_FILE}"
+      "${CMAKE_CURRENT_SOURCE_DIR}/${RESOURCES_PATH}/${RESOURCE_FILE}"
+      "${CMAKE_CURRENT_BINARY_DIR}/${RESOURCE_COPY_PATH}/${RESOURCE_FILE}"
     )
   endforeach()
 

--- a/cmake/add_install_rules.cmake
+++ b/cmake/add_install_rules.cmake
@@ -41,7 +41,7 @@ function(add_install_rules)
     endforeach()
 
     # Bundle the resources
-    install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}${RESOURCE_COPY_PATH}/"
+    install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/${RESOURCE_COPY_PATH}"
             DESTINATION "${INSTALL_DIR_RESOURCES}")
 
     # Bundle required licenses

--- a/docs/build-linux.md
+++ b/docs/build-linux.md
@@ -4,8 +4,12 @@ Two build methods are available for Linux — using the [system libraries](#buil
 provided by your Linux distribution or using the [vcpkg tool](#building-using-vcpkg)
 to fetch and compile dependencies.
 
-The vcpkg method is used by the team to provide our official binaries, which are
-intended to be run on different distros — they only depend on glibc.
+Both library options are available using CMake presets, which we highly
+recommend because they're CI-tested and produce a binary using consistent
+compiler flags. Run `cmake --list-presets` to list the presets.
+
+The vcpkg presets are used by the team to provide our official binaries, which
+are intended to be run on different distros — they only depend on glibc.
 
 ## Packaging
 

--- a/docs/build-macos.md
+++ b/docs/build-macos.md
@@ -1,8 +1,12 @@
 # Building on macOS
 
-macOS builds can be created using the Meson buildsystem, compiled using the
-Clang or GCC compilers, and provided with dependencies using the Homebrew or
-MacPorts package managers.
+macOS builds can be created using CMake or the Meson build tools, compiled
+using the Clang or GCC compilers, and provided with dependencies using the
+Homebrew or MacPorts package managers.
+
+We recommend using CMake with presets because they're CI-tested and produce a
+binary using consistent compiler flags. Run `cmake --list-presets` to list the
+presets.
 
 We recommend using Homebrew and Clang because Apple's Core SDKs can be used
 only with Apple's fork of the Clang compiler.

--- a/docs/build-windows.md
+++ b/docs/build-windows.md
@@ -1,6 +1,11 @@
 # Building on Windows
 
-Windows builds can be created using:
+Windows builds can be created using CMake, Visual Studio, or Meson:
+
+- CMake is used to produce the official release package, and therefore is the
+  recommended build tool. We also recommend using presets because they're
+  CI-tested and produce a binary using consistent compiler flags. Run `cmake
+  --list-presets` to list the presets.
 
 - Visual Studio 2022 IDE suite with Clang/LLVM compiler, and vcpkg to provide
   dependencies. This is the fully-supported toolchain used to create release
@@ -9,13 +14,6 @@ Windows builds can be created using:
 - The Clang or GCC compilers using the Meson build system running within the
   MSYS2 environment to provide dependencies (deprecated, support will be probably
   removed in the future).
-
-> **Note**
->
-> CMake support is currently an experimental internal-only, work-in-progress
-> feature; it's not ready for public consumption yet. Please ignore the
-> `CMakeLists.txt` files in the source tree.
-
 
 ## Build using Visual Studio
 


### PR DESCRIPTION
# Description

This PR came about because the resources were only created correctly if a cmake preset was used, which wasn't mentioned in the documentation however was discovered by @weirddan455 in #4861. 

This PR fixes the resource creation problem (even if presets aren't used), and now recommends using a preset:

<img width="1311" height="406" alt="Screenshot_20260504_093626" src="https://github.com/user-attachments/assets/0a0fdbf3-aec0-409e-9178-a705315cb6a1" />

## Related issues

#4861 

# Manual testing

Tested with and without presets, and confirmed that it properly fails if a preset isn't used.

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [Y] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [ ] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [x] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

