### PR TITLE
Improve disk noise and disk speed settings log output

### DIFF
--- a/src/audio/disk_noise.cpp
+++ b/src/audio/disk_noise.cpp
@@ -25,6 +25,18 @@ CHECK_NARROWING();
 static std::unique_ptr<DiskNoises> disk_noises    = nullptr;
 static const unsigned int DiskNoiseSampleRateInHz = 22050;
 
+const char* to_string(const DiskNoiseMode disk_noise_mode)
+{
+	switch (disk_noise_mode) {
+	case DiskNoiseMode::Off: return "off";
+	case DiskNoiseMode::SeekOnly: return "seek-only";
+	case DiskNoiseMode::On: return "on";
+	default:
+		assertm(false, "Invalid DiskNoiseMode enum");
+		return "unknown disk noise mode";
+	}
+}
+
 DiskNoises::DiskNoises(const DiskNoiseMode floppy_disk_noise_mode,
                        const DiskNoiseMode hard_disk_noise_mode,
                        const std::string& spin_up, const std::string& spin,
@@ -382,8 +394,13 @@ DiskNoiseDevice::DiskNoiseDevice(const DiskType disk_type,
         : disk_noise_mode(disk_noise_mode),
           disk_type(disk_type)
 {
+
+	LOG_INFO("DISKNOISE: %s noise emulation %s",
+	         to_string(disk_type),
+	         to_string(disk_noise_mode));
+
+	// Do not continue further if disk noise is disabled
 	if (disk_noise_mode == DiskNoiseMode::Off) {
-		LOG_INFO("DISKNOISE: Disk noise emulation disabled");
 		return;
 	}
 

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -137,8 +137,35 @@ static uint16_t DOS_GetAmount(void) {
 #include "cpu/cpu.h"
 #endif
 
+const char* to_string(const DiskType disk_type)
+{
+	switch (disk_type) {
+	case DiskType::Floppy: return "floppy";
+	case DiskType::HardDisk: return "hard disk";
+	case DiskType::CdRom: return "CD-ROM";
+	default: assertm(false, "Invalid DiskType"); return "unknown disk type";
+	}
+}
+
+const char* to_string(const DiskSpeed disk_speed)
+{
+	switch (disk_speed) {
+	case DiskSpeed::Maximum: return "maximum";
+	case DiskSpeed::Fast: return "fast";
+	case DiskSpeed::Medium: return "medium";
+	case DiskSpeed::Slow: return "slow";
+	default:
+		assertm(false, "Invalid DiskSpeed");
+		return "unknown disk speed";
+	}
+}
+
 void DOS_SetDiskSpeed(DiskSpeed disk_speed, DiskType disk_type)
 {
+	LOG_INFO("DOS: Setting %s disk speed to %s",
+	         to_string(disk_type),
+	         to_string(disk_speed));
+
 	switch (disk_type) {
 	case DiskType::Floppy: disk_settings.fdd_disk_speed = disk_speed; break;
 	case DiskType::HardDisk:

--- a/src/dos/dos.h
+++ b/src/dos/dos.h
@@ -84,6 +84,8 @@ enum MediaId : uint8_t {
 };
 
 enum class DiskType { Floppy, HardDisk, CdRom };
+const char* to_string(DiskType disk_type);
+const char* to_string(DiskSpeed disk_speed);
 
 #define DOS_FILES   255
 #define DOS_DRIVES  26


### PR DESCRIPTION
# Description

This PR improves the log output of disknoise emulation and disk speed settings. It specifies which type of noise emulation is meant and whether it is disabled, or enabled for spin and/or seek noises, and shows the active setting of the disk speed.

<img width="961" height="67" alt="image" src="https://github.com/user-attachments/assets/e8ab0441-e203-45eb-83d1-08a9d3897fd9" />

<img width="675" height="43" alt="image" src="https://github.com/user-attachments/assets/1a93d621-5526-405c-b716-d12ccd24299a" />


## Related issues

Fixes #4879 

# Manual testing

Tested with all combinations of settings.

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [X] Linux


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

