### PR TITLE
Add video frame capture endpoint to webserver API

### DIFF
--- a/src/gui/render/render.cpp
+++ b/src/gui/render/render.cpp
@@ -31,10 +31,37 @@
 #include "utils/math_utils.h"
 #include "utils/string_utils.h"
 
+#include "render_shared.h"
+
+#include <atomic>
+
 CHECK_NARROWING();
 
 Render render;
 ScalerLineHandler RENDER_DrawLine;
+
+static std::mutex shared_frame_mutex;
+static RenderedImage shared_frame = {};
+static std::atomic<bool> shared_frame_available{false};
+
+void RENDER_UpdateSharedFrame(const RenderedImage& image)
+{
+	std::lock_guard<std::mutex> lock(shared_frame_mutex);
+	shared_frame.free();
+	shared_frame = image.deep_copy();
+	shared_frame_available.store(true);
+}
+
+RenderedImage RENDER_GetSharedFrame()
+{
+	std::lock_guard<std::mutex> lock(shared_frame_mutex);
+	return shared_frame.deep_copy();
+}
+
+bool RENDER_HasSharedFrame()
+{
+	return shared_frame_available.load();
+}
 
 static void render_callback(GFX_CallbackFunctions_t function);
 
@@ -314,9 +341,11 @@ static void handle_capture_frame()
 		// The video capturer doesn't create a copy, and consequently
 		// doesn't free the rendered image either.
 		CAPTURE_AddFrame(new_image, frames_per_second);
+		RENDER_UpdateSharedFrame(new_image);
 
 	} else {
 		CAPTURE_AddFrame(image, frames_per_second);
+		RENDER_UpdateSharedFrame(image);
 	}
 }
 

--- a/src/gui/render/render.cpp
+++ b/src/gui/render/render.cpp
@@ -341,11 +341,9 @@ static void handle_capture_frame()
 		// The video capturer doesn't create a copy, and consequently
 		// doesn't free the rendered image either.
 		CAPTURE_AddFrame(new_image, frames_per_second);
-		RENDER_UpdateSharedFrame(new_image);
 
 	} else {
 		CAPTURE_AddFrame(image, frames_per_second);
-		RENDER_UpdateSharedFrame(image);
 	}
 }
 
@@ -387,6 +385,27 @@ void RENDER_EndUpdate([[maybe_unused]] bool abort)
 
 	if (CAPTURE_IsCapturingImage() || CAPTURE_IsCapturingVideo()) {
 		handle_capture_frame();
+	}
+
+	{
+		RenderedImage image = {};
+		image.params        = render.src;
+		image.image_data    = reinterpret_cast<uint8_t*>(
+                        render.scale.cache.data());
+		image.palette = render.palette.rgb;
+		image.pitch   = render.scale.cache_pitch;
+
+		// When scan doubling is baked into the render cache (e.g.,
+		// VGA mode 13h on the texture/surface backend), the cache
+		// contains twice as many rows as the native resolution.
+		// Use video_mode.height for the true native height and
+		// skip every other row by doubling the pitch.
+		if (render.src.rendered_double_scan) {
+			image.params.height = render.src.video_mode.height;
+			image.pitch         = render.scale.cache_pitch * 2;
+		}
+
+		RENDER_UpdateSharedFrame(image);
 	}
 
 	// Only deinterlace the output if the frame has changed

--- a/src/gui/render/render_shared.h
+++ b/src/gui/render/render_shared.h
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: 2026 The DOSBox Staging Team
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#ifndef DOSBOX_RENDER_SHARED_H
+#define DOSBOX_RENDER_SHARED_H
+
+#include "misc/rendered_image.h"
+
+void RENDER_UpdateSharedFrame(const RenderedImage& image);
+RenderedImage RENDER_GetSharedFrame();
+bool RENDER_HasSharedFrame();
+
+#endif // DOSBOX_RENDER_SHARED_H

--- a/src/webserver/CMakeLists.txt
+++ b/src/webserver/CMakeLists.txt
@@ -3,6 +3,10 @@ target_sources(libdosboxcommon PRIVATE
   webserver.cpp
   cpu.cpp
   memory.cpp
-  dos.cpp)
+  dos.cpp
+  video.cpp)
 
-target_link_libraries(libdosboxcommon PRIVATE simde)
+find_package(JPEG REQUIRED)
+find_package(PNG REQUIRED)
+
+target_link_libraries(libdosboxcommon PRIVATE simde JPEG::JPEG PNG::PNG)

--- a/src/webserver/meson.build
+++ b/src/webserver/meson.build
@@ -3,14 +3,17 @@ libwebserver_sources = [
     'cpu.cpp',
     'dos.cpp',
     'memory.cpp',
+    'video.cpp',
     'webserver.cpp',
 ]
+
+jpeg_dep = dependency('libjpeg', required: true)
 
 libwebserver = static_library(
     'webserver',
     libwebserver_sources,
     include_directories: incdir,
-    dependencies: [],
+    dependencies: [png_dep, jpeg_dep],
     cpp_args: warnings,
 )
 

--- a/src/webserver/video.cpp
+++ b/src/webserver/video.cpp
@@ -258,12 +258,26 @@ void VideoHandlers::GetFrameInfo(const httplib::Request&, httplib::Response& res
 
 	auto frame = RENDER_GetSharedFrame();
 
+	const auto& vm = frame.params.video_mode;
+
 	json j;
 	j["width"]        = frame.params.width;
 	j["height"]       = frame.params.height;
 	j["pixel_format"] = pixel_format_name(frame.params.pixel_format);
 	j["pitch"]        = frame.pitch;
 	j["is_paletted"]  = frame.is_paletted();
+
+	j["video_mode"]["width"]             = vm.width;
+	j["video_mode"]["height"]            = vm.height;
+	j["video_mode"]["is_graphics_mode"]  = vm.is_graphics_mode;
+	j["video_mode"]["is_double_scanned"] = vm.is_double_scanned_mode;
+	j["video_mode"]["graphics_standard"] = to_string(vm.graphics_standard);
+	j["video_mode"]["color_depth"]       = to_string(vm.color_depth);
+	j["video_mode"]["bios_mode_number"]  = vm.bios_mode_number;
+
+	j["rendered_double_scan"] = frame.params.rendered_double_scan;
+	j["double_width"]         = frame.params.double_width;
+	j["double_height"]        = frame.params.double_height;
 
 	frame.free();
 

--- a/src/webserver/video.cpp
+++ b/src/webserver/video.cpp
@@ -1,0 +1,273 @@
+// SPDX-FileCopyrightText: 2026 The DOSBox Staging Team
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "video.h"
+#include "webserver.h"
+
+#include "gui/render/render_shared.h"
+#include "misc/rendered_image.h"
+#include "misc/video.h"
+
+#include "libs/json/json.h"
+
+#include <jpeglib.h>
+#include <png.h>
+
+#include <cstring>
+#include <vector>
+
+using json = nlohmann::json;
+
+namespace Webserver {
+
+static std::vector<uint8_t> convert_to_rgb888(const RenderedImage& image)
+{
+	const auto w = image.params.width;
+	const auto h = image.params.height;
+	std::vector<uint8_t> rgb(w * h * 3);
+
+	for (int y = 0; y < h; y++) {
+		const auto* src_row = image.image_data + y * image.pitch;
+		auto* dst_row       = rgb.data() + y * w * 3;
+
+		switch (image.params.pixel_format) {
+		case PixelFormat::Indexed8:
+			for (int x = 0; x < w; x++) {
+				const auto idx     = src_row[x];
+				dst_row[x * 3 + 0] = image.palette[idx].red;
+				dst_row[x * 3 + 1] = image.palette[idx].green;
+				dst_row[x * 3 + 2] = image.palette[idx].blue;
+			}
+			break;
+		case PixelFormat::BGRX32_ByteArray:
+			for (int x = 0; x < w; x++) {
+				dst_row[x * 3 + 0] = src_row[x * 4 + 2]; // R
+				dst_row[x * 3 + 1] = src_row[x * 4 + 1]; // G
+				dst_row[x * 3 + 2] = src_row[x * 4 + 0]; // B
+			}
+			break;
+		case PixelFormat::BGR24_ByteArray:
+			for (int x = 0; x < w; x++) {
+				dst_row[x * 3 + 0] = src_row[x * 3 + 2]; // R
+				dst_row[x * 3 + 1] = src_row[x * 3 + 1]; // G
+				dst_row[x * 3 + 2] = src_row[x * 3 + 0]; // B
+			}
+			break;
+		case PixelFormat::RGB555_Packed16:
+			for (int x = 0; x < w; x++) {
+				const auto px = reinterpret_cast<const uint16_t*>(
+				        src_row)[x];
+				dst_row[x * 3 + 0] = static_cast<uint8_t>(
+				        ((px >> 10) & 0x1F) * 255 / 31);
+				dst_row[x * 3 + 1] = static_cast<uint8_t>(
+				        ((px >> 5) & 0x1F) * 255 / 31);
+				dst_row[x * 3 + 2] = static_cast<uint8_t>(
+				        (px & 0x1F) * 255 / 31);
+			}
+			break;
+		case PixelFormat::RGB565_Packed16:
+			for (int x = 0; x < w; x++) {
+				const auto px = reinterpret_cast<const uint16_t*>(
+				        src_row)[x];
+				dst_row[x * 3 + 0] = static_cast<uint8_t>(
+				        ((px >> 11) & 0x1F) * 255 / 31);
+				dst_row[x * 3 + 1] = static_cast<uint8_t>(
+				        ((px >> 5) & 0x3F) * 255 / 63);
+				dst_row[x * 3 + 2] = static_cast<uint8_t>(
+				        (px & 0x1F) * 255 / 31);
+			}
+			break;
+		default: std::memset(dst_row, 0, w * 3); break;
+		}
+	}
+	return rgb;
+}
+
+static std::string encode_jpeg(const RenderedImage& image, int quality = 80)
+{
+	auto rgb     = convert_to_rgb888(image);
+	const auto w = image.params.width;
+	const auto h = image.params.height;
+
+	struct jpeg_compress_struct cinfo = {};
+	struct jpeg_error_mgr jerr        = {};
+	cinfo.err                         = jpeg_std_error(&jerr);
+	jpeg_create_compress(&cinfo);
+
+	unsigned char* buf     = nullptr;
+	unsigned long buf_size = 0;
+	jpeg_mem_dest(&cinfo, &buf, &buf_size);
+
+	cinfo.image_width      = w;
+	cinfo.image_height     = h;
+	cinfo.input_components = 3;
+	cinfo.in_color_space   = JCS_RGB;
+	jpeg_set_defaults(&cinfo);
+	jpeg_set_quality(&cinfo, quality, TRUE);
+	jpeg_start_compress(&cinfo, TRUE);
+
+	while (cinfo.next_scanline < cinfo.image_height) {
+		auto* row = rgb.data() + cinfo.next_scanline * w * 3;
+		jpeg_write_scanlines(&cinfo, &row, 1);
+	}
+
+	jpeg_finish_compress(&cinfo);
+	jpeg_destroy_compress(&cinfo);
+
+	std::string result(reinterpret_cast<char*>(buf), buf_size);
+	free(buf);
+	return result;
+}
+
+static void write_png_to_buffer(png_structp png_ptr, png_bytep data, png_size_t length)
+{
+	auto* out = static_cast<std::string*>(png_get_io_ptr(png_ptr));
+	out->append(reinterpret_cast<char*>(data), length);
+}
+
+static std::string encode_png(const RenderedImage& image)
+{
+	auto rgb     = convert_to_rgb888(image);
+	const auto w = image.params.width;
+	const auto h = image.params.height;
+
+	std::string result;
+
+	auto* png_ptr  = png_create_write_struct(PNG_LIBPNG_VER_STRING,
+                                                nullptr,
+                                                nullptr,
+                                                nullptr);
+	auto* info_ptr = png_create_info_struct(png_ptr);
+
+	png_set_write_fn(png_ptr, &result, write_png_to_buffer, nullptr);
+
+	png_set_IHDR(png_ptr,
+	             info_ptr,
+	             w,
+	             h,
+	             8,
+	             PNG_COLOR_TYPE_RGB,
+	             PNG_INTERLACE_NONE,
+	             PNG_COMPRESSION_TYPE_DEFAULT,
+	             PNG_FILTER_TYPE_DEFAULT);
+
+	png_set_compression_level(png_ptr, 1);
+	png_write_info(png_ptr, info_ptr);
+
+	for (int y = 0; y < h; y++) {
+		auto* row = rgb.data() + y * w * 3;
+		png_write_row(png_ptr, row);
+	}
+
+	png_write_end(png_ptr, nullptr);
+	png_destroy_write_struct(&png_ptr, &info_ptr);
+
+	return result;
+}
+
+static std::string encode_raw(const RenderedImage& image)
+{
+	const auto w      = static_cast<uint32_t>(image.params.width);
+	const auto h      = static_cast<uint32_t>(image.params.height);
+	const auto pitch  = static_cast<int32_t>(image.pitch);
+	const auto pf     = static_cast<uint8_t>(image.params.pixel_format);
+	const auto is_pal = image.is_paletted();
+	const uint16_t pal_count = is_pal ? 256 : 0;
+
+	const auto data_size   = static_cast<size_t>(h * std::abs(pitch));
+	const auto header_size = sizeof(w) + sizeof(h) + sizeof(pitch) +
+	                         sizeof(pf) + sizeof(pal_count);
+	const auto palette_size = static_cast<size_t>(pal_count * 3);
+
+	std::string result;
+	result.resize(header_size + palette_size + data_size);
+	auto* p = result.data();
+
+	std::memcpy(p, &w, sizeof(w));
+	p += sizeof(w);
+	std::memcpy(p, &h, sizeof(h));
+	p += sizeof(h);
+	std::memcpy(p, &pitch, sizeof(pitch));
+	p += sizeof(pitch);
+	std::memcpy(p, &pf, sizeof(pf));
+	p += sizeof(pf);
+	std::memcpy(p, &pal_count, sizeof(pal_count));
+	p += sizeof(pal_count);
+
+	if (is_pal) {
+		for (int i = 0; i < pal_count; i++) {
+			*p++ = image.palette[i].red;
+			*p++ = image.palette[i].green;
+			*p++ = image.palette[i].blue;
+		}
+	}
+
+	std::memcpy(p, image.image_data, data_size);
+
+	return result;
+}
+
+static const char* pixel_format_name(PixelFormat pf)
+{
+	switch (pf) {
+	case PixelFormat::Indexed8: return "Indexed8";
+	case PixelFormat::RGB555_Packed16: return "RGB555_Packed16";
+	case PixelFormat::RGB565_Packed16: return "RGB565_Packed16";
+	case PixelFormat::BGR24_ByteArray: return "BGR24_ByteArray";
+	case PixelFormat::BGRX32_ByteArray: return "BGRX32_ByteArray";
+	default: return "Unknown";
+	}
+}
+
+void VideoHandlers::GetFrame(const httplib::Request& req, httplib::Response& res)
+{
+	if (!RENDER_HasSharedFrame()) {
+		res.status = 503;
+		json err;
+		err["error"] = "No frame available yet";
+		send_json(res, err);
+		return;
+	}
+
+	auto frame        = RENDER_GetSharedFrame();
+	const auto format = req.get_param_value("format");
+
+	if (format == "png") {
+		auto data = encode_png(frame);
+		res.set_content(std::move(data), "image/png");
+	} else if (format == "raw") {
+		auto data = encode_raw(frame);
+		res.set_content(std::move(data), "application/octet-stream");
+	} else {
+		auto data = encode_jpeg(frame);
+		res.set_content(std::move(data), "image/jpeg");
+	}
+
+	frame.free();
+}
+
+void VideoHandlers::GetFrameInfo(const httplib::Request&, httplib::Response& res)
+{
+	if (!RENDER_HasSharedFrame()) {
+		res.status = 503;
+		json err;
+		err["error"] = "No frame available yet";
+		send_json(res, err);
+		return;
+	}
+
+	auto frame = RENDER_GetSharedFrame();
+
+	json j;
+	j["width"]        = frame.params.width;
+	j["height"]       = frame.params.height;
+	j["pixel_format"] = pixel_format_name(frame.params.pixel_format);
+	j["pitch"]        = frame.pitch;
+	j["is_paletted"]  = frame.is_paletted();
+
+	frame.free();
+
+	send_json(res, j);
+}
+
+} // namespace Webserver

--- a/src/webserver/video.h
+++ b/src/webserver/video.h
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2026 The DOSBox Staging Team
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#ifndef DOSBOX_WEBSERVER_VIDEO_H
+#define DOSBOX_WEBSERVER_VIDEO_H
+
+#include "libs/http/http.h"
+
+namespace Webserver {
+
+struct VideoHandlers {
+	static void GetFrame(const httplib::Request& req, httplib::Response& res);
+	static void GetFrameInfo(const httplib::Request& req, httplib::Response& res);
+};
+
+} // namespace Webserver
+
+#endif // DOSBOX_WEBSERVER_VIDEO_H

--- a/src/webserver/webserver.cpp
+++ b/src/webserver/webserver.cpp
@@ -6,6 +6,7 @@
 #include "cpu.h"
 #include "dos.h"
 #include "memory.h"
+#include "video.h"
 
 #include <set>
 #include <string>
@@ -65,6 +66,9 @@ static void setup_api_handlers()
 	server.Get("/api/v1/memory/:segment/:offset/:len", ReadMemoryCommand::Get);
 	server.Put("/api/v1/memory/:offset", WriteMemoryCommand::Put);
 	server.Put("/api/v1/memory/:segment/:offset", WriteMemoryCommand::Put);
+
+	server.Get("/api/v1/video/frame", VideoHandlers::GetFrame);
+	server.Get("/api/v1/video/frame/info", VideoHandlers::GetFrameInfo);
 }
 
 static std::string strip_port(const std::string& host)

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -8,6 +8,7 @@
     "gtest",
     "iir1",
     "libmt32emu",
+    "libjpeg-turbo",
     "libpng",
     "opusfile",
     "fluidsynth",


### PR DESCRIPTION
# Description

This is a new feature for the new webserver REST API and adds two new REST API endpoints for capturing the current screen:

- `GET /api/v1/video/frame` — returns the current frame as JPEG (default), PNG (`?format=png`), or raw pixel data (`?format=raw`)
- `GET /api/v1/video/frame/info` — returns frame metadata (dimensions, pixel format, pitch)

Each rendered frame gets deep-copied into a shared buffer behind a mutex, so the webserver can read it without stalling emulation. The copy runs in `RENDER_EndUpdate()`, meaning the buffer is always current - it doesn't depend on screenshot or video capture being active.

Output formats:
- **JPEG**: fast, small (~23 KB for 320x200), good for streaming or quick checks
- **PNG**: lossless, larger (~63 KB), good for reference screenshots
- **Raw**: pixel-perfect with header (width, height, pitch, format, palette), for programmatic consumers

This is useful for automated testing, accessibility tooling, remote monitoring, or recording without the SDL capture pipeline.

A new dependency has been added, libjpeg-turbo (added to vcpkg.json).

# Release notes

Added video frame capture endpoints to the REST API webserver. You can now grab the current screen as JPEG, PNG, or raw pixel data, and query what video mode is active. The capture returns the native game resolution regardless of which renderer backend is in use.

Output formats:
- **JPEG**: fast, small (~23 KB for 320x200), good for streaming or quick checks
- **PNG**: lossless, larger (~63 KB), good for reference screenshots
- **Raw**: pixel-perfect with header (width, height, pitch, format, palette), for programmatic processing who need the raw frames.

# Manual testing

```
$ curl http://localhost:8386/api/v1/video/frame -o frame.jpg
$ curl http://localhost:8386/api/v1/video/frame?format=png -o frame.png
$ curl http://localhost:8386/api/v1/video/frame/info
{
  "width": 320,
  "height": 200,
  "pixel_format": "BGRX32_ByteArray",
  "pitch": 2560,
  "is_paletted": false,
  "video_mode": {
    "width": 320,
    "height": 200,
    "is_graphics_mode": true,
    "is_double_scanned": true,
    "graphics_standard": "VGA",
    "color_depth": "256-colour",
    "bios_mode_number": 19
  },
  "rendered_double_scan": true,
  "double_width": true,
  "double_height": false
}
```

**Demo screenshots from games in various resolutions**
Frames have been captured partially in Windows, partially in Linux via REST API calls. Format is usually PNG, but also some select in JPG for comparison.

**Dungeon Hack** (320x200)
<img width="320" height="200" alt="frame_opengl_hack" src="https://github.com/user-attachments/assets/08b38273-944e-49bf-a3fe-6776be22d340" />

**NetHack 3.4.0** (VGA text mode, 80x25 / 720x400)
<img width="720" height="400" alt="frame_opengl_nethack" src="https://github.com/user-attachments/assets/b90eede7-9a24-4852-9daa-ca376ef2dd41" />

**EGATrek** (EGA 640x350; first is JPG, second PNG)
<img width="640" height="350" alt="frame_opengl_egatrek" src="https://github.com/user-attachments/assets/927e0c9b-16d2-4145-b737-e7a9a8cdd01d" />
<img width="640" height="350" alt="frame_opengl_egatrek" src="https://github.com/user-attachments/assets/f0d314b4-ca1f-42ec-a269-f09385899e37" />

**Warlords 2** (VGA 640x480 16 colors)
<img width="640" height="480" alt="frame_opengl_wl2" src="https://github.com/user-attachments/assets/931b9813-259e-4c7f-9f79-cf7e44dd4a5b" />


**Hi-Octane** (VESA VGA 640x480 256 colors)
<img width="640" height="480" alt="frame_opengl_hioctane_640" src="https://github.com/user-attachments/assets/645b79d7-2f0a-4425-b81a-d9b49aa26792" />

**Ravenloft: Strahd's Possession** (320x400 256 Colors, ModeX; note that it is not aspect corrected)
<img width="320" height="400" alt="frame_opengl_ravenloft" src="https://github.com/user-attachments/assets/d7c08ff2-4c67-431b-b147-30c879a9ae4c" />

_Please describe the tests that you ran to verify your changes._
Tested with seven games across VGA 13h, EGA, VGA 12h, VESA, Mode X, and text mode on both renderer backends. All return correct native-resolution frames.

For details how exactly the calls were made, see above section of "Manual testing".

procedure was:
 - starting dosbox-staging with default renderer in Linux (opengl) and Windows (direct3d), as well as the texture renderer.
 - mounted the games and started them individually.
 - ran on cmd with curl calls, first the info route, then capturing the frame.
 - examined the individual result files with an image viewer if they are really match the expected image formats and resolution.

Operating systems were:
- used vcpkg for libiir and munt/mt32, rest standard native toolchain, no cross-compiling.
- Debian Trixie 13 with KDE desktop
- Windows 10 LTSC in a KVM on Debian host with native toolchain, as denoted in building guide.

The change has been manually tested on:

- [x] Windows
- [ ] macOS
- [x] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [ ] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [x] my change has been manually tested on Windows, macOS, and Linux.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [x] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

