### PR TITLE
Fix 'integer_scaling = auto' triggering for non-CRT shaders

### DIFF
--- a/src/gui/render/render.cpp
+++ b/src/gui/render/render.cpp
@@ -1414,9 +1414,9 @@ DosBox::Rect RENDER_CalcDrawRectInPixels(const DosBox::Rect& canvas_size_px,
 			        integer_scale_factor);
 		}
 
-		// Handles the `sharp` shader fallback when the viewport
-		// is is too small for CRT shaders; integer scaling is
-		// then disabled.
+		// Non-CRT shader (including the `sharp` shader fallback
+		// when the viewport is too small for CRT shaders);
+		// integer scaling is then disabled.
 		return draw_size_fit_px;
 	};
 

--- a/src/gui/render/shader_manager.cpp
+++ b/src/gui/render/shader_manager.cpp
@@ -57,10 +57,12 @@ ShaderDescriptor ShaderDescriptor::FromString(const std::string& descriptor,
 
 bool ShaderDescriptor::EnforceAutoIntegerScaling() const
 {
-	// Turn off vertical integer scaling for the 'sharp' shader
-	// in 'integer_scaling = auto' mode
-	//
-	return (shader_name != ShaderName::Sharp);
+	// 'integer_scaling = auto' enables integer scaling only for CRT
+	// shaders. For any other shader (e.g., 'sharp', 'bilinear',
+	// 'nearest', scaler shaders, or third-party shaders) the user
+	// typically wants the image to fill the viewport; they can opt in
+	// explicitly with 'integer_scaling = vertical' or 'horizontal'.
+	return shader_name.starts_with("crt/");
 }
 
 std::optional<Shader> ShaderManager::LoadShader(const std::string& shader_name)


### PR DESCRIPTION
## Summary

`ShaderDescriptor::EnforceAutoIntegerScaling()` was returning `true` for every shader except `sharp`, so bilinear, nearest, catmull-rom, scaler shaders, and third-party shaders all triggered the auto integer-scaling logic. Per the `integer_scaling` config docs, `auto` should only enable integer scaling for adaptive CRT shaders.

Switch the check to a `"crt/"` path-prefix match. All shaders in `resources/shaders/crt/` keep their current behaviour; everything else now correctly falls through to fit-to-viewport. Users who want integer scaling with a non-CRT shader can opt in explicitly with `integer_scaling = vertical` or `horizontal`.

Also refresh the stale "sharp shader fallback" comment in `render.cpp` to reflect that the fallback covers any non-CRT shader.

Fixes #4897

## Test plan

- [ ] Repro from the issue: `integer_scaling = auto`, `output = opengl`, `shader = bilinear`, run Flashback (256x224). Image should now fill the viewport (no integer scaling).
- [ ] Regression: `shader = crt-auto` on a normal-sized viewport still gets vertical integer scaling with the 3.5x / 4.5x half-steps below 5.0x.
- [ ] Regression: `shader = sharp` still doesn't trigger integer scaling.
- [ ] `integer_scaling = vertical` still works for any shader.