### PR TITLE
Fix VS2022 presets

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -142,11 +142,13 @@
       "generator": "Visual Studio 17 2022",
       "binaryDir": "${sourceDir}/build/debug-windows-vs2022",
       "cacheVariables": {
+        "IS_PRESET_USED" : "TRUE",
         "CMAKE_GENERATOR_TOOLSET": "ClangCL",
         "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
         "CMAKE_FIND_PACKAGE_PREFER_CONFIG" : "ON",
         "CMAKE_BUILD_TYPE": "Debug",
-        "RESOURCE_COPY_PATH": "/Resources"
+        "VCPKG_TARGET_TRIPLET": "x64-windows-static",
+        "VCPKG_HOST_TRIPLET": "x64-windows"
       },
       "environment": {
         "UseMultiToolTask": "true",
@@ -160,11 +162,13 @@
       "generator": "Visual Studio 17 2022",
       "binaryDir": "${sourceDir}/build/release-windows-vs2022",
       "cacheVariables": {
+        "IS_PRESET_USED" : "TRUE",
         "CMAKE_GENERATOR_TOOLSET": "ClangCL",
         "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
         "CMAKE_FIND_PACKAGE_PREFER_CONFIG" : "ON",
         "CMAKE_BUILD_TYPE": "Release",
-        "RESOURCE_COPY_PATH": "/Resources"
+        "VCPKG_TARGET_TRIPLET": "x64-windows-static",
+        "VCPKG_HOST_TRIPLET": "x64-windows"
       },
       "environment": {
         "UseMultiToolTask": "true",
@@ -226,6 +230,22 @@
       "cacheVariables": {
         "OPT_DOCUMENTATION": "ON"
       }
+    },
+    {
+      "name": "debug-windows-vs2022-manual",
+      "displayName": "Debug (Windows, with offline manual)",
+      "inherits": "debug-windows-vs2022",
+      "cacheVariables": {
+        "OPT_DOCUMENTATION": "ON"
+      }
+    },
+    {
+      "name": "release-windows-vs2022-manual",
+      "displayName": "Release (Windows, with offline manual)",
+      "inherits": "release-windows-vs2022",
+      "cacheVariables": {
+        "OPT_DOCUMENTATION": "ON"
+      }
     }
   ],
   "buildPresets": [
@@ -282,6 +302,16 @@
       "nativeToolOptions": ["-quiet"]
     },
     {
+      "name": "debug-windows-vs2022",
+      "configurePreset" : "debug-windows-vs2022",
+      "configuration": "Debug"
+    },
+    {
+      "name": "release-windows-vs2022",
+      "configurePreset" : "release-windows-vs2022",
+      "configuration": "Release"
+    },
+    {
       "name": "debug-windows",
       "configurePreset" : "debug-windows",
       "configuration": "Debug"
@@ -299,6 +329,16 @@
     {
       "name": "release-windows-manual",
       "configurePreset" : "release-windows-manual",
+      "configuration": "Release"
+    },
+    {
+      "name": "debug-windows-vs2022-manual",
+      "configurePreset" : "debug-windows-vs2022-manual",
+      "configuration": "Debug"
+    },
+    {
+      "name": "release-windows-vs2022-manual",
+      "configurePreset" : "release-windows-vs2022-manual",
       "configuration": "Release"
     }
   ],
@@ -424,6 +464,22 @@
     {
       "name": "release-windows-manual",
       "configurePreset" : "release-windows-manual",
+      "configuration": "Release",
+      "output": {
+        "outputOnFailure": true
+      }
+    },
+    {
+      "name": "debug-windows-vs2022-manual",
+      "configurePreset" : "debug-windows-vs2022-manual",
+      "configuration": "Debug",
+      "output": {
+        "outputOnFailure": true
+      }
+    },
+    {
+      "name": "release-windows-vs2022-manual",
+      "configurePreset" : "release-windows-vs2022-manual",
       "configuration": "Release",
       "output": {
         "outputOnFailure": true


### PR DESCRIPTION
# Description

The vs2026 PR sat open for so long that I missed updating the vs2022 presets with the correct changes.

# Manual testing

I cannot install older versions of VS without a subscription, so I can't test these vs2022 presets directly; I originally created them as a courtesy to those who haven't upgraded to vs2026.

The change has been manually tested on:

- [x] Windows
- [ ] macOS
- [ ] Linux


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [ ] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

