### PR TITLE
Run unit tests in parallel on CI

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -132,7 +132,7 @@ jobs:
       - name: Run tests
         run: |
           set -xo pipefail
-          ctest --preset ${{ matrix.conf.cmake_preset }} 2>&1 | tee tests.log
+          ctest -j 4 --preset ${{ matrix.conf.cmake_preset }} 2>&1 | tee tests.log
 
       - name: Summarize warnings
         env:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -98,7 +98,7 @@ jobs:
       - name: Run tests
         run: |
           set -xo pipefail
-          ctest --preset release-macos-${{ matrix.conf.arch }} 2>&1 | tee tests.log
+          ctest -j 4 --preset release-macos-${{ matrix.conf.arch }} 2>&1 | tee tests.log
 
       - name: Dump workspace contents
         run: find $RUNNER_WORKSPACE

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -112,7 +112,7 @@ jobs:
         if:    ${{ !matrix.conf.debugger }}
         shell: pwsh
         run: |
-          ctest --preset release-windows 2>&1 | Tee-Object -FilePath tests.log
+          ctest -j 4 --preset release-windows 2>&1 | Tee-Object -FilePath tests.log
 
       - name:  Build release with debugger
         if:    ${{ matrix.conf.debugger }}

--- a/docs/build-linux.md
+++ b/docs/build-linux.md
@@ -227,20 +227,23 @@ To run the entire test suite, execute the following (use the same CMake preset
 you used for building):
 
 ```bash
-ctest --preset debug-linux
+ctest -j 8 --preset debug-linux
 ```
+
+The `-j 8` option runs the tests in parallel on 8 CPU cores. You can adjust
+this to suit your system.
 
 To run all test cases in a single test suite, pass in the name of the suite
 with the `-R` option:
 
 ```bash
-ctest --preset debug-linux -R DOS_FilesTest
+ctest -j 8 --preset debug-linux -R DOS_FilesTest
 ```
 
 You can narrow this down to run a single test case only:
 
 ```bash
-ctest --preset debug-linux -R DOS_FilesTest.DOS_MakeName_Basic_Failures
+ctest -j 8 --preset debug-linux -R DOS_FilesTest.DOS_MakeName_Basic_Failures
 ```
 
 To run a group of tests, you can use wildcards and regexes. E.g. to run all
@@ -248,13 +251,13 @@ test cases in the `DOS_FilesTest` suite with names starting with
 `DOS_MakeName_`:
 
 ```bash
-ctest --preset debug-linux -R "DOS_FilesTest.DOS_MakeName_*"
+ctest -j 8 --preset debug-linux -R "DOS_FilesTest.DOS_MakeName_*"
 ```
 
 Pass in the `-V` option to see the DOSBox Staging log output:
 
 ```bash
-ctest --preset debug-linux -R DOS_FilesTest.DOS_MakeName_Basic_Failures -V
+ctest -j 8 --preset debug-linux -R DOS_FilesTest.DOS_MakeName_Basic_Failures -V
 ```
 
 You might want to run the test executable directly to get coloured output, and


### PR DESCRIPTION
# Description

Running the unit tests in parallel scales linearly, so we can shave off some time from the CI runtimes this way. Parallelisation is safe as each test launches its own process and we don't rely on filesystem (or other) side effects.

Also updating the build documentation.

# Manual testing

Tested locally that `-j 4` reduces unit test runtimes about 3.5-fold (from ~50 seconds to ~14 on macOS), and `-j 8` 5.5-fold (~9 seconds). 

The change has been manually tested on:

- [ ] Windows
- [x] macOS
- [ ] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

