### PR TITLE
Upgrade to C++23 and fix compatibility issues

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -25,7 +25,7 @@ ColumnLimit: 80
 # C/C++ Language specifics
 #
 Language: Cpp
-Standard: c++20
+Standard: Latest
 
 # Align qualifiers with the type instead of the variable name
 # int* var; // 'var' is a pointer-to-int

--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -27,7 +27,7 @@ conventions — do not reformat it.
 
 # Language
 
-- C++20; use the standard library over C-style alternatives
+- C++23; use the standard library over C-style alternatives
 - Never use C++ iostreams
 - Never use C string functions — only `std::string` and `std::string_view`
 - Never write `using namespace std;`

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ project(dosbox-staging
 
 set(DOSBOX_VERSION ${PROJECT_VERSION}-RC1)
 
-set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 # ccache support

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Development builds are automatically created on every commit merged to the `main
 | **Feature**                | **Status**                          |
 | -------------------------- | -------------------------------     |
 | **Version control**        | Git                                 |
-| **Language**               | C++20                               |
+| **Language**               | C++23                               |
 | **Logging**                | Loguru for C++<sup>[3]</sup>        |
 | **Build system**           | CMake + Ninja or Visual Studio 2022 |
 | **Dependency manager**     | vcpkg                               |

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -78,7 +78,7 @@ The rules outlined below apply to new code landing in the `main` branch.
 
 ### Language standard
 
-We use C++20 while avoiding the more complex areas of C++ and object-oriented
+We use C++23 while avoiding the more complex areas of C++ and object-oriented
 design. To clarify:
 
 - Avoid designing your code in a complex object-oriented style. This does not
@@ -86,7 +86,7 @@ design. To clarify:
   inheritance, overblown class hierarchies, operator overloading, iostreams
   for stdout/stderr, etc".
 
-- C++20 has a [rich standard library](https://en.cppreference.com/w/cpp/20),
+- C++23 has a [rich standard library](https://en.cppreference.com/w/cpp/23),
   use it. We use [STL
   containers](https://en.cppreference.com/w/cpp/container),
   [std::filesystem](https://en.cppreference.com/w/cpp/filesystem), and various

--- a/docs/build-linux.md
+++ b/docs/build-linux.md
@@ -57,7 +57,7 @@ These are generic, distro-independent building instructions.
 
 ### Install the necessary build tools
 
-- GCC or Clang compiler (the compiler has to support C++20)
+- GCC or Clang compiler (the compiler has to support C++23)
 - Git
 - CMake
 - pkg-config
@@ -406,7 +406,7 @@ Install dependencies listed in [README.md](README.md). Although `ccache` is
 optional, we recommend installing it because Meson will use it to greatly speed
 up builds. The minimum set of dependencies is:
 
-- C/C++ compiler with support for C++20
+- C/C++ compiler with support for C++23
 - SDL >= 2.0.5
 - Opusfile
 - Meson >= 0.56

--- a/meson.build
+++ b/meson.build
@@ -9,7 +9,7 @@ project(
     license: 'GPL-2.0-or-later',
     meson_version: '>= 0.59.0',
     default_options: [
-        'cpp_std=c++20',
+        'cpp_std=c++23',
         'buildtype=release',
         'b_ndebug=if-release',
         'b_staticpic=false',

--- a/src/dos/dos_code_page.cpp
+++ b/src/dos/dos_code_page.cpp
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <array>
 #include <fstream>
+#include <iterator>
 #include <optional>
 #include <set>
 #include <unordered_map>

--- a/src/dos/programs/mousectl.cpp
+++ b/src/dos/programs/mousectl.cpp
@@ -220,9 +220,7 @@ std::string MOUSECTL::GetMapStatusStr(const MouseMapStatus map_status)
 	case MouseMapStatus::Disabled:
 		return MSG_Get("PROGRAM_MOUSECTL_TABLE_STATUS_DISABLED");
 
-	default:
-		assert(false); // missing implementation
-		return nullptr;
+	default: assert(false); return {};
 	}
 }
 

--- a/src/gui/mapper.cpp
+++ b/src/gui/mapper.cpp
@@ -81,9 +81,21 @@ static void SetActiveEvent(CEvent * event);
 static void SetActiveBind(CBind * _bind);
 extern uint8_t int10_font_14[256 * 14];
 
-static std::vector<std::unique_ptr<CEvent>> events;
-static std::vector<std::unique_ptr<CButton>> buttons;
-static std::vector<CBindGroup *> bindgroups;
+// C++23 std::default_delete requires the type to be complete at instantiation,
+// but CEvent/CButton register themselves in these vectors from their
+// constructors, so the vectors must be declared before the class definitions.
+// Using a custom deleter avoids the completeness check at the declaration site.
+template <typename T>
+struct DeferredDelete {
+	void operator()(T* p) const
+	{
+		delete p;
+	}
+};
+
+static std::vector<std::unique_ptr<CEvent, DeferredDelete<CEvent>>> events;
+static std::vector<std::unique_ptr<CButton, DeferredDelete<CButton>>> buttons;
+static std::vector<CBindGroup*> bindgroups;
 static std::vector<CHandlerEvent *> handlergroup;
 static std::list<CBind *> all_binds;
 static std::queue<std::string> auto_type_queue = {};

--- a/src/hardware/ide.cpp
+++ b/src/hardware/ide.cpp
@@ -6,8 +6,9 @@
 #include "ide.h"
 
 #include <algorithm>
-#include <cmath>
+#include <bit>
 #include <cassert>
+#include <cmath>
 
 #include "audio/mixer.h"
 #include "config/config.h"

--- a/src/libs/residfp/Filter6581.h
+++ b/src/libs/residfp/Filter6581.h
@@ -29,6 +29,9 @@
 
 #include "Filter.h"
 #include "FilterModelConfig6581.h"
+// Required before the class definition: unique_ptr<Integrator6581> = {} triggers
+// the constexpr destructor in C++23, which requires the type to be complete.
+#include "Integrator6581.h"
 
 namespace reSIDfp
 {

--- a/src/libs/residfp/SID.h
+++ b/src/libs/residfp/SID.h
@@ -26,6 +26,9 @@
 #include <memory>
 
 #include "siddefs-fp.h"
+// Required before the class definition because unique_ptr<Voice> voice[3] = {}
+// triggers the constexpr destructor in C++23, which requires a complete type.
+#include "Voice.h"
 
 namespace reSIDfp
 {
@@ -35,7 +38,6 @@ class Filter6581;
 class Filter8580;
 class ExternalFilter;
 class Potentiometer;
-class Voice;
 class Resampler;
 
 /**


### PR DESCRIPTION
# Description

Upgrades the project to compile with C++23. Does not include any code changes except the bare minimum required to compile successfully.

This paves the way for a handful of C++23 features that might be useful:

- `std::expected`
- `std::print / std::println`
- `std::mdspan`
- `std::to_underlying`
- `std::flat_map`

# Manual testing

Ran the build artifacts.

The change has been manually tested on:

- [x] Windows
- [x] macOS
- [ ] Linux


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

