### PR TITLE
Fix Frontier: First Encounters crash on non-x86 platforms

### DIFF
--- a/src/cpu/core_dynrec/decoder_opcodes.h
+++ b/src/cpu/core_dynrec/decoder_opcodes.h
@@ -389,10 +389,11 @@ static void dyn_push_seg(uint8_t seg) {
 	MOV_SEG_VAL_TO_HOST_REG(FC_OP1,seg);
 	if (decode.big_op) {
 		gen_extend_word(false,FC_OP1);
-		gen_call_function_raw((void*)&dynrec_push_dword);
+		gen_call_function_raw((void*)&dynrec_push_dword_checked);
 	} else {
-		gen_call_function_raw((void*)&dynrec_push_word);
+		gen_call_function_raw((void*)&dynrec_push_word_checked);
 	}
+	dyn_check_exception(FC_RETOP);
 }
 
 static void dyn_pop_seg(uint8_t seg) {
@@ -402,8 +403,12 @@ static void dyn_pop_seg(uint8_t seg) {
 
 static void dyn_push_reg(uint8_t reg) {
 	MOV_REG_WORD_TO_HOST_REG(FC_OP1,reg,decode.big_op);
-	if (decode.big_op) gen_call_function_raw((void*)&dynrec_push_dword);
-	else gen_call_function_raw((void*)&dynrec_push_word);
+	if (decode.big_op) {
+		gen_call_function_raw((void*)&dynrec_push_dword_checked);
+	} else {
+		gen_call_function_raw((void*)&dynrec_push_word_checked);
+	}
+	dyn_check_exception(FC_RETOP);
 }
 
 static void dyn_pop_reg(uint8_t reg) {
@@ -414,18 +419,23 @@ static void dyn_pop_reg(uint8_t reg) {
 
 static void dyn_push_byte_imm(int8_t imm) {
 	gen_mov_dword_to_reg_imm(FC_OP1,(uint32_t)imm);
-	if (decode.big_op) gen_call_function_raw((void*)&dynrec_push_dword);
-	else gen_call_function_raw((void*)&dynrec_push_word);
+	if (decode.big_op) {
+		gen_call_function_raw((void*)&dynrec_push_dword_checked);
+	} else {
+		gen_call_function_raw((void*)&dynrec_push_word_checked);
+	}
+	dyn_check_exception(FC_RETOP);
 }
 
 static void dyn_push_word_imm(Bitu imm) {
 	if (decode.big_op) {
 		gen_mov_dword_to_reg_imm(FC_OP1,imm);
-		gen_call_function_raw((void*)&dynrec_push_dword);
+		gen_call_function_raw((void*)&dynrec_push_dword_checked);
 	} else {
 		gen_mov_word_to_reg_imm(FC_OP1,(uint16_t)imm);
-		gen_call_function_raw((void*)&dynrec_push_word);
+		gen_call_function_raw((void*)&dynrec_push_word_checked);
 	}
+	dyn_check_exception(FC_RETOP);
 }
 
 static void dyn_pop_ev(void) {

--- a/src/cpu/core_dynrec/operators.h
+++ b/src/cpu/core_dynrec/operators.h
@@ -1974,6 +1974,30 @@ static void DRC_CALL_CONV dynrec_push_dword(uint32_t value) {
 	reg_esp=new_esp;
 }
 
+static bool DRC_CALL_CONV dynrec_push_word_checked(uint16_t value) DRC_FC;
+static bool DRC_CALL_CONV dynrec_push_word_checked(uint16_t value)
+{
+	const uint32_t new_esp = (reg_esp & cpu.stack.notmask) |
+	                         ((reg_esp - 2) & cpu.stack.mask);
+	if (mem_writew_checked(SegPhys(ss) + (new_esp & cpu.stack.mask), value)) {
+		return true;
+	}
+	reg_esp = new_esp;
+	return false;
+}
+
+static bool DRC_CALL_CONV dynrec_push_dword_checked(uint32_t value) DRC_FC;
+static bool DRC_CALL_CONV dynrec_push_dword_checked(uint32_t value)
+{
+	const uint32_t new_esp = (reg_esp & cpu.stack.notmask) |
+	                         ((reg_esp - 4) & cpu.stack.mask);
+	if (mem_writed_checked(SegPhys(ss) + (new_esp & cpu.stack.mask), value)) {
+		return true;
+	}
+	reg_esp = new_esp;
+	return false;
+}
+
 static uint16_t DRC_CALL_CONV dynrec_pop_word(void) DRC_FC;
 static uint16_t DRC_CALL_CONV dynrec_pop_word(void) {
 	uint16_t val=mem_readw(SegPhys(ss) + (reg_esp & cpu.stack.mask));


### PR DESCRIPTION
# Description

Fix crash in Frontier: First Encounters on non-x86 platforms by updating dynrec to use same checked writes as the dyn_x86 core.

Although targeted at fixing FE, this is a general improvement that may also help other programs.

## Related issues

Fixes #2900 

# Release notes

We've fixed a long-standing incompatibility with **Frontier: First Encounters (1995)** that caused a crash on non-x86 systems when hitting a key to bypass the intro sequence and start the game.

# Manual testing

Tested First Encounters on macOS. It used to crash after two keystrokes during the intro, now it correctly loads the game screen on key press:

<img width="1215" height="971" alt="image" src="https://github.com/user-attachments/assets/0cb66e64-86c6-408f-9635-2c3293093271" />

Tested QTD to ensure no performance regression and several protected mode demos such as Sunflower, Heaven 7, and moralhardcandy.

The change has been manually tested on:

- [ ] Windows
- [x] macOS
- [ ] Linux


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

