### PR TITLE
Update French translation strings and typo fixes

### DIFF
--- a/resources/translations/fr.po
+++ b/resources/translations/fr.po
@@ -2033,7 +2033,7 @@ msgstr "non-standard"
 #, c-format, no-wrap
 msgctxt "KEYBOARD_LAYOUT_NAME_US"
 msgid "US (standard, QWERTY/national)"
-msgstr "US (standard, QWERTY/national)"
+msgstr "US (standard, QWERTY/nationale)"
 
 #: src/dos/dos_locale.cpp:1695
 #, c-format, no-wrap
@@ -2357,13 +2357,13 @@ msgstr "Géorgien (QWERTY/national)"
 #, c-format, no-wrap
 msgctxt "KEYBOARD_LAYOUT_NAME_KK"
 msgid "Kazakh (QWERTY/national)"
-msgstr "Kazakh (QWERTY/national)"
+msgstr "Kazakh (QWERTY/nationale)"
 
 #: src/dos/dos_locale.cpp:1695
 #, c-format, no-wrap
 msgctxt "KEYBOARD_LAYOUT_NAME_KK476"
 msgid "Kazakh (476, QWERTY/national)"
-msgstr "Kazakh (476, QWERTY/national)"
+msgstr "Kazakh (476, QWERTY/nationale)"
 
 #: src/dos/dos_locale.cpp:1695
 #, c-format, no-wrap
@@ -2603,7 +2603,7 @@ msgstr "Turc (non-standard)"
 #, c-format, no-wrap
 msgctxt "KEYBOARD_LAYOUT_NAME_TT"
 msgid "Tatar (standard, QWERTY/national)"
-msgstr "Tatar (standard, QWERTY/national)"
+msgstr "Tatar (standard, QWERTY/nationale)"
 
 #: src/dos/dos_locale.cpp:1695
 #, c-format, no-wrap
@@ -8234,7 +8234,7 @@ msgstr ""
 " lancement. La saisie démarre après [color=light-cyan]WAIT[reset] secondes, puis chaque\n"
 " touche est envoyée toutes les [color=white]PACE[reset] secondes. Le caractère\n"
 " [color=light-cyan],[reset] ajoute un délai [color=white]PACE[reset] supplémentaire.\n"
-" [color=white]WAIT[reset] et [color=white]PACE[reset] valent 2 et 0.5 par défaut si non sspécifiés.\n"
+" [color=white]WAIT[reset] et [color=white]PACE[reset] valent 2 et 0.5 par défaut si non spécifiés.\n"
 " La liste des noms de touches disponibles est affichée avec l'option -list.\n"
 "\n"
 "Exemples :\n"
@@ -9826,13 +9826,13 @@ msgstr "[color=white]Canal        Volume    Volume (dB)   Mode     Xfeed  Reverb
 #, c-format, no-wrap
 msgctxt "SHELL_CMD_MIXER_CHANNEL_OFF"
 msgid "off"
-msgstr "off"
+msgstr "désactivé"
 
 #: src/dos/programs/mixer.cpp:827
 #, c-format, no-wrap
 msgctxt "SHELL_CMD_MIXER_CHANNEL_STEREO"
 msgid "Stereo"
-msgstr "Stereo"
+msgstr "Stéréo"
 
 #: src/dos/programs/mixer.cpp:828
 #, c-format, no-wrap


### PR DESCRIPTION
# Description

Updated some leftovers in the French translation files.

# Release notes

"Updated French translations"

# Manual testing

Tested sucessfully inside dosbox staging:

With this launchsettings.json in VS2026:

`{
  "version": "0.2.1",
  "defaults": {},
  "configurations": [
    {
      "type": "default",
      "project": "CMakeLists.txt",
      "projectTarget": "dosbox.exe (Debug\\dosbox.exe)",
      "name": "dosbox.exe (Debug\\dosbox.exe)",
      "args": [
        "--lang fr"
      ]
    }
  ]
}`

The change has been manually tested on:

- [X] Windows
- [ ] macOS
- [ ] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [X] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [X] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [ ] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [X] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [X] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

