### PR TITLE
Fix VGA double scan regression

### DIFF
--- a/src/gui/render/render.cpp
+++ b/src/gui/render/render.cpp
@@ -536,7 +536,7 @@ void RENDER_SetSize(const ImageInfo& image_info, const double frames_per_second)
 // The same reasoning applies to nearest-neighbour interpolation in texture
 // output mode.
 //
-static void set_scan_and_pixel_doubling()
+void RENDER_SetScanAndPixelDoubling()
 {
 	bool force_vga_single_scan   = false;
 	bool force_no_pixel_doubling = false;
@@ -720,7 +720,7 @@ static bool handle_shader_auto_switching(const VideoMode& video_mode,
 		return false;
 	}
 
-	set_scan_and_pixel_doubling();
+	RENDER_SetScanAndPixelDoubling();
 
 	if (reinit_renderer) {
 		// No need to reinit the renderer if the double scaning
@@ -793,11 +793,11 @@ static bool set_shader(const std::string& descriptor)
 		                      descriptor.c_str(),
 		                      ShaderName::Sharp);
 
-		set_scan_and_pixel_doubling();
+		RENDER_SetScanAndPixelDoubling();
 		return true;
 
 	case Ok:
-		set_scan_and_pixel_doubling();
+		RENDER_SetScanAndPixelDoubling();
 		handle_auto_image_adjustment_settings(VGA_GetCurrentVideoMode());
 		set_image_adjustment_settings();
 		return true;
@@ -847,7 +847,7 @@ static void reload_shader([[maybe_unused]] const bool pressed)
 
 	GFX_GetRenderer()->ForceReloadCurrentShader();
 
-	set_scan_and_pixel_doubling();
+	RENDER_SetScanAndPixelDoubling();
 
 	// The shader settings might have been changed (e.g. force_single_scan,
 	// force_no_pixel_doubling), so force re-rendering the image using the

--- a/src/gui/render/render.h
+++ b/src/gui/render/render.h
@@ -270,4 +270,6 @@ void RENDER_SetPalette(const uint8_t entry, const uint8_t red,
 bool RENDER_NotifyVideoModeChanged(const VideoMode& video_mode);
 void RENDER_NotifyEgaModeWithVgaPalette();
 
+void RENDER_SetScanAndPixelDoubling();
+
 #endif // DOSBOX_RENDER_H

--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -2022,6 +2022,8 @@ static void notify_sdl_setting_updated(SectionProp& section,
 
 #if C_OPENGL && defined(MACOSX)
 		update_viewport();
+		RENDER_SetScanAndPixelDoubling();
+		GFX_ResetScreen();
 #endif
 
 	} else if (prop_name == "window_position") {
@@ -2361,6 +2363,9 @@ static bool handle_sdl_windowevent(const SDL_Event& event)
 		sdl.display_number = new_display_number;
 
 		update_viewport();
+		RENDER_SetScanAndPixelDoubling();
+		GFX_ResetScreen();
+
 		notify_new_mouse_screen_params();
 		return true;
 	}
@@ -2374,6 +2379,9 @@ static bool handle_sdl_windowevent(const SDL_Event& event)
 
 		check_and_handle_dpi_change(sdl.window, new_width);
 		update_viewport();
+		RENDER_SetScanAndPixelDoubling();
+		GFX_ResetScreen();
+
 		notify_new_mouse_screen_params();
 		return true;
 	}


### PR DESCRIPTION
# Description

Fixes https://github.com/dosbox-staging/dosbox-staging/issues/4862

See commit description for details.


## Related issues

- https://github.com/dosbox-staging/dosbox-staging/issues/4862


# Manual testing

## Repro case

- Set the screen resolution to 2560x1440 (this is important; the bug doesn't manifest at 1080p or 4k)
- Start any 320x200 VGA game with the default config (just make sure it's a game that switches to 320x200 and stays there; games that do rapid mode switches can skew the results).
- The `crt/vga-1080p-fake-double-scan` shader gets picked.
- Maximize the window or switch to fullscreen. In both, cases the `crt/crt-hyllian:vga-1440p` gets picked and the output is **double-scanned**.

## Other tests

Repeated the repro steps with a bunch of other EGA and VGA games to make sure auto shader switching works. Including **Gods** that uses EGA modes with custom VGA palettes, therefore the output must appear double scanned.

The change has been manually tested on:

- [x] Windows
- [x] macOS
- [ ] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

