### PR TITLE
Add `wrap_modeN` shader pragma

### DIFF
--- a/resources/shaders/_internal/checkerboard-dedither-linearize.glsl
+++ b/resources/shaders/_internal/checkerboard-dedither-linearize.glsl
@@ -12,6 +12,7 @@
 /*
 
 #pragma name        CheckerboardDedither_Linearize
+#pragma wrap_mode0  ClampToEdge
 #pragma output_size VideoMode
 
 #pragma linear_filtering off

--- a/resources/shaders/_internal/checkerboard-dedither-pass1.glsl
+++ b/resources/shaders/_internal/checkerboard-dedither-pass1.glsl
@@ -12,6 +12,7 @@
 /*
 
 #pragma name        CheckerboardDedither_Pass1
+#pragma wrap_mode0  ClampToEdge
 #pragma output_size VideoMode
 
 #pragma linear_filtering off

--- a/resources/shaders/_internal/checkerboard-dedither-pass2.glsl
+++ b/resources/shaders/_internal/checkerboard-dedither-pass2.glsl
@@ -14,6 +14,8 @@
 #pragma name        CheckerboardDedither_Pass2
 #pragma input0      Previous
 #pragma input1      CheckerboardDedither_Linearize
+#pragma wrap_mode0  ClampToEdge
+#pragma wrap_mode1  ClampToEdge
 #pragma output_size VideoMode
 
 #pragma linear_filtering off

--- a/resources/shaders/_internal/checkerboard-dedither-pass3.glsl
+++ b/resources/shaders/_internal/checkerboard-dedither-pass3.glsl
@@ -14,6 +14,8 @@
 #pragma name        CheckerboardDedither_Pass3
 #pragma input0      Previous
 #pragma input1      CheckerboardDedither_Linearize
+#pragma wrap_mode0  ClampToEdge
+#pragma wrap_mode1  ClampToEdge
 #pragma output_size VideoMode
 
 #pragma linear_filtering off

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -14,6 +14,7 @@ target_sources(dosboxcommon PRIVATE
   render/shader.cpp
   render/shader_manager.cpp
   render/shader_pipeline.cpp
+  render/shader_pragma_parser.cpp
 )
 
 target_link_libraries(dosboxcommon PRIVATE OpenGL::GL simpleini)

--- a/src/gui/render/README.md
+++ b/src/gui/render/README.md
@@ -274,3 +274,23 @@ Example:
 ```
 #pragma parameter PHOSPHOR_LAYOUT "PHOSPHOR LAYOUT" 2.0 0.0 19.0 1.0
 ```
+
+#### wrap_modeN
+
+Specifies the wrap mode for the input texture with index N (see `inputN`).
+If unset, the setting defaults to `ClampToEdge`.
+
+Valid values:
+
+- `Repeat` — Corresponds to `GL_REPEAT`
+- `MirroredRepeat` —  Corresponds to `GL_MIRRORED_REPEAT`
+- `ClampToEdge` —  Corresponds to `GL_CLAMP_TO_EDGE`
+- `ClampToBorder` —  Corresponds to `GL_CLAMP_TO_BORDER`
+
+
+
+Example:
+
+```
+#pragma wrap_mode0 Repeat
+```

--- a/src/gui/render/opengl_renderer.cpp
+++ b/src/gui/render/opengl_renderer.cpp
@@ -357,8 +357,8 @@ void OpenGlRenderer::RecreateInputTexture()
 	glActiveTexture(GL_TEXTURE0);
 	glBindTexture(GL_TEXTURE_2D, input_texture.texture);
 
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER);
+	// Wrap mode is set on the bound sampler object in the shader
+	// pipeline, per the `#pragma wrap_modeN` of each shader pass input.
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 

--- a/src/gui/render/private/shader_common.h
+++ b/src/gui/render/private/shader_common.h
@@ -11,8 +11,6 @@
 #include <unordered_map>
 #include <vector>
 
-#include "glad/gl.h"
-
 namespace SymbolicShaderName {
 
 constexpr auto AutoGraphicsStandard = "crt-auto";

--- a/src/gui/render/private/shader_common.h
+++ b/src/gui/render/private/shader_common.h
@@ -232,6 +232,26 @@ inline const char* to_string(const ShaderOutputSize s)
 	}
 }
 
+enum class TextureWrapMode {
+	Repeat,
+	MirroredRepeat,
+	ClampToEdge,
+	ClampToBorder
+};
+
+inline const char* to_string(const TextureWrapMode m)
+{
+	using enum TextureWrapMode;
+
+	switch (m) {
+	case Repeat: return "Repeat";
+	case MirroredRepeat: return "MirroredRepeat";
+	case ClampToEdge: return "ClampToEdge";
+	case ClampToBorder: return "ClampToBorder";
+	default: assertm(false, "Invalid TextureWrapMode value"); return "";
+	}
+}
+
 struct ShaderInfo {
 	// Resolved shader name without the file extension. The name might
 	// optionally contain a relative or absolute directory path.
@@ -240,8 +260,13 @@ struct ShaderInfo {
 	// Name of the shader pass set via `#pragma name`
 	std::string pass_name = {};
 
+	// Input texture IDs and wrap modes (parallel vectors;
+	// set via `#pragma inputN` / `#pragma wrap_modeN`)
 	std::vector<std::string> input_ids = {"Previous"};
-	ShaderOutputSize output_size       = ShaderOutputSize::Previous;
+	std::vector<TextureWrapMode> input_wrap_modes = {TextureWrapMode::ClampToEdge};
+
+	// Output size mode set via `#pragma output_size`
+	ShaderOutputSize output_size = ShaderOutputSize::Previous;
 
 	ShaderPreset default_preset = {};
 };

--- a/src/gui/render/private/shader_manager.h
+++ b/src/gui/render/private/shader_manager.h
@@ -8,7 +8,6 @@
 #include <string>
 #include <unordered_map>
 #include <utility>
-#include <vector>
 
 #include "gui/private/common.h"
 #include "shader.h"
@@ -63,32 +62,6 @@ private:
 	std::optional<ShaderPreset> LoadShaderPreset(
 	        const ShaderDescriptor& descriptor,
 	        const ShaderPreset& default_preset) const;
-
-	struct ParseShaderPragmaResult {
-		ShaderPreset preset                = {};
-		std::string pass_name              = "";
-		std::vector<std::string> input_ids = {};
-		ShaderOutputSize output_size       = {};
-	};
-
-	std::optional<ParseShaderPragmaResult> ParseShaderPragmas(
-	        const std::string& shader_name, const std::string& shader_source) const;
-
-	bool SetShaderSetting(const std::string& name, const std::string& value,
-	                      ShaderSettings& out_settings) const;
-
-	std::optional<std::pair<std::string, float>> ParseParameterPragma(
-	        const std::string& pragma_value) const;
-
-	std::optional<std::pair<std::string, std::string>> ParseSettingPragma(
-	        const std::string& pragma) const;
-
-	std::optional<std::string> ParseNamePragma(const std::string& pragma) const;
-
-	std::optional<std::pair<int, std::string>> ParseInputPragma(
-	        const std::string& pragma) const;
-
-	std::optional<ShaderOutputSize> ParseOutputSizePragma(const std::string& pragma) const;
 
 	// Keys are the shader names including the path part but without the
 	// .glsl file extension

--- a/src/gui/render/private/shader_pipeline.h
+++ b/src/gui/render/private/shader_pipeline.h
@@ -108,8 +108,14 @@ private:
 
 	std::optional<Shader> main_shader = {};
 
-	GLuint nearest_sampler = 0;
-	GLuint linear_sampler  = 0;
+	// Pre-created OpenGL sampler objects, one per (filter, wrap)
+	// combination. Indexed by [TextureFilterMode][TextureWrapMode].
+	static constexpr size_t NumFilterModes        = 2;
+	static constexpr size_t NumWrapModes          = 4;
+	GLuint samplers[NumFilterModes][NumWrapModes] = {};
+
+	GLuint GetSampler(const TextureFilterMode filter,
+	                  const TextureWrapMode wrap) const;
 
 	// ---------------------------------------------------------------------
 	// Shader passes

--- a/src/gui/render/private/shader_pragma_parser.h
+++ b/src/gui/render/private/shader_pragma_parser.h
@@ -13,10 +13,11 @@
 namespace ShaderPragma {
 
 struct ParseResult {
-	ShaderPreset preset                = {};
-	std::string pass_name              = {};
-	std::vector<std::string> input_ids = {};
-	ShaderOutputSize output_size       = {};
+	ShaderPreset preset                           = {};
+	std::string pass_name                         = {};
+	std::vector<std::string> input_ids            = {};
+	std::vector<TextureWrapMode> input_wrap_modes = {};
+	ShaderOutputSize output_size                  = {};
 };
 
 // Parse all `#pragma` directives from the GLSL source of a shader. Returns

--- a/src/gui/render/private/shader_pragma_parser.h
+++ b/src/gui/render/private/shader_pragma_parser.h
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText:  2026-2026 The DOSBox Staging Team
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#ifndef DOSBOX_SHADER_PRAGMA_PARSER_H
+#define DOSBOX_SHADER_PRAGMA_PARSER_H
+
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "shader_common.h"
+
+namespace ShaderPragma {
+
+struct ParseResult {
+	ShaderPreset preset                = {};
+	std::string pass_name              = {};
+	std::vector<std::string> input_ids = {};
+	ShaderOutputSize output_size       = {};
+};
+
+// Parse all `#pragma` directives from the GLSL source of a shader. Returns
+// the populated result on success, or an empty optional if any pragma
+// failed to parse (all errors are logged via `LOG_ERR`).
+std::optional<ParseResult> Parse(const std::string& shader_name,
+                                 const std::string& shader_source);
+
+// Apply a single named shader setting (e.g. "linear_filtering", "off") to
+// `out_settings`. Used for both `#pragma` parsing and `[settings]` INI
+// section parsing. Returns false on unknown setting name or invalid value.
+bool SetSetting(const std::string& name, const std::string& value,
+                ShaderSettings& out_settings);
+
+} // namespace ShaderPragma
+
+#endif // DOSBOX_SHADER_PRAGMA_PARSER_H

--- a/src/gui/render/shader_manager.cpp
+++ b/src/gui/render/shader_manager.cpp
@@ -172,6 +172,7 @@ std::optional<Shader> ShaderManager::LoadAndBuildShader(const std::string& shade
 	shader.info = {shader_name,
 	               pragmas.pass_name,
 	               pragmas.input_ids,
+	               pragmas.input_wrap_modes,
 	               pragmas.output_size,
 	               pragmas.preset};
 

--- a/src/gui/render/shader_manager.cpp
+++ b/src/gui/render/shader_manager.cpp
@@ -6,7 +6,6 @@
 #include <algorithm>
 #include <cassert>
 #include <fstream>
-#include <regex>
 #include <unordered_map>
 
 #include <SDL.h>
@@ -14,6 +13,7 @@
 #include "simpleini/SimpleIni.h"
 
 #include "misc/notifications.h"
+#include "private/shader_pragma_parser.h"
 #include "utils/checks.h"
 #include "utils/string_utils.h"
 
@@ -159,7 +159,7 @@ std::optional<Shader> ShaderManager::LoadAndBuildShader(const std::string& shade
 
 	const auto& shader_source = *maybe_shader_source;
 
-	const auto maybe_pragmas = ParseShaderPragmas(shader_name, shader_source);
+	const auto maybe_pragmas = ShaderPragma::Parse(shader_name, shader_source);
 	if (!maybe_pragmas) {
 		LOG_ERR("RENDER: Error parsing pragmas of shader '%s'",
 		        shader_name.c_str());
@@ -273,7 +273,7 @@ std::optional<ShaderPreset> ShaderManager::LoadShaderPreset(
 	if (const auto settings = ini.GetSection("settings"); settings) {
 		for (const auto& [name, value] : *settings) {
 
-			if (!SetShaderSetting(name.pItem, value, preset.settings)) {
+			if (!ShaderPragma::SetSetting(name.pItem, value, preset.settings)) {
 				LOG_ERR("RENDER: Invalid shader setting, name: '%s', value: '%s'",
 				        name.pItem,
 				        value);
@@ -413,305 +413,6 @@ std::optional<std::string> ShaderManager::FindShaderAndReadSource(
 		    (std_fs::is_regular_file(path) || std_fs::is_symlink(path))) {
 			return read_shader(path);
 		}
-	}
-	return {};
-}
-
-std::optional<ShaderManager::ParseShaderPragmaResult> ShaderManager::ParseShaderPragmas(
-        const std::string& shader_name, const std::string& shader_source) const
-{
-	// We'll try to parse all pragmas and report all errors
-	bool has_errors = false;
-
-	ParseShaderPragmaResult result = {};
-
-	// The default preset has no name
-	result.preset.name.clear();
-
-	std::unordered_map<int, std::string> input_ids = {};
-	auto highest_input_index                       = -1;
-
-	try {
-		const std::regex re("\\s*#pragma\\s+(.+)");
-
-		std::sregex_iterator next(shader_source.begin(),
-		                          shader_source.end(),
-		                          re);
-		const std::sregex_iterator end;
-
-		while (next != end) {
-			std::smatch match = *next;
-
-			auto pragma = match[1].str();
-
-			if (pragma.starts_with("parameter")) {
-				if (const auto maybe_result = ParseParameterPragma(pragma);
-				    maybe_result) {
-
-					const auto& [param_name,
-					             default_value] = *maybe_result;
-
-					result.preset.params[param_name] = default_value;
-				} else {
-					LOG_ERR("RENDER: Invalid shader parameter pragma: '%s'",
-					        pragma.c_str());
-					has_errors = true;
-				}
-
-			} else if (pragma.starts_with("name")) {
-				if (const auto maybe_name = ParseNamePragma(pragma);
-				    maybe_name) {
-
-					result.pass_name = *maybe_name;
-				} else {
-					LOG_ERR("RENDER: Invalid shader pass name pragma: '%s'",
-					        pragma.c_str());
-					has_errors = true;
-				}
-
-			} else if (pragma.starts_with("input")) {
-				if (const auto maybe_result = ParseInputPragma(pragma);
-				    maybe_result) {
-
-					const auto& [input_index,
-					             input_name] = *maybe_result;
-
-					input_ids[input_index] = input_name;
-
-					highest_input_index = std::max(
-					        input_index, highest_input_index);
-				} else {
-					LOG_ERR("RENDER: Invalid input name pragme: '%s'",
-					        pragma.c_str());
-					has_errors = true;
-				}
-
-			} else if (pragma.starts_with("output_size")) {
-				if (const auto maybe_output_size = ParseOutputSizePragma(
-				            pragma);
-				    maybe_output_size) {
-
-					result.output_size = *maybe_output_size;
-				} else {
-					LOG_ERR("RENDER: Invalid output size pragma: '%s'",
-					        pragma.c_str());
-					has_errors = true;
-				}
-
-			} else {
-				bool parse_ok = false;
-
-				if (const auto maybe_setting = ParseSettingPragma(pragma);
-				    maybe_setting) {
-
-					const auto& [name, value] = *maybe_setting;
-
-					parse_ok = SetShaderSetting(
-					        name, value, result.preset.settings);
-				}
-				if (!parse_ok) {
-					LOG_ERR("RENDER: Invalid shader setting pragma: '%s'",
-					        pragma.c_str());
-					has_errors = true;
-				}
-			}
-
-			++next;
-		}
-	} catch (std::regex_error& e) {
-		LOG_ERR("RENDER: Regex error while parsing shader '%s' for pragmas: %d",
-		        shader_name.c_str(),
-		        e.code());
-
-		has_errors = true;
-	}
-
-	// Validate and store texture input IDs
-	const auto num_inputs = check_cast<int>(input_ids.size());
-
-	if (num_inputs != (highest_input_index + 1)) {
-		LOG_ERR("RENDER: Shader input indices are invalid "
-		        "(%d inputs but highest input index is %d)",
-		        num_inputs,
-		        highest_input_index);
-
-		has_errors = true;
-	}
-
-	if (num_inputs == 0) {
-		result.input_ids = {"Previous"};
-	} else {
-		for (auto i = 0; i <= highest_input_index; ++i) {
-			result.input_ids.emplace_back(input_ids[i]);
-		}
-	}
-
-	if (has_errors) {
-		return {};
-	}
-
-	return result;
-}
-
-bool ShaderManager::SetShaderSetting(const std::string& name, const std::string& value,
-                                     ShaderSettings& out_settings) const
-{
-	assert(!name.empty());
-
-	const auto maybe_bool = parse_bool_setting(value);
-	if (!maybe_bool) {
-		return false;
-	}
-	const auto bool_value = *maybe_bool;
-
-	if (name == "force_single_scan") {
-		out_settings.force_single_scan = bool_value;
-		return true;
-	}
-
-	if (name == "force_no_pixel_doubling") {
-		out_settings.force_no_pixel_doubling = bool_value;
-		return true;
-	}
-
-	if (name == "linear_filtering") {
-		out_settings.texture_filter_mode =
-		        (bool_value ? TextureFilterMode::Bilinear
-		                    : TextureFilterMode::NearestNeighbour);
-		return true;
-	}
-
-	if (name == "float_output") {
-		out_settings.float_output_texture = bool_value;
-		return true;
-	}
-
-	return false;
-}
-
-std::optional<std::pair<std::string, float>> ShaderManager::ParseParameterPragma(
-        const std::string& pragma) const
-{
-	assert(!pragma.empty());
-
-	// Parameter format example:
-	//
-	//   #pragma parameter OUTPUT_GAMMA "OUTPUT GAMMA" 2.2 0.0 5.0 0.1
-	//
-	const auto parts = split(strip_prefix(pragma, "parameter"), "\"");
-	if (parts.size() != 3) {
-		return {};
-	}
-	// parts[0] - param (variable) name (OUTPUT_GAMMA)
-	// parts[1] - display name (OUTPUT GAMMA)
-	// parts[2] - values (4 space-separated floats)
-
-	auto param_name = parts[0];
-	trim(param_name);
-
-	const auto params = split(parts[2]);
-	if (params.size() != 4) {
-		return {};
-	}
-	// params[0] - default value (2.2)
-	// params[1] - min value     (0.0)
-	// params[2] - max value     (5.0)
-	// params[3] - value step    (0.1)
-
-	const auto maybe_default_val = parse_float(params[0]);
-	if (!maybe_default_val) {
-		return {};
-	}
-
-	return {
-	        {param_name, *maybe_default_val}
-        };
-}
-
-std::optional<std::pair<std::string, std::string>> ShaderManager::ParseSettingPragma(
-        const std::string& pragma) const
-{
-	// Shader setting format:
-	//
-	//   #pragma force_single_scan on
-	//
-	const auto parts = split(pragma);
-	if (parts.size() != 2) {
-		return {};
-	}
-	return {
-	        {parts[0], parts[1]}
-        };
-}
-
-std::optional<std::string> ShaderManager::ParseNamePragma(const std::string& pragma) const
-{
-	// Shader pass name format:
-	//
-	//   #pragma name Main_Pass1
-	//
-	const auto parts = split(strip_prefix(pragma, "name"));
-	if (parts.size() != 1) {
-		return {};
-	}
-	return parts[0];
-}
-
-std::optional<ShaderOutputSize> ShaderManager::ParseOutputSizePragma(
-        const std::string& pragma) const
-{
-	// Output size format:
-	//
-	//   #pragma output_size VideoMode
-	//
-	// Valid values are: Previous, Rendered, VideoMode, Viewport
-	//
-	const auto parts = split(strip_prefix(pragma, "output_size"));
-	if (parts.size() != 1) {
-		return {};
-	}
-	const auto& type = parts[0];
-
-	using enum ShaderOutputSize;
-
-	if (type == "Previous") {
-		return Previous;
-
-	} else if (type == "Rendered") {
-		return Rendered;
-
-	} else if (type == "VideoMode") {
-		return VideoMode;
-
-	} else if (type == "Viewport") {
-		return Viewport;
-	}
-
-	return {};
-}
-
-std::optional<std::pair<int, std::string>> ShaderManager::ParseInputPragma(
-        const std::string& pragma) const
-{
-	// Shader input format:
-	//
-	//   #pragma input0 Main_Pass2
-	//   #pragma input1 Previous
-	//   ...
-	//
-	const auto parts = split(strip_prefix(pragma, "input"));
-	if (parts.size() != 2) {
-		return {};
-	}
-
-	const auto& index_str = parts[0];
-
-	if (auto maybe_int = parse_int(index_str); maybe_int) {
-		const auto& name = parts[1];
-
-		return {
-		        {*maybe_int, name}
-                };
 	}
 	return {};
 }

--- a/src/gui/render/shader_pipeline.cpp
+++ b/src/gui/render/shader_pipeline.cpp
@@ -21,21 +21,28 @@ CHECK_NARROWING();
 
 std::string ShaderPass::ToString() const
 {
-	return format_str(
-	        "shader.info.name:        %s\n"
-	        "shader.info.pass_name:   %s\n"
-	        "shader.info.input_ids:   %s\n"
-	        "shader.info.output_size: %s\n"
-	        "shader.program_object:   %d\n\n"
+	std::vector<std::string> wrap_mode_names = {};
+	for (const auto mode : shader.info.input_wrap_modes) {
+		wrap_mode_names.emplace_back(to_string(mode));
+	}
 
-	        "in_textures:             %s\n"
-	        "out_size:                %s\n"
-	        "out_fbo:                 %d\n"
-	        "out_texture:             %d\n",
+	return format_str(
+	        "shader.info.name:             %s\n"
+	        "shader.info.pass_name:        %s\n"
+	        "shader.info.input_ids:        %s\n"
+	        "shader.info.input_wrap_modes: %s\n"
+	        "shader.info.output_size:      %s\n"
+	        "shader.program_object:        %d\n\n"
+
+	        "in_textures:                  %s\n"
+	        "out_size:                     %s\n"
+	        "out_fbo:                      %d\n"
+	        "out_texture:                  %d\n",
 
 	        shader.info.name.c_str(),
 	        shader.info.pass_name.c_str(),
 	        join(shader.info.input_ids).c_str(),
+	        join(wrap_mode_names).c_str(),
 	        to_string(shader.info.output_size),
 	        shader.program_object,
 
@@ -60,31 +67,89 @@ ShaderPipeline::~ShaderPipeline()
 	DestroySamplers();
 }
 
+static GLint to_gl_filter(const TextureFilterMode m)
+{
+	using enum TextureFilterMode;
+
+	switch (m) {
+	case NearestNeighbour: return GL_NEAREST;
+	case Bilinear: return GL_LINEAR;
+	default: assertm(false, "Invalid TextureFilterMode"); return GL_LINEAR;
+	}
+}
+
+static GLint to_gl_wrap(const TextureWrapMode m)
+{
+	using enum TextureWrapMode;
+
+	switch (m) {
+	case Repeat: return GL_REPEAT;
+	case MirroredRepeat: return GL_MIRRORED_REPEAT;
+	case ClampToEdge: return GL_CLAMP_TO_EDGE;
+	case ClampToBorder: return GL_CLAMP_TO_BORDER;
+	default:
+		assertm(false, "Invalid TextureWrapMode");
+		return GL_CLAMP_TO_EDGE;
+	}
+}
+
 void ShaderPipeline::CreateSamplers()
 {
-	glGenSamplers(1, &nearest_sampler);
-	glSamplerParameteri(nearest_sampler, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-	glSamplerParameteri(nearest_sampler, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-	glSamplerParameteri(nearest_sampler, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER);
-	glSamplerParameteri(nearest_sampler, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER);
+	using enum TextureFilterMode;
+	using enum TextureWrapMode;
 
-	glGenSamplers(1, &linear_sampler);
-	glSamplerParameteri(linear_sampler, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-	glSamplerParameteri(linear_sampler, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-	glSamplerParameteri(linear_sampler, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER);
-	glSamplerParameteri(linear_sampler, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER);
+	constexpr TextureFilterMode filters[] = {NearestNeighbour, Bilinear};
+	constexpr TextureWrapMode wraps[]     = {Repeat,
+	                                         MirroredRepeat,
+	                                         ClampToEdge,
+	                                         ClampToBorder};
+
+	for (const auto filter : filters) {
+		for (const auto wrap : wraps) {
+			const auto f = static_cast<size_t>(filter);
+			const auto w = static_cast<size_t>(wrap);
+
+			const auto gl_filter = to_gl_filter(filter);
+			const auto gl_wrap   = to_gl_wrap(wrap);
+
+			glGenSamplers(1, &samplers[f][w]);
+
+			glSamplerParameteri(samplers[f][w],
+			                    GL_TEXTURE_MIN_FILTER,
+			                    gl_filter);
+
+			glSamplerParameteri(samplers[f][w],
+			                    GL_TEXTURE_MAG_FILTER,
+			                    gl_filter);
+
+			glSamplerParameteri(samplers[f][w], GL_TEXTURE_WRAP_S, gl_wrap);
+			glSamplerParameteri(samplers[f][w], GL_TEXTURE_WRAP_T, gl_wrap);
+		}
+	}
 }
 
 void ShaderPipeline::DestroySamplers()
 {
-	if (nearest_sampler) {
-		glDeleteSamplers(1, &nearest_sampler);
-		nearest_sampler = 0;
+	for (size_t f = 0; f < NumFilterModes; ++f) {
+		for (size_t w = 0; w < NumWrapModes; ++w) {
+			if (samplers[f][w]) {
+				glDeleteSamplers(1, &samplers[f][w]);
+				samplers[f][w] = 0;
+			}
+		}
 	}
-	if (linear_sampler) {
-		glDeleteSamplers(1, &linear_sampler);
-		linear_sampler = 0;
-	}
+}
+
+GLuint ShaderPipeline::GetSampler(const TextureFilterMode filter,
+                                  const TextureWrapMode wrap) const
+{
+	const auto f = static_cast<size_t>(filter);
+	const auto w = static_cast<size_t>(wrap);
+
+	assert(f < NumFilterModes);
+	assert(w < NumWrapModes);
+
+	return samplers[f][w];
 }
 
 bool ShaderPipeline::IsPipelineComplete() const
@@ -309,9 +374,8 @@ GLuint ShaderPipeline::CreateTexture(const DosBox::Rect& size,
 	glActiveTexture(GL_TEXTURE0);
 	glBindTexture(GL_TEXTURE_2D, texture);
 
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER);
-
+	// Wrap mode is set on the bound sampler object in `RenderPass()`,
+	// per the `#pragma wrap_modeN` of each shader pass input.
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
 
@@ -433,26 +497,19 @@ void ShaderPipeline::RenderPass(const ShaderPass& pass,
 	glBindFramebuffer(GL_FRAMEBUFFER, pass.out_fbo);
 	glClear(GL_COLOR_BUFFER_BIT);
 
+	const auto& info = pass.shader.info;
+	const auto filter_mode = info.default_preset.settings.texture_filter_mode;
+
 	for (size_t i = 0; i < pass.in_textures.size(); ++i) {
 		glActiveTexture(GL_TEXTURE0 + check_cast<GLenum>(i));
 		glBindTexture(GL_TEXTURE_2D, pass.in_textures[i]);
 
-		// Bind sampler with the requested filter mode to the texture unit
-		const auto& preset = pass.shader.info.default_preset;
+		// Bind sampler with the requested filter and wrap mode to the
+		// texture unit
+		const auto wrap_mode = info.input_wrap_modes[i];
 
-		const auto texture_unit = check_cast<GLuint>(i);
-
-		switch (preset.settings.texture_filter_mode) {
-		case TextureFilterMode::NearestNeighbour:
-			glBindSampler(texture_unit, nearest_sampler);
-			break;
-
-		case TextureFilterMode::Bilinear:
-			glBindSampler(texture_unit, linear_sampler);
-			break;
-
-		default: assertm(false, "Invalid TextureFilterMode");
-		}
+		glBindSampler(check_cast<GLuint>(i),
+		              GetSampler(filter_mode, wrap_mode));
 	}
 
 	// Set up viewport

--- a/src/gui/render/shader_pragma_parser.cpp
+++ b/src/gui/render/shader_pragma_parser.cpp
@@ -1,0 +1,324 @@
+// SPDX-FileCopyrightText:  2023-2026 The DOSBox Staging Team
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "private/shader_pragma_parser.h"
+
+#include <algorithm>
+#include <cassert>
+#include <regex>
+#include <unordered_map>
+#include <utility>
+
+#include "config/setup.h"
+#include "misc/logging.h"
+#include "utils/checks.h"
+#include "utils/string_utils.h"
+
+CHECK_NARROWING();
+
+namespace ShaderPragma {
+
+bool SetSetting(const std::string& name, const std::string& value,
+                ShaderSettings& out_settings)
+{
+	assert(!name.empty());
+
+	const auto maybe_bool = parse_bool_setting(value);
+	if (!maybe_bool) {
+		return false;
+	}
+	const auto bool_value = *maybe_bool;
+
+	if (name == "force_single_scan") {
+		out_settings.force_single_scan = bool_value;
+		return true;
+	}
+
+	if (name == "force_no_pixel_doubling") {
+		out_settings.force_no_pixel_doubling = bool_value;
+		return true;
+	}
+
+	if (name == "linear_filtering") {
+		out_settings.texture_filter_mode =
+		        (bool_value ? TextureFilterMode::Bilinear
+		                    : TextureFilterMode::NearestNeighbour);
+		return true;
+	}
+
+	if (name == "float_output") {
+		out_settings.float_output_texture = bool_value;
+		return true;
+	}
+
+	return false;
+}
+
+namespace {
+
+std::optional<std::pair<std::string, float>> parse_parameter_pragma(const std::string& pragma)
+{
+	assert(!pragma.empty());
+
+	// Parameter format example:
+	//
+	//   #pragma parameter OUTPUT_GAMMA "OUTPUT GAMMA" 2.2 0.0 5.0 0.1
+	//
+	const auto parts = split(strip_prefix(pragma, "parameter"), "\"");
+	if (parts.size() != 3) {
+		return {};
+	}
+	// parts[0] - param (variable) name (OUTPUT_GAMMA)
+	// parts[1] - display name (OUTPUT GAMMA)
+	// parts[2] - values (4 space-separated floats)
+
+	auto param_name = parts[0];
+	trim(param_name);
+
+	const auto params = split(parts[2]);
+	if (params.size() != 4) {
+		return {};
+	}
+	// params[0] - default value (2.2)
+	// params[1] - min value     (0.0)
+	// params[2] - max value     (5.0)
+	// params[3] - value step    (0.1)
+
+	const auto maybe_default_val = parse_float(params[0]);
+	if (!maybe_default_val) {
+		return {};
+	}
+
+	return {
+	        {param_name, *maybe_default_val}
+        };
+}
+
+std::optional<std::pair<std::string, std::string>> parse_setting_pragma(
+        const std::string& pragma)
+{
+	// Shader setting format:
+	//
+	//   #pragma force_single_scan on
+	//
+	const auto parts = split(pragma);
+	if (parts.size() != 2) {
+		return {};
+	}
+	return {
+	        {parts[0], parts[1]}
+        };
+}
+
+std::optional<std::string> parse_name_pragma(const std::string& pragma)
+{
+	// Shader pass name format:
+	//
+	//   #pragma name Main_Pass1
+	//
+	const auto parts = split(strip_prefix(pragma, "name"));
+	if (parts.size() != 1) {
+		return {};
+	}
+	return parts[0];
+}
+
+std::optional<ShaderOutputSize> parse_output_size_pragma(const std::string& pragma)
+{
+	// Output size format:
+	//
+	//   #pragma output_size VideoMode
+	//
+	// Valid values are: Previous, Rendered, VideoMode, Viewport
+	//
+	const auto parts = split(strip_prefix(pragma, "output_size"));
+	if (parts.size() != 1) {
+		return {};
+	}
+	const auto& type = parts[0];
+
+	using enum ShaderOutputSize;
+
+	if (type == "Previous") {
+		return Previous;
+
+	} else if (type == "Rendered") {
+		return Rendered;
+
+	} else if (type == "VideoMode") {
+		return VideoMode;
+
+	} else if (type == "Viewport") {
+		return Viewport;
+	}
+
+	return {};
+}
+
+std::optional<std::pair<int, std::string>> parse_input_pragma(const std::string& pragma)
+{
+	// Shader input format:
+	//
+	//   #pragma input0 Main_Pass2
+	//   #pragma input1 Previous
+	//   ...
+	//
+	const auto parts = split(strip_prefix(pragma, "input"));
+	if (parts.size() != 2) {
+		return {};
+	}
+
+	const auto& index_str = parts[0];
+
+	if (auto maybe_int = parse_int(index_str); maybe_int) {
+		const auto& name = parts[1];
+
+		return {
+		        {*maybe_int, name}
+                };
+	}
+	return {};
+}
+
+} // namespace
+
+std::optional<ParseResult> Parse(const std::string& shader_name,
+                                 const std::string& shader_source)
+{
+	// We'll try to parse all pragmas and report all errors
+	bool has_errors = false;
+
+	ParseResult result = {};
+
+	// The default preset has no name
+	result.preset.name.clear();
+
+	std::unordered_map<int, std::string> input_ids = {};
+	auto highest_input_index                       = -1;
+
+	try {
+		const std::regex re("\\s*#pragma\\s+(.+)");
+
+		std::sregex_iterator next(shader_source.begin(),
+		                          shader_source.end(),
+		                          re);
+		const std::sregex_iterator end;
+
+		while (next != end) {
+			std::smatch match = *next;
+
+			auto pragma = match[1].str();
+
+			if (pragma.starts_with("parameter")) {
+				if (const auto maybe_result = parse_parameter_pragma(
+				            pragma);
+				    maybe_result) {
+
+					const auto& [param_name,
+					             default_value] = *maybe_result;
+
+					result.preset.params[param_name] = default_value;
+				} else {
+					LOG_ERR("RENDER: Invalid shader parameter pragma: '%s'",
+					        pragma.c_str());
+					has_errors = true;
+				}
+
+			} else if (pragma.starts_with("name")) {
+				if (const auto maybe_name = parse_name_pragma(pragma);
+				    maybe_name) {
+
+					result.pass_name = *maybe_name;
+				} else {
+					LOG_ERR("RENDER: Invalid shader pass name pragma: '%s'",
+					        pragma.c_str());
+					has_errors = true;
+				}
+
+			} else if (pragma.starts_with("input")) {
+				if (const auto maybe_result = parse_input_pragma(pragma);
+				    maybe_result) {
+
+					const auto& [input_index,
+					             input_name] = *maybe_result;
+
+					input_ids[input_index] = input_name;
+
+					highest_input_index = std::max(
+					        input_index, highest_input_index);
+				} else {
+					LOG_ERR("RENDER: Invalid input name pragma: '%s'",
+					        pragma.c_str());
+					has_errors = true;
+				}
+
+			} else if (pragma.starts_with("output_size")) {
+				if (const auto maybe_output_size =
+				            parse_output_size_pragma(pragma);
+				    maybe_output_size) {
+
+					result.output_size = *maybe_output_size;
+				} else {
+					LOG_ERR("RENDER: Invalid output size pragma: '%s'",
+					        pragma.c_str());
+					has_errors = true;
+				}
+
+			} else {
+				bool parse_ok = false;
+
+				if (const auto maybe_setting = parse_setting_pragma(
+				            pragma);
+				    maybe_setting) {
+
+					const auto& [name, value] = *maybe_setting;
+
+					parse_ok = SetSetting(name,
+					                      value,
+					                      result.preset.settings);
+				}
+				if (!parse_ok) {
+					LOG_ERR("RENDER: Invalid shader setting pragma: '%s'",
+					        pragma.c_str());
+					has_errors = true;
+				}
+			}
+
+			++next;
+		}
+	} catch (std::regex_error& e) {
+		LOG_ERR("RENDER: Regex error while parsing shader '%s' for pragmas: %d",
+		        shader_name.c_str(),
+		        e.code());
+
+		has_errors = true;
+	}
+
+	// Validate and store texture input IDs
+	const auto num_inputs = check_cast<int>(input_ids.size());
+
+	if (num_inputs != (highest_input_index + 1)) {
+		LOG_ERR("RENDER: Shader input indices are invalid "
+		        "(%d inputs but highest input index is %d)",
+		        num_inputs,
+		        highest_input_index);
+
+		has_errors = true;
+	}
+
+	if (num_inputs == 0) {
+		result.input_ids = {"Previous"};
+	} else {
+		for (auto i = 0; i <= highest_input_index; ++i) {
+			result.input_ids.emplace_back(input_ids[i]);
+		}
+	}
+
+	if (has_errors) {
+		return {};
+	}
+
+	return result;
+}
+
+} // namespace ShaderPragma

--- a/src/gui/render/shader_pragma_parser.cpp
+++ b/src/gui/render/shader_pragma_parser.cpp
@@ -180,6 +180,49 @@ std::optional<std::pair<int, std::string>> parse_input_pragma(const std::string&
 	return {};
 }
 
+std::optional<std::pair<int, TextureWrapMode>> parse_wrap_mode_pragma(const std::string& pragma)
+{
+	// Shader wrap mode format:
+	//
+	//   #pragma wrap_mode0 ClampToEdge
+	//   #pragma wrap_mode1 Repeat
+	//   ...
+	//
+	const auto parts = split(strip_prefix(pragma, "wrap_mode"));
+	if (parts.size() != 2) {
+		return {};
+	}
+
+	const auto maybe_int = parse_int(parts[0]);
+	if (!maybe_int) {
+		return {};
+	}
+
+	using enum TextureWrapMode;
+
+	const auto& mode_str = parts[1];
+
+	if (mode_str == "Repeat") {
+		return {
+		        {*maybe_int, Repeat}
+                };
+	} else if (mode_str == "MirroredRepeat") {
+		return {
+		        {*maybe_int, MirroredRepeat}
+                };
+	} else if (mode_str == "ClampToEdge") {
+		return {
+		        {*maybe_int, ClampToEdge}
+                };
+	} else if (mode_str == "ClampToBorder") {
+		return {
+		        {*maybe_int, ClampToBorder}
+                };
+	}
+
+	return {};
+}
+
 } // namespace
 
 std::optional<ParseResult> Parse(const std::string& shader_name,
@@ -193,8 +236,11 @@ std::optional<ParseResult> Parse(const std::string& shader_name,
 	// The default preset has no name
 	result.preset.name.clear();
 
-	std::unordered_map<int, std::string> input_ids = {};
-	auto highest_input_index                       = -1;
+	std::unordered_map<int, std::string> input_ids      = {};
+	std::unordered_map<int, TextureWrapMode> wrap_modes = {};
+
+	auto highest_input_index     = -1;
+	auto highest_wrap_mode_index = -1;
 
 	try {
 		const std::regex re("\\s*#pragma\\s+(.+)");
@@ -264,6 +310,24 @@ std::optional<ParseResult> Parse(const std::string& shader_name,
 					has_errors = true;
 				}
 
+			} else if (pragma.starts_with("wrap_mode")) {
+				if (const auto maybe_result = parse_wrap_mode_pragma(
+				            pragma);
+				    maybe_result) {
+
+					const auto& [wrap_index,
+					             wrap_mode] = *maybe_result;
+
+					wrap_modes[wrap_index] = wrap_mode;
+
+					highest_wrap_mode_index = std::max(
+					        wrap_index, highest_wrap_mode_index);
+				} else {
+					LOG_ERR("RENDER: Invalid wrap mode pragma: '%s'",
+					        pragma.c_str());
+					has_errors = true;
+				}
+
 			} else {
 				bool parse_ok = false;
 
@@ -312,6 +376,26 @@ std::optional<ParseResult> Parse(const std::string& shader_name,
 		for (auto i = 0; i <= highest_input_index; ++i) {
 			result.input_ids.emplace_back(input_ids[i]);
 		}
+	}
+
+	// Validate and store per-input texture wrap modes
+	const auto num_inputs_resolved = check_cast<int>(result.input_ids.size());
+
+	if (highest_wrap_mode_index >= num_inputs_resolved) {
+		LOG_ERR("RENDER: Shader wrap mode index %d has no matching input "
+		        "(shader has %d input(s))",
+		        highest_wrap_mode_index,
+		        num_inputs_resolved);
+
+		has_errors = true;
+	}
+
+	result.input_wrap_modes.reserve(num_inputs_resolved);
+	for (auto i = 0; i < num_inputs_resolved; ++i) {
+		const auto it = wrap_modes.find(i);
+		result.input_wrap_modes.push_back(
+		        it != wrap_modes.end() ? it->second
+		                               : TextureWrapMode::ClampToEdge);
 	}
 
 	if (has_errors) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,6 +24,7 @@ add_executable(dosbox_tests
     rgb_tests.cpp
     ring_buffer_tests.cpp
     rwqueue_tests.cpp
+    shader_pragma_parser_tests.cpp
     shell_cmds_tests.cpp
     shell_redirection_tests.cpp
     string_utils_tests.cpp

--- a/tests/shader_pragma_parser_tests.cpp
+++ b/tests/shader_pragma_parser_tests.cpp
@@ -330,6 +330,93 @@ TEST(ShaderPragmaParser, SetSettingInvalidValue)
 }
 
 // ----------------------------------------------------------------------------
+// #pragma wrap_modeN
+// ----------------------------------------------------------------------------
+
+TEST(ShaderPragmaParser, WrapModeDefaultsToClampToEdge)
+{
+	const auto result = Parse("test", "");
+
+	ASSERT_TRUE(result.has_value());
+
+	EXPECT_EQ(result->input_wrap_modes,
+	          (std::vector<TextureWrapMode>{TextureWrapMode::ClampToEdge}));
+}
+
+TEST(ShaderPragmaParser, WrapModeAllValidValues)
+{
+	const std::string source =
+	        "#pragma input0 In0\n"
+	        "#pragma input1 In1\n"
+	        "#pragma input2 In2\n"
+	        "#pragma input3 In3\n"
+	        "#pragma wrap_mode0 Repeat\n"
+	        "#pragma wrap_mode1 MirroredRepeat\n"
+	        "#pragma wrap_mode2 ClampToEdge\n"
+	        "#pragma wrap_mode3 ClampToBorder\n";
+
+	const auto result = Parse("test", source);
+
+	ASSERT_TRUE(result.has_value());
+
+	using enum TextureWrapMode;
+	EXPECT_EQ(result->input_wrap_modes,
+	          (std::vector<TextureWrapMode>{
+	                  Repeat, MirroredRepeat, ClampToEdge, ClampToBorder}));
+}
+
+TEST(ShaderPragmaParser, WrapModeUnspecifiedInputsDefault)
+{
+	// Two inputs, only the first has a wrap mode set explicitly.
+	const std::string source =
+	        "#pragma input0 In0\n"
+	        "#pragma input1 In1\n"
+	        "#pragma wrap_mode0 Repeat\n";
+
+	const auto result = Parse("test", source);
+
+	ASSERT_TRUE(result.has_value());
+
+	using enum TextureWrapMode;
+	EXPECT_EQ(result->input_wrap_modes,
+	          (std::vector<TextureWrapMode>{Repeat, ClampToEdge}));
+}
+
+TEST(ShaderPragmaParser, WrapModeWithImplicitDefaultInput)
+{
+	// No `inputN` pragmas: the implicit `input0 Previous` is used,
+	// and `wrap_mode0` applies to it.
+	const auto result = Parse("test", "#pragma wrap_mode0 MirroredRepeat\n");
+
+	ASSERT_TRUE(result.has_value());
+	EXPECT_EQ(result->input_ids, (std::vector<std::string>{"Previous"}));
+
+	EXPECT_EQ(result->input_wrap_modes,
+	          (std::vector<TextureWrapMode>{TextureWrapMode::MirroredRepeat}));
+}
+
+TEST(ShaderPragmaParser, WrapModeInvalidValue)
+{
+	EXPECT_FALSE(Parse("test", "#pragma wrap_mode0 Bogus\n").has_value());
+}
+
+TEST(ShaderPragmaParser, WrapModeNonNumericIndex)
+{
+	EXPECT_FALSE(Parse("test", "#pragma wrap_modeX Repeat\n").has_value());
+}
+
+TEST(ShaderPragmaParser, WrapModeMissingValue)
+{
+	EXPECT_FALSE(Parse("test", "#pragma wrap_mode0\n").has_value());
+}
+
+TEST(ShaderPragmaParser, WrapModeIndexOutOfRange)
+{
+	// Only `input0` exists (implicitly), but wrap_mode5 is specified.
+	EXPECT_FALSE(Parse("test", "#pragma wrap_mode5 Repeat\n").has_value());
+}
+
+// ----------------------------------------------------------------------------
 // Multi-pragma combinations
 // ----------------------------------------------------------------------------
 
@@ -340,6 +427,8 @@ TEST(ShaderPragmaParser, FullShaderHeader)
 	        "#pragma name CrtHyllian_Main\n"
 	        "#pragma input0 Previous\n"
 	        "#pragma input1 ImageAdjustments\n"
+	        "#pragma wrap_mode0 ClampToBorder\n"
+	        "#pragma wrap_mode1 Repeat\n"
 	        "#pragma output_size Viewport\n"
 	        "#pragma linear_filtering off\n"
 	        "#pragma force_single_scan on\n"
@@ -355,6 +444,10 @@ TEST(ShaderPragmaParser, FullShaderHeader)
 
 	EXPECT_EQ(result->input_ids,
 	          (std::vector<std::string>{"Previous", "ImageAdjustments"}));
+
+	EXPECT_EQ(result->input_wrap_modes,
+	          (std::vector<TextureWrapMode>{TextureWrapMode::ClampToBorder,
+	                                        TextureWrapMode::Repeat}));
 
 	EXPECT_EQ(result->output_size, ShaderOutputSize::Viewport);
 

--- a/tests/shader_pragma_parser_tests.cpp
+++ b/tests/shader_pragma_parser_tests.cpp
@@ -1,0 +1,398 @@
+// SPDX-FileCopyrightText:  2026-2026 The DOSBox Staging Team
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "gui/render/private/shader_pragma_parser.h"
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+using namespace ShaderPragma;
+
+// ----------------------------------------------------------------------------
+// Defaults (no pragmas)
+// ----------------------------------------------------------------------------
+
+TEST(ShaderPragmaParser, EmptySource)
+{
+	const auto result = Parse("test", "");
+
+	ASSERT_TRUE(result.has_value());
+	EXPECT_EQ(result->pass_name, "");
+	EXPECT_EQ(result->input_ids, (std::vector<std::string>{"Previous"}));
+	EXPECT_EQ(result->output_size, ShaderOutputSize::Previous);
+	EXPECT_TRUE(result->preset.params.empty());
+}
+
+TEST(ShaderPragmaParser, NoPragmasInSource)
+{
+	const std::string source =
+	        "void main() {\n"
+	        "    gl_FragColor = vec4(1.0);\n"
+	        "}\n";
+
+	const auto result = Parse("test", source);
+
+	ASSERT_TRUE(result.has_value());
+	EXPECT_EQ(result->pass_name, "");
+	EXPECT_EQ(result->input_ids, (std::vector<std::string>{"Previous"}));
+	EXPECT_EQ(result->output_size, ShaderOutputSize::Previous);
+	EXPECT_TRUE(result->preset.params.empty());
+}
+
+// ----------------------------------------------------------------------------
+// #pragma name
+// ----------------------------------------------------------------------------
+
+TEST(ShaderPragmaParser, NameValid)
+{
+	const auto result = Parse("test", "#pragma name Main_Pass1\n");
+
+	ASSERT_TRUE(result.has_value());
+	EXPECT_EQ(result->pass_name, "Main_Pass1");
+}
+
+TEST(ShaderPragmaParser, NameInBlockComment)
+{
+	// Per the README convention: pragmas are wrapped in a block comment,
+	// each on its own line, so the GLSL compiler ignores them while we
+	// still pick them up.
+	const std::string source =
+	        "/*\n"
+	        "#pragma name Wrapped_Pass\n"
+	        "*/\n"
+	        "void main() {}\n";
+
+	const auto result = Parse("test", source);
+
+	ASSERT_TRUE(result.has_value());
+	EXPECT_EQ(result->pass_name, "Wrapped_Pass");
+}
+
+TEST(ShaderPragmaParser, NameMissingValue)
+{
+	EXPECT_FALSE(Parse("test", "#pragma name\n").has_value());
+}
+
+TEST(ShaderPragmaParser, NameTooManyTokens)
+{
+	EXPECT_FALSE(Parse("test", "#pragma name Foo Bar\n").has_value());
+}
+
+// ----------------------------------------------------------------------------
+// #pragma inputN
+// ----------------------------------------------------------------------------
+
+TEST(ShaderPragmaParser, SingleInput)
+{
+	const auto result = Parse("test", "#pragma input0 Main_Pass2\n");
+
+	ASSERT_TRUE(result.has_value());
+	EXPECT_EQ(result->input_ids, (std::vector<std::string>{"Main_Pass2"}));
+}
+
+TEST(ShaderPragmaParser, TwoInputsInOrder)
+{
+	const std::string source =
+	        "#pragma input0 Previous\n"
+	        "#pragma input1 Helper_Pass\n";
+
+	const auto result = Parse("test", source);
+
+	ASSERT_TRUE(result.has_value());
+
+	EXPECT_EQ(result->input_ids,
+	          (std::vector<std::string>{"Previous", "Helper_Pass"}));
+}
+
+TEST(ShaderPragmaParser, TwoInputsReversedOrder)
+{
+	// Indices, not declaration order, determine slot.
+	const std::string source =
+	        "#pragma input1 Helper_Pass\n"
+	        "#pragma input0 Previous\n";
+
+	const auto result = Parse("test", source);
+
+	ASSERT_TRUE(result.has_value());
+
+	EXPECT_EQ(result->input_ids,
+	          (std::vector<std::string>{"Previous", "Helper_Pass"}));
+}
+
+TEST(ShaderPragmaParser, NonContiguousInputIndices)
+{
+	// input0 + input2, missing input1.
+	const std::string source =
+	        "#pragma input0 Previous\n"
+	        "#pragma input2 Helper_Pass\n";
+
+	EXPECT_FALSE(Parse("test", source).has_value());
+}
+
+TEST(ShaderPragmaParser, InputNonNumericIndex)
+{
+	EXPECT_FALSE(Parse("test", "#pragma inputX Previous\n").has_value());
+}
+
+TEST(ShaderPragmaParser, InputMissingName)
+{
+	EXPECT_FALSE(Parse("test", "#pragma input0\n").has_value());
+}
+
+// ----------------------------------------------------------------------------
+// #pragma output_size
+// ----------------------------------------------------------------------------
+
+TEST(ShaderPragmaParser, OutputSizePrevious)
+{
+	const auto result = Parse("test", "#pragma output_size Previous\n");
+
+	ASSERT_TRUE(result.has_value());
+	EXPECT_EQ(result->output_size, ShaderOutputSize::Previous);
+}
+
+TEST(ShaderPragmaParser, OutputSizeRendered)
+{
+	const auto result = Parse("test", "#pragma output_size Rendered\n");
+
+	ASSERT_TRUE(result.has_value());
+	EXPECT_EQ(result->output_size, ShaderOutputSize::Rendered);
+}
+
+TEST(ShaderPragmaParser, OutputSizeVideoMode)
+{
+	const auto result = Parse("test", "#pragma output_size VideoMode\n");
+
+	ASSERT_TRUE(result.has_value());
+	EXPECT_EQ(result->output_size, ShaderOutputSize::VideoMode);
+}
+
+TEST(ShaderPragmaParser, OutputSizeViewport)
+{
+	const auto result = Parse("test", "#pragma output_size Viewport\n");
+
+	ASSERT_TRUE(result.has_value());
+	EXPECT_EQ(result->output_size, ShaderOutputSize::Viewport);
+}
+
+TEST(ShaderPragmaParser, OutputSizeInvalidValue)
+{
+	EXPECT_FALSE(Parse("test", "#pragma output_size Banana\n").has_value());
+}
+
+TEST(ShaderPragmaParser, OutputSizeMissingValue)
+{
+	EXPECT_FALSE(Parse("test", "#pragma output_size\n").has_value());
+}
+
+// ----------------------------------------------------------------------------
+// #pragma parameter
+// ----------------------------------------------------------------------------
+
+TEST(ShaderPragmaParser, ParameterValid)
+{
+	const auto result = Parse(
+	        "test",
+	        "#pragma parameter OUTPUT_GAMMA \"OUTPUT GAMMA\" 2.2 0.0 5.0 0.1\n");
+
+	ASSERT_TRUE(result.has_value());
+	ASSERT_TRUE(result->preset.params.contains("OUTPUT_GAMMA"));
+	EXPECT_FLOAT_EQ(result->preset.params.at("OUTPUT_GAMMA"), 2.2f);
+}
+
+TEST(ShaderPragmaParser, ParameterMultiple)
+{
+	const std::string source =
+	        "#pragma parameter A \"AAA\" 1.0 0.0 2.0 0.5\n"
+	        "#pragma parameter B \"BBB\" -3.0 -5.0 0.0 0.25\n";
+
+	const auto result = Parse("test", source);
+
+	ASSERT_TRUE(result.has_value());
+	EXPECT_FLOAT_EQ(result->preset.params.at("A"), 1.0f);
+	EXPECT_FLOAT_EQ(result->preset.params.at("B"), -3.0f);
+}
+
+TEST(ShaderPragmaParser, ParameterWrongArgCount)
+{
+	// Only 3 numbers instead of 4 after the display name.
+	EXPECT_FALSE(
+	        Parse("test", "#pragma parameter A \"AAA\" 1.0 0.0 2.0\n").has_value());
+}
+
+TEST(ShaderPragmaParser, ParameterNonFloatDefault)
+{
+	EXPECT_FALSE(Parse("test", "#pragma parameter A \"AAA\" notafloat 0.0 2.0 0.5\n")
+	                     .has_value());
+}
+
+// ----------------------------------------------------------------------------
+// Setting pragmas (linear_filtering, float_output, force_*)
+// ----------------------------------------------------------------------------
+
+TEST(ShaderPragmaParser, LinearFilteringOn)
+{
+	const auto result = Parse("test", "#pragma linear_filtering on\n");
+
+	ASSERT_TRUE(result.has_value());
+	EXPECT_EQ(result->preset.settings.texture_filter_mode,
+	          TextureFilterMode::Bilinear);
+}
+
+TEST(ShaderPragmaParser, LinearFilteringOff)
+{
+	const auto result = Parse("test", "#pragma linear_filtering off\n");
+
+	ASSERT_TRUE(result.has_value());
+	EXPECT_EQ(result->preset.settings.texture_filter_mode,
+	          TextureFilterMode::NearestNeighbour);
+}
+
+TEST(ShaderPragmaParser, FloatOutputOn)
+{
+	const auto result = Parse("test", "#pragma float_output on\n");
+
+	ASSERT_TRUE(result.has_value());
+	EXPECT_TRUE(result->preset.settings.float_output_texture);
+}
+
+TEST(ShaderPragmaParser, FloatOutputOff)
+{
+	const auto result = Parse("test", "#pragma float_output off\n");
+
+	ASSERT_TRUE(result.has_value());
+	EXPECT_FALSE(result->preset.settings.float_output_texture);
+}
+
+TEST(ShaderPragmaParser, ForceSingleScanOn)
+{
+	const auto result = Parse("test", "#pragma force_single_scan on\n");
+
+	ASSERT_TRUE(result.has_value());
+	EXPECT_TRUE(result->preset.settings.force_single_scan);
+}
+
+TEST(ShaderPragmaParser, ForceNoPixelDoublingOn)
+{
+	const auto result = Parse("test", "#pragma force_no_pixel_doubling on\n");
+
+	ASSERT_TRUE(result.has_value());
+	EXPECT_TRUE(result->preset.settings.force_no_pixel_doubling);
+}
+
+TEST(ShaderPragmaParser, SettingInvalidBool)
+{
+	EXPECT_FALSE(Parse("test", "#pragma linear_filtering maybe\n").has_value());
+}
+
+TEST(ShaderPragmaParser, UnknownSetting)
+{
+	EXPECT_FALSE(Parse("test", "#pragma what_is_this on\n").has_value());
+}
+
+// ----------------------------------------------------------------------------
+// SetSetting (also used by [settings] INI section)
+// ----------------------------------------------------------------------------
+
+TEST(ShaderPragmaParser, SetSettingForceSingleScan)
+{
+	ShaderSettings settings = {};
+
+	EXPECT_TRUE(SetSetting("force_single_scan", "yes", settings));
+	EXPECT_TRUE(settings.force_single_scan);
+
+	EXPECT_TRUE(SetSetting("force_single_scan", "no", settings));
+	EXPECT_FALSE(settings.force_single_scan);
+}
+
+TEST(ShaderPragmaParser, SetSettingLinearFiltering)
+{
+	ShaderSettings settings = {};
+
+	EXPECT_TRUE(SetSetting("linear_filtering", "on", settings));
+	EXPECT_EQ(settings.texture_filter_mode, TextureFilterMode::Bilinear);
+
+	EXPECT_TRUE(SetSetting("linear_filtering", "off", settings));
+	EXPECT_EQ(settings.texture_filter_mode, TextureFilterMode::NearestNeighbour);
+}
+
+TEST(ShaderPragmaParser, SetSettingUnknownName)
+{
+	ShaderSettings settings = {};
+	EXPECT_FALSE(SetSetting("nope", "on", settings));
+}
+
+TEST(ShaderPragmaParser, SetSettingInvalidValue)
+{
+	ShaderSettings settings = {};
+	EXPECT_FALSE(SetSetting("linear_filtering", "maybe", settings));
+}
+
+// ----------------------------------------------------------------------------
+// Multi-pragma combinations
+// ----------------------------------------------------------------------------
+
+TEST(ShaderPragmaParser, FullShaderHeader)
+{
+	const std::string source =
+	        "/*\n"
+	        "#pragma name CrtHyllian_Main\n"
+	        "#pragma input0 Previous\n"
+	        "#pragma input1 ImageAdjustments\n"
+	        "#pragma output_size Viewport\n"
+	        "#pragma linear_filtering off\n"
+	        "#pragma force_single_scan on\n"
+	        "#pragma float_output on\n"
+	        "#pragma parameter PHOSPHOR_LAYOUT \"PHOSPHOR LAYOUT\" 2.0 0.0 19.0 1.0\n"
+	        "*/\n"
+	        "void main() {}\n";
+
+	const auto result = Parse("test", source);
+
+	ASSERT_TRUE(result.has_value());
+	EXPECT_EQ(result->pass_name, "CrtHyllian_Main");
+
+	EXPECT_EQ(result->input_ids,
+	          (std::vector<std::string>{"Previous", "ImageAdjustments"}));
+
+	EXPECT_EQ(result->output_size, ShaderOutputSize::Viewport);
+
+	EXPECT_EQ(result->preset.settings.texture_filter_mode,
+	          TextureFilterMode::NearestNeighbour);
+
+	EXPECT_TRUE(result->preset.settings.force_single_scan);
+	EXPECT_TRUE(result->preset.settings.float_output_texture);
+	EXPECT_FLOAT_EQ(result->preset.params.at("PHOSPHOR_LAYOUT"), 2.0f);
+}
+
+TEST(ShaderPragmaParser, AllErrorsReported)
+{
+	// Two invalid pragmas in the same source. Parsing keeps going,
+	// returns empty optional, and (when run) emits two LOG_ERR lines.
+	const std::string source =
+	        "#pragma name\n"
+	        "#pragma output_size Bogus\n";
+
+	EXPECT_FALSE(Parse("test", source).has_value());
+}
+
+// ----------------------------------------------------------------------------
+// Whitespace and formatting tolerance
+// ----------------------------------------------------------------------------
+
+TEST(ShaderPragmaParser, ExtraWhitespaceBetweenTokens)
+{
+	const auto result = Parse("test", "#pragma    input0    Previous\n");
+
+	ASSERT_TRUE(result.has_value());
+	EXPECT_EQ(result->input_ids, (std::vector<std::string>{"Previous"}));
+}
+
+TEST(ShaderPragmaParser, LeadingWhitespaceBeforePragma)
+{
+	const auto result = Parse("test", "    #pragma name Indented_Pass\n");
+
+	ASSERT_TRUE(result.has_value());
+	EXPECT_EQ(result->pass_name, "Indented_Pass");
+}


### PR DESCRIPTION
# Description

Reported by @GranMinigun before he disappeared. I can't repro this, but he presented a screenshot as proof. With `shader = bilinear` enabled, he could witness an 1px gray line around the rendered output on a 100% background.

Regardless of whether I can repro it or not, I know what the problem is. It's better not to set GL_CLAMP_TO_BORDER for every texture, but let the shader request it per texture via the pragmas.

<img width="737" height="163" alt="image" src="https://github.com/user-attachments/assets/de461dda-6432-4af4-a40f-7cf0109f4cb3" />

Only one pass of the 4-pass dedithering shader needs GL_CLAMP_TO_BORDER to remove some edge artifacts:

### With `GL_CLAMP_TO_BORDER` (correct)

The 1px edge around the image is dedithered.

<img width="2133" height="1600" alt="image0015-rendered" src="https://github.com/user-attachments/assets/fb2636ed-5381-47bf-8ee5-23064d956cc0" />

### With `GL_CLAMP_TO_EDGE` (incorrect)

The 1px edge around the image is NOT dedithered. First-world issue, overall. Very minor. But why not do it properly, right.

<img width="2133" height="1600" alt="image0016-rendered" src="https://github.com/user-attachments/assets/7d2c88b9-3322-4743-aff6-82b9ddf8f1a9" />


# Release notes

N/A (we'll backport to 0.83.0)

# Manual testing

See the above screenshots.

_Non-trivial changes **must be** tested on all three OSes we support. If you can't test on a particular OS, ask the team or contributors for help._

The change has been manually tested on:

- [ ] Windows
- [x] macOS
- [ ] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [x] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

