### PR TITLE
Fix legacy `windowresolution` setting fallback

### DIFF
--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -136,11 +136,11 @@ Config& Config::operator=(Config&& source) noexcept
 	}
 
 	// Move each member
-	cmdline         = std::move(source.cmdline);
-	sections        = std::move(source.sections);
-	secure_mode     = std::move(source.secure_mode);
-	startup_params  = std::move(source.startup_params);
-	config_files    = std::move(source.config_files);
+	cmdline        = std::move(source.cmdline);
+	sections       = std::move(source.sections);
+	secure_mode    = std::move(source.secure_mode);
+	startup_params = std::move(source.startup_params);
+	config_files   = std::move(source.config_files);
 
 	loaded_config_paths_canonical = std::move(source.loaded_config_paths_canonical);
 

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -602,3 +602,30 @@ void Config::ParseArguments()
 
 	arguments.editconf = cmdline->FindRemoveOptionalArgument("editconf");
 }
+
+static std::string make_scoped_setting_name(const std::string& section_name,
+                                            const std::string& property_name)
+{
+	return format_str("%s.%s", section_name.c_str(), property_name.c_str());
+}
+
+void Config::AppendParsedSetting(const std::string& section_name,
+                                 const std::string& property_name)
+{
+	parsed_settings.emplace_back(
+	        make_scoped_setting_name(section_name, property_name));
+}
+
+int Config::GetSettingParseOrder(const std::string& section_name,
+                                 const std::string& property_name)
+{
+	const auto it = std::ranges::find(parsed_settings,
+	                                  make_scoped_setting_name(section_name,
+	                                                           property_name));
+
+	if (it == parsed_settings.end()) {
+		return -1;
+	} else {
+		return it - parsed_settings.begin();
+	}
+}

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -12,8 +12,8 @@
 #include <vector>
 
 #include "config/setup.h"
-#include "shell/command_line.h"
 #include "misc/std_filesystem.h"
+#include "shell/command_line.h"
 
 // clang-format off
 enum class StartupVerbosity {
@@ -61,9 +61,9 @@ public:
 	CommandLineArguments arguments = {};
 
 private:
-	std::deque<Section*> sections            = {};
+	std::deque<Section*> sections                = {};
 	AutoExecSection overwritten_autoexec_section = {};
-	std::string overwritten_autoexec_conf    = {};
+	std::string overwritten_autoexec_conf        = {};
 
 	bool secure_mode = false;
 

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -9,6 +9,7 @@
 #include <deque>
 #include <functional>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "config/setup.h"
@@ -64,6 +65,8 @@ private:
 	std::deque<Section*> sections                = {};
 	AutoExecSection overwritten_autoexec_section = {};
 	std::string overwritten_autoexec_conf        = {};
+
+	std::vector<std::string> parsed_settings = {};
 
 	bool secure_mode = false;
 
@@ -144,6 +147,17 @@ public:
 	}
 
 	StartupVerbosity GetStartupVerbosity() const;
+
+	// Should be called after a config setting is parsed when reading the
+	// config files to store the setting parse order.
+	void AppendParsedSetting(const std::string& section_name,
+	                         const std::string& property_name);
+
+	// Return the parse order of the setting during reading the config files.
+	// Higher numbers means the setting was parsed later. -1 is returned if
+	// the setting wasn't set in the configs.
+	int GetSettingParseOrder(const std::string& section_name,
+	                         const std::string& property_name);
 };
 
 using ConfigPtr = std::unique_ptr<Config>;

--- a/src/config/setup.cpp
+++ b/src/config/setup.cpp
@@ -903,7 +903,7 @@ PropMultiValRemain* SectionProp::AddMultiValRemain(const std::string& _propname,
 
 int SectionProp::GetInt(const std::string& _propname) const
 {
-	for (const auto &property : properties) {
+	for (const auto& property : properties) {
 		if (property->propname == _propname) {
 			return property->GetValue();
 		}
@@ -913,7 +913,7 @@ int SectionProp::GetInt(const std::string& _propname) const
 
 bool SectionProp::GetBool(const std::string& _propname) const
 {
-	for (const auto &property : properties) {
+	for (const auto& property : properties) {
 		if (property->propname == _propname) {
 			return property->GetValue();
 		}
@@ -923,7 +923,7 @@ bool SectionProp::GetBool(const std::string& _propname) const
 
 double SectionProp::GetDouble(const std::string& _propname) const
 {
-	for (const auto &property : properties) {
+	for (const auto& property : properties) {
 		if (property->propname == _propname) {
 			return property->GetValue();
 		}
@@ -933,7 +933,7 @@ double SectionProp::GetDouble(const std::string& _propname) const
 
 PropPath* SectionProp::GetPath(const std::string& _propname) const
 {
-	for (const auto &property : properties) {
+	for (const auto& property : properties) {
 		if (property->propname == _propname) {
 			auto val = dynamic_cast<PropPath*>(property);
 			if (val) {
@@ -948,7 +948,7 @@ PropPath* SectionProp::GetPath(const std::string& _propname) const
 
 PropMultiVal* SectionProp::GetMultiVal(const std::string& _propname) const
 {
-	for (const auto &property : properties) {
+	for (const auto& property : properties) {
 		if (property->propname == _propname) {
 			auto val = dynamic_cast<PropMultiVal*>(property);
 			if (val) {
@@ -963,7 +963,7 @@ PropMultiVal* SectionProp::GetMultiVal(const std::string& _propname) const
 
 PropMultiValRemain* SectionProp::GetMultiValRemain(const std::string& _propname) const
 {
-	for (const auto &property : properties) {
+	for (const auto& property : properties) {
 		if (property->propname == _propname) {
 			auto val = dynamic_cast<PropMultiValRemain*>(property);
 			if (val) {
@@ -978,7 +978,7 @@ PropMultiValRemain* SectionProp::GetMultiValRemain(const std::string& _propname)
 
 Property* SectionProp::GetProperty(int index)
 {
-	for (const auto &property : properties) {
+	for (const auto& property : properties) {
 		if (!index--) {
 			return property;
 		}
@@ -988,7 +988,7 @@ Property* SectionProp::GetProperty(int index)
 
 Property* SectionProp::GetProperty(const std::string_view propname)
 {
-	for (const auto &property : properties) {
+	for (const auto& property : properties) {
 		if (iequals(property->propname, propname)) {
 			return property;
 		}
@@ -998,7 +998,7 @@ Property* SectionProp::GetProperty(const std::string_view propname)
 
 std::string SectionProp::GetString(const std::string& _propname) const
 {
-	for (const auto &property : properties) {
+	for (const auto& property : properties) {
 		if (iequals(property->propname, _propname)) {
 			return (property->GetValue());
 		}

--- a/src/config/setup.cpp
+++ b/src/config/setup.cpp
@@ -1046,6 +1046,8 @@ Hex SectionProp::GetHex(const std::string& _propname) const
 
 bool SectionProp::HandleInputLine(const std::string& line)
 {
+	assert(control);
+
 	// Parse a configuration setting in the 'setting_name = setting_value'
 	// format
 	const std::string::size_type loc = line.find('=');
@@ -1074,12 +1076,12 @@ bool SectionProp::HandleInputLine(const std::string& line)
 	trim(setting_value_str);
 
 	// Find the configuration setting and try to set it
-	for (auto& p : properties) {
-		if (strcasecmp(p->propname.c_str(), setting_name.c_str()) != 0) {
+	for (auto& prop : properties) {
+		if (strcasecmp(prop->propname.c_str(), setting_name.c_str()) != 0) {
 			continue;
 		}
 
-		if (p->IsDeprecated()) {
+		if (prop->IsDeprecated()) {
 			NOTIFY_DisplayWarning(Notification::Source::Console,
 			                      "CONFIG",
 			                      "PROGRAM_CONFIG_DEPRECATED_SETTING",
@@ -1090,12 +1092,14 @@ bool SectionProp::HandleInputLine(const std::string& line)
 			                      create_setting_help_msg_name(
 			                              setting_name));
 
-			if (!p->IsDeprecatedButAllowed()) {
+			if (!prop->IsDeprecatedButAllowed()) {
 				return false;
 			}
 		}
 
-		return p->SetValue(setting_value_str);
+		control->AppendParsedSetting(GetName(), prop->propname);
+
+		return prop->SetValue(setting_value_str);;
 	}
 
 	// We couldn't find the config setting; display an error

--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -1479,6 +1479,32 @@ static void save_window_size(const int w, const int h)
 		sdl.windowed.canvas_size.w = w;
 		sdl.windowed.canvas_size.h = h;
 	}
+
+	set_section_property_value("sdl", "window_size", format_str("%dx%d", w, h));
+}
+
+static void handle_window_size_pref_after_config_load()
+{
+	assert(control);
+
+	constexpr auto SectionName    = "sdl";
+	constexpr auto LegacyPrefName = "windowresolution";
+	constexpr auto NewPrefName    = "window_size";
+
+	const auto legacy_pref_order = control->GetSettingParseOrder(SectionName,
+	                                                             LegacyPrefName);
+
+	const auto new_pref_order = control->GetSettingParseOrder(SectionName,
+	                                                          NewPrefName);
+
+	if (legacy_pref_order > new_pref_order) {
+		const auto legacy_pref = get_sdl_section()->GetString(LegacyPrefName);
+
+		// Move setting from the legacy setting into the new one
+		set_section_property_value(SectionName, NewPrefName, legacy_pref);
+	}
+
+	set_section_property_value(SectionName, LegacyPrefName, "");
 }
 
 // Takes in:
@@ -1493,15 +1519,7 @@ static void save_window_size(const int w, const int h)
 //
 static void configure_window_size()
 {
-	const auto window_size_pref = []() {
-		const auto legacy_pref = get_sdl_section()->GetString(
-		        "windowresolution");
-		if (!legacy_pref.empty()) {
-			set_section_property_value("sdl", "windowresolution", "");
-			set_section_property_value("sdl", "window_size", legacy_pref);
-		}
-		return get_sdl_section()->GetString("window_size");
-	}();
+	const auto window_size_pref = get_sdl_section()->GetString("window_size");
 
 	// Get the coarse resolution from the users setting, and adjust
 	// refined scaling mode if an exact resolution is desired.
@@ -1537,6 +1555,19 @@ static void configure_window_size()
 	        refined_size.x,
 	        refined_size.y,
 	        sdl.display_number);
+}
+
+static void set_window_size()
+{
+	if (sdl.fullscreen.mode == FullscreenMode::ForcedBorderless &&
+	    sdl.is_fullscreen) {
+
+		sdl.fullscreen.prev_window.width = sdl.windowed.width;
+
+		sdl.fullscreen.prev_window.height = sdl.windowed.height;
+	} else {
+		SDL_SetWindowSize(sdl.window, sdl.windowed.width, sdl.windowed.height);
+	}
 }
 
 static void save_window_position_from_conf()
@@ -1902,6 +1933,8 @@ void GFX_InitAndStartGui()
 	configure_renderer();
 
 	save_window_position_from_conf();
+
+	handle_window_size_pref_after_config_load();
 	configure_window_size();
 
 	sdl.draw.render_width_px  = minimum_window_size.x;
@@ -2045,18 +2078,20 @@ static void notify_sdl_setting_updated(SectionProp& section,
 
 	} else if (prop_name == "window_size") {
 		configure_window_size();
+		set_window_size();
 
-		if (sdl.fullscreen.mode == FullscreenMode::ForcedBorderless &&
-		    sdl.is_fullscreen) {
+	} else if (prop_name == "windowresolution") {
+		// Move setting from the legacy setting into the new one
+		constexpr auto LegacyPrefName = "windowresolution";
+		constexpr auto NewPrefName    = "window_size";
 
-			sdl.fullscreen.prev_window.width = sdl.windowed.width;
+		const auto legacy_pref = get_sdl_section()->GetString(LegacyPrefName);
 
-			sdl.fullscreen.prev_window.height = sdl.windowed.height;
-		} else {
-			SDL_SetWindowSize(sdl.window,
-			                  sdl.windowed.width,
-			                  sdl.windowed.height);
-		}
+		set_section_property_value("sdl", LegacyPrefName, "");
+		set_section_property_value("sdl", NewPrefName, legacy_pref);
+
+		configure_window_size();
+		set_window_size();
 
 	} else if (prop_name == "window_titlebar") {
 		TITLEBAR_ReadConfig();
@@ -2262,10 +2297,6 @@ static bool handle_sdl_windowevent(const SDL_Event& event)
 
 		if (!sdl.is_fullscreen) {
 			save_window_size(width, height);
-
-			set_section_property_value("sdl",
-			                           "window_size",
-			                           format_str("%dx%d", width, height));
 		}
 
 		if (width != last_width && height != last_height) {

--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -173,17 +173,17 @@ double GFX_GetHostRefreshRate()
 
 	if (display_in_use < 0) {
 		LOG_ERR("SDL: Could not get the current window index: %s",
-				SDL_GetError());
+		        SDL_GetError());
 		return DefaultHostRefreshRateHz;
 	}
 	if (SDL_GetCurrentDisplayMode(display_in_use, &mode) != 0) {
 		LOG_ERR("SDL: Could not get the current display mode: %s",
-				SDL_GetError());
+		        SDL_GetError());
 		return DefaultHostRefreshRateHz;
 	}
 	if (mode.refresh_rate < RefreshRateMin) {
 		LOG_WARNING("SDL: Got a strange refresh rate of %d Hz",
-					mode.refresh_rate);
+		            mode.refresh_rate);
 		return DefaultHostRefreshRateHz;
 	}
 
@@ -302,24 +302,27 @@ static bool is_unpause_event(const SDL_Event event, const SDL_Keysym unpause_key
 
 	if (event.key.keysym.sym == unpause_key.sym) {
 		// These are the only mods we're going to care about.
-		// Others mods include caps lock and num lock which we should not look at.
-		constexpr uint16_t ModMask = KMOD_CTRL | KMOD_SHIFT | KMOD_ALT | KMOD_GUI;
+		// Others mods include caps lock and num lock which we should
+		// not look at.
+		constexpr uint16_t ModMask = KMOD_CTRL | KMOD_SHIFT | KMOD_ALT |
+		                             KMOD_GUI;
 		const uint16_t unpause_mod = unpause_key.mod & ModMask;
 		if ((event.key.keysym.mod & unpause_mod) == unpause_mod) {
 			return true;
 		}
 	}
 
-	// Also check previously hard-coded Alt+Pause on Windows/Linux
-	// and Command+P on Mac to ensure we don't have regressions.
-	#if defined(MACOSX)
+// Also check previously hard-coded Alt+Pause on Windows/Linux
+// and Command+P on Mac to ensure we don't have regressions.
+#if defined(MACOSX)
 	constexpr uint16_t DefaultMod = KMOD_GUI;
-	constexpr int32_t DefaultKey = SDLK_p;
-	#else
+	constexpr int32_t DefaultKey  = SDLK_p;
+#else
 	constexpr uint16_t DefaultMod = KMOD_ALT;
-	constexpr int32_t DefaultKey = SDLK_PAUSE;
-	#endif
-	return event.key.keysym.sym == DefaultKey && (event.key.keysym.mod & DefaultMod);
+	constexpr int32_t DefaultKey  = SDLK_PAUSE;
+#endif
+	return event.key.keysym.sym == DefaultKey &&
+	       (event.key.keysym.mod & DefaultMod);
 }
 
 [[maybe_unused]] static void pause_emulation(bool pressed)
@@ -328,9 +331,12 @@ static bool is_unpause_event(const SDL_Event event, const SDL_Keysym unpause_key
 		return;
 	}
 
-	// Bit of a hack but this is the key that was used to pause so let's also check it to unpause.
-	// We should really be relying on MAPPER_CheckEvent() but that is not possible inside this janky pause loop.
-	// TODO: In the future, re-work pause logic so we use the main event loop all the time.
+	// Bit of a hack but this is the key that was used to pause so let's
+	// also check it to unpause. We should really be relying on
+	// MAPPER_CheckEvent() but that is not possible inside this janky pause
+	// loop.
+	// TODO: In the future, re-work pause logic so we use the main event
+	// loop all the time.
 	const auto unpause_key = MAPPER_GetLastKeyPressed();
 
 	const auto inkeymod = static_cast<uint16_t>(SDL_GetModState());
@@ -646,7 +652,7 @@ static void set_minimum_window_size()
 
 	constexpr auto MinimumWidth = 640;
 
-	minimum_window_size  = {iround(MinimumWidth), iround(minimum_height)};
+	minimum_window_size = {iround(MinimumWidth), iround(minimum_height)};
 
 	// The SDL documentation is incorrect; this will set the minimum window
 	// size in logical units, not pixels.
@@ -1838,7 +1844,8 @@ void GFX_InitSdl()
 
 	// Initialise SDL (timer is needed for title bar animations)
 	if (SDL_InitSubSystem(SDL_INIT_VIDEO | SDL_INIT_TIMER) < 0) {
-		E_Exit("SDL: Failed to init SDL video and timer: %s", SDL_GetError());
+		E_Exit("SDL: Failed to init SDL video and timer: %s",
+		       SDL_GetError());
 	}
 
 	if (is_using_kmsdrm_driver() && !check_kmsdrm_setting()) {
@@ -1866,7 +1873,8 @@ void GFX_InitSdl()
 	// Check for .dosbox document packages dropped from Finder
 	// (double-click to open or drag-and-drop onto the app icon)
 
-	// Sleep briefly to allow the OS time to queue the drop event before we poll.
+	// Sleep briefly to allow the OS time to queue the drop event before we
+	// poll.
 	SDL_Delay(100);
 
 	SDL_Event event;
@@ -2059,7 +2067,8 @@ static void notify_sdl_setting_updated(SectionProp& section,
 		}
 
 	} else {
-		LOG_WARNING("SDL: Runtime change unhandled for property: '%s'", prop_name.c_str());
+		LOG_WARNING("SDL: Runtime change unhandled for property: '%s'",
+		            prop_name.c_str());
 	}
 }
 
@@ -2375,7 +2384,7 @@ static bool handle_sdl_windowevent(const SDL_Event& event)
 
 		// The window size has changed either as a result of an API call
 		// or through the system or user changing the window size.
-		const auto new_width  = event.window.data1;
+		const auto new_width = event.window.data1;
 
 		check_and_handle_dpi_change(sdl.window, new_width);
 		update_viewport();
@@ -2700,11 +2709,12 @@ static void init_sdl_config_settings(SectionProp& section)
 	        "                      borderless mode might result in decreased performance\n"
 	        "                      and slightly worse frame pacing (e.g., scrolling in 2D\n"
 	        "                      games not appearing perfectly smooth).");
-	pstring->SetValues({"standard",
+	pstring->SetValues({
+	        "standard",
 #ifdef WIN32
-	                    "forced-borderless",
+	        "forced-borderless",
 #endif
-	                    });
+	});
 
 	pstring->SetDeprecatedWithAlternateValue("desktop", "standard");
 
@@ -2894,7 +2904,7 @@ void GFX_Quit()
 	// Renderer must be destoryed before SDL_Quit() is called.
 	// Otherwise we can get segfaults and sadness.
 	sdl.renderer = {};
-	sdl.window = nullptr;
+	sdl.window   = nullptr;
 
 	SDL_Quit();
 #endif


### PR DESCRIPTION
# Description

This was causing problems for eXoDOS where they need to use `windowresolution` in the top level config (because they use other DOSBox variants, too, not just Staging) and override the setting in the Staging-specific `options.conf`... or the reverse... or something like that 😅  I find it hard to keep track of how they're doing things exactly, but in any case, this is a bug that needs fixing 😎 

### Repro steps

Create two config files:

#### `res.conf`

```ini
[sdl]
windowresolution = 640x2000
```

#### `size.conf`

```ini
[sdl]
window_size = 1400x500
```

Then try loading the two config files in different orders:

`dosbox --conf res.conf --conf size.conf`
`dosbox --conf size.conf --conf res.conf`

The `windowresolution` setting will always take precedence, regardless of the config loading order. That's because both settings will be set as they're two distinct settings, and we have no information of their actual _parse order_ during the config loading process. Without that information, the best we can do is hardcode a preferred precedence (now we're preferring `windowresolution`, which in retrospect was a mistake).

### Solution

By keeping track of the actual parse order of the loaded config settings, we can make sure the "last set setting" wins.

I don't anticipate many settings to require this special handling (only `DeprecatedButAllowed` settings need this), but it's a nice clean(ish) general solution — didn't want to add further specialised hackery only for these handful of settings. 

This was the least invasive way I could think of to shoehorn this into the existing messy config system. One day we'll probably rewrite it, until then this will do.

# Manual testing

Verify for the below cases that:
  - `window_size` contains the size of the window
  - `windowresolution` is empty
  - always the last set setting "wins"

Test cases:

- Start with `--conf res.conf` only (sets `windowresolution`)
- Start with `--conf size.conf` only (sets `window_size`)
- Start with `--conf res.conf --conf size.conf`
- Start with `--conf size.conf --conf res.conf`
- Start with `--conf size.conf --set "windowresolution 666x2000"`
- Start with `--conf res.conf --set "windowresolution 666x2000"`
- Start with `--conf res.conf --set "window_size 1400x500"`
- Start without args, then execute `windowresolution 666x200`
- Start without args, then execute `window_size 1400x500`
- Start without args, then execute the above two in both orders
- Start without args, resize window, then run `window_size` -- should contain the actual size of the resized window, and `windowresolution` should be empty

The change has been manually tested on:

- [ ] Windows
- [x] macOS
- [ ] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

