### PR TITLE
Add Claude Code rules for C++ style, docs style, and commits

### DIFF
--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -1,0 +1,76 @@
+---
+description: C++ code style rules
+globs: src/**/*.{cpp,h}
+---
+
+# General principles
+
+- Simplest, most minimal solution wins; don't overengineer or future-proof
+- Prefer composition over inheritance; prefer immutability
+- Small, focused, pure functions; single responsibility per component
+- Look for existing patterns in the codebase first — don't reinvent the wheel
+- Self-documenting code; no restating the obvious in comments
+- Only add abstractions when justified by current needs
+- Prefer loose coupling and high cohesion
+- Keep testability in mind
+- Clarity and maintainability first; only optimise with measurements
+- When in doubt, underengineer
+
+# Scope
+
+These rules apply to `src/` only. Vendored code in `src/libs/` follows its own
+conventions — do not reformat it.
+
+# After any code change, verify:
+
+1. `clang-format -i <changed files>` or `./scripts/tools/format-commit.sh`
+
+# Language
+
+- C++20; use the standard library over C-style alternatives
+- Never use C++ iostreams
+- Never use C string functions — only `std::string` and `std::string_view`
+- Never write `using namespace std;`
+- Avoid exceptions except for signalling RAII construction failures
+- Avoid complex template metaprogramming and complex macros
+- Use RAII and smart pointers for resource management
+- Prefer `constexpr`, `static_assert`, lambdas, range-based loops
+- Prefer pre-increment/decrement (`++i`, `--i`)
+- Use namespaces for grouping, not name prefixes
+- Restrict SDL to rendering, window management, OpenGL, input, and OS-level
+  audio/MIDI — check if C++ stdlib or SDL already provides what you need
+  before adding custom code
+
+# Naming
+
+- `UpperCamelCase` for types, free functions, methods, enums, constants
+- `lower_snake_case` for variables, arguments, struct members, static functions
+- Don't uppercase acronyms: `PngWriter`, not `PNGWriter`
+- No Hungarian notation
+- Always include unit suffixes: `delay_ms`, `cutoff_freq_hz`
+- Old code uses `MODULENAME_FunctionName` for public interfaces — don't replace
+  these with namespaces
+
+# Types
+
+- Prefer `auto`
+- Prefer plain `int` for numbers; don't micro-optimise integer sizes
+- Use `int64_t` for large numbers rather than `uint32_t`
+- Use `intXX_t`/`uintXX_t` only for binary protocols; `size_t` only for stdlib interfaces
+- Prefer enum classes
+- Prefer `std::optional` over sentinel values or out-parameters
+- Default to `std::vector`; use `std::unordered_map` over `std::map` unless ordering is needed
+- Always initialise variables and struct members
+- Maintain `const`-correctness throughout
+
+# Includes & headers
+
+- Sort includes per Google C++ Style Guide
+- Header guards: `DOSBOX_HEADERNAME_H` or `DOSBOX_MODULENAME_HEADERNAME_H`
+- New code: add `CHECK_NARROWING()` and include `"util/checks.h"`
+
+# Comments
+
+- Use `//` for block comments
+- End-of-line comments only for tabular data
+- Debug logging: wrap with `#if 0` / `#endif` or per-topic define switches

--- a/.claude/rules/commits.md
+++ b/.claude/rules/commits.md
@@ -1,0 +1,17 @@
+---
+description: Git commit rules
+globs: "**/*"
+---
+
+# Commits
+
+- All commits must compile individually (this is enforced)
+- Prefixes: `build:`, `ci:`, `docs:`, `style:`, `website:`
+- Do NOT use `fix:`, `feat:`, `refactor:`, `test:` prefixes
+- Style-only changes in their own `style:` commits; okay to include in
+  functional commits if affecting ≤10-20 lines
+- Documentation content: `docs:` prefix
+- Website layout/theme: `website:` prefix
+- Formatting-only changes: separate commit
+- Never add Co-Authored-By lines to commits
+- Verify all commits compile: `scripts/tools/compile-commits.sh`

--- a/.claude/rules/docs-style.md
+++ b/.claude/rules/docs-style.md
@@ -1,0 +1,47 @@
+---
+description: Rules for verifying and writing mkdocs documentation
+globs: website/**/*.md, website/**/*.yml, website/**/*.html
+---
+
+# After any docs/website change, run both before presenting results:
+
+1. `cd website && mkdocs build` -- zero warnings required
+2. `cd website && ../scripts/linting/verify-markdown.sh` -- zero warnings required
+
+# Writing style
+
+- Use British spelling (colour, centre, favourite, analyse, etc.)
+
+- Write for regular users, not developers — assume no MS-DOS or retro PC experience
+
+- Before adding new formatting or markup patterns, find an existing example in
+  the docs and match it
+
+- Most manual pages are divided into two parts: a conversational guide, and a
+  reference section (under "Configuration settings")
+
+- We document configuration sections topically; it's okay if settings from the
+  same config section are documented in different chapters
+
+- The "Configuration settings" section must copy the setting's description
+  from the code verbatim; that's the baseline, then we can enhance it with
+  additional info if needed
+
+- Look for opportunities to create cross-references across chapters
+
+- Look for opportunities to include interesting trivia, e.g. games that use a
+  given feature (use web search for research).
+  
+- All referenced games must link to the game's page on Mobygames
+
+# If editing SASS
+
+- Regenerate CSS from `extra-scss/extra.scss` and commit both `.scss` and `.css`
+
+# Version bumps
+
+Update ALL of these together:
+- Rename `website/docs/<old>/` directories
+- `website/docs/versions.json`
+- `mkdocs.yml`: nav paths, redirect targets, exclude globs
+- `hooks/offline.py`: `DUMMY_INDEX_PAGES`


### PR DESCRIPTION
# Description

As per title. Claude will pick these up automatically.

I think it's a good starting point, we can always add stuff later. But keep in mind, it's recommended to keep it under 200-lines. We just want to put actionable stuff there, and nothing too vague and abstract.

# Manual testing

None — we'll just watch the magic unfold 😎 🪄 🧙🏻‍♂️ 

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [ ] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

