### PR TITLE
Fix auto integer scaling

### DIFF
--- a/src/gui/render/render.cpp
+++ b/src/gui/render/render.cpp
@@ -1414,9 +1414,9 @@ DosBox::Rect RENDER_CalcDrawRectInPixels(const DosBox::Rect& canvas_size_px,
 			        integer_scale_factor);
 		}
 
-		// Handles the `sharp` shader fallback when the viewport
-		// is is too small for CRT shaders; integer scaling is
-		// then disabled.
+		// Non-CRT shader (including the `sharp` shader fallback
+		// when the viewport is too small for CRT shaders);
+		// integer scaling is then disabled.
 		return draw_size_fit_px;
 	};
 

--- a/src/gui/render/render.cpp
+++ b/src/gui/render/render.cpp
@@ -1682,19 +1682,22 @@ static void init_render_settings(SectionProp& section)
 	        "other dimension. If the image is larger than the viewport, the integer scaling\n"
 	        "constraint is auto-disabled (same as 'off'). Possible values:\n"
 	        "\n"
-	        "  auto:        A special vertical mode auto-enabled only for the adaptive CRT\n"
-	        "               shaders (see `shader`). This mode has refinements over standard\n"
-	        "               vertical integer scaling: 3.5x and 4.5x scaling factors are also\n"
-	        "               allowed, and integer scaling is disabled above 5.0x scaling.\n"
+	        "  auto:        A special vertical mode auto-enabled only for the CRT shaders\n"
+	        "               (see `shader`). This mode has refinements over standard vertical\n"
+	        "               integer scaling: 3.5x and 4.5x scaling factors are also allowed,\n"
+	        "               and integer scaling is disabled above 5.0x scaling.\n"
 	        "\n"
-	        "  vertical:    Constrain the vertical scaling factor to integer values.\n"
-	        "               This is the recommended setting for third-party shaders to avoid\n"
-	        "               uneven scanlines and interference artifacts.\n"
+	        "  vertical:    Constrain the vertical scaling factor to integer values. This is\n"
+	        "               the recommended setting for 3rd party CRT shaders with scanline\n"
+	        "               simulation to avoid uneven scanlines and interference artifacts.\n"
+	        "               For the built-in CRT shaders, use 'auto'.\n"
 	        "\n"
-	        "  horizontal:  Constrain the horizontal scaling factor to integer values.\n"
+	        "  horizontal:  Constrain the horizontal scaling factor to integer values. Might\n"
+	        "               be useful on low-resolution displays to optimise for horizontal\n"
+	        "               text sharpness.\n"
 	        "\n"
-	        "  off:         No integer scaling constraint is applied; the image fills the\n"
-	        "               viewport while maintaining the configured aspect ratio.");
+	        "  off:         Apply no integer scaling constraint; the image fills the viewport\n"
+	        "               while maintaining the configured aspect ratio.");
 
 	string_prop = section.AddString("viewport", Always, "fit");
 	string_prop->SetHelp(

--- a/src/gui/render/shader_manager.cpp
+++ b/src/gui/render/shader_manager.cpp
@@ -57,10 +57,11 @@ ShaderDescriptor ShaderDescriptor::FromString(const std::string& descriptor,
 
 bool ShaderDescriptor::EnforceAutoIntegerScaling() const
 {
-	// Turn off vertical integer scaling for the 'sharp' shader
-	// in 'integer_scaling = auto' mode
+	// 'integer_scaling = auto' enables integer scaling only for the CRT
+	// shaders (either set via the adaptive meta-shaders, e.g., `crt-auto`, or
+	// directly via `crt/crt-hyllian:4k` or similar).
 	//
-	return (shader_name != ShaderName::Sharp);
+	return shader_name.starts_with("crt/");
 }
 
 std::optional<Shader> ShaderManager::LoadShader(const std::string& shader_name)

--- a/website/docs/0.83/manual/graphics/adapters.md
+++ b/website/docs/0.83/manual/graphics/adapters.md
@@ -6,9 +6,9 @@ to DOS programs and, in some cases, enables additional hardware like sound
 chips.
 
 The default **`svga_s3`** ([S3 Trio64](#s3-trio64)) covers the widest range of
-games, from standard VGA through high-resolution SVGA. You only need to
-change it for titles that specifically require an older standard, typically
-early to mid-1980s games written for [CGA](#cga), [Tandy](#tandy-1000), or
+games, from standard VGA through high-resolution SVGA. You only need to change
+it for titles that specifically require an older standard, typically early to
+mid-1980s games written for [CGA](#cga), [Tandy](#tandy-1000), or
 [Hercules](#hercules-graphics-card) hardware, or demoscene productions
 targeting specific [SVGA chipsets](#vga-and-svga).
 
@@ -36,8 +36,7 @@ and a number of Sierra and other titles that shipped with Hercules drivers.
 
 DOSBox Staging emulates the Hercules with selectable monochrome phosphor
 palettes (amber, green, white, paperwhite) that can be cycled with ++f11++ or
-set via the
-[`monochrome_palette`](rendering.md#monochrome_palette) setting.
+set via the [`monochrome_palette`](rendering.md#monochrome_palette) setting.
 
 {{ figure(
     "https://www.dosbox-staging.org/static/images/getting-started/pop-hercules-amber.png",
@@ -122,9 +121,9 @@ opportunity, cloned the PCjr's enhanced graphics and sound into the [Tandy
 their Radio Shack stores nationwide in the USA. The rest is history --- the
 PCjr is a footnote, the Tandy 1000 is beloved.
 
-Setting `machine = pcjr` enables PCjr graphics, [PCjr
-sound](../sound/sound-devices/tandy.md) and [composite
-video](composite-video.md) emulation.
+Setting `machine = pcjr` enables PCjr graphics,
+[PCjr sound](../sound/sound-devices/tandy.md) and
+[composite video](composite-video.md) emulation.
 
 
 ### Tandy 1000
@@ -157,14 +156,12 @@ advantage over standard PCs.
 
 Combined with enhanced graphics and sound, the Tandy 1000 was the best
 consumer-grade DOS gaming platform of the mid-1980s. Many Sierra titles
-([King's Quest](https://www.mobygames.com/game/122/kings-quest/), [Space
-Quest](https://www.mobygames.com/game/114/space-quest-chapter-i-the-sarien-encounter/),
-[Leisure Suit
-Larry](https://www.mobygames.com/game/379/leisure-suit-larry-in-the-land-of-the-lounge-lizards/)),
-[Defender of the
-Crown](https://www.mobygames.com/game/181/defender-of-the-crown/), and [Sid
-Meier's Pirates!](https://www.mobygames.com/game/214/sid-meiers-pirates/) look
-and sound noticeably better in Tandy mode compared to standard CGA.
+([King's Quest](https://www.mobygames.com/game/122/kings-quest/),
+[Space Quest](https://www.mobygames.com/game/114/space-quest-chapter-i-the-sarien-encounter/),
+[Leisure Suit Larry](https://www.mobygames.com/game/379/leisure-suit-larry-in-the-land-of-the-lounge-lizards/)),
+[Defender of the Crown](https://www.mobygames.com/game/181/defender-of-the-crown/),
+and [Sid Meier's Pirates!](https://www.mobygames.com/game/214/sid-meiers-pirates/)
+look and sound noticeably better in Tandy mode compared to standard CGA.
 
 Setting `machine = tandy` also enables
 [Tandy sound](../sound/sound-devices/tandy.md) and
@@ -182,9 +179,9 @@ elsewhere deliberately exploited this effect.
 
 DOSBox Staging faithfully emulates composite output for all three adapters,
 including adjustable hue, saturation, contrast, and brightness. This is
-essential for playing early Sierra AGI games ([King's
-Quest](https://www.mobygames.com/game/122/kings-quest/), [Space
-Quest](https://www.mobygames.com/game/114/space-quest-chapter-i-the-sarien-encounter/))
+essential for playing early Sierra AGI games
+([King's Quest](https://www.mobygames.com/game/122/kings-quest/),
+[Space Quest](https://www.mobygames.com/game/114/space-quest-chapter-i-the-sarien-encounter/))
 as the artists intended. See [Composite video](composite-video.md) for
 configuration details and hotkeys.
 
@@ -200,23 +197,23 @@ memory.
 
 EGA was the dominant PC graphics standard from roughly 1985 to 1990. Most
 celebrated games of the period, including
-[Loom](https://www.mobygames.com/game/176/loom/), [The Secret of Monkey
-Island](https://www.mobygames.com/game/616/the-secret-of-monkey-island/), and
-the early Sierra adventures, ran in 16-colour 320&times;200, a resolution
+[Loom](https://www.mobygames.com/game/176/loom/),
+[The Secret of Monkey Island](https://www.mobygames.com/game/616/the-secret-of-monkey-island/),
+and the early Sierra adventures, ran in 16-colour 320&times;200, a resolution
 shared equally by [EGA](#ega) and [Tandy](#tandy-1000). EGA's higher 640×350
 resolution was used mainly by strategy titles, simulations, and illustrated
 text adventures that benefited from the extra detail. Legend Entertainment's
-[Spellcasting
-101](https://www.mobygames.com/game/1027/spellcasting-101-sorcerers-get-all-the-girls/)
-and [Timequest]() are good examples of games built specifically around it.
-Most games used [dithering](rendering.md#dedithering) creatively to simulate
-more colours than the 16-colour palette could display directly.
+[Spellcasting 101](https://www.mobygames.com/game/1027/spellcasting-101-sorcerers-get-all-the-girls/)
+and [Timequest](https://www.mobygames.com/game/1026/timequest/) are good
+examples of games built specifically around it. Most games used
+[dithering](rendering.md#dedithering) creatively to simulate more colours than
+the 16-colour palette could display directly.
 
 !!! note
 
-    EGA is *not* backward compatible with Hercules/MDA text modes.
-    Games expecting CGA monitor behaviour on an EGA card may also
-    show differences, as DOSBox emulates the EGA with an EGA-class monitor.
+    EGA is *not* backward compatible with Hercules/MDA text modes. Games
+    expecting CGA monitor behaviour on an EGA card may also show differences,
+    as DOSBox emulates the EGA with an EGA-class monitor.
 
 {{ figure(
     "https://www.dosbox-staging.org/static/images/getting-started/pop-ega.jpg",
@@ -242,10 +239,10 @@ default `svga_s3` is the best general-purpose choice.
 
     A small number of games and demos rely on per-scanline VGA timing tricks
     that change graphics settings mid-frame (e.g.,
-    [Lemmings](https://www.mobygames.com/game/683/lemmings/), [Pinball
-    Fantasies](https://www.mobygames.com/game/571/pinball-fantasies/), [Alien
-    Carnage](https://www.mobygames.com/game/522/alien-carnage/)). These may
-    need the `svga_paradise` machine type, which is the closest to IBM's
+    [Lemmings](https://www.mobygames.com/game/683/lemmings/),
+    [Pinball Fantasies](https://www.mobygames.com/game/571/pinball-fantasies/),
+    [Alien Carnage](https://www.mobygames.com/game/522/alien-carnage/)). These
+    may need the `svga_paradise` machine type, which is the closest to IBM's
     original VGA implementation. See also
     [`vga_render_per_scanline`](../system/general.md#vga_render_per_scanline).
 
@@ -296,8 +293,8 @@ occasional title written specifically for this chipset.
 
 `machine = svga_et4000`
 
-The **Tseng Labs ET4000** (1989) was the successor to the ET3000 and one of the
-most popular SVGA chipsets of the early 1990s — widely adopted,
+The **Tseng Labs ET4000** (1989) was the successor to the ET3000 and one of
+the most popular SVGA chipsets of the early 1990s — widely adopted,
 well-supported, and significantly more capable than its predecessor. It offers
 a wider range of extended modes and defaults to 1 MB of video memory
 (configurable to 256 KB or 512 KB via
@@ -335,16 +332,17 @@ modes are exposed to software.
 
     Some games and GOG releases ship with **UniVBE** (Universal VESA BIOS
     Extensions), a third-party VESA driver from the 1990s. DOSBox Staging's
-    built-in VESA implementation is fully compliant, making UniVBE
-    unnecessary --- and it can actually cause graphical glitches. If a game
-    has trouble with SVGA modes, check for a bundled `UNIVBE.EXE` or
-    `UVCONFIG.EXE` and try preventing it from loading (remove the line from
-    the game's batch file, or rename the file).
+    built-in VESA implementation is fully compliant, making UniVBE unnecessary
+    --- and it can actually cause graphical glitches. If a game has trouble
+    with SVGA modes, check for a bundled `UNIVBE.EXE` or `UVCONFIG.EXE` and
+    try preventing it from loading (remove the line from the game's batch
+    file, or rename the file).
 
 Two variants are available for specific compatibility needs:
 
 - `machine = vesa_oldvbe` --- Same S3 Trio64, but limited to VESA VBE 1.2.
   Use for games that malfunction with VBE 2.0.
+
 - `machine = vesa_nolfb` --- S3 Trio64 with VESA VBE 2.0 but without the
   linear framebuffer hack. Needed by a small number of titles.
 
@@ -353,20 +351,20 @@ Two variants are available for specific compatibility needs:
 
 <div class="compact" markdown>
 
-| `machine` value    | Adapter                                          | Year   | Max colours                   | Max resolution           |
-| ------------------ | ------------------------------------------------ | ------ | ----------------------        | ------------------------ |
-| `hercules`         | Hercules HGC                                     | 1982   | 2 (monochrome)                | 720&times;348            |
-| `cga_mono`         | CGA (monochrome&nbsp;monitor)                    | 1981   | 16 (monochrome)               | 640&times;200            |
-| `cga`              | CGA                                              | 1981   | 4 (16&nbsp;in&nbsp;composite) | 640&times;200            |
-| `pcjr`             | PCjr                                             | 1983   | 16                            | 640&times;200            |
-| `tandy`            | Tandy 1000                                       | 1984   | 16                            | 640&times;200            |
-| `ega`              | EGA                                              | 1984   | 16                            | 640&times;350            |
-| `svga_paradise`    | Paradise PVGA1A                                  | 1988   | 256                           | 1024&times;768           |
-| `svga_et3000`      | Tseng Labs ET3000                                | 1987   | 256                           | 1024&times;768           |
-| `svga_et4000`      | Tseng Labs ET4000                                | 1989   | 65K                           | 1280&times;1024          |
-| `svga_s3`          | S3 Trio64, VBE 2.0 *default*{ .default }         | 1994   | 16.7M                         | 1600&times;1200          |
-| `vesa_oldvbe`      | S3 Trio64, VBE 1.2                               | 1994   | 16.7M                         | 1600&times;1200          |
-| `vesa_nolfb`       | S3 Trio64, VBE 2.0 (no&nbsp;LFB)                 | 1994   | 16.7M                         | 1600&times;1200          |
+| `machine` value    | Adapter                                          | Year   | Max colours                   | Max resolution
+| ------------------ | ------------------------------------------------ | ------ | ----------------------        | ----------------
+| `hercules`         | Hercules HGC                                     | 1982   | 2 (monochrome)                | 720&times;348
+| `cga_mono`         | CGA (monochrome&nbsp;monitor)                    | 1981   | 16 (monochrome)               | 640&times;200
+| `cga`              | CGA                                              | 1981   | 4 (16&nbsp;in&nbsp;composite) | 640&times;200
+| `pcjr`             | PCjr                                             | 1983   | 16                            | 640&times;200
+| `tandy`            | Tandy 1000                                       | 1984   | 16                            | 640&times;200
+| `ega`              | EGA                                              | 1984   | 16                            | 640&times;350
+| `svga_paradise`    | Paradise PVGA1A                                  | 1988   | 256                           | 1024&times;768
+| `svga_et3000`      | Tseng Labs ET3000                                | 1987   | 256                           | 1024&times;768
+| `svga_et4000`      | Tseng Labs ET4000                                | 1989   | 65K                           | 1280&times;1024
+| `svga_s3`          | S3 Trio64, VBE 2.0 *default*{ .default }         | 1994   | 16.7M                         | 1600&times;1200
+| `vesa_oldvbe`      | S3 Trio64, VBE 1.2                               | 1994   | 16.7M                         | 1600&times;1200
+| `vesa_nolfb`       | S3 Trio64, VBE 2.0 (no&nbsp;LFB)                 | 1994   | 16.7M                         | 1600&times;1200
 
 </div>
 

--- a/website/docs/0.83/manual/graphics/rendering.md
+++ b/website/docs/0.83/manual/graphics/rendering.md
@@ -36,6 +36,7 @@ Beyond CRT emulation, DOSBox Staging can also
 [deinterlace FMV video](#deinterlacing) to remove the distracting black lines
 found in many 90s games.
 
+
 ## Adaptive CRT shaders
 
 DOSBox Staging includes adaptive CRT shaders that automatically select the
@@ -99,9 +100,9 @@ scaling is practically a non-issue.
 
 Most DOS games used non-square pixels and were designed for 4:3 CRT displays.
 The standard 320&times;200 VGA mode fills a 4:3 screen completely, which is
-only possible if each pixel is a slightly tall rectangle --- exactly 20% taller
-than wide, giving a pixel aspect ratio (PAR) of 1:1.2 (or 5:6). You can derive
-this from the display: 4:3 scales to 320:240, and 240 / 200 = 1.2.
+only possible if each pixel is a slightly tall rectangle --- exactly 20%
+taller than wide, giving a pixel aspect ratio (PAR) of 1:1.2 (or 5:6). You can
+derive this from the display: 4:3 scales to 320:240, and 240 / 200 = 1.2.
 
 Aspect ratio correction is enabled by default (`aspect = auto`) so games look
 as intended. Without it, 320&times;200 content appears squished on modern
@@ -109,12 +110,15 @@ square-pixel displays.
 
 A small number of DOS games need square pixels (`aspect = square-pixels`).
 These are typically European games ported from the PAL Amiga, where the
-original art was designed for square pixels at 320&times;256. Studios
-known for this include Revolution Software ([Beneath a Steel Sky](https://www.mobygames.com/game/386/beneath-a-steel-sky/), [Lure of
-the Temptress](https://www.mobygames.com/game/1134/lure-of-the-temptress/)), Delphine Software ([Another World](https://www.mobygames.com/game/564/out-of-this-world/), [Flashback](https://www.mobygames.com/game/555/flashback-the-quest-for-identity/)), and
-Coktel Vision ([Gobliiins](https://www.mobygames.com/game/1154/gobliiins/) series). The tell-tale sign is scanned or
-hand-drawn artwork that appears vertically stretched with aspect ratio
-correction enabled.
+original art was designed for square pixels at 320&times;256. Studios known
+for this include Revolution Software
+([Beneath a Steel Sky](https://www.mobygames.com/game/386/beneath-a-steel-sky/),
+[Lure of the Temptress](https://www.mobygames.com/game/1134/lure-of-the-temptress/)),
+Delphine Software ([Another World](https://www.mobygames.com/game/564/out-of-this-world/),
+[Flashback](https://www.mobygames.com/game/555/flashback-the-quest-for-identity/)),
+and Coktel Vision ([Gobliiins](https://www.mobygames.com/game/1154/gobliiins/)
+series). The tell-tale sign is scanned or hand-drawn artwork that appears
+vertically stretched with aspect ratio correction enabled.
 
 Pixels are square (1:1 PAR) in 640&times;480 and higher resolutions. A few
 other modes have their own non-square PARs: 640&times;350 EGA (1:1.37 PAR),
@@ -128,9 +132,9 @@ pixel aspect ratios, see [Aspect ratios & black borders](aspect-ratios.md).
 DOSBox Staging also has a "stretch everything" mode for when aspect ratio
 authenticity isn't the priority.
 
-The `stretch` aspect mode calculates the aspect ratio from the viewport dimensions,
-allowing you to force arbitrary aspect ratios. For example, to stretch a game
-to fill the entire screen:
+The `stretch` aspect mode calculates the aspect ratio from the viewport
+dimensions, allowing you to force arbitrary aspect ratios. For example, to
+stretch a game to fill the entire screen:
 
 ```ini
 [sdl]
@@ -179,27 +183,26 @@ Different CRT monitors used different phosphor chemistries, giving each a
 distinct colour character. DOSBox Staging can emulate these via the
 [`crt_color_profile`](#crt_color_profile) setting.
 
-- **`p22`** --- P22 phosphors were the most common in PC monitors, producing warmer,
-  slightly desaturated colours. This is what most people saw when playing DOS
-  games.
+- **`p22`** --- P22 phosphors were the most common in PC monitors, producing
+  warmer, slightly desaturated colours. This is what most people saw when
+  playing DOS games.
 
-- **`smpte-c`** --- SMPT-C broadcast standard phosphors are close to P22 but with tighter
-  colour tolerances, used in professional video monitors.
+- **`smpte-c`** --- SMPT-C broadcast standard phosphors are close to P22 but
+  with tighter colour tolerances, used in professional video monitors.
 
-- **`ebu`** --- EBU phosphors are the European broadcast standard, found in high-end
-  professional monitors like the Sony BVM/PVM series.
+- **`ebu`** --- EBU phosphors are the European broadcast standard, found in
+  high-end professional monitors like the Sony BVM/PVM series.
 
-- **`philips`** --- Philips home computer monitors (e.g., the Commodore 1084S) had
-  distinctly warm, yellowish whites at roughly 6100K.
+- **`philips`** --- Philips home computer monitors (e.g., the Commodore 1084S)
+  had distinctly warm, yellowish whites at roughly 6100K.
 
-- **`trinitron`** --- Sony Trinitrion monitors were known for punchy, vivid colours with a
-  cool blue-white colour temperature around 9300K.
+- **`trinitron`** --- Sony Trinitrion monitors were known for punchy, vivid
+  colours with a cool blue-white colour temperature around 9300K.
 
 The `auto` setting picks the profile that matches the era: CGA and EGA games
-get P22 (matching the monitors of that era), VGA games also get P22,
-composite video gets SMPTE-C, and the arcade shaders use Philips. See the
-[Automatic image adjustments](#automatic-image-adjustments) table for the full
-mapping.
+get P22 (matching the monitors of that era), VGA games also get P22, composite
+video gets SMPTE-C, and the arcade shaders use Philips. See the [Automatic
+image adjustments](#automatic-image-adjustments) table for the full mapping.
 
 
 ## Monochrome display emulation
@@ -212,13 +215,13 @@ terminal looks:
   IBM 5151 with an amber phosphor. This was the most common monochrome display
   in offices and the most comfortable for extended reading.
 
-- **`green`** --- the classic green phosphor look of the original IBM 5151 green
-  screen, a staple of the early PC era.
+- **`green`** --- the classic green phosphor look of the original IBM 5151
+  green screen, a staple of the early PC era.
 
 - **`white`** --- a cool blue-white typical of later monochrome VGA monitors.
 
-- **`paperwhite`** --- the Hercules-era paperwhite phosphor, a warmer, slightly
-  yellowish white that's easier on the eyes than pure white.
+- **`paperwhite`** --- the Hercules-era paperwhite phosphor, a warmer,
+  slightly yellowish white that's easier on the eyes than pure white.
 
 You can cycle through the available palettes via hotkeys during gameplay.
 
@@ -295,7 +298,6 @@ If you have a wide gamut display, the `auto` defaults for
 [`color_space`](#color_space) give you accurate colours out of the box. The
 Philips and Trinitron profiles show the biggest difference on DCI-P3 versus
 sRGB displays.
-
 
 
 ## Deinterlacing
@@ -439,9 +441,6 @@ The `[parameters]` section overrides shader-specific parameters declared in
 the shader source.
 
 
-
-
-
 ## Image adjustments
 
 The image adjustment system emulates the controls of a CRT monitor. The
@@ -454,14 +453,18 @@ The available adjustments are:
 - [`brightness`](#brightness) and [`contrast`](#contrast) emulate the
   corresponding CRT monitor knobs --- brightness sets the black point, contrast
   sets the white point.
+
 - [`gamma`](#gamma) applies additional gamma correction relative to the
   emulated monitor's gamma.
+
 - [`digital_contrast`](#digital_contrast) and [`saturation`](#saturation) are
   applied directly to the raw framebuffer RGB values, unlike the CRT-emulating
   brightness/contrast controls.
+
 - [`color_temperature`](#color_temperature) adjusts the white point in Kelvin;
   [`color_temperature_luma_preserve`](#color_temperature_luma_preserve)
   controls how much luminosity is preserved during the adjustment.
+
 - [`red_gain`](#red_gain), [`green_gain`](#green_gain), and
   [`blue_gain`](#blue_gain) adjust individual colour channel gain.
 
@@ -586,13 +589,18 @@ You can set the rendering parameters in the `[render]` configuration section.
       prioritises developer intent and how people experienced the games at
       the time of release. An appropriate shader variant is auto-selected
       based on the graphics standard of the current video mode and the
-      viewport size, irrespective of the [`machine`](../system/general.md#machine) setting.
+      viewport size, irrespective of the
+      [`machine`](../system/general.md#machine) setting.
+
     - `crt-auto-machine` -- A variation of `crt-auto`; this emulates a fixed
-      CRT monitor for the video adapter configured via the [`machine`](../system/general.md#machine) setting.
+      CRT monitor for the video adapter configured via the
+      [`machine`](../system/general.md#machine) setting.
+
     - `crt-auto-arcade` -- Emulation of an arcade or home computer monitor
       with a less sharp image and thick scanlines in low-resolution video
       modes. This is a fantasy option that never existed in real life, but it
       can be a lot of fun, especially with DOS ports of Amiga games.
+
     - `crt-auto-arcade-sharp` -- A sharper arcade shader variant for those
       who like the thick scanlines but want to retain the sharpness of a
       typical PC monitor.
@@ -607,8 +615,10 @@ You can set the rendering parameters in the `[render]` configuration section.
       resulting in a sharp image with minimum blur while maintaining the
       correct pixel aspect ratio. This is the recommended option for those
       who don't want to use the adaptive CRT shaders.
+
     - `bilinear` -- Upscale the image using bilinear interpolation (results
       in a blurry image).
+
     - `nearest` -- Upscale the image using nearest-neighbour interpolation
       (also known as "no bilinear"). This results in the sharpest possible
       image at the expense of uneven pixels, especially with non-square pixel
@@ -623,9 +633,11 @@ You can set the rendering parameters in the `[render]` configuration section.
     The bundled shaders include:
 
     - **Interpolation**: `sharp`, `bilinear`, `nearest`, `catmull-rom`
+
     - **CRT**: `crt-hyllian`,
       `vga-1080p`, `vga-1080p-fake-double-scan` (all used by the adaptive CRT
       shaders with different presets)
+
     - **Scaler**: `advinterp2x`, `advinterp3x`, `advmame2x`, `advmame3x`,
       `xbr-lv2-3d`, `xbr-lv2-noblend`, `xbr-lv3`
 
@@ -635,10 +647,11 @@ You can set the rendering parameters in the `[render]` configuration section.
 
     !!! note
 
-        Start DOSBox Staging with the [`--list-shaders`](../using-dosbox-staging/command-line.md#-list-shaders)
-        command line option to see the full list of available shaders. You can also use an absolute
-        or relative path to a file. In all cases, you may omit the shader's
-        `.glsl` file extension.
+        Start DOSBox Staging with the
+        [`--list-shaders`](../using-dosbox-staging/command-line.md#-list-shaders)
+        command line option to see the full list of available shaders. You can
+        also use an absolute or relative path to a file. In all cases, you may
+        omit the shader's `.glsl` file extension.
 
 
 ### Image adjustments
@@ -682,14 +695,19 @@ You can set the rendering parameters in the `[render]` configuration section.
       appropriate for the currently active adaptive CRT shader (e.g.,
       `crt-auto`), or the current machine type for regular shaders (e.g.,
       `sharp`).
+
     - `none` -- Display raw colours without any colour profile transforms.
       This will result in inaccurate colours and gamma on modern displays
       compared to how games looked on a real CRT in the 1980s and 90s.
+
     - `ebu` -- EBU standard phosphor emulation, used in high-end professional
       CRT monitors, such as the Sony BVM/PVM series.
+
     - `p22` -- P22 phosphor emulation, most common in lower-end CRT monitors.
+
     - `smpte-c` -- SMPTE "C" phosphor emulation, the standard for American
       broadcast video monitors.
+
     - `philips` -- Philips CRT monitor colours typical to 15 kHz home
       computer monitors (e.g., the Commodore 1084S). The intended use of
       this profile is with `color_temperature` set to 6500. The output will
@@ -697,6 +715,7 @@ You can set the rendering parameters in the `[render]` configuration section.
       "baked into" the profile. You can still tweak the relative white
       balance by changing `color_temperature`. Needs a DCI-P3 display for
       the most accurate results.
+
     - `trinitron` -- Typical Sony Trinitron CRT TV and monitor colours. The
       intended use of this profile is with `color_temperature` set to 6500.
       The output will look blueish due to the ~9300 K Trinitron CRT colour
@@ -733,8 +752,8 @@ You can set the rendering parameters in the `[render]` configuration section.
 
 :   Set the digital contrast of the video output (`0` by default). Valid
     range is -50 to 50. This works very differently from the
-    [`contrast`](#contrast) virtual monitor setting; digital contrast is applied
-    to the raw RGB values of the framebuffer image.
+    [`contrast`](#contrast) virtual monitor setting; digital contrast is
+    applied to the raw RGB values of the framebuffer image.
 
 ##### black_level
 
@@ -748,6 +767,7 @@ You can set the rendering parameters in the `[render]` configuration section.
     - `auto` *default*{ .default } -- Raise the black level for PCjr, Tandy,
       CGA and EGA video modes only for adaptive CRT shaders; for any other
       shader, use 0.
+
     - `<number>` -- Set the black level raise amount. Valid range is 0 to
       100. 0 does not raise the black level.
 
@@ -760,8 +780,8 @@ You can set the rendering parameters in the `[render]` configuration section.
 ##### saturation
 
 :   Set the saturation of the video output (`0` by default). Valid range is
-    -50 to 50. This is digital saturation applied to the raw RGB values of
-    the framebuffer image, similarly to [`digital_contrast`](#digital_contrast).
+    -50 to 50. This is digital saturation applied to the raw RGB values of the
+    framebuffer image, similarly to [`digital_contrast`](#digital_contrast).
 
 ##### color_temperature
 
@@ -773,6 +793,7 @@ You can set the rendering parameters in the `[render]` configuration section.
       appropriate for the currently active adaptive CRT shader (e.g.,
       `crt-auto`), or the current machine type for regular shaders (e.g.,
       `sharp`).
+
     - `<number>` -- Specify colour temperature in Kelvin (K). Valid range is
       3000 to 10000. 6500 K is the neutral point for most modern displays.
       Values below 6500 result in warmer colours, values above 6500 in
@@ -855,26 +876,35 @@ You can set the rendering parameters in the `[render]` configuration section.
 
     - `default` *default*{ .default } -- The canonical CGA palette, as
       emulated by VGA adapters.
+
     - `tandy <bl>` -- Emulation of an idealised Tandy monitor with adjustable
       brown level. The brown level can be provided as an optional second
       parameter (0--red, 50--brown, 100--dark yellow; defaults to 50).
+
     - `tandy-warm` -- Emulation of the actual colour output of an unknown
       Tandy monitor. Intended to be used with `crt_color_profile = none` and
       `color_temperature = 6500`.
+
     - `ibm5153 <c>` -- Emulation of the actual colour output of an IBM 5153
       monitor with a unique contrast control that dims non-bright colours
       only. The contrast can be optionally provided as a second parameter (0
       to 100; defaults to 100). Intended to be used with
       `crt_color_profile = none` and `color_temperature = 6500`.
+
     - `agi-amiga-v1`, `agi-amiga-v2`, `agi-amiga-v3` -- Palettes used by the
       Amiga ports of Sierra AGI games.
+
     - `agi-amigaish` -- A mix of EGA and Amiga colours used by the Sarien
       AGI-interpreter.
+
     - `scumm-amiga` -- Palette used by the Amiga ports of LucasArts EGA
       games.
+
     - `colodore` -- Commodore 64 inspired colours based on the Colodore
       palette.
+
     - `colodore-sat` -- Colodore palette with 20% more saturation.
+
     - `dga16` -- A modern take on the canonical CGA palette with dialled back
       contrast.
 
@@ -904,13 +934,18 @@ You can set the rendering parameters in the `[render]` configuration section.
     <div class="compact" markdown>
 
     - `off` *default*{ .default } -- Disable deinterlacing.
+
     - `on` -- Enable deinterlacing at `medium` strength.
+
     - `light` -- Light deinterlacing. Black scanlines are softened to mimic
       the CRT look.
+
     - `medium` -- Medium deinterlacing. Best balance between removing black
       lines, increasing brightness, and keeping the higher resolution look.
+
     - `strong` -- Strong deinterlacing. Image brightness is almost completely
       restored at the expense of diminishing the higher resolution look.
+
     - `full` -- Full deinterlacing. Completely removes black lines and
       maximises brightness, but the image will appear blockier.
 
@@ -933,7 +968,9 @@ You can set the rendering parameters in the `[render]` configuration section.
     Possible values:
 
     - `off` *default*{ .default } -- Disable dedithering.
+
     - `on` -- Enable dedithering (at full strength).
+
     - `<number>` -- Set dedithering strength from 0 (off) to 100 (full
       strength). Lower values result in a subtle softening of dither
       patterns; higher values blend between the original and the dedithered

--- a/website/docs/0.83/manual/graphics/rendering.md
+++ b/website/docs/0.83/manual/graphics/rendering.md
@@ -511,26 +511,32 @@ You can set the rendering parameters in the `[render]` configuration section.
 
 ##### integer_scaling
 
-:   Constrain the horizontal or vertical scaling factor to the largest
-    integer value so the image still fits into the viewport. The configured
-    aspect ratio is always maintained according to the [`aspect`](#aspect) and
-    [`viewport`](#viewport) settings, which may result in a non-integer scaling
-    factor in the other dimension. If the image is larger than the viewport,
-    the integer scaling constraint is auto-disabled (same as `off`).
+:   Constrain the horizontal or vertical scaling factor to the largest integer
+    value so the image still fits into the viewport. The configured aspect
+    ratio is always maintained according to the [`aspect`](#aspect) and
+    [`viewport`](#viewport) settings, which may result in a non-integer
+    scaling factor in the other dimension. If the image is larger than the
+    viewport, the integer scaling constraint is auto-disabled (same as `off`).
 
     Possible values:
 
     - `auto` *default*{ .default } -- A special vertical mode auto-enabled
-      only for the adaptive CRT shaders (see [`shader`](#shader)). This mode
-      has refinements over standard vertical integer scaling: 3.5x and 4.5x
+      only for the CRT shaders (see [`shader`](#shader)). This mode has
+      refinements over standard vertical integer scaling: 3.5x and 4.5x
       scaling factors are also allowed, and integer scaling is disabled above
       5.0x scaling.
-    - `vertical` -- Constrain the vertical scaling factor to integer values.
-      This is the recommended setting for third-party shaders to avoid uneven
-      scanlines and interference artifacts.
+
+    - `vertical`` -- Constrain the vertical scaling factor to integer values.
+      This is the recommended setting for 3rd party CRT shaders with scanline
+      emulation to avoid uneven scanlines and interference artifacts. For the
+      built-in CRT shaders, use `auto`. This mode is also recommended on
+      low-resolution displays with [`deinterlacing`](#deinterlacing) enabled.
+
     - `horizontal` -- Constrain the horizontal scaling factor to integer
-      values.
-    - `off` -- No integer scaling constraint is applied; the image fills the
+      values. Might be useful on low-resolution displays to optimise for
+      horizontal text sharpness.
+
+    - `off` -- Apply no integer scaling constraint; the image fills the
       viewport while maintaining the configured aspect ratio.
 
 


### PR DESCRIPTION
# Description

Fixes https://github.com/dosbox-staging/dosbox-staging/issues/4897

Now `integer_scaling = auto` disables integer scaling for all non-CRT shaders, not just `sharp`.

## Related issues

- https://github.com/dosbox-staging/dosbox-staging/issues/4897

# Release notes

- `integer_scaling = auto` now auto-enables vertical integer scaling for all CRT shaders, not just the adaptive one (e.g., when you set a specific CRT shader & preset combo directly).


# Manual testing

- Tested that with the stock settings (`integer_scaling` on `auto`) `sharp`, `bilinear`, `neares`, `interpolation/catmull-rom`, and `scaler/xbr-lv3` doesn't trigger vertical integer scaling
- Tested that `crt-auto` and `crt/crt-hyllian:vga-4k` does trigger vertical integer scaling


The change has been manually tested on:

- [ ] Windows
- [x] macOS
- [ ] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [x] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [x] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

