### PR TITLE
Small improvements to the web server

### DIFF
--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -116,7 +116,9 @@ static Bitu normal_loop()
 
 	while (true) {
 		if (PIC_RunQueue()) {
-			Webserver::Bridge::Instance().ProcessRequests();
+			if (WEBSERVER_IsEnabled()) {
+				Webserver::Bridge::Instance().ProcessRequests();
+			}
 
 			ret = (*cpudecoder)();
 			if (ret < 0) {

--- a/src/webserver/webserver.cpp
+++ b/src/webserver/webserver.cpp
@@ -127,9 +127,8 @@ static void setup_host_validation(const std::string& addr, int port)
 	        });
 }
 
-static void run(std::string addr, int port)
+static void run(const std::string addr, const int port, const std::string resource_home)
 {
-	const auto resource_home = get_resource_path("webserver").string();
 	const auto config_home = (get_config_dir() / DefaultWebserverDir).string();
 
 	server.set_mount_point("/", config_home);
@@ -192,10 +191,11 @@ void WEBSERVER_Init()
 	auto section = get_section("webserver");
 
 	if (section->GetBool("webserver_enabled")) {
-		auto addr = section->GetString("webserver_bind_address");
-		auto port = section->GetInt("webserver_port");
+		const auto addr = section->GetString("webserver_bind_address");
+		const auto port = section->GetInt("webserver_port");
+		const auto resource_home = get_resource_path("webserver").string();
 
-		std::thread thread(Webserver::run, addr, port);
+		std::thread thread(Webserver::run, addr, port, resource_home);
 
 		thread.detach();
 	}

--- a/src/webserver/webserver.cpp
+++ b/src/webserver/webserver.cpp
@@ -186,11 +186,15 @@ static void init_config_settings(SectionProp& section)
 
 } // namespace Webserver
 
+static bool is_webserver_enabled = false;
+
 void WEBSERVER_Init()
 {
 	auto section = get_section("webserver");
 
 	if (section->GetBool("webserver_enabled")) {
+		is_webserver_enabled = true;
+
 		const auto addr = section->GetString("webserver_bind_address");
 		const auto port = section->GetInt("webserver_port");
 		const auto resource_home = get_resource_path("webserver").string();
@@ -213,4 +217,9 @@ void WEBSERVER_AddConfigSection(const ConfigPtr& conf)
 	auto section = conf->AddSection("webserver");
 
 	Webserver::init_config_settings(*section);
+}
+
+bool WEBSERVER_IsEnabled()
+{
+	return is_webserver_enabled;
 }

--- a/src/webserver/webserver.h
+++ b/src/webserver/webserver.h
@@ -72,5 +72,6 @@ void send_json(httplib::Response& res, const nlohmann::json& j);
 void WEBSERVER_Init();
 void WEBSERVER_Destroy();
 void WEBSERVER_AddConfigSection(const ConfigPtr& conf);
+bool WEBSERVER_IsEnabled();
 
 #endif // DOSBOX_WEBSERVER_H


### PR DESCRIPTION
# Description

Read commit messages. It was calling a function that was not thread safe. I also identified a performance regression that happened even when the server was turned off.

# Manual testing

Lots of benchmarking. Tested all the basic functionalities of the web server.

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [x] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

