### PR TITLE
Add recognition of multiple floppy extensions and recognition as floppy images based on disk geometry

### DIFF
--- a/src/dos/programs/mount.cpp
+++ b/src/dos/programs/mount.cpp
@@ -937,9 +937,28 @@ bool MOUNT::ProcessPaths(MountParameters& params, bool path_relative_to_last_con
 					    ext == "ccd") {
 						params.type   = "iso";
 						params.fstype = "iso";
-					} else if (ext == "img" ||
-					           ext == "ima" || ext == "vhd") {
+					} else if (ext == "vhd") {
 						params.type = "hdd";
+					} else if (ext == "vfd" || ext == "flp" ||
+					           ext == "360" || ext == "720" ||
+					           ext == "1200" || ext == "1440") {
+						params.type = "floppy";
+					} else if (ext == "img" ||
+					           ext == "ima" || ext == "dsk") {
+						const auto file_size_kb =
+						        static_cast<uint32_t>(
+						                t2.st_size / 1024);
+						const auto& geometries =
+						        BIOS_GetDiskGeometryList();
+						const bool is_floppy = std::ranges::any_of(
+						        geometries,
+						        [file_size_kb](
+						                const DiskGeometry& geo) {
+							        return geo.ksize ==
+							               file_size_kb;
+						        });
+						params.type = is_floppy ? "floppy"
+						                        : "hdd";
 					}
 				}
 			}

--- a/src/ints/bios_disk.cpp
+++ b/src/ints/bios_disk.cpp
@@ -39,7 +39,7 @@ static uint8_t last_status;
 static uint8_t last_drive;
 uint16_t imgDTASeg;
 RealPt imgDTAPtr;
-DOS_DTA *imgDTA;
+DOS_DTA* imgDTA;
 bool killRead;
 static bool swapping_requested;
 
@@ -51,59 +51,70 @@ std::array<std::shared_ptr<imageDisk>, MAX_SWAPPABLE_DISKS> diskSwap  = {};
 
 unsigned int swapPosition;
 
-void updateDPT(void) {
+void updateDPT(void)
+{
 	uint32_t tmpheads, tmpcyl, tmpsect, tmpsize;
-	if(imageDiskList[2]) {
-		PhysPt dp0physaddr=CALLBACK_PhysPointer(diskparm0);
+	if (imageDiskList[2]) {
+		PhysPt dp0physaddr = CALLBACK_PhysPointer(diskparm0);
 		imageDiskList[2]->Get_Geometry(&tmpheads, &tmpcyl, &tmpsect, &tmpsize);
-		phys_writew(dp0physaddr,(uint16_t)tmpcyl);
-		phys_writeb(dp0physaddr+0x2,(uint8_t)tmpheads);
-		phys_writew(dp0physaddr+0x3,0);
-		phys_writew(dp0physaddr+0x5,(uint16_t)-1);
-		phys_writeb(dp0physaddr+0x7,0);
-		phys_writeb(dp0physaddr+0x8,(0xc0 | (((imageDiskList[2]->heads) > 8) << 3)));
-		phys_writeb(dp0physaddr+0x9,0);
-		phys_writeb(dp0physaddr+0xa,0);
-		phys_writeb(dp0physaddr+0xb,0);
-		phys_writew(dp0physaddr+0xc,(uint16_t)tmpcyl);
-		phys_writeb(dp0physaddr+0xe,(uint8_t)tmpsect);
+		phys_writew(dp0physaddr, (uint16_t)tmpcyl);
+		phys_writeb(dp0physaddr + 0x2, (uint8_t)tmpheads);
+		phys_writew(dp0physaddr + 0x3, 0);
+		phys_writew(dp0physaddr + 0x5, (uint16_t)-1);
+		phys_writeb(dp0physaddr + 0x7, 0);
+		phys_writeb(dp0physaddr + 0x8,
+		            (0xc0 | (((imageDiskList[2]->heads) > 8) << 3)));
+		phys_writeb(dp0physaddr + 0x9, 0);
+		phys_writeb(dp0physaddr + 0xa, 0);
+		phys_writeb(dp0physaddr + 0xb, 0);
+		phys_writew(dp0physaddr + 0xc, (uint16_t)tmpcyl);
+		phys_writeb(dp0physaddr + 0xe, (uint8_t)tmpsect);
 	}
-	if(imageDiskList[3]) {
-		PhysPt dp1physaddr=CALLBACK_PhysPointer(diskparm1);
+	if (imageDiskList[3]) {
+		PhysPt dp1physaddr = CALLBACK_PhysPointer(diskparm1);
 		imageDiskList[3]->Get_Geometry(&tmpheads, &tmpcyl, &tmpsect, &tmpsize);
-		phys_writew(dp1physaddr,(uint16_t)tmpcyl);
-		phys_writeb(dp1physaddr+0x2,(uint8_t)tmpheads);
-		phys_writeb(dp1physaddr+0xe,(uint8_t)tmpsect);
+		phys_writew(dp1physaddr, (uint16_t)tmpcyl);
+		phys_writeb(dp1physaddr + 0x2, (uint8_t)tmpheads);
+		phys_writeb(dp1physaddr + 0xe, (uint8_t)tmpsect);
 	}
 }
 
-void incrementFDD(void) {
-	uint16_t equipment=mem_readw(BIOS_CONFIGURATION);
-	if(equipment&1) {
-		Bitu numofdisks = (equipment>>6)&3;
+void incrementFDD(void)
+{
+	uint16_t equipment = mem_readw(BIOS_CONFIGURATION);
+	if (equipment & 1) {
+		Bitu numofdisks = (equipment >> 6) & 3;
 		numofdisks++;
-		if(numofdisks > 1) numofdisks=1;//max 2 floppies at the moment
-		equipment&=~0x00C0;
-		equipment|=(numofdisks<<6);
-	} else equipment|=1;
+		if (numofdisks > 1) {
+			numofdisks = 1; // max 2 floppies at the moment
+		}
+		equipment &= ~0x00C0;
+		equipment |= (numofdisks << 6);
+	} else {
+		equipment |= 1;
+	}
 	BIOS_SetEquipment(equipment);
 }
 
-template<typename T, size_t N>
-static size_t disk_array_prefix_size(const std::array<T, N> &images) {
+template <typename T, size_t N>
+static size_t disk_array_prefix_size(const std::array<T, N>& images)
+{
 	size_t num = 0;
-	for (const auto &disk : images) {
-		if (!disk)
+	for (const auto& disk : images) {
+		if (!disk) {
 			break;
+		}
 		num++;
 	}
 	return num;
 }
 
-void swapInDisks(unsigned int swap_position) {
+void swapInDisks(unsigned int swap_position)
+{
 	const size_t boot_disks_num = disk_array_prefix_size(diskSwap);
-	if (boot_disks_num == 0)
+	if (boot_disks_num == 0) {
 		return;
+	}
 
 	assert(swap_position < boot_disks_num);
 	const unsigned int pos_1 = swap_position;
@@ -111,27 +122,34 @@ void swapInDisks(unsigned int swap_position) {
 
 	imageDiskList[0] = diskSwap[pos_1];
 	LOG_MSG("Loaded disk A from swaplist position %u - \"%s\"",
-	        pos_1, diskSwap[pos_1]->diskname);
+	        pos_1,
+	        diskSwap[pos_1]->diskname);
 
 	imageDiskList[1] = diskSwap[pos_2];
 	LOG_MSG("Loaded disk B from swaplist position %u - \"%s\"",
-	        pos_2, diskSwap[pos_2]->diskname);
+	        pos_2,
+	        diskSwap[pos_2]->diskname);
 }
 
-bool getSwapRequest(void) {
-	bool sreq=swapping_requested;
+bool getSwapRequest(void)
+{
+	bool sreq          = swapping_requested;
 	swapping_requested = false;
 	return sreq;
 }
 
-void swapInNextDisk(bool pressed) {
-	if (!pressed)
+void swapInNextDisk(bool pressed)
+{
+	if (!pressed) {
 		return;
+	}
 	DriveManager::CycleAllDisks();
 	/* Hack/feature: rescan all disks as well */
 	LOG_MSG("Diskcaching reset for normal mounted drives.");
-	for(Bitu i=0;i<DOS_DRIVES;i++) {
-		if (Drives[i]) Drives[i]->EmptyCache();
+	for (Bitu i = 0; i < DOS_DRIVES; i++) {
+		if (Drives[i]) {
+			Drives[i]->EmptyCache();
+		}
 	}
 	swapPosition++;
 	if (!diskSwap[swapPosition]) {
@@ -141,23 +159,26 @@ void swapInNextDisk(bool pressed) {
 	swapping_requested = true;
 }
 
-
-uint8_t imageDisk::Read_Sector(uint32_t head,uint32_t cylinder,uint32_t sector,void * data) {
+uint8_t imageDisk::Read_Sector(uint32_t head, uint32_t cylinder,
+                               uint32_t sector, void* data)
+{
 	uint32_t sectnum;
 
-	sectnum = ( (cylinder * heads + head) * sectors ) + sector - 1L;
+	sectnum = ((cylinder * heads + head) * sectors) + sector - 1L;
 
 	return Read_AbsoluteSector(sectnum, data);
 }
 
-uint8_t imageDisk::Read_AbsoluteSector(uint32_t sectnum, void *data)
+uint8_t imageDisk::Read_AbsoluteSector(uint32_t sectnum, void* data)
 {
 	const auto bytenum = check_cast<cross_off_t>(sectnum) * sector_size;
 
 	if (last_action == WRITE || bytenum != current_fpos) {
 		if (cross_fseeko(diskimg, bytenum, SEEK_SET) != 0) {
 			LOG_ERR("BIOSDISK: Could not seek to sector %u in file '%s': %s",
-			        sectnum, diskname, strerror(errno));
+			        sectnum,
+			        diskname,
+			        strerror(errno));
 			return 0xff;
 		}
 	}
@@ -171,24 +192,26 @@ uint8_t imageDisk::Read_AbsoluteSector(uint32_t sectnum, void *data)
 
 	size_t ret   = fread(data, 1, sector_size, diskimg);
 	current_fpos = bytenum + ret;
-	last_action=READ;
+	last_action  = READ;
 
 	return 0x00;
 }
 
-uint8_t imageDisk::Write_Sector(uint32_t head,uint32_t cylinder,uint32_t sector,void * data) {
+uint8_t imageDisk::Write_Sector(uint32_t head, uint32_t cylinder,
+                                uint32_t sector, void* data)
+{
 	uint32_t sectnum;
 
-	sectnum = ( (cylinder * heads + head) * sectors ) + sector - 1L;
+	sectnum = ((cylinder * heads + head) * sectors) + sector - 1L;
 
 	return Write_AbsoluteSector(sectnum, data);
 }
 
-
-uint8_t imageDisk::Write_AbsoluteSector(uint32_t sectnum, void *data) {
+uint8_t imageDisk::Write_AbsoluteSector(uint32_t sectnum, void* data)
+{
 	const auto bytenum = check_cast<cross_off_t>(sectnum) * sector_size;
 
-	//LOG_MSG("Writing sectors to %ld at bytenum %d", sectnum, bytenum);
+	// LOG_MSG("Writing sectors to %ld at bytenum %d", sectnum, bytenum);
 
 	if (last_action == READ || bytenum != current_fpos) {
 		if (cross_fseeko(diskimg, bytenum, SEEK_SET) != 0) {
@@ -209,13 +232,13 @@ uint8_t imageDisk::Write_AbsoluteSector(uint32_t sectnum, void *data) {
 
 	size_t ret   = fwrite(data, 1, sector_size, diskimg);
 	current_fpos = bytenum + ret;
-	last_action=WRITE;
+	last_action  = WRITE;
 
-	return ((ret>0)?0x00:0x05);
-
+	return ((ret > 0) ? 0x00 : 0x05);
 }
 
-imageDisk::imageDisk(FILE *img_file, const char *img_name, uint32_t img_size_k, bool is_hdd)
+imageDisk::imageDisk(FILE* img_file, const char* img_name, uint32_t img_size_k,
+                     bool is_hdd)
         : hardDrive(is_hdd),
           active(false),
           diskimg(img_file),
@@ -227,28 +250,29 @@ imageDisk::imageDisk(FILE *img_file, const char *img_name, uint32_t img_size_k, 
           current_fpos(0),
           last_action(NONE)
 {
-	fseek(diskimg,0,SEEK_SET);
-	memset(diskname,0,512);
+	fseek(diskimg, 0, SEEK_SET);
+	memset(diskname, 0, 512);
 	safe_strcpy(diskname, img_name);
 	if (!is_hdd) {
-		uint8_t i=0;
+		uint8_t i      = 0;
 		bool founddisk = false;
-		while (DiskGeometryList[i].ksize!=0x0) {
+		while (DiskGeometryList[i].ksize != 0x0) {
 			if ((DiskGeometryList[i].ksize == img_size_k) ||
 			    (DiskGeometryList[i].ksize + 1 == img_size_k)) {
-				if (DiskGeometryList[i].ksize != img_size_k)
+				if (DiskGeometryList[i].ksize != img_size_k) {
 					LOG_MSG("ImageLoader: image file with additional data, might not load!");
-				founddisk = true;
-				active = true;
+				}
+				founddisk  = true;
+				active     = true;
 				floppytype = i;
-				heads = DiskGeometryList[i].headscyl;
-				cylinders = DiskGeometryList[i].cylcount;
-				sectors = DiskGeometryList[i].secttrack;
+				heads      = DiskGeometryList[i].headscyl;
+				cylinders  = DiskGeometryList[i].cylcount;
+				sectors    = DiskGeometryList[i].secttrack;
 				break;
 			}
 			i++;
 		}
-		if(!founddisk) {
+		if (!founddisk) {
 			active = false;
 		} else {
 			incrementFDD();
@@ -256,65 +280,68 @@ imageDisk::imageDisk(FILE *img_file, const char *img_name, uint32_t img_size_k, 
 	}
 }
 
-void imageDisk::Set_Geometry(uint32_t setHeads, uint32_t setCyl, uint32_t setSect, uint32_t setSectSize) {
-	heads = setHeads;
-	cylinders = setCyl;
-	sectors = setSect;
+void imageDisk::Set_Geometry(uint32_t setHeads, uint32_t setCyl,
+                             uint32_t setSect, uint32_t setSectSize)
+{
+	heads       = setHeads;
+	cylinders   = setCyl;
+	sectors     = setSect;
 	sector_size = setSectSize;
-	active = true;
+	active      = true;
 }
 
-void imageDisk::Get_Geometry(uint32_t * getHeads, uint32_t *getCyl, uint32_t *getSect, uint32_t *getSectSize) {
-	*getHeads = heads;
-	*getCyl = cylinders;
-	*getSect = sectors;
+void imageDisk::Get_Geometry(uint32_t* getHeads, uint32_t* getCyl,
+                             uint32_t* getSect, uint32_t* getSectSize)
+{
+	*getHeads    = heads;
+	*getCyl      = cylinders;
+	*getSect     = sectors;
 	*getSectSize = sector_size;
 }
 
-uint8_t imageDisk::GetBiosType(void) {
-	if(!hardDrive) {
+uint8_t imageDisk::GetBiosType(void)
+{
+	if (!hardDrive) {
 		return (uint8_t)DiskGeometryList[floppytype].biosval;
-	} else return 0;
+	} else {
+		return 0;
+	}
 }
 
-uint32_t imageDisk::getSectSize(void) {
+uint32_t imageDisk::getSectSize(void)
+{
 	return sector_size;
 }
 
-static uint8_t GetDosDriveNumber(uint8_t biosNum) {
-	switch(biosNum) {
-		case 0x0:
-			return 0x0;
-		case 0x1:
-			return 0x1;
-		case 0x80:
-			return 0x2;
-		case 0x81:
-			return 0x3;
-		case 0x82:
-			return 0x4;
-		case 0x83:
-			return 0x5;
-		default:
-			return 0x7f;
+static uint8_t GetDosDriveNumber(uint8_t biosNum)
+{
+	switch (biosNum) {
+	case 0x0: return 0x0;
+	case 0x1: return 0x1;
+	case 0x80: return 0x2;
+	case 0x81: return 0x3;
+	case 0x82: return 0x4;
+	case 0x83: return 0x5;
+	default: return 0x7f;
 	}
 }
 
-static bool driveInactive(uint8_t driveNum) {
+static bool driveInactive(uint8_t driveNum)
+{
 	if (driveNum >= MAX_DISK_IMAGES) {
-		LOG(LOG_BIOS,LOG_ERROR)("Disk %d non-existent", driveNum);
+		LOG(LOG_BIOS, LOG_ERROR)("Disk %d non-existent", driveNum);
 		last_status = 0x01;
 		CALLBACK_SCF(true);
 		return true;
 	}
-	if(!imageDiskList[driveNum]) {
-		LOG(LOG_BIOS,LOG_ERROR)("Disk %d not active", driveNum);
+	if (!imageDiskList[driveNum]) {
+		LOG(LOG_BIOS, LOG_ERROR)("Disk %d not active", driveNum);
 		last_status = 0x01;
 		CALLBACK_SCF(true);
 		return true;
 	}
-	if(!imageDiskList[driveNum]->active) {
-		LOG(LOG_BIOS,LOG_ERROR)("Disk %d not active", driveNum);
+	if (!imageDiskList[driveNum]->active) {
+		LOG(LOG_BIOS, LOG_ERROR)("Disk %d not active", driveNum);
 		last_status = 0x01;
 		CALLBACK_SCF(true);
 		return true;
@@ -322,59 +349,66 @@ static bool driveInactive(uint8_t driveNum) {
 	return false;
 }
 
-template<typename T, size_t N>
-static bool has_image(const std::array<T, N> &arr) {
-	auto to_bool = [](const T &x) { return bool(x); };
+template <typename T, size_t N>
+static bool has_image(const std::array<T, N>& arr)
+{
+	auto to_bool = [](const T& x) { return bool(x); };
 	return std::any_of(std::begin(arr), std::end(arr), to_bool);
 }
 
-static Bitu INT13_DiskHandler(void) {
+static Bitu INT13_DiskHandler(void)
+{
 	uint16_t segat, bufptr;
 	uint8_t sectbuf[512];
-	uint8_t  drivenum;
+	uint8_t drivenum;
 	Bitu t;
-	last_drive = reg_dl;
-	drivenum = GetDosDriveNumber(reg_dl);
+	last_drive            = reg_dl;
+	drivenum              = GetDosDriveNumber(reg_dl);
 	const bool any_images = has_image(imageDiskList);
 
 	// unconditionally enable the interrupt flag
 	CALLBACK_SIF(true);
 
-	//drivenum = 0;
-	//LOG_MSG("INT13: Function %x called on drive %x (dos drive %d)", reg_ah,  reg_dl, drivenum);
+	// drivenum = 0;
+	// LOG_MSG("INT13: Function %x called on drive %x (dos drive %d)",
+	// reg_ah,  reg_dl, drivenum);
 
-	// NOTE: the 0xff error code returned in some cases is questionable; 0x01 seems more correct
-	switch(reg_ah) {
+	// NOTE: the 0xff error code returned in some cases is questionable;
+	// 0x01 seems more correct
+	switch (reg_ah) {
 	case 0x0: /* Reset disk */
-		{
-			/* if there aren't any diskimages (so only localdrives and virtual drives)
-			 * always succeed on reset disk. If there are diskimages then and only then
-			 * do real checks
-			 */
-			if (any_images && driveInactive(drivenum)) {
-				/* driveInactive sets carry flag if the specified drive is not available */
-				if (is_machine_cga() || is_machine_pcjr()) {
-					/* those bioses call floppy drive reset for invalid drive values */
-					if (((imageDiskList[0]) && (imageDiskList[0]->active)) || ((imageDiskList[1]) && (imageDiskList[1]->active))) {
-						if (!is_machine_pcjr() && reg_dl < 0x80) {
-							reg_ip++;
-						}
-						last_status = 0x00;
-						CALLBACK_SCF(false);
+	{
+		/* if there aren't any diskimages (so only localdrives and
+		 * virtual drives) always succeed on reset disk. If there are
+		 * diskimages then and only then do real checks
+		 */
+		if (any_images && driveInactive(drivenum)) {
+			/* driveInactive sets carry flag if the specified drive
+			 * is not available */
+			if (is_machine_cga() || is_machine_pcjr()) {
+				/* those bioses call floppy drive reset for
+				 * invalid drive values */
+				if (((imageDiskList[0]) && (imageDiskList[0]->active)) ||
+				    ((imageDiskList[1]) &&
+				     (imageDiskList[1]->active))) {
+					if (!is_machine_pcjr() && reg_dl < 0x80) {
+						reg_ip++;
 					}
+					last_status = 0x00;
+					CALLBACK_SCF(false);
 				}
-				return CBRET_NONE;
 			}
-			if (!is_machine_pcjr() && reg_dl < 0x80) {
-				reg_ip++;
-			}
-			last_status = 0x00;
-			CALLBACK_SCF(false);
+			return CBRET_NONE;
 		}
-        break;
+		if (!is_machine_pcjr() && reg_dl < 0x80) {
+			reg_ip++;
+		}
+		last_status = 0x00;
+		CALLBACK_SCF(false);
+	} break;
 	case 0x1: /* Get status of last operation */
 
-		if(last_status != 0x00) {
+		if (last_status != 0x00) {
 			reg_ah = last_status;
 			CALLBACK_SCF(true);
 		} else {
@@ -383,27 +417,33 @@ static Bitu INT13_DiskHandler(void) {
 		}
 		break;
 	case 0x2: /* Read sectors */
-		if (reg_al==0) {
+		if (reg_al == 0) {
 			reg_ah = 0x01;
 			CALLBACK_SCF(true);
 			return CBRET_NONE;
 		}
 		if (drivenum >= MAX_DISK_IMAGES || !imageDiskList[drivenum]) {
-			if (drivenum >= DOS_DRIVES || !Drives[drivenum] || Drives[drivenum]->IsRemovable()) {
+			if (drivenum >= DOS_DRIVES || !Drives[drivenum] ||
+			    Drives[drivenum]->IsRemovable()) {
 				reg_ah = 0x01;
 				CALLBACK_SCF(true);
 				return CBRET_NONE;
 			}
-			// Inherit the Earth cdrom and Amberstar use it as a disk test
-			if (((reg_dl&0x80)==0x80) && (reg_dh==0) && ((reg_cl&0x3f)==1)) {
+			// Inherit the Earth cdrom and Amberstar use it as a
+			// disk test
+			if (((reg_dl & 0x80) == 0x80) && (reg_dh == 0) &&
+			    ((reg_cl & 0x3f) == 1)) {
 				if (reg_ch == 0) {
-					// write some MBR data into buffer for Amberstar installer
+					// write some MBR data into buffer for
+					// Amberstar installer
 					real_writeb(SegValue(es),
 					            reg_bx + 0x1be,
-					            0x80); // first partition is active
+					            0x80); // first partition is
+					                   // active
 					real_writeb(SegValue(es),
 					            reg_bx + 0x1c2,
-					            0x06); // first partition is FAT16B
+					            0x06); // first partition is
+					                   // FAT16B
 				}
 				reg_ah = 0;
 				CALLBACK_SCF(false);
@@ -416,19 +456,23 @@ static Bitu INT13_DiskHandler(void) {
 			return CBRET_NONE;
 		}
 
-		segat = SegValue(es);
+		segat  = SegValue(es);
 		bufptr = reg_bx;
 		for (Bitu i = 0; i < reg_al; i++) {
-			last_status = imageDiskList[drivenum]->Read_Sector((uint32_t)reg_dh, (uint32_t)(reg_ch | ((reg_cl & 0xc0)<< 2)), (uint32_t)((reg_cl & 63)+i), sectbuf);
-			if((last_status != 0x00) || killRead) {
+			last_status = imageDiskList[drivenum]->Read_Sector(
+			        (uint32_t)reg_dh,
+			        (uint32_t)(reg_ch | ((reg_cl & 0xc0) << 2)),
+			        (uint32_t)((reg_cl & 63) + i),
+			        sectbuf);
+			if ((last_status != 0x00) || killRead) {
 				LOG_MSG("Error in disk read");
 				killRead = false;
-				reg_ah = 0x04;
+				reg_ah   = 0x04;
 				CALLBACK_SCF(true);
 				return CBRET_NONE;
 			}
-			for(t=0;t<512;t++) {
-				real_writeb(segat,bufptr,sectbuf[t]);
+			for (t = 0; t < 512; t++) {
+				real_writeb(segat, bufptr, sectbuf[t]);
 				bufptr++;
 			}
 		}
@@ -436,19 +480,23 @@ static Bitu INT13_DiskHandler(void) {
 		CALLBACK_SCF(false);
 		break;
 	case 0x3: /* Write sectors */
-		if(driveInactive(drivenum)) {
+		if (driveInactive(drivenum)) {
 			reg_ah = 0xff;
 			CALLBACK_SCF(true);
 			return CBRET_NONE;
 		}
 		bufptr = reg_bx;
 		for (Bitu i = 0; i < reg_al; i++) {
-			for(t=0;t<imageDiskList[drivenum]->getSectSize();t++) {
-				sectbuf[t] = real_readb(SegValue(es),bufptr);
+			for (t = 0; t < imageDiskList[drivenum]->getSectSize(); t++) {
+				sectbuf[t] = real_readb(SegValue(es), bufptr);
 				bufptr++;
 			}
-			last_status = imageDiskList[drivenum]->Write_Sector((uint32_t)reg_dh, (uint32_t)(reg_ch | ((reg_cl & 0xc0) << 2)), (uint32_t)((reg_cl & 63) + i), &sectbuf[0]);
-			if(last_status != 0x00) {
+			last_status = imageDiskList[drivenum]->Write_Sector(
+			        (uint32_t)reg_dh,
+			        (uint32_t)(reg_ch | ((reg_cl & 0xc0) << 2)),
+			        (uint32_t)((reg_cl & 63) + i),
+			        &sectbuf[0]);
+			if (last_status != 0x00) {
 				CALLBACK_SCF(true);
 				return CBRET_NONE;
 			}
@@ -457,12 +505,12 @@ static Bitu INT13_DiskHandler(void) {
 		CALLBACK_SCF(false);
 		break;
 	case 0x04: /* Verify sectors */
-		if (reg_al==0) {
+		if (reg_al == 0) {
 			reg_ah = 0x01;
 			CALLBACK_SCF(true);
 			return CBRET_NONE;
 		}
-		if(driveInactive(drivenum)) {
+		if (driveInactive(drivenum)) {
 			reg_ah = last_status;
 			return CBRET_NONE;
 		}
@@ -472,23 +520,23 @@ static Bitu INT13_DiskHandler(void) {
 		segat = SegValue(es);
 		bufptr = reg_bx;
 		for(i=0;i<reg_al;i++) {
-			last_status = imageDiskList[drivenum]->Read_Sector((uint32_t)reg_dh, (uint32_t)(reg_ch | ((reg_cl & 0xc0)<< 2)), (uint32_t)((reg_cl & 63)+i), sectbuf);
-			if(last_status != 0x00) {
-				LOG_MSG("Error in disk read");
-				CALLBACK_SCF(true);
-				return CBRET_NONE;
-			}
-			for(t=0;t<512;t++) {
-				real_writeb(segat,bufptr,sectbuf[t]);
-				bufptr++;
-			}
+		        last_status =
+		imageDiskList[drivenum]->Read_Sector((uint32_t)reg_dh,
+		(uint32_t)(reg_ch | ((reg_cl & 0xc0)<< 2)), (uint32_t)((reg_cl &
+		63)+i), sectbuf); if(last_status != 0x00) { LOG_MSG("Error in
+		disk read"); CALLBACK_SCF(true); return CBRET_NONE;
+		        }
+		        for(t=0;t<512;t++) {
+		                real_writeb(segat,bufptr,sectbuf[t]);
+		                bufptr++;
+		        }
 		}*/
 		reg_ah = 0x00;
-		//Qbix: The following codes don't match my specs. al should be number of sector verified
-		//reg_al = 0x10; /* CRC verify failed */
-		//reg_al = 0x00; /* CRC verify succeeded */
+		// Qbix: The following codes don't match my specs. al should be
+		// number of sector verified reg_al = 0x10; /* CRC verify failed
+		// */ reg_al = 0x00; /* CRC verify succeeded */
 		CALLBACK_SCF(false);
-          
+
 		break;
 	case 0x05: /* Format track */
 		if (driveInactive(drivenum)) {
@@ -500,32 +548,50 @@ static Bitu INT13_DiskHandler(void) {
 		CALLBACK_SCF(false);
 		break;
 	case 0x08: /* Get drive parameters */
-		if(driveInactive(drivenum)) {
+		if (driveInactive(drivenum)) {
 			last_status = 0x07;
-			reg_ah = last_status;
+			reg_ah      = last_status;
 			CALLBACK_SCF(true);
 			return CBRET_NONE;
 		}
 		reg_ax = 0x00;
 		reg_bl = imageDiskList[drivenum]->GetBiosType();
 		uint32_t tmpheads, tmpcyl, tmpsect, tmpsize;
-		imageDiskList[drivenum]->Get_Geometry(&tmpheads, &tmpcyl, &tmpsect, &tmpsize);
-		if (tmpcyl==0) LOG(LOG_BIOS,LOG_ERROR)("INT13 DrivParm: cylinder count zero!");
-		else tmpcyl--;		// cylinder count -> max cylinder
-		if (tmpheads==0) LOG(LOG_BIOS,LOG_ERROR)("INT13 DrivParm: head count zero!");
-		else tmpheads--;	// head count -> max head
+		imageDiskList[drivenum]->Get_Geometry(&tmpheads,
+		                                      &tmpcyl,
+		                                      &tmpsect,
+		                                      &tmpsize);
+		if (tmpcyl == 0) {
+			LOG(LOG_BIOS,
+			    LOG_ERROR)("INT13 DrivParm: cylinder count zero!");
+		} else {
+			tmpcyl--; // cylinder count -> max cylinder
+		}
+		if (tmpheads == 0) {
+			LOG(LOG_BIOS, LOG_ERROR)("INT13 DrivParm: head count zero!");
+		} else {
+			tmpheads--; // head count -> max head
+		}
 		reg_ch = (uint8_t)(tmpcyl & 0xff);
-		reg_cl = (uint8_t)(((tmpcyl >> 2) & 0xc0) | (tmpsect & 0x3f)); 
+		reg_cl = (uint8_t)(((tmpcyl >> 2) & 0xc0) | (tmpsect & 0x3f));
 		reg_dh = (uint8_t)tmpheads;
 		last_status = 0x00;
-		if (reg_dl&0x80) {	// harddisks
+		if (reg_dl & 0x80) { // harddisks
 			reg_dl = 0;
-			if(imageDiskList[2]) reg_dl++;
-			if(imageDiskList[3]) reg_dl++;
-		} else {		// floppy disks
+			if (imageDiskList[2]) {
+				reg_dl++;
+			}
+			if (imageDiskList[3]) {
+				reg_dl++;
+			}
+		} else { // floppy disks
 			reg_dl = 0;
-			if(imageDiskList[0]) reg_dl++;
-			if(imageDiskList[1]) reg_dl++;
+			if (imageDiskList[0]) {
+				reg_dl++;
+			}
+			if (imageDiskList[1]) {
+				reg_dl++;
+			}
 		}
 		CALLBACK_SCF(false);
 		break;
@@ -535,18 +601,20 @@ static Bitu INT13_DiskHandler(void) {
 		break;
 	case 0x15: /* Get disk type */
 		/* Korean Powerdolls uses this to detect harddrives */
-		LOG(LOG_BIOS,LOG_WARN)("INT13: Get disktype used!");
+		LOG(LOG_BIOS, LOG_WARN)("INT13: Get disktype used!");
 		if (any_images) {
-			if(driveInactive(drivenum)) {
+			if (driveInactive(drivenum)) {
 				last_status = 0x07;
-				reg_ah = last_status;
+				reg_ah      = last_status;
 				CALLBACK_SCF(true);
 				return CBRET_NONE;
 			}
 
 			uint32_t tmpheads, tmpcyl, tmpsect, tmpsize;
-			imageDiskList[drivenum]->Get_Geometry(&tmpheads, &tmpcyl,
-			                                      &tmpsect, &tmpsize);
+			imageDiskList[drivenum]->Get_Geometry(&tmpheads,
+			                                      &tmpcyl,
+			                                      &tmpsect,
+			                                      &tmpsize);
 			// Store intermediate calculations in 64-bit to avoid
 			// accidental integer overflow on temporary value:
 			uint64_t largesize = tmpheads;
@@ -555,29 +623,36 @@ static Bitu INT13_DiskHandler(void) {
 			largesize *= tmpsize;
 			const auto ts = static_cast<uint32_t>(largesize / 512);
 
-			reg_ah = (drivenum <2)?1:3; //With 2 for floppy MSDOS starts calling int 13 ah 16
-			if(reg_ah == 3) {
-				reg_cx = static_cast<uint16_t>(ts >>16);
+			reg_ah = (drivenum < 2) ? 1 : 3; // With 2 for floppy
+			                                 // MSDOS starts calling
+			                                 // int 13 ah 16
+			if (reg_ah == 3) {
+				reg_cx = static_cast<uint16_t>(ts >> 16);
 				reg_dx = static_cast<uint16_t>(ts & 0xffff);
 			}
 			CALLBACK_SCF(false);
 		} else {
-			if (drivenum <DOS_DRIVES && (Drives[drivenum] != nullptr || drivenum <2)) {
-				if (drivenum <2) {
-					//TODO use actual size (using 1.44 for now).
+			if (drivenum < DOS_DRIVES &&
+			    (Drives[drivenum] != nullptr || drivenum < 2)) {
+				if (drivenum < 2) {
+					// TODO use actual size (using 1.44 for
+					// now).
 					reg_ah = 0x1; // type
-//					reg_cx = 0;
-//					reg_dx = 2880; //Only set size for harddrives.
+					              //					reg_cx
+					//= 0; 					reg_dx = 2880; //Only set size
+					//for harddrives.
 				} else {
-					//TODO use actual size (using 105 mb for now).
+					// TODO use actual size (using 105 mb
+					// for now).
 					reg_ah = 0x3; // type
 					reg_cx = 3;
 					reg_dx = 0x4800;
 				}
 				CALLBACK_SCF(false);
-			} else { 
-				LOG(LOG_BIOS,LOG_WARN)("INT13: no images, but invalid drive for call 15");
-				reg_ah=0xff;
+			} else {
+				LOG(LOG_BIOS, LOG_WARN)(
+				        "INT13: no images, but invalid drive for call 15");
+				reg_ah = 0xff;
 				CALLBACK_SCF(true);
 			}
 		}
@@ -585,23 +660,27 @@ static Bitu INT13_DiskHandler(void) {
 	case 0x17: /* Set disk type for format */
 		/* Pirates! needs this to load */
 		killRead = true;
-		reg_ah = 0x00;
+		reg_ah   = 0x00;
 		CALLBACK_SCF(false);
 		break;
 	default:
-		LOG(LOG_BIOS,LOG_ERROR)("INT13: Function %x called on drive %x (dos drive %d)", reg_ah,  reg_dl, drivenum);
-		reg_ah=0xff;
+		LOG(LOG_BIOS,
+		    LOG_ERROR)("INT13: Function %x called on drive %x (dos drive %d)",
+		               reg_ah,
+		               reg_dl,
+		               drivenum);
+		reg_ah = 0xff;
 		CALLBACK_SCF(true);
 	}
 	return CBRET_NONE;
 }
 
-
-void BIOS_SetupDisks(void) {
-/* TODO Start the time correctly */
-	call_int13=CALLBACK_Allocate();	
-	CALLBACK_Setup(call_int13,&INT13_DiskHandler,CB_INT13,"Int 13 Bios disk");
-	RealSetVec(0x13,CALLBACK_RealPointer(call_int13));
+void BIOS_SetupDisks(void)
+{
+	/* TODO Start the time correctly */
+	call_int13 = CALLBACK_Allocate();
+	CALLBACK_Setup(call_int13, &INT13_DiskHandler, CB_INT13, "Int 13 Bios disk");
+	RealSetVec(0x13, CALLBACK_RealPointer(call_int13));
 
 	// Clean any the numbered images
 	imageDiskList.fill(nullptr);
@@ -609,27 +688,26 @@ void BIOS_SetupDisks(void) {
 	// Clear any raw disk images
 	diskSwap.fill(nullptr);
 
-	diskparm0 = CALLBACK_Allocate();
-	diskparm1 = CALLBACK_Allocate();
+	diskparm0    = CALLBACK_Allocate();
+	diskparm1    = CALLBACK_Allocate();
 	swapPosition = 0;
 
-	RealSetVec(0x41,CALLBACK_RealPointer(diskparm0));
-	RealSetVec(0x46,CALLBACK_RealPointer(diskparm1));
+	RealSetVec(0x41, CALLBACK_RealPointer(diskparm0));
+	RealSetVec(0x46, CALLBACK_RealPointer(diskparm1));
 
-	PhysPt dp0physaddr=CALLBACK_PhysPointer(diskparm0);
-	PhysPt dp1physaddr=CALLBACK_PhysPointer(diskparm1);
+	PhysPt dp0physaddr = CALLBACK_PhysPointer(diskparm0);
+	PhysPt dp1physaddr = CALLBACK_PhysPointer(diskparm1);
 	for (int i = 0; i < 16; i++) {
-		phys_writeb(dp0physaddr+i,0);
-		phys_writeb(dp1physaddr+i,0);
+		phys_writeb(dp0physaddr + i, 0);
+		phys_writeb(dp1physaddr + i, 0);
 	}
 
 	imgDTASeg = 0;
 
-/* Setup the Bios Area */
-	mem_writeb(BIOS_HARDDISK_COUNT,2);
+	/* Setup the Bios Area */
+	mem_writeb(BIOS_HARDDISK_COUNT, 2);
 
-	MAPPER_AddHandler(swapInNextDisk, SDL_SCANCODE_F4, PRIMARY_MOD,
-	                  "swapimg", "Swap Image");
-	killRead = false;
+	MAPPER_AddHandler(swapInNextDisk, SDL_SCANCODE_F4, PRIMARY_MOD, "swapimg", "Swap Image");
+	killRead           = false;
 	swapping_requested = false;
 }

--- a/src/ints/bios_disk.cpp
+++ b/src/ints/bios_disk.cpp
@@ -16,7 +16,7 @@
 #include "hardware/memory.h"
 #include "utils/string_utils.h"
 
-static const std::vector<diskGeo> disk_geometry_list = {
+static const std::vector<DiskGeometry> disk_geometry_list = {
         { 160,  8, 1, 40, 0}, // SS/DD 5.25"
         { 180,  9, 1, 40, 0}, // SS/DD 5.25"
         { 200, 10, 1, 40, 0}, // SS/DD 5.25" (booters)

--- a/src/ints/bios_disk.cpp
+++ b/src/ints/bios_disk.cpp
@@ -33,6 +33,11 @@ static const std::vector<DiskGeometry> disk_geometry_list = {
         {2880, 36, 2, 80, 6}, // DS/ED 3.5"
 };
 
+const std::vector<DiskGeometry>& BIOS_GetDiskGeometryList()
+{
+	return disk_geometry_list;
+}
+
 callback_number_t call_int13 = 0;
 Bitu diskparm0, diskparm1;
 static uint8_t last_status;

--- a/src/ints/bios_disk.cpp
+++ b/src/ints/bios_disk.cpp
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <cassert>
 #include <utility>
+#include <vector>
 
 #include "cpu/callback.h"
 #include "cpu/registers.h"
@@ -15,7 +16,7 @@
 #include "hardware/memory.h"
 #include "utils/string_utils.h"
 
-diskGeo DiskGeometryList[] = {
+static const std::vector<diskGeo> disk_geometry_list = {
         { 160,  8, 1, 40, 0}, // SS/DD 5.25"
         { 180,  9, 1, 40, 0}, // SS/DD 5.25"
         { 200, 10, 1, 40, 0}, // SS/DD 5.25" (booters)
@@ -30,7 +31,6 @@ diskGeo DiskGeometryList[] = {
         {1720, 21, 2, 82, 4}, // DS/HD 3.5"  (DMF)
         {1840, 23, 2, 80, 4}, // DS/HD 3.5"  (XDF)
         {2880, 36, 2, 80, 6}, // DS/ED 3.5"
-        {   0,  0, 0,  0, 0}
 };
 
 callback_number_t call_int13 = 0;
@@ -254,23 +254,21 @@ imageDisk::imageDisk(FILE* img_file, const char* img_name, uint32_t img_size_k,
 	memset(diskname, 0, 512);
 	safe_strcpy(diskname, img_name);
 	if (!is_hdd) {
-		uint8_t i      = 0;
 		bool founddisk = false;
-		while (DiskGeometryList[i].ksize != 0x0) {
-			if ((DiskGeometryList[i].ksize == img_size_k) ||
-			    (DiskGeometryList[i].ksize + 1 == img_size_k)) {
-				if (DiskGeometryList[i].ksize != img_size_k) {
+		for (uint8_t i = 0; i < disk_geometry_list.size(); ++i) {
+			const auto& geo = disk_geometry_list[i];
+			if (geo.ksize == img_size_k || geo.ksize + 1 == img_size_k) {
+				if (geo.ksize != img_size_k) {
 					LOG_MSG("ImageLoader: image file with additional data, might not load!");
 				}
 				founddisk  = true;
 				active     = true;
 				floppytype = i;
-				heads      = DiskGeometryList[i].headscyl;
-				cylinders  = DiskGeometryList[i].cylcount;
-				sectors    = DiskGeometryList[i].secttrack;
+				heads      = geo.headscyl;
+				cylinders  = geo.cylcount;
+				sectors    = geo.secttrack;
 				break;
 			}
-			i++;
 		}
 		if (!founddisk) {
 			active = false;
@@ -302,7 +300,7 @@ void imageDisk::Get_Geometry(uint32_t* getHeads, uint32_t* getCyl,
 uint8_t imageDisk::GetBiosType(void)
 {
 	if (!hardDrive) {
-		return (uint8_t)DiskGeometryList[floppytype].biosval;
+		return static_cast<uint8_t>(disk_geometry_list[floppytype].biosval);
 	} else {
 		return 0;
 	}

--- a/src/ints/bios_disk.h
+++ b/src/ints/bios_disk.h
@@ -25,7 +25,6 @@ struct diskGeo {
 	uint16_t cylcount;  /* Cylinders per side */
 	uint16_t biosval;   /* Type to return from BIOS */
 };
-extern diskGeo DiskGeometryList[];
 
 class imageDisk  {
 public:

--- a/src/ints/bios_disk.h
+++ b/src/ints/bios_disk.h
@@ -9,6 +9,7 @@
 #include <cstdio>
 #include <array>
 #include <memory>
+#include <vector>
 
 #include "dos/dos.h"
 #include "hardware/memory.h"
@@ -25,6 +26,8 @@ struct DiskGeometry {
 	uint16_t cylcount;  /* Cylinders per side */
 	uint16_t biosval;   /* Type to return from BIOS */
 };
+
+const std::vector<DiskGeometry>& BIOS_GetDiskGeometryList();
 
 class imageDisk  {
 public:

--- a/src/ints/bios_disk.h
+++ b/src/ints/bios_disk.h
@@ -18,7 +18,7 @@
 #define BIOS_MAX_DISK 10
 
 #define MAX_SWAPPABLE_DISKS 20
-struct diskGeo {
+struct DiskGeometry {
 	uint32_t ksize;  /* Size in kilobytes */
 	uint16_t secttrack; /* Sectors per track */
 	uint16_t headscyl;  /* Heads per cylinder */

--- a/website/docs/0.83/manual/using-dosbox-staging/storage.md
+++ b/website/docs/0.83/manual/using-dosbox-staging/storage.md
@@ -196,7 +196,18 @@ mount C /path/to/saves -t overlay
 mount A floppy.img -t floppy
 ```
 
-Supported floppy image formats: `.img`, `.ima` (raw sector images).
+Supported floppy image formats: `.img`, `.ima`, `.dsk` (raw sector images),
+`.vfd` (Virtual Floppy Disk), `.flp` (raw floppy image).
+
+Numeric extensions matching standard floppy sizes are also recognised:
+`.360`, `.720`, `.1200`, `.1440`.
+
+When using `.img`, `.ima`, or `.dsk` files without an explicit `-t floppy`
+flag, DOSBox Staging detects the image type automatically by matching the
+file size against known floppy disk geometries (see
+[Floppy disk formats](#floppy-disk-formats) below). Images that match a
+standard floppy size are mounted as floppy drives; all others are mounted as
+hard disk images.
 
 #### Floppy disk formats
 


### PR DESCRIPTION
# Description

Add recognition for .ima, .img, .vfd, .flp, .360, .720, .1200, .1440, .dsk floppy images when file size matches standard floppy geometry. 

- Unclear extensions (.ima, .img, .dsk) use size-based detection against DiskGeometryList to distinguish floppy from HDD images. 
- Known floppy extensions (.vfd, .flp, numeric) always route as floppy. 
- .vhd stay as HDD-only.

The explicit `-t floppy` and `-t hdd` overrides are not touched.

# Release notes

### Add floppy sector image support to MOUNT

The MOUNT command now recognises floppy-specific file extensions and automatically selects the correct drive type.

Images with the extensions .vfd, .flp, .360, .720, .1200, or .1440 are mounted as floppy drives without needing the -t floppy flag. For the common .img, .ima, and .dsk extensions, the image file size is compared against standard floppy disk geometries. If it matches a known floppy format, the image is mounted as a floppy drive; otherwise it is mounted as a hard disk image.

This eliminates a common source of confusion where floppy images were silently mounted as hard disks, causing games to fail to boot or behave incorrectly.

# Manual testing

Test cases were performed with .img (automatic detection) and .vfd floppy images of the Spelljammer game (2x 1,44 MB 3,5" floppy disks).

<img width="1875" height="815" alt="linux-mount-floppy-img-01" src="https://github.com/user-attachments/assets/3c3733d1-523d-41b0-bbfa-d6e882175efe" />
<img width="1900" height="838" alt="linux-mount-floppy-img-02" src="https://github.com/user-attachments/assets/15d9631a-bab6-4683-b610-7495b7a9c179" />
<img width="1074" height="877" alt="windows-mount-floppy-img-01" src="https://github.com/user-attachments/assets/fe8d64b3-8fe1-4626-a7df-4083d90ded14" />
<img width="1305" height="890" alt="windows-mount-floppy-img-02" src="https://github.com/user-attachments/assets/9474d25f-bbb9-4d7e-9cb3-adee59399403" />

The change has been manually tested on:

- [x] Windows
- [ ] macOS
- [x] Linux

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [x] my change has been manually tested on Windows, macOS, and Linux. 
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [x] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

---

*This patch was developed with AI coding tool assistance (Claude Code). I reviewed, tested, and take full responsibility for all changes.*
