### PR TITLE
Automatic documentation preview deploys

### DIFF
--- a/.github/workflows/deploy-website-preview-main.yml
+++ b/.github/workflows/deploy-website-preview-main.yml
@@ -1,0 +1,21 @@
+name: Deploy website preview (main)
+permissions: read-all
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'website/**'
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-website-preview-main
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    uses: ./.github/workflows/deploy-website.yml
+    with:
+      source_branch: main
+      destination_prefix: main
+    secrets: inherit

--- a/.github/workflows/deploy-website-preview-pr-cleanup.yml
+++ b/.github/workflows/deploy-website-preview-pr-cleanup.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Update sticky comment
         if: env.cleaned == 'true'
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         with:
           header: website-preview
           number: ${{ env.PR_NUMBER }}

--- a/.github/workflows/deploy-website-preview-pr-cleanup.yml
+++ b/.github/workflows/deploy-website-preview-pr-cleanup.yml
@@ -1,0 +1,79 @@
+name: Cleanup website preview (PR)
+
+# Workflow-level permissions kept as `read-all`; see the matching note in
+# deploy-website-preview-pr.yml. `pull-requests: write` is set at the job
+# level on `cleanup` instead.
+permissions: read-all
+
+on:
+  pull_request:
+    types: [closed]
+
+    # Symmetric with deploy-website-preview-pr.yml: only PRs targeting main
+    # ever produced a preview, so only those need automatic cleanup.
+    branches: [main]
+
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number whose preview should be removed'
+        required: true
+        type: string
+
+concurrency:
+  group: deploy-website-preview-pr-${{ github.event.pull_request.number || github.event.inputs.pr_number }}
+  cancel-in-progress: true
+
+jobs:
+  cleanup:
+    if: >-
+      github.event_name == 'workflow_dispatch'
+      || github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-slim
+    env:
+      PR_NUMBER: ${{ github.event.pull_request.number || github.event.inputs.pr_number }}
+
+    steps:
+      - name: Check out Pages repo
+        uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.ACCESS_TOKEN_REPO }}
+          repository: dosbox-staging/dosbox-staging.github.io
+          ref: master
+          submodules: false
+
+      - name: Remove preview if present
+        run: |
+          PREVIEW_DIR="preview/pr-${PR_NUMBER}"
+
+          if [[ -d "$PREVIEW_DIR" ]]; then
+            git config user.name "GitHub Actions Bot"
+            git config user.email "<>"
+            git rm -rf "$PREVIEW_DIR"
+            git commit -m "Remove preview for PR #${PR_NUMBER}"
+
+            # Retry on non-fast-forward: a cancelled deploy for the same PR
+            # may still be mid-`git push` when we get here (cancel-in-progress
+            # is not synchronous). Rebase + retry ensures cleanup wins.
+            for i in 1 2 3; do
+              git push && break
+              git pull --rebase
+            done
+
+            echo "cleaned=true" >> "$GITHUB_ENV"
+          else
+            echo "cleaned=false" >> "$GITHUB_ENV"
+          fi
+
+      - name: Update sticky comment
+        if: env.cleaned == 'true'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: website-preview
+          number: ${{ env.PR_NUMBER }}
+          message: |
+            > [!NOTE]
+            > ## 📖 Website preview removed

--- a/.github/workflows/deploy-website-preview-pr.yml
+++ b/.github/workflows/deploy-website-preview-pr.yml
@@ -1,0 +1,68 @@
+name: Deploy website preview (PR)
+
+# NOTE: keep workflow-level permissions as `read-all`. Setting fine-grained
+# permissions here (e.g. `pull-requests: write`) causes GitHub to fail this
+# workflow at startup with `startup_failure` when it calls deploy-website.yml
+# as a reusable workflow. The `pull-requests: write` permission needed by
+# the `comment` job is set at the job level instead.
+permissions: read-all
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+    # PRs against release/* (or anything other than main) are excluded — release
+    # deploys to the live site stay manual via deploy-website.yml.
+    branches: [main]
+    paths:
+      - 'website/**'
+
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number (used for the preview/pr-<N> path and sticky comment)'
+        required: true
+        type: string
+      branch:
+        description: 'Branch to deploy from'
+        required: true
+        type: string
+
+concurrency:
+  group: deploy-website-preview-pr-${{ github.event.pull_request.number || github.event.inputs.pr_number }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    if: >-
+      github.event_name == 'workflow_dispatch'
+      || github.event.pull_request.head.repo.full_name == github.repository
+    uses: ./.github/workflows/deploy-website.yml
+    with:
+      source_branch: ${{ github.event.pull_request.head.ref || github.event.inputs.branch }}
+      destination_prefix: pr-${{ github.event.pull_request.number || github.event.inputs.pr_number }}
+    secrets: inherit
+
+  comment:
+    needs: deploy
+    if: >-
+      github.event_name == 'workflow_dispatch'
+      || github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-slim
+
+    steps:
+      - uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: website-preview
+          number: ${{ github.event.pull_request.number || github.event.inputs.pr_number }}
+          message: |
+            > [!TIP]
+            > ## 📖 [Website preview for this PR](https://www.dosbox-staging.org/preview/pr-${{ github.event.pull_request.number || github.event.inputs.pr_number }}/)
+            > Updated for commit `${{ github.event.pull_request.head.sha || github.event.inputs.branch }}`.
+
+            > [!WARNING]
+            > The deployed preview can take a few minutes to actually become visible at this URL after this comment was created or updated. Give it a short wait and refresh if you see an outdated version or a 404.
+

--- a/.github/workflows/deploy-website-preview-pr.yml
+++ b/.github/workflows/deploy-website-preview-pr.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-slim
 
     steps:
-      - uses: marocchino/sticky-pull-request-comment@v2
+      - uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         with:
           header: website-preview
           number: ${{ github.event.pull_request.number || github.event.inputs.pr_number }}

--- a/.github/workflows/deploy-website.md
+++ b/.github/workflows/deploy-website.md
@@ -1,0 +1,92 @@
+# Website deploy workflows
+
+The following workflows are used to deploy the website and preview websites:
+
+| File                                    | Role
+| ---                                     | ---
+| `deploy-website.yml`                    | Reusable workflow; does the actual build and publih
+| `deploy-website-preview-main.yml`       | Auto-deploys merges to `main` under the `preview/main/` prefix on the website
+| `deploy-website-preview-pr.yml`         | Auto-deploys PRs under the `preview/pr-<N>/` prefix on the website
+| `deploy-website-preview-pr-cleanup.yml` | Removes `preview/pr-<N>/` from the website on PR close
+
+GitHub Actions does not recurse into subdirectories under
+`.github/workflows/`, so the files share a prefix instead of living in a
+folder.
+
+## Preview website URLs
+
+- `https://www.dosbox-staging.org/preview/main/` --- preview website of the
+    current work-in-progress alpha version (the next release)
+
+- `https://www.dosbox-staging.org/preview/pr-<N>/` --- preview websites for
+    PRs containing documentation changes
+
+The PR-deploy workflow also posts a sticky comment on the PR with the preview
+URL; the cleanup workflow updates that same comment when the preview is
+removed.
+
+## Reusable deploy workflow
+
+The `deploy-website.yml` builds the MkDocs site from a given branch and pushes
+the output to the separate `dosbox-staging/dosbox-staging.github.io` GitHub
+Pages repo. It has two triggers:
+
+- `workflow_dispatch` --- manual entry point for release deploys to root
+- `workflow_call` --- invoked by the three wrappers below
+
+The workflow has two inputs:
+
+- `source_branch` (required) --- branch of `dosbox-staging` to build from
+- `destination_prefix` (optional):
+  - If empty, deploys to the root of the Pages repo (live website at
+    https://www.dosbos.staging.org)
+  - If non-empty, deploys with the `preview/<prefix>/` to the preview website
+    available at https://www.dosbos.staging.org/preview/<prefix>/
+
+When deploying to root, the deletion step explicitly preserves `./preview/*`,
+`./static`, `./tools`, and older version dirs like `./0.82`. That keeps
+release deploys from clobbering preview content.
+
+## Auto-deploys
+
+| Workflow                                | Auto trigger                                                              | Deploys to
+| ---                                     | ---                                                                       | ---
+| `deploy-website-preview-main.yml`       | push to `main`, paths: `website/**`                                       | `preview/main/`
+| `deploy-website-preview-pr.yml`         | PR opened / synchronize / reopened, **base: `main`**, paths: `website/**` | `preview/pr-<N>/`
+| `deploy-website-preview-pr-cleanup.yml` | PR closed, **base: `main`**                                               | (removes `preview/pr-<N>/`)
+
+Auto-deploys are deliberately scoped to `main` and PRs targeting `main`. Deploys
+to the live website root (and any work on `release/*` branches) remain a manual
+operation via `deploy-website.yml`'s `workflow_dispatch`.
+
+Each wrapper has its own `workflow_dispatch` button, so you can manually rerun
+any of them if needed.
+
+## Fork PRs
+
+PRs from forks are skipped --- they don't have access to the deploy token. A
+maintainer who wants to preview a fork PR can push the same branch to the main
+repo and trigger `deploy-website-preview-pr.yml` manually with the target PR
+number.
+
+## Concurrency
+
+All four workflows use `cancel-in-progress: true` and the following
+concurrency groups:
+
+- `deploy-website-preview-main` --- main auto-deploy and its manual trigger.
+- `deploy-website-preview-pr-<N>` --- shared by the PR deploy and the PR
+  cleanup. A `closed` event therefore cancels any in-flight deploy for the
+  same PR.
+
+Because cancel-in-progress is not strictly synchronous (a cancelled step may
+still complete), the deploy and cleanup workflows both wrap their final `git
+push` in a bounded `pull --rebase` & retry loop. If a cancelled sibling lands
+its push first, the next one rebases and tries again.
+
+## Retrying a failed run
+
+Use GitHub's built-in "Re-run failed jobs" button on the workflow run page.
+The re-run replays the original event payload (same PR, same SHA), so it
+just retries against the current state of the source branch.
+

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -88,6 +88,7 @@ jobs:
           DEST_PATH=$(pwd)/${{ env.dest_path_prefix }}
 
           mkdocs build --config-file $MKDOCS_SRC_PATH/mkdocs.yml --site-dir $TEMP_PATH
+          mkdir -p $DEST_PATH
           cp -rf $TEMP_PATH/* $DEST_PATH
           rm -rf $TEMP_PATH
           touch $DEST_PATH/.nojekyll

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -105,5 +105,11 @@ jobs:
           git add .
           git add .nojekyll
           git commit -m "Deployed current website (${{ env.source_git_hash }})"
-          git push
+
+          # Retry on non-fast-forward: a cancelled sibling run (cancel-in-progress
+          # is not synchronous) may land its push between our checkout and ours.
+          for i in 1 2 3; do
+            git push && break
+            git pull --rebase
+          done
 

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -14,12 +14,27 @@ on:
         description: 'Deploy to this path prefix (leave empty for the current version)'
         type: string
 
+  workflow_call:
+    inputs:
+      source_branch:
+        description: 'Branch to deploy the website from'
+        required: true
+        type: string
+
+      destination_prefix:
+        description: 'Deploy to this path prefix (leave empty for the current version)'
+        type: string
+
 jobs:
   linting:
     uses: ./.github/workflows/linting.yml
 
   build_and_deploy_website:
     needs: linting
+    # linting.yml's own `if:` skips it on same-repo PRs (it's already run on
+    # push). Without this guard the dependent job would be skipped too,
+    # cascading to skip the deploy when called via workflow_call from a PR.
+    if: ${{ always() && (needs.linting.result == 'success' || needs.linting.result == 'skipped') }}
     runs-on: ubuntu-slim
     steps:
       - name: Check out MkDocs sources
@@ -104,6 +119,15 @@ jobs:
           cd dosbox-staging.github.io
           git add .
           git add .nojekyll
+
+          # Skip if the rebuilt site is byte-identical (e.g. a PR push that
+          # only changed non-website files but the PR overall touches
+          # website/**, so the workflow still fires).
+          if git diff --cached --quiet; then
+            echo "No changes to publish."
+            exit 0
+          fi
+
           git commit -m "Deployed current website (${{ env.source_git_hash }})"
 
           # Retry on non-fast-forward: a cancelled sibling run (cancel-in-progress

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -95,7 +95,7 @@ jobs:
           arch: "${{ matrix.conf.arch }}"
 
       - name: Set up CMake
-        uses: lukka/get-cmake@v4.3.2
+        uses: lukka/get-cmake@7bfc9baacbbdcb5e37957ad05c3546b3e222be3c # v4.3.2
 
       - name:  Log environment
         shell: pwsh

--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -159,6 +159,36 @@ these sparingly.
 > **Always double-check** the success of your deploy on the live website after
 > a few minutes to confirm you haven't screwed up the deploy!
 
+### Automatic preview deploys for PRs and `main`
+
+You don't need to run the Deploy website action by hand to preview your
+changes once they're in a PR or merged to `main`. Two things happen
+automatically:
+
+- **PRs against `main` that change anything under `website/`** are built
+  and published at `https://www.dosbox-staging.org/preview/pr-<xxxx>/`, where
+  `<xxxx>` is the numeric PR identifier from the end of the PR's URL. A sticky
+  comment on the PR links to the preview and is updated on every push; the
+  preview is removed when the PR closes.
+
+- **Merges to `main` that touch `website/`** republish the preview of the
+  work-in-progress alpha version (next release) at
+  `https://www.dosbox-staging.org/preview/main/`.
+
+> [!WARNING] The preview may take a few minutes to appear live
+> After the GitHub Actions workflow finishes, the deployed preview can take a
+> minute or two to actually become visible at its URL. Give it a short wait
+> and refresh if you see an outdated version or a 404.
+
+Auto-deploys are deliberately limited to:
+
+- **In-repo PRs only.** PRs from forks are skipped (the deploy uses a
+  personal access token we can't safely hand to fork-controlled code).
+
+- **PRs targeting `main` only.** PRs against `release/*` are excluded ---
+  live website deploys off the latest `release/*` branch remain a
+  deliberate manual step (see the two subsections above).
+
 
 ## Previewing website & documentation changes locally
 

--- a/website/docs/0.83/getting-started/beneath-a-steel-sky.md
+++ b/website/docs/0.83/getting-started/beneath-a-steel-sky.md
@@ -4,6 +4,8 @@ toc_depth: 3
 
 # Beneath a Steel Sky
 
+Testing testing
+
 The next game we're going to set up is [Beneath a Steel
 Sky](https://www.mobygames.com/game/386/beneath-a-steel-sky/), a cyberpunk
 sci-fi adventure game from 1994. It's one of the standout timeless classics of


### PR DESCRIPTION
# Description

This PR introduces automatic documentation preview deploys from feature branches and whenever we merge doco changes to `main`. This allows the author and the reviewer to quickly check how the doco changes look in the rendered manual at the preview website without having to use local preview (it mainly helps the reviewer; it's hard to judge doco changes by reading the diff, you really need to read or at least the entire chapter to make sure things read well).

See the documentation update commit for further details.

### Auto-deploy conditions

- When a PR has any changes in `website/*`, an automatic documentation deploy will happen. The preview will be available at http://dosbox-staging.org/preview/pr-xxxx where `xxxx` is the numeric PR number.
- A sticky comment on the PR links to the preview site and is updated on every push
- Similarly, when `website/*` changes get merged to main`, the preview will be available at http://dosbox-staging.org/preview/main (this is our up to date preview of the doco of the current WIP alpha version)

### Cleanup

- Once the PR has been merged or closed, the  preview at http://dosbox-staging.org/preview/pr-xxxx gets auto-deleted from the GitHub pages repository
- The sticky comment indicates if the preview has been successfully removed

### Exclusions

- Only in-repo PRs are affected (the deploy actions use my own private key; we don't want to leak that)
- Only PRs against `main` are eligible for auto-deploys — PRs against `release/*` branches are excluded (the actual website is deployed from the last `release/*` branch; I want that to remain a manual process, so no changes in deploying the actual live website)

# Manual testing

- Asked Claude to extensively test this by raising test PRs, including race conditions, edge cases, retries, etc.. I watched do it and read the test reports 🍿😎 Here are the test PRs:
  - https://github.com/dosbox-staging/dosbox-staging/pull/4893
  - https://github.com/dosbox-staging/dosbox-staging/pull/4894
- I've tested it manually too by adding a simple doco test commit to this PR (will revert before merging) so we can see it in action

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [ ] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [ ] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [x] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

