### PR TITLE
[smoketest] Website preview workflows

### DIFF
--- a/.github/workflows/deploy-website-preview-main.yml
+++ b/.github/workflows/deploy-website-preview-main.yml
@@ -1,0 +1,21 @@
+name: Deploy website preview (main)
+permissions: read-all
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'website/**'
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-website-preview-main
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    uses: ./.github/workflows/deploy-website.yml
+    with:
+      source_branch: main
+      destination_prefix: main
+    secrets: inherit

--- a/.github/workflows/deploy-website-preview-pr-cleanup.yml
+++ b/.github/workflows/deploy-website-preview-pr-cleanup.yml
@@ -1,0 +1,64 @@
+name: Cleanup website preview (PR)
+permissions:
+  contents: read
+  pull-requests: write
+
+on:
+  pull_request:
+    types: [closed]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number whose preview should be removed'
+        required: true
+        type: string
+
+concurrency:
+  group: deploy-website-preview-pr-${{ github.event.pull_request.number || inputs.pr_number }}
+  cancel-in-progress: true
+
+jobs:
+  cleanup:
+    if: >-
+      github.event_name == 'workflow_dispatch'
+      || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-slim
+    env:
+      PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+    steps:
+      - name: Check out Pages repo
+        uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.ACCESS_TOKEN_REPO }}
+          repository: dosbox-staging/dosbox-staging.github.io
+          ref: master
+          submodules: false
+
+      - name: Remove preview if present
+        run: |
+          PREVIEW_DIR="preview/pr-${PR_NUMBER}"
+          if [[ -d "$PREVIEW_DIR" ]]; then
+            git config user.name "GitHub Actions Bot"
+            git config user.email "<>"
+            git rm -rf "$PREVIEW_DIR"
+            git commit -m "Remove preview for PR #${PR_NUMBER}"
+            # Retry on non-fast-forward: a cancelled deploy for the same PR
+            # may still be mid-`git push` when we get here (cancel-in-progress
+            # is not synchronous). Rebase + retry ensures cleanup wins.
+            for i in 1 2 3; do
+              git push && break
+              git pull --rebase
+            done
+            echo "cleaned=true" >> "$GITHUB_ENV"
+          else
+            echo "cleaned=false" >> "$GITHUB_ENV"
+          fi
+
+      - name: Update sticky comment
+        if: env.cleaned == 'true'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: website-preview
+          number: ${{ env.PR_NUMBER }}
+          message: |
+            📖 Website preview removed.

--- a/.github/workflows/deploy-website-preview-pr-cleanup.yml
+++ b/.github/workflows/deploy-website-preview-pr-cleanup.yml
@@ -1,7 +1,5 @@
 name: Cleanup website preview (PR)
-permissions:
-  contents: read
-  pull-requests: write
+permissions: read-all
 
 on:
   pull_request:
@@ -22,6 +20,9 @@ jobs:
     if: >-
       github.event_name == 'workflow_dispatch'
       || github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-slim
     env:
       PR_NUMBER: ${{ github.event.pull_request.number || github.event.inputs.pr_number }}

--- a/.github/workflows/deploy-website-preview-pr-cleanup.yml
+++ b/.github/workflows/deploy-website-preview-pr-cleanup.yml
@@ -14,7 +14,7 @@ on:
         type: string
 
 concurrency:
-  group: deploy-website-preview-pr-${{ github.event.pull_request.number || inputs.pr_number }}
+  group: deploy-website-preview-pr-${{ github.event.pull_request.number || github.event.inputs.pr_number }}
   cancel-in-progress: true
 
 jobs:
@@ -24,7 +24,7 @@ jobs:
       || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-slim
     env:
-      PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+      PR_NUMBER: ${{ github.event.pull_request.number || github.event.inputs.pr_number }}
     steps:
       - name: Check out Pages repo
         uses: actions/checkout@v6

--- a/.github/workflows/deploy-website-preview-pr-cleanup.yml
+++ b/.github/workflows/deploy-website-preview-pr-cleanup.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Update sticky comment
         if: env.cleaned == 'true'
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         with:
           header: website-preview
           number: ${{ env.PR_NUMBER }}

--- a/.github/workflows/deploy-website-preview-pr.yml
+++ b/.github/workflows/deploy-website-preview-pr.yml
@@ -17,6 +17,10 @@ on:
         required: true
         type: string
 
+concurrency:
+  group: deploy-website-preview-pr-${{ github.event.pull_request.number || github.event.inputs.pr_number }}
+  cancel-in-progress: true
+
 jobs:
   deploy:
     if: >-

--- a/.github/workflows/deploy-website-preview-pr.yml
+++ b/.github/workflows/deploy-website-preview-pr.yml
@@ -1,51 +1,17 @@
 name: Deploy website preview (PR)
-permissions:
-  contents: read
-  pull-requests: write
+permissions: read-all
 
 on:
   pull_request:
     types: [opened, synchronize, reopened]
     paths:
       - 'website/**'
-  workflow_dispatch:
-    inputs:
-      pr_number:
-        description: 'PR number (used for the preview/pr-<N> path and sticky comment)'
-        required: true
-        type: string
-      branch:
-        description: 'Branch to deploy from'
-        required: true
-        type: string
-
-concurrency:
-  group: deploy-website-preview-pr-${{ github.event.pull_request.number || github.event.inputs.pr_number }}
-  cancel-in-progress: true
 
 jobs:
   deploy:
-    if: >-
-      github.event_name == 'workflow_dispatch'
-      || github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event.pull_request.head.repo.full_name == github.repository
     uses: ./.github/workflows/deploy-website.yml
     with:
-      source_branch: ${{ github.event.pull_request.head.ref || github.event.inputs.branch }}
-      destination_prefix: pr-${{ github.event.pull_request.number || github.event.inputs.pr_number }}
+      source_branch: ${{ github.event.pull_request.head.ref }}
+      destination_prefix: pr-${{ github.event.pull_request.number }}
     secrets: inherit
-
-  comment:
-    needs: deploy
-    if: >-
-      github.event_name == 'workflow_dispatch'
-      || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-slim
-    steps:
-      - uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
-        with:
-          header: website-preview
-          number: ${{ github.event.pull_request.number || github.event.inputs.pr_number }}
-          message: |
-            📖 **Website preview:** https://www.dosbox-staging.org/preview/pr-${{ github.event.pull_request.number || github.event.inputs.pr_number }}/
-
-            _Updated for commit ${{ github.event.pull_request.head.sha || github.event.inputs.branch }}._

--- a/.github/workflows/deploy-website-preview-pr.yml
+++ b/.github/workflows/deploy-website-preview-pr.yml
@@ -20,7 +20,7 @@ on:
         type: string
 
 concurrency:
-  group: deploy-website-preview-pr-${{ github.event.pull_request.number || inputs.pr_number }}
+  group: deploy-website-preview-pr-${{ github.event.pull_request.number || github.event.inputs.pr_number }}
   cancel-in-progress: true
 
 jobs:
@@ -30,8 +30,8 @@ jobs:
       || github.event.pull_request.head.repo.full_name == github.repository
     uses: ./.github/workflows/deploy-website.yml
     with:
-      source_branch: ${{ github.event.pull_request.head.ref || inputs.branch }}
-      destination_prefix: pr-${{ github.event.pull_request.number || inputs.pr_number }}
+      source_branch: ${{ github.event.pull_request.head.ref || github.event.inputs.branch }}
+      destination_prefix: pr-${{ github.event.pull_request.number || github.event.inputs.pr_number }}
     secrets: inherit
 
   comment:
@@ -44,8 +44,8 @@ jobs:
       - uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         with:
           header: website-preview
-          number: ${{ github.event.pull_request.number || inputs.pr_number }}
+          number: ${{ github.event.pull_request.number || github.event.inputs.pr_number }}
           message: |
-            📖 **Website preview:** https://www.dosbox-staging.org/preview/pr-${{ github.event.pull_request.number || inputs.pr_number }}/
+            📖 **Website preview:** https://www.dosbox-staging.org/preview/pr-${{ github.event.pull_request.number || github.event.inputs.pr_number }}/
 
-            _Updated for commit ${{ github.event.pull_request.head.sha || inputs.branch }}._
+            _Updated for commit ${{ github.event.pull_request.head.sha || github.event.inputs.branch }}._

--- a/.github/workflows/deploy-website-preview-pr.yml
+++ b/.github/workflows/deploy-website-preview-pr.yml
@@ -1,0 +1,51 @@
+name: Deploy website preview (PR)
+permissions:
+  contents: read
+  pull-requests: write
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'website/**'
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number (used for the preview/pr-<N> path and sticky comment)'
+        required: true
+        type: string
+      branch:
+        description: 'Branch to deploy from'
+        required: true
+        type: string
+
+concurrency:
+  group: deploy-website-preview-pr-${{ github.event.pull_request.number || inputs.pr_number }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    if: >-
+      github.event_name == 'workflow_dispatch'
+      || github.event.pull_request.head.repo.full_name == github.repository
+    uses: ./.github/workflows/deploy-website.yml
+    with:
+      source_branch: ${{ github.event.pull_request.head.ref || inputs.branch }}
+      destination_prefix: pr-${{ github.event.pull_request.number || inputs.pr_number }}
+    secrets: inherit
+
+  comment:
+    needs: deploy
+    if: >-
+      github.event_name == 'workflow_dispatch'
+      || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-slim
+    steps:
+      - uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: website-preview
+          number: ${{ github.event.pull_request.number || inputs.pr_number }}
+          message: |
+            📖 **Website preview:** https://www.dosbox-staging.org/preview/pr-${{ github.event.pull_request.number || inputs.pr_number }}/
+
+            _Updated for commit ${{ github.event.pull_request.head.sha || inputs.branch }}._

--- a/.github/workflows/deploy-website-preview-pr.yml
+++ b/.github/workflows/deploy-website-preview-pr.yml
@@ -6,12 +6,24 @@ on:
     types: [opened, synchronize, reopened]
     paths:
       - 'website/**'
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number (used for the preview/pr-<N> path and sticky comment)'
+        required: true
+        type: string
+      branch:
+        description: 'Branch to deploy from'
+        required: true
+        type: string
 
 jobs:
   deploy:
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: >-
+      github.event_name == 'workflow_dispatch'
+      || github.event.pull_request.head.repo.full_name == github.repository
     uses: ./.github/workflows/deploy-website.yml
     with:
-      source_branch: ${{ github.event.pull_request.head.ref }}
-      destination_prefix: pr-${{ github.event.pull_request.number }}
+      source_branch: ${{ github.event.pull_request.head.ref || github.event.inputs.branch }}
+      destination_prefix: pr-${{ github.event.pull_request.number || github.event.inputs.pr_number }}
     secrets: inherit

--- a/.github/workflows/deploy-website-preview-pr.yml
+++ b/.github/workflows/deploy-website-preview-pr.yml
@@ -1,5 +1,7 @@
 name: Deploy website preview (PR)
-permissions: read-all
+permissions:
+  contents: read
+  pull-requests: write
 
 on:
   pull_request:
@@ -31,3 +33,19 @@ jobs:
       source_branch: ${{ github.event.pull_request.head.ref || github.event.inputs.branch }}
       destination_prefix: pr-${{ github.event.pull_request.number || github.event.inputs.pr_number }}
     secrets: inherit
+
+  comment:
+    needs: deploy
+    if: >-
+      github.event_name == 'workflow_dispatch'
+      || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-slim
+    steps:
+      - uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
+        with:
+          header: website-preview
+          number: ${{ github.event.pull_request.number || github.event.inputs.pr_number }}
+          message: |
+            📖 **Website preview:** https://www.dosbox-staging.org/preview/pr-${{ github.event.pull_request.number || github.event.inputs.pr_number }}/
+
+            _Updated for commit ${{ github.event.pull_request.head.sha || github.event.inputs.branch }}._

--- a/.github/workflows/deploy-website-preview-pr.yml
+++ b/.github/workflows/deploy-website-preview-pr.yml
@@ -41,7 +41,7 @@ jobs:
       || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-slim
     steps:
-      - uses: marocchino/sticky-pull-request-comment@v2
+      - uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         with:
           header: website-preview
           number: ${{ github.event.pull_request.number || inputs.pr_number }}

--- a/.github/workflows/deploy-website-preview-pr.yml
+++ b/.github/workflows/deploy-website-preview-pr.yml
@@ -1,7 +1,5 @@
 name: Deploy website preview (PR)
-permissions:
-  contents: read
-  pull-requests: write
+permissions: read-all
 
 on:
   pull_request:

--- a/.github/workflows/deploy-website-preview-pr.yml
+++ b/.github/workflows/deploy-website-preview-pr.yml
@@ -41,11 +41,5 @@ jobs:
       || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-slim
     steps:
-      - uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
-        with:
-          header: website-preview
-          number: ${{ github.event.pull_request.number || github.event.inputs.pr_number }}
-          message: |
-            📖 **Website preview:** https://www.dosbox-staging.org/preview/pr-${{ github.event.pull_request.number || github.event.inputs.pr_number }}/
-
-            _Updated for commit ${{ github.event.pull_request.head.sha || github.event.inputs.branch }}._
+      - name: smoketest no-op
+        run: echo "comment job ran"

--- a/.github/workflows/deploy-website-preview-pr.yml
+++ b/.github/workflows/deploy-website-preview-pr.yml
@@ -37,7 +37,16 @@ jobs:
     if: >-
       github.event_name == 'workflow_dispatch'
       || github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-slim
     steps:
-      - name: smoketest no-op
-        run: echo "comment job ran"
+      - uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
+        with:
+          header: website-preview
+          number: ${{ github.event.pull_request.number || github.event.inputs.pr_number }}
+          message: |
+            📖 **Website preview:** https://www.dosbox-staging.org/preview/pr-${{ github.event.pull_request.number || github.event.inputs.pr_number }}/
+
+            _Updated for commit ${{ github.event.pull_request.head.sha || github.event.inputs.branch }}._

--- a/.github/workflows/deploy-website.md
+++ b/.github/workflows/deploy-website.md
@@ -1,0 +1,88 @@
+# Website deploy workflows
+
+Five files cover everything that publishes the MkDocs site to
+`dosbox-staging.github.io`:
+
+| File | Role |
+| --- | --- |
+| `deploy-website.yml` | Reusable workflow. Does the actual build + push. |
+| `deploy-website-preview-main.yml` | Auto-deploy `main` → `preview/main/`. |
+| `deploy-website-preview-pr.yml` | Auto-deploy PRs → `preview/pr-<N>/`. |
+| `deploy-website-preview-pr-cleanup.yml` | Remove `preview/pr-<N>/` on PR close. |
+| `deploy-website.md` | This file. |
+
+GitHub Actions does not recurse into subdirectories under
+`.github/workflows/`, so the files share a prefix instead of living in a
+folder.
+
+## The reusable workflow: `deploy-website.yml`
+
+Builds the MkDocs site from a given branch and pushes the output to the
+separate `dosbox-staging/dosbox-staging.github.io` Pages repo. Two triggers:
+
+- `workflow_dispatch` — manual entry point for release deploys to root.
+- `workflow_call` — invoked by the three wrappers below.
+
+Two inputs:
+
+- `source_branch` (required) — branch of `dosbox-staging` to build from.
+- `destination_prefix` (optional):
+  - empty → deploys to the root of the Pages repo (production release).
+  - non-empty → deploys to `preview/<prefix>/`.
+
+When deploying to root, the deletion step explicitly preserves
+`./preview/*`, `./static`, `./tools`, and older version dirs like `./0.82`.
+That keeps release deploys from clobbering preview content.
+
+## Auto-deploys
+
+| Workflow | Auto trigger | Manual trigger inputs | Deploys to |
+| --- | --- | --- | --- |
+| `deploy-website-preview-main.yml` | push to `main`, paths: `website/**` | none | `preview/main/` |
+| `deploy-website-preview-pr.yml` | PR opened / synchronize / reopened, paths: `website/**` | `pr_number`, `branch` | `preview/pr-<N>/` |
+| `deploy-website-preview-pr-cleanup.yml` | PR closed | `pr_number` | (removes `preview/pr-<N>/`) |
+
+Each wrapper has its own `workflow_dispatch` button (Actions → pick workflow
+→ Run workflow) so you can manually rerun any of them if needed.
+
+## Live URLs
+
+- `https://www.dosbox-staging.org/preview/main/`
+- `https://www.dosbox-staging.org/preview/pr-<N>/`
+
+The PR-deploy workflow also posts a sticky comment on the PR with the
+preview URL; the cleanup workflow updates that same comment when the
+preview is removed.
+
+## Fork PRs
+
+PRs from forks are skipped — they don't have access to the deploy token. A
+maintainer who wants to preview a fork PR can push the same branch to the
+main repo and trigger `deploy-website-preview-pr.yml` manually with the
+target PR number.
+
+## Concurrency
+
+All four workflows use `cancel-in-progress: true`. Concurrency groups:
+
+- `deploy-website-preview-main` — main auto-deploy and its manual trigger.
+- `deploy-website-preview-pr-<N>` — shared by the PR deploy and the PR
+  cleanup. A `closed` event therefore cancels any in-flight deploy for the
+  same PR.
+
+Because cancel-in-progress is not strictly synchronous (a cancelled step
+may still complete), the deploy and cleanup workflows both wrap their final
+`git push` in a bounded `pull --rebase` + retry loop. If a cancelled
+sibling lands its push first, the next one rebases and tries again.
+
+## Retrying a failed run
+
+Use GitHub's built-in "Re-run failed jobs" button on the workflow run page.
+The re-run replays the original event payload (same PR, same SHA), so it
+just retries against the current state of the source branch.
+
+## Adding another auto-deploy
+
+Copy `deploy-website-preview-main.yml`, adjust the trigger, and set the two
+inputs (`source_branch`, `destination_prefix`) to whatever you want. No
+other changes needed — the reusable workflow handles the rest.

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -31,6 +31,8 @@ jobs:
 
   build_and_deploy_website:
     needs: linting
+    # linting.yml skips itself on same-repo PRs (already linted on push) — allow that
+    if: ${{ always() && (needs.linting.result == 'success' || needs.linting.result == 'skipped') }}
     runs-on: ubuntu-slim
     steps:
       - name: Check out MkDocs sources

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -88,6 +88,7 @@ jobs:
           DEST_PATH=$(pwd)/${{ env.dest_path_prefix }}
 
           mkdocs build --config-file $MKDOCS_SRC_PATH/mkdocs.yml --site-dir $TEMP_PATH
+          mkdir -p $DEST_PATH
           cp -rf $TEMP_PATH/* $DEST_PATH
           rm -rf $TEMP_PATH
           touch $DEST_PATH/.nojekyll

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -117,6 +117,12 @@ jobs:
           cd dosbox-staging.github.io
           git add .
           git add .nojekyll
+          # Skip if the rebuilt site is byte-identical (common when a PR push
+          # changes only non-website files but the PR overall touches website/**).
+          if git diff --cached --quiet; then
+            echo "No changes to publish."
+            exit 0
+          fi
           git commit -m "Deployed current website (${{ env.source_git_hash }})"
           # Retry on non-fast-forward: a cancelled sibling run (cancel-in-progress
           # is not synchronous) may land its push between our checkout and ours.

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -14,6 +14,17 @@ on:
         description: 'Deploy to this path prefix (leave empty for the current version)'
         type: string
 
+  workflow_call:
+    inputs:
+      source_branch:
+        description: 'Branch to deploy the website from'
+        required: true
+        type: string
+
+      destination_prefix:
+        description: 'Deploy to this path prefix (leave empty for the current version)'
+        type: string
+
 jobs:
   linting:
     uses: ./.github/workflows/linting.yml

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -105,5 +105,10 @@ jobs:
           git add .
           git add .nojekyll
           git commit -m "Deployed current website (${{ env.source_git_hash }})"
-          git push
+          # Retry on non-fast-forward: a cancelled sibling run (cancel-in-progress
+          # is not synchronous) may land its push between our checkout and ours.
+          for i in 1 2 3; do
+            git push && break
+            git pull --rebase
+          done
 

--- a/.github/workflows/test-minimal-pr-deploy.yml
+++ b/.github/workflows/test-minimal-pr-deploy.yml
@@ -1,0 +1,16 @@
+name: TEST minimal PR deploy
+permissions: read-all
+
+on:
+  pull_request:
+    types: [synchronize]
+    paths:
+      - 'website/**'
+
+jobs:
+  deploy:
+    uses: ./.github/workflows/deploy-website.yml
+    with:
+      source_branch: claude-smoketest-website-deploys
+      destination_prefix: smoketest-min
+    secrets: inherit

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -95,7 +95,7 @@ jobs:
           arch: "${{ matrix.conf.arch }}"
 
       - name: Set up CMake
-        uses: lukka/get-cmake@v4.3.2
+        uses: lukka/get-cmake@7bfc9baacbbdcb5e37957ad05c3546b3e222be3c # v4.3.2
 
       - name:  Log environment
         shell: pwsh

--- a/website/docs/about/index.md
+++ b/website/docs/about/index.md
@@ -154,3 +154,6 @@ playing multiplayer DOS games over Ethernet).
 
     Do note, however, that the lack of such log messages **does not** imply or
     guarantee bug-free operation!
+
+<!-- smoketest: website-preview workflow trigger -->
+


### PR DESCRIPTION
**Do not merge.** Smoke-test PR for the new website-preview workflows introduced on `jn/doco-auto-deploys`.

Adds a one-line HTML comment to `website/docs/about/index.md` so the PR-preview workflow's `paths: ['website/**']` filter actually fires.

Expected:
- `deploy-website-preview-pr.yml` fires → `preview/pr-<N>/` lands on dosbox-staging.github.io
- Sticky comment with preview URL appears below
- On close: `deploy-website-preview-pr-cleanup.yml` fires → preview removed, sticky comment updated