### PR TITLE
Improve PC speaker impulse model

### DIFF
--- a/src/hardware/CMakeLists.txt
+++ b/src/hardware/CMakeLists.txt
@@ -14,6 +14,7 @@ target_sources(dosboxcommon PRIVATE
   audio/pcspeaker.cpp
   audio/pcspeaker_discrete.cpp
   audio/pcspeaker_impulse.cpp
+  audio/pcspeaker_pit.cpp
   audio/ps1audio.cpp
   audio/soundblaster.cpp
   audio/speaker.cpp
@@ -94,4 +95,3 @@ target_link_libraries(dosboxcommon PRIVATE
 if (C_MANYMOUSE)
   target_link_libraries(dosboxcommon PRIVATE manymouse)
 endif()
-

--- a/src/hardware/audio/pcspeaker.cpp
+++ b/src/hardware/audio/pcspeaker.cpp
@@ -72,7 +72,9 @@ static void init_pcspeaker_settings(SectionProp& section)
 	        "              in a small number of programs.\n"
 	        "\n"
 	        "  discrete:   Legacy simplified PC speaker emulation; only use this on specific\n"
-	        "              titles that give you problems with the 'impulse' model.\n"
+	        "              titles that give you problems with the 'impulse' model,\n"
+	        "              and please report any issues. The discrete model is\n"
+	        "              deprecated and will be removed in a future release.\n"
 	        "\n"
 	        "  none, off:  Don't emulate the PC speaker.");
 	pstring->SetValues({"impulse", "discrete", "none", "off"});

--- a/src/hardware/audio/pcspeaker_discrete.cpp
+++ b/src/hardware/audio/pcspeaker_discrete.cpp
@@ -196,6 +196,20 @@ void PcSpeakerDiscrete::ForwardPIT(const float newindex)
 	}
 }
 
+// Control word written for channel 2: drain pending audio with the old state,
+// then park in a safe sentinel until SetCounter installs the new count.
+void PcSpeakerDiscrete::SetPITControl(const PitMode /*pit_mode*/)
+{
+	const auto newindex = static_cast<float>(PIC_TickIndex());
+	ForwardPIT(newindex);
+
+	prev_pit_mode = pit_mode;
+	pit_last      = 0;
+	pit_mode      = PitMode::InterruptOnTerminalCount;
+
+	channel->WakeUp();
+}
+
 // PIT-mode activation
 void PcSpeakerDiscrete::SetCounter(int count, const PitMode mode)
 {
@@ -245,7 +259,7 @@ void PcSpeakerDiscrete::SetCounter(int count, const PitMode mode)
 
 	case PitMode::SquareWaveAlias:
 	case PitMode::SquareWave:
-		if (count == 0 || count < minimum_tick_rate) {
+		if (count < minimum_tick_rate) {
 			// skip frequencies that can't be represented
 			pit_last = 0;
 			pit_mode = PitMode::InterruptOnTerminalCount;

--- a/src/hardware/audio/pcspeaker_impulse.cpp
+++ b/src/hardware/audio/pcspeaker_impulse.cpp
@@ -1,491 +1,319 @@
-// SPDX-FileCopyrightText:  2020-2025 The DOSBox Staging Team
-// SPDX-FileCopyrightText:  2011-2011  ripa, from vogons.org
-// SPDX-FileCopyrightText:  2002-2021 The DOSBox Team
+// SPDX-FileCopyrightText:  2025-2026 The DOSBox Staging Team
 // SPDX-License-Identifier: GPL-2.0-or-later
-
-// NOTE: a lot of this code assumes that the callback is called every emulated
-// millisecond
 
 #include "private/pcspeaker_impulse.h"
 
+#include <algorithm>
+#include <cmath>
+
 #include "utils/checks.h"
-#include "utils/math_utils.h"
 
 CHECK_NARROWING();
 
-// Comment out the following to use the reference implementation.
-#define USE_LOOKUP_TABLES 1
-
-void PcSpeakerImpulse::AddPITOutput(const float index)
-{
-	if (prev_port_b.speaker_output) {
-		AddImpulse(index, pit.amplitude);
-	}
-}
-
-void PcSpeakerImpulse::ForwardPIT(const float new_index)
-{
-	auto passed = new_index - pit.last_index;
-
-	auto delay_base = pit.last_index;
-
-	pit.last_index = new_index;
-
-	switch (pit.mode) {
-	case PitMode::Inactive: return;
-
-	case PitMode::InterruptOnTerminalCount:
-		if (pit.index >= pit.max_ms) {
-			/// counter reached zero before previous call so do nothing
-			return;
-		}
-		pit.index += passed;
-		if (pit.index >= pit.max_ms) {
-			// counter reached zero between previous and this call
-			const auto delay = delay_base + pit.max_ms - pit.index + passed;
-			pit.amplitude    = positive_amplitude;
-			AddPITOutput(delay);
-		}
-		return;
-
-	case PitMode::OneShot:
-		if (pit.mode1_waiting_for_counter) {
-			// assert output amplitude is high
-			return; // counter not written yet
-		}
-		if (pit.mode1_waiting_for_trigger) {
-			// assert output amplitude is high
-			return; // no pulse yet
-		}
-		if (pit.index >= pit.max_ms) {
-			// counter reached zero before previous call so do nothing
-			return;
-		}
-		pit.index += passed;
-		if (pit.index >= pit.max_ms) {
-			// counter reached zero between previous and this call
-			const auto delay = delay_base + pit.max_ms - pit.index + passed;
-			pit.amplitude    = positive_amplitude;
-			AddPITOutput(delay);
-			// finished with this pulse
-			pit.mode1_waiting_for_trigger = 1;
-		}
-		return;
-
-	case PitMode::RateGenerator:
-	case PitMode::RateGeneratorAlias:
-		while (passed > 0) {
-			// passed the initial low cycle?
-			if (pit.index >= pit.half_ms) {
-				// Start a new low cycle
-				if ((pit.index + passed) >= pit.max_ms) {
-					const auto delay = pit.max_ms - pit.index;
-					delay_base += delay;
-					passed -= delay;
-					pit.amplitude = negative_amplitude;
-					AddPITOutput(delay_base);
-					pit.index = 0;
-				} else {
-					pit.index += passed;
-					return;
-				}
-			} else {
-				if ((pit.index + passed) >= pit.half_ms) {
-					const auto delay = pit.half_ms - pit.index;
-					delay_base += delay;
-					passed -= delay;
-					pit.amplitude = positive_amplitude;
-					AddPITOutput(delay_base);
-					pit.index = pit.half_ms;
-				} else {
-					pit.index += passed;
-					return;
-				}
-			}
-		}
-		break;
-
-	case PitMode::SquareWave:
-	case PitMode::SquareWaveAlias:
-		if (!pit.mode3_counting)
-			break;
-		while (passed > 0) {
-			// Determine where in the wave we're located
-			if (pit.index >= pit.half_ms) {
-				if ((pit.index + passed) >= pit.max_ms) {
-					const auto delay = pit.max_ms - pit.index;
-					delay_base += delay;
-					passed -= delay;
-					pit.amplitude = positive_amplitude;
-					AddPITOutput(delay_base);
-					pit.index = 0;
-					// Load the new count
-					pit.max_ms  = pit.new_max_ms;
-					pit.half_ms = pit.new_half_ms;
-				} else {
-					pit.index += passed;
-					return;
-				}
-			} else {
-				if ((pit.index + passed) >= pit.half_ms) {
-					const auto delay = pit.half_ms - pit.index;
-					delay_base += delay;
-					passed -= delay;
-					pit.amplitude = negative_amplitude;
-					AddPITOutput(delay_base);
-					pit.index = pit.half_ms;
-					// Load the new count
-					pit.max_ms  = pit.new_max_ms;
-					pit.half_ms = pit.new_half_ms;
-				} else {
-					pit.index += passed;
-					return;
-				}
-			}
-		}
-		break;
-
-	case PitMode::SoftwareStrobe:
-		if (pit.index < pit.max_ms) {
-			// Check if we're gonna pass the end this block
-			if (pit.index + passed >= pit.max_ms) {
-				const auto delay = pit.max_ms - pit.index;
-				delay_base += delay;
-				// passed -= delay; // not currently used
-				pit.amplitude = negative_amplitude;
-				// No new events unless reprogrammed
-				AddPITOutput(delay_base);
-				pit.index = pit.max_ms;
-			} else
-				pit.index += passed;
-		}
-		break;
-	default:
-		// other modes not implemented
-		break;
-	}
-}
-
-void PcSpeakerImpulse::SetPITControl(const PitMode pit_mode)
-{
-	const auto new_index = static_cast<float>(PIC_TickIndex());
-	ForwardPIT(new_index);
-#ifdef SPKR_DEBUGGING
-	LOG_INFO("PCSPEAKER: %f pit command: %s", PIC_FullIndex(), pit_mode_to_string(pit_mode));
+#if 0
+#define DEBUG_PCSPEAKER 1
 #endif
-	// TODO: implement all modes
-	switch (pit_mode) {
-	case PitMode::OneShot:
-		pit.mode      = pit_mode;
-		pit.amplitude = positive_amplitude;
 
-		pit.mode1_waiting_for_counter = 1;
-		pit.mode1_waiting_for_trigger = 0;
-		break;
-
-	case PitMode::SquareWave:
-	case PitMode::SquareWaveAlias:
-		pit.mode      = pit_mode;
-		pit.amplitude = positive_amplitude;
-
-		pit.mode3_counting = false;
-		break;
-
-	default: return;
-	}
-	AddPITOutput(new_index);
-}
-
-void PcSpeakerImpulse::SetCounter(const int cntr, const PitMode pit_mode)
+// Unnormalized sinc: sinc(0) = 1, sinc(x) = sin(x)/x
+static constexpr double sinc(const double x)
 {
-#ifdef SPKR_DEBUGGING
-	LOG_INFO("PCSPEAKER: %f counter: %u, mode: %s", PIC_FullIndex(), cntr, pit_mode_to_string(pit_mode));
-#endif
-	const auto new_index = static_cast<float>(PIC_TickIndex());
-
-	const auto duration_of_count_ms = ms_per_pit_tick * static_cast<float>(cntr);
-	ForwardPIT(new_index);
-
-	switch (pit_mode) {
-	case PitMode::InterruptOnTerminalCount:
-		// used with "realsound" (PWM)
-		pit.index = 0;
-
-		pit.amplitude = negative_amplitude;
-		pit.max_ms    = duration_of_count_ms;
-
-		AddPITOutput(new_index);
-		break;
-
-	case PitMode::OneShot: // used by Star Control 1
-		pit.mode1_pending_max = duration_of_count_ms;
-		if (pit.mode1_waiting_for_counter) {
-			// assert output amplitude is high
-			pit.mode1_waiting_for_counter = 0;
-			pit.mode1_waiting_for_trigger = 1;
-		}
-		break;
-
-	// Single cycle low, rest low high generator
-	case PitMode::RateGenerator:
-	case PitMode::RateGeneratorAlias:
-		pit.index     = 0;
-		pit.amplitude = negative_amplitude;
-
-		AddPITOutput(new_index);
-
-		pit.max_ms  = duration_of_count_ms;
-		pit.half_ms = ms_per_pit_tick;
-		break;
-
-	case PitMode::SquareWave:
-	case PitMode::SquareWaveAlias:
-		if (cntr < minimum_counter) {
-			// avoid breaking digger music
-			pit.amplitude = positive_amplitude;
-			pit.mode      = PitMode::Inactive;
-
-			AddPITOutput(new_index);
-			return;
-		}
-		pit.new_max_ms  = duration_of_count_ms;
-		pit.new_half_ms = pit.new_max_ms / 2;
-		if (!pit.mode3_counting) {
-			pit.index = 0;
-
-			pit.max_ms  = pit.new_max_ms;
-			pit.half_ms = pit.new_half_ms;
-			if (prev_port_b.timer2_gating) {
-				pit.mode3_counting = true;
-				// probably not necessary
-				pit.amplitude = positive_amplitude;
-				AddPITOutput(new_index);
-			}
-		}
-		break;
-
-	case PitMode::SoftwareStrobe:
-		pit.amplitude = positive_amplitude;
-		AddPITOutput(new_index);
-		pit.index  = 0;
-		pit.max_ms = duration_of_count_ms;
-		break;
-
-	default:
-#ifdef SPKR_DEBUGGING
-		LOG_WARNING("PCSPEAKER: Unhandled speaker PIT mode: '%s' at %f", pit_mode_to_string(pit_mode), PIC_FullIndex());
-#endif
-		return;
+	if (x == 0.0) {
+		return 1.0;
 	}
-	pit.mode = pit_mode;
-}
-
-void PcSpeakerImpulse::SetType(const PpiPortB &port_b)
-{
-#ifdef SPKR_DEBUGGING
-	LOG_INFO("PCSPEAKER: %f output: %s, clock gate %s",
-	         PIC_FullIndex(),
-	         port_b.speaker_output ? "pit" : "forced low",
-	         port_b.timer2_gating ? "on" : "off");
-#endif
-	const auto new_index = static_cast<float>(PIC_TickIndex());
-	ForwardPIT(new_index);
-	// pit clock gate enable rising edge is a trigger
-	const bool pit_trigger = !prev_port_b.timer2_gating && port_b.timer2_gating;
-
-	prev_port_b.data = port_b.data;
-	if (pit_trigger) {
-		switch (pit.mode) {
-		case PitMode::OneShot:
-			if (pit.mode1_waiting_for_counter) {
-				// assert output amplitude is high
-				break;
-			}
-			pit.amplitude = negative_amplitude;
-			pit.index     = 0;
-			pit.max_ms    = pit.mode1_pending_max;
-
-			pit.mode1_waiting_for_trigger = 0;
-			break;
-
-		case PitMode::SquareWave:
-		case PitMode::SquareWaveAlias:
-			pit.mode3_counting = true;
-			// pit.new_max_ms = pit.new_max_ms; // typo or bug?
-			pit.index       = 0;
-			pit.max_ms      = pit.new_max_ms;
-			pit.new_half_ms = pit.new_max_ms / 2;
-			pit.half_ms     = pit.new_half_ms;
-			pit.amplitude   = positive_amplitude;
-			break;
-
-		default:
-			// TODO: implement other modes
-			break;
-		}
-	} else if (!port_b.timer2_gating) {
-		switch (pit.mode) {
-		case PitMode::OneShot:
-			// gate amplitude does not affect mode1
-			break;
-
-		case PitMode::SquareWave:
-		case PitMode::SquareWaveAlias:
-			// low gate forces pit output high
-			pit.amplitude      = positive_amplitude;
-			pit.mode3_counting = false;
-			break;
-
-		default:
-			// TODO: implement other modes
-			break;
-		}
-	}
-	if (port_b.speaker_output) {
-		AddImpulse(new_index, pit.amplitude);
-	} else {
-		AddImpulse(new_index, negative_amplitude);
-	}
-}
-
-// TODO: check if this is accurate
-static double sinc(const double t)
-{
-	double result = 1.0;
-
-	constexpr auto sinc_accuracy = 20;
-	for (auto k = 1; k < sinc_accuracy; ++k) {
-		result *= cos(t / pow(2.0, k));
-	}
-	return result;
+	return std::sin(x) / x;
 }
 
 float PcSpeakerImpulse::CalcImpulse(const double t) const
 {
-	// raised-cosine-windowed sinc function
-	const double fs = sample_rate_hz;
-	const auto fc   = fs / (2 + static_cast<double>(cutoff_margin));
-	const auto q    = static_cast<double>(sinc_filter_quality);
-	if ((0 < t) && (t * fs < q)) {
-		const auto window    = 1.0 + cos(2 * fs * M_PI * (q / (2 * fs) - t) / q);
-		const auto amplitude = window * (sinc(2 * fc * M_PI * (t - q / (2 * fs)))) / 2.0;
-		return static_cast<float>(amplitude);
-	} else
-		return 0.0f;
+	// Raised-cosine-windowed sinc, identical to the impulse model
+	constexpr double Fs = SampleRateHz;
+	constexpr double Fc = Fs / (2.0 + CutoffMargin);
+	constexpr double Q  = static_cast<double>(SincFilterQuality);
+
+	// The model integrates these impulses, so the integrated step height is
+	// proportional to the sum of the taps, which grows with the sample rate
+	// (more taps span the same fixed-duration window). Normalise by the
+	// reference rate so the step height (output loudness) matches
+	// the original 32 kHz model.
+	constexpr double Gain = ReferenceSampleRateHz / Fs;
+
+	float res = 0.0f;
+
+	if ((0 < t) && (t * Fs < Q)) {
+		constexpr auto Midpoint = Q / (2.0 * Fs);
+		const auto window = 1.0 +
+		                    std::cos(2.0 * Fs * M_PI * (Midpoint - t) / Q);
+		const auto amplitude = Gain * window *
+		                       sinc(2.0 * Fc * M_PI * (t - Midpoint)) / 2.0;
+		res = static_cast<float>(amplitude);
+	}
+
+	return res;
 }
 
-void PcSpeakerImpulse::AddImpulse(float index, const int16_t amplitude)
+void PcSpeakerImpulse::HandleWakeUp()
 {
-	if (channel->WakeUp())
-		pit.prev_amplitude = neutral_amplitude;
+	if (channel->WakeUp()) {
+		prev_amplitude = NeutralAmplitude;
+	}
+}
 
-	// Did the amplitude change?
-	if (amplitude == pit.prev_amplitude)
+void PcSpeakerImpulse::InitializeLut()
+{
+	const auto sample_step = 1.0 /
+	                         (static_cast<double>(SampleRateHz) *
+	                          SincOversamplingFactor);
+
+	double sample_time = 0.0;
+	for (auto it = impulse_lut.begin(); it != impulse_lut.end(); ++it) {
+		*it = CalcImpulse(sample_time);
+		sample_time += sample_step;
+	}
+}
+
+void PcSpeakerImpulse::AddImpulse(const float index, const int16_t amplitude)
+{
+	if (amplitude == prev_amplitude) {
 		return;
-
-	pit.prev_amplitude = amplitude;
-	// Make sure the time index is valid
-	index = clamp(index, 0.0f, 1.0f);
-
-#ifdef USE_LOOKUP_TABLES
-	// Use pre-calculated sinc lookup tables
-	const auto samples_in_impulse = index * sample_rate_per_ms;
-	auto phase = static_cast<int>(samples_in_impulse * sinc_oversampling_factor) %
-	             sinc_oversampling_factor;
-	auto offset = static_cast<int>(samples_in_impulse);
-	if (phase != 0) {
-		offset++;
-		phase = sinc_oversampling_factor - phase;
 	}
+	prev_amplitude = amplitude;
 
-	for (auto i = 0; i < sinc_filter_quality; ++i) {
-		const auto wave_i    = check_cast<uint16_t>(offset + i);
-		const auto impulse_i = check_cast<uint16_t>(
-		        phase + i * sinc_oversampling_factor);
-		waveform_deque.at(wave_i) += amplitude * impulse_lut.at(impulse_i);
+	const auto clamped = std::clamp(index, 0.0f, 1.0f);
+
+	const auto base      = static_cast<double>(clamped) * SampleRatePerMs;
+	const auto phase_raw = static_cast<int>(base * SincOversamplingFactor) %
+	                       SincOversamplingFactor;
+
+	const auto offset = static_cast<int>(base) + (phase_raw != 0 ? 1 : 0);
+
+	const auto phase = (phase_raw != 0) ? (SincOversamplingFactor - phase_raw)
+	                                    : 0;
+	const auto k_start = (phase_raw == 0) ? 1 : 0;
+
+	const auto k_end = std::min(SincFilterQuality,
+	                            static_cast<int>(waveform.size()) - offset);
+
+	for (auto k = k_start; k < k_end; ++k) {
+		waveform[static_cast<size_t>(offset) + static_cast<size_t>(k)] +=
+		        amplitude *
+		        impulse_lut[static_cast<size_t>(phase) +
+		                    static_cast<size_t>(k) * static_cast<size_t>(SincOversamplingFactor)];
+	}
+}
+
+int16_t PcSpeakerImpulse::OutputAmplitude(const bool speaker_enabled,
+                                          const OutputState output)
+{
+	if (!speaker_enabled) {
+		return NegativeAmplitude;
+	}
+	return (output == OutputState::High) ? PositiveAmplitude : NegativeAmplitude;
+}
+
+void PcSpeakerImpulse::ApplyTransitions(const std::vector<PitCounter::Transition>& transitions,
+                                        const float index_base,
+                                        const bool speaker_enabled)
+{
+	for (const auto& t : transitions) {
+		const auto index = index_base + t.offset_ms;
+		AddImpulse(index, OutputAmplitude(speaker_enabled, t.output));
 	}
 }
 
-#else
-	// Mathematically intensive reference implementation
-	const auto portion_of_ms = static_cast <double>(index) / MillisInSecond;
-	for (size_t i = 0; i < waveform_deque.size(); ++i) {
-		const auto impulse_time = static_cast<double>(i) / sample_rate_hz -
-		                          portion_of_ms;
+float PcSpeakerImpulse::SyncPitToTick()
+{
+	HandleWakeUp();
 
-		waveform_deque[i] += amplitude * CalcImpulse(impulse_time);
+	const auto index = static_cast<float>(PIC_TickIndex());
+	const auto delta = index - pit_last_index;
+	if (delta > 0.0f) {
+		const auto t = pit_counter.Advance(delta);
+		ApplyTransitions(t, pit_last_index, port_b.speaker_output);
 	}
+	pit_last_index = index;
+	return index;
 }
+
+// Control word written (timer.cpp calls this before SetCounter when mode changes)
+void PcSpeakerImpulse::SetPITControl(const PitMode pit_mode)
+{
+#ifdef DEBUG_PCSPEAKER
+	LOG_INFO("PCSPEAKER: %.3f ctrl=%s gate=%d m3=%d spk=%d",
+	         PIC_FullIndex(),
+	         pit_mode_to_string(pit_mode),
+	         pit_counter.IsGateEnabled(),
+	         pit_counter.IsMode3Active(),
+	         static_cast<int>(port_b.speaker_output));
 #endif
+	const auto index = SyncPitToTick();
+
+	const auto t = pit_counter.WriteControl(pit_mode);
+	ApplyTransitions(t, index, port_b.speaker_output);
+}
+
+// Count register written
+void PcSpeakerImpulse::SetCounter(const int counter, const PitMode pit_mode)
+{
+#ifdef DEBUG_PCSPEAKER
+	LOG_INFO("PCSPEAKER: %.3f counter=%d mode=%s gate=%d m3=%d spk=%d under=%d",
+	         PIC_FullIndex(),
+	         counter,
+	         pit_mode_to_string(pit_mode),
+	         pit_counter.IsGateEnabled(),
+	         pit_counter.IsMode3Active(),
+	         static_cast<int>(port_b.speaker_output),
+	         static_cast<int>(have_undersampled_reload));
+#endif
+	const auto index = SyncPitToTick();
+
+	const bool is_square = (pit_mode == PitMode::SquareWave ||
+	                        pit_mode == PitMode::SquareWaveAlias);
+
+	if (is_square && counter > 0 && counter < MinimumCounter) {
+		// Counter is too high-frequency to represent at our sample
+		// rate. Rapid reloads of undersampled counts are used by some
+		// programs as a noise source; toggle amplitude for each such
+		// reload.
+		const auto now_ms = static_cast<float>(PIC_FullIndex());
+		const auto previous_reload_gap_ms = now_ms - undersampled_reload_ms;
+		const auto is_rapid_reload = have_undersampled_reload &&
+		                             previous_reload_gap_ms >= 0.0f &&
+		                             previous_reload_gap_ms <=
+		                                     MaxUndersampledReloadGapMs;
+
+		if (port_b.timer2_gating_and_speaker_out.all() && is_rapid_reload) {
+			// Toggle — emit whatever the opposite of current output is
+			const int16_t toggled = (prev_amplitude == PositiveAmplitude)
+			                              ? NegativeAmplitude
+			                              : PositiveAmplitude;
+			AddImpulse(index, toggled);
+		}
+
+		// Stop the PIT from producing further output at the old
+		// frequency. Without this, Advance() keeps oscillating at the
+		// prior valid period.
+		pit_counter.Invalidate();
+
+		have_undersampled_reload = true;
+		undersampled_reload_ms   = now_ms;
+		return;
+	}
+
+	have_undersampled_reload = false;
+
+	const auto t = pit_counter.WriteCount(counter);
+	ApplyTransitions(t, index, port_b.speaker_output);
+
+	// If a gate-rising edge was suppressed while in undersampled state,
+	// pit_counter.gate is still false. Sync it now so oscillation can start.
+	// In the normal path (gate already synced), EnableGate(true) is a no-op.
+	if (port_b.timer2_gating) {
+		const auto gate_t = pit_counter.EnableGate(true);
+		ApplyTransitions(gate_t, index, port_b.speaker_output);
+	}
+
+#ifdef DEBUG_PCSPEAKER
+	LOG_INFO("PCSPEAKER: %.3f counter=%d -> gate=%d m3=%d",
+	         PIC_FullIndex(),
+	         counter,
+	         pit_counter.IsGateEnabled(),
+	         pit_counter.IsMode3Active());
+#endif
+}
+
+// Port B changed (speaker_output and/or timer2_gating bits)
+void PcSpeakerImpulse::SetType(const PpiPortB& new_port_b)
+{
+#ifdef DEBUG_PCSPEAKER
+	LOG_INFO("PCSPEAKER: %.3f type spk=%d gate=%d (was spk=%d gate=%d) m3=%d under=%d",
+	         PIC_FullIndex(),
+	         static_cast<int>(new_port_b.speaker_output),
+	         static_cast<int>(new_port_b.timer2_gating),
+	         static_cast<int>(port_b.speaker_output),
+	         static_cast<int>(port_b.timer2_gating),
+	         pit_counter.IsMode3Active(),
+	         static_cast<int>(have_undersampled_reload));
+#endif
+	const auto index = SyncPitToTick();
+
+	const bool gate_changed = new_port_b.timer2_gating != port_b.timer2_gating;
+	const bool speaker_enabled = new_port_b.speaker_output;
+	port_b.data                = new_port_b.data;
+
+	const bool gate_triggered = gate_changed && new_port_b.timer2_gating;
+
+	if (gate_changed) {
+		// Don't allow a gate-rising edge to restart the PIT while we
+		// are in the undersampled-suppressed state; the stored period
+		// is ultrasonic. Gate-falling still propagates so modes 2/3
+		// correctly force output HIGH.
+		if (!gate_triggered || !have_undersampled_reload) {
+			const auto t = pit_counter.EnableGate(new_port_b.timer2_gating);
+			ApplyTransitions(t, index, speaker_enabled);
+		}
+	}
+
+	AddImpulse(index,
+	           OutputAmplitude(speaker_enabled, pit_counter.GetOutputState()));
+}
 
 void PcSpeakerImpulse::PicCallback(const int requested_frames)
 {
-	ForwardPIT(1.0f);
-	pit.last_index = 0;
+	HandleWakeUp();
+
+	// Advance PIT to end of this 1 ms tick
+	const auto remaining = 1.0f - pit_last_index;
+	if (remaining > 0.0f) {
+		const auto t = pit_counter.Advance(remaining);
+		ApplyTransitions(t, pit_last_index, port_b.speaker_output);
+	}
+	pit_last_index = 0.0f;
+
+	render_buf.clear();
+
 	int remaining_frames = requested_frames;
 
-	static float accumulator = 0;
-	while (remaining_frames > 0 && waveform_deque.size()) {
-		// Pop the first sample off the waveform
-		accumulator += waveform_deque.front();
-		waveform_deque.pop_front();
-		waveform_deque.push_back(0.0f);
+	while (remaining_frames > 0 && !waveform.empty()) {
+		accumulator += waveform.front();
+		waveform.pop_front();
+		waveform.push_back(0.0f);
 
-		// std::move only used here because it won't compile without
-		// This is just a float so it's safe to use afterwards
-		output_queue.NonblockingEnqueue(std::move(accumulator));
+		render_buf.emplace_back(accumulator);
 		--remaining_frames;
 
-		// Keep a tally of sequential silence so we can sleep the channel
-		tally_of_silence = fabsf(accumulator) > 1.0f
+		tally_of_silence = (std::abs(accumulator) > 1.0f)
 		                         ? 0
 		                         : tally_of_silence + 1;
 
-		// Scale down the running volume amplitude. Eventually it will
-		// hit 0 if no other waveforms are generated.
-		accumulator *= sinc_amplitude_fade;
+		accumulator *= SincAmplitudeFade;
 	}
 
-	// Write silence if the waveform deque ran out
-	if (remaining_frames)
-		pit.prev_amplitude = neutral_amplitude;
-
-	while (remaining_frames) {
-		output_queue.NonblockingEnqueue(neutral_amplitude);
+	// Pad with silence if waveform deque ran out
+	if (remaining_frames > 0) {
+		prev_amplitude = NeutralAmplitude;
+	}
+	while (remaining_frames > 0) {
+		render_buf.emplace_back(NeutralAmplitude);
 		++tally_of_silence;
 		--remaining_frames;
 	}
-}
 
-void PcSpeakerImpulse::InitializeImpulseLUT()
-{
-	assert(impulse_lut.size() == sinc_filter_width);
-
-	for (auto i = 0u; i < sinc_filter_width; ++i) {
-		impulse_lut[i] = CalcImpulse(i / (static_cast<double>(sample_rate_hz) *
-		                                  sinc_oversampling_factor));
-	}
+	output_queue.NonblockingBulkEnqueue(render_buf);
 }
 
 void PcSpeakerImpulse::SetFilterState(const FilterState filter_state)
 {
 	assert(channel);
 
-	// Setup filters
 	if (filter_state == FilterState::On) {
-		// The filters are meant to emulate the bandwidth limited
-		// sound of the small PC speaker. This more accurately
-		// reflects people's actual experience of the PC speaker
-		// sound than the raw unfiltered output, and it's a lot
-		// more pleasant to listen to, especially in headphones.
-		constexpr auto hp_order          = 3;
-		constexpr auto hp_cutoff_freq_hz = 120;
-		channel->ConfigureHighPassFilter(hp_order, hp_cutoff_freq_hz);
+		constexpr auto HpOrder        = 3;
+		constexpr auto HpCutoffFreqHz = 120;
+		channel->ConfigureHighPassFilter(HpOrder, HpCutoffFreqHz);
 		channel->SetHighPassFilter(FilterState::On);
 
-		constexpr auto lp_order          = 3;
-		constexpr auto lp_cutoff_freq_hz = 4300;
-		channel->ConfigureLowPassFilter(lp_order, lp_cutoff_freq_hz);
+		constexpr auto LpOrder        = 3;
+		constexpr auto LpCutoffFreqHz = 4300;
+		channel->ConfigureLowPassFilter(LpOrder, LpCutoffFreqHz);
 		channel->SetLowPassFilter(FilterState::On);
 	} else {
 		channel->SetHighPassFilter(FilterState::Off);
@@ -501,46 +329,39 @@ bool PcSpeakerImpulse::TryParseAndSetCustomFilter(const std::string& filter_choi
 
 PcSpeakerImpulse::PcSpeakerImpulse()
 {
-	// The implementation is tuned to working with sample rates that are
-	// multiples of 8000, such as 8 Khz, 16 Khz, or 32 Khz. Anything besides
-	// these will produce unwanted artifacts.
-	static_assert(sample_rate_hz >= 8000, "Sample rate must be at least 8 kHz");
-	static_assert(sample_rate_hz % 1000 == 0,
-	              "Sample rate must be a multiple of 1000");
+	static_assert(SampleRateHz > 0 && SampleRateHz % 8000 == 0,
+	              "Sample rate must be a multiple of 8000 to avoid artifacts");
 
-	InitializeImpulseLUT();
+	InitializeLut();
+	waveform.resize(WaveformSize, 0.0f);
 
-	// Size the waveform queue
-	constexpr auto waveform_size = sinc_filter_quality + sample_rate_per_ms;
-	waveform_deque.resize(waveform_size, 0.0f);
-
-	// Register the sound channel
-	constexpr bool Stereo = false;
-	constexpr bool SignedData = true;
+	constexpr bool Stereo      = false;
+	constexpr bool SignedData  = true;
 	constexpr bool NativeOrder = true;
-	const auto callback = std::bind(MIXER_PullFromQueueCallback<PcSpeakerImpulse, float, Stereo, SignedData, NativeOrder>,
-	                                std::placeholders::_1,
-	                                this);
+
+	const auto callback = [this](int frames) {
+		MIXER_PullFromQueueCallback<PcSpeakerImpulse, float, Stereo, SignedData, NativeOrder>(
+		        frames, this);
+	};
 
 	channel = MIXER_AddChannel(callback,
-	                           sample_rate_hz,
-	                           device_name,
+	                           SampleRateHz,
+	                           DeviceName,
 	                           {ChannelFeature::Sleep,
 	                            ChannelFeature::ChorusSend,
 	                            ChannelFeature::ReverbSend,
 	                            ChannelFeature::Synthesizer});
 	assert(channel);
 
-	LOG_MSG("%s: Initialised %s model", device_name, model_name);
+	channel->SetPeakAmplitude(PositiveAmplitude);
 
-	channel->SetPeakAmplitude(positive_amplitude);
+	LOG_MSG("%s: Initialised %s model", DeviceName, ModelName);
 }
 
 PcSpeakerImpulse::~PcSpeakerImpulse()
 {
-	LOG_MSG("%s: Shutting down %s model", device_name, model_name);
+	LOG_MSG("%s: Shutting down %s model", DeviceName, ModelName);
 
-	// Deregister the mixer channel, after which it's cleaned up
 	assert(channel);
 	MIXER_DeregisterChannel(channel);
 }

--- a/src/hardware/audio/pcspeaker_pit.cpp
+++ b/src/hardware/audio/pcspeaker_pit.cpp
@@ -1,0 +1,368 @@
+// SPDX-FileCopyrightText:  2025-2026 The DOSBox Staging Team
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "private/pcspeaker_pit.h"
+
+#include "utils/checks.h"
+
+#include <algorithm>
+
+CHECK_NARROWING();
+
+void PitCounter::Emit(const OutputState state, const float offset_ms,
+                      std::vector<Transition>& out)
+{
+	if (state == output_state) {
+		return;
+	}
+	output_state = state;
+	out.emplace_back(Transition{offset_ms, state});
+}
+
+// Intel 8254 / 82C54 datasheet, mode definitions:
+//
+//   Mode 0: output LOW on control word write; counting starts after count
+//           load (gate high). Output goes HIGH at terminal count and latches.
+//   Mode 1: output HIGH on control word write; counting started by gate
+//           rising edge, not by count load. Output LOW during count, HIGH at TC.
+//   Mode 2: output HIGH on control word write; LOW pulse (1 clock) at
+//           terminal count every N clocks. Gate low forces output HIGH and
+//           freezes count; gate rising edge restarts.
+//   Mode 3: output HIGH on control word write; square wave, HIGH for ceil(N/2)
+//           clocks, LOW for floor(N/2) clocks. New count takes effect at next
+//           half-period boundary. Gate same as mode 2.
+//   Mode 4: output HIGH on control word write; like mode 0 start, but
+//           generates a single 1-clock LOW pulse at TC instead of latching.
+//   Mode 5: gate-triggered like mode 1, output like mode 4.
+
+void PitCounter::Invalidate()
+{
+	// Like a gate-low event: mode 3 forces output HIGH when counting stops.
+	// Without this, output_state is frozen mid-cycle (often LOW), which
+	// causes AddImpulse to drop the next rising edge via deduplication.
+	if (mode3_active) {
+		output_state = OutputState::High;
+	}
+	mode3_active       = false;
+	mode3_retain_phase = true;
+	counting           = false;
+}
+
+PitMode PitCounter::Canonical(const PitMode m)
+{
+	switch (m) {
+	case PitMode::RateGeneratorAlias: return PitMode::RateGenerator;
+	case PitMode::SquareWaveAlias: return PitMode::SquareWave;
+	default: return m;
+	}
+}
+
+std::vector<PitCounter::Transition> PitCounter::WriteControl(const PitMode new_mode)
+{
+	std::vector<Transition> out;
+	mode     = Canonical(new_mode);
+	counting = false;
+	phase_ms = 0.0f;
+
+	switch (mode) {
+	case PitMode::InterruptOnTerminalCount:
+		// Output goes LOW immediately on control word write
+		Emit(OutputState::Low, 0.0f, out);
+		break;
+
+	case PitMode::OneShot:
+	case PitMode::HardwareStrobe:
+		// Output goes HIGH immediately; count load arms the trigger
+		Emit(OutputState::High, 0.0f, out);
+		mode1_awaiting_count   = true;
+		mode1_awaiting_trigger = false;
+		break;
+
+	case PitMode::RateGenerator:
+	case PitMode::SquareWave:
+	case PitMode::SoftwareStrobe:
+		// Output goes HIGH immediately
+		Emit(OutputState::High, 0.0f, out);
+		mode3_active       = false;
+		mode3_retain_phase = false;
+		break;
+
+	default: break;
+	}
+
+	return out;
+}
+
+std::vector<PitCounter::Transition> PitCounter::WriteCount(const int count)
+{
+	std::vector<Transition> out;
+
+	// Per 8254 spec (Figure 22): count 0 is equivalent to 65536 (2^16)
+	const int effective_count = (count == 0) ? 0x10000 : count;
+	const auto duration_ms = MsPerTick * static_cast<float>(effective_count);
+
+	switch (mode) {
+	case PitMode::InterruptOnTerminalCount:
+		// Per 8254: after TC, a new count write forces output LOW again.
+		if (output_state == OutputState::High) {
+			Emit(OutputState::Low, 0.0f, out);
+		}
+		phase_ms  = 0.0f;
+		period_ms = duration_ms;
+		counting  = gate;
+		break;
+
+	case PitMode::SoftwareStrobe:
+		phase_ms  = 0.0f;
+		period_ms = duration_ms;
+		counting  = gate;
+		break;
+
+	case PitMode::OneShot:
+	case PitMode::HardwareStrobe:
+		mode1_pending_ms = duration_ms;
+		if (mode1_awaiting_count) {
+			mode1_awaiting_count   = false;
+			mode1_awaiting_trigger = true;
+		}
+		break;
+
+	case PitMode::RateGenerator:
+		new_period_ms = duration_ms;
+		if (!counting) {
+			period_ms = new_period_ms;
+			half_ms   = std::max(period_ms - MsPerTick, 0.0f);
+			if (gate) {
+				phase_ms = 0.0f;
+				counting = true;
+				Emit(OutputState::High, 0.0f, out);
+			}
+		}
+		// If already counting, new period takes effect at the next
+		// period boundary via Advance (same deferred-update pattern as
+		// Mode 3).
+		break;
+
+	case PitMode::SquareWave:
+		new_period_ms = duration_ms;
+		new_half_ms   = MsPerTick * static_cast<float>((count + 1) / 2);
+		if (!mode3_active) {
+			period_ms = new_period_ms;
+			half_ms   = new_half_ms;
+			if (gate) {
+				if (!mode3_retain_phase) {
+					phase_ms = 0.0f;
+					Emit(OutputState::High, 0.0f, out);
+				}
+				mode3_active       = true;
+				mode3_retain_phase = false;
+			}
+		}
+		break;
+
+	default: break;
+	}
+
+	return out;
+}
+
+std::vector<PitCounter::Transition> PitCounter::EnableGate(const bool new_gate)
+{
+	std::vector<Transition> out;
+	const bool rising  = !gate && new_gate;
+	const bool falling = gate && !new_gate;
+	gate               = new_gate;
+
+	switch (mode) {
+	case PitMode::InterruptOnTerminalCount:
+	case PitMode::SoftwareStrobe:
+		// Gate low freezes count; gate high resumes
+		if (rising && !counting && period_ms > 0.0f) {
+			counting = true;
+		} else if (falling) {
+			counting = false;
+		}
+		break;
+
+	case PitMode::OneShot:
+		// Gate rising edge triggers / retriggers; OUT goes LOW immediately
+		if (rising && !mode1_awaiting_count && !mode1_awaiting_trigger) {
+			phase_ms  = 0.0f;
+			period_ms = mode1_pending_ms;
+			counting  = true;
+			Emit(OutputState::Low, 0.0f, out);
+		} else if (rising && mode1_awaiting_trigger) {
+			phase_ms               = 0.0f;
+			period_ms              = mode1_pending_ms;
+			mode1_awaiting_trigger = false;
+			counting               = true;
+			Emit(OutputState::Low, 0.0f, out);
+		}
+		// Gate falling has no effect once counting
+		break;
+
+	case PitMode::HardwareStrobe:
+		// Gate rising edge triggers / retriggers; OUT stays HIGH until
+		// TC (spec: "GATE has no effect on OUT" for mode 5)
+		if (rising && !mode1_awaiting_count && !mode1_awaiting_trigger) {
+			phase_ms  = 0.0f;
+			period_ms = mode1_pending_ms;
+			counting  = true;
+		} else if (rising && mode1_awaiting_trigger) {
+			phase_ms               = 0.0f;
+			period_ms              = mode1_pending_ms;
+			mode1_awaiting_trigger = false;
+			counting               = true;
+		}
+		// Gate falling has no effect once counting
+		break;
+
+	case PitMode::RateGenerator:
+		if (falling) {
+			// Gate low forces output HIGH and freezes count
+			counting = false;
+			Emit(OutputState::High, 0.0f, out);
+		} else if (rising) {
+			// Gate rising restarts from the beginning of the
+			// period; pick up any count written while gate was low.
+			phase_ms  = 0.0f;
+			period_ms = new_period_ms;
+			half_ms   = std::max(period_ms - MsPerTick, 0.0f);
+			counting  = true;
+			Emit(OutputState::High, 0.0f, out);
+		}
+		break;
+
+	case PitMode::SquareWave:
+		if (falling) {
+			mode3_active       = false;
+			mode3_retain_phase = false;
+			Emit(OutputState::High, 0.0f, out);
+		} else if (rising) {
+			phase_ms           = 0.0f;
+			period_ms          = new_period_ms;
+			half_ms            = new_half_ms;
+			mode3_active       = true;
+			mode3_retain_phase = false;
+			Emit(OutputState::High, 0.0f, out);
+		}
+		break;
+
+	default: break;
+	}
+
+	return out;
+}
+
+void PitCounter::AdvanceCountdown(const float duration_ms,
+                                  std::vector<Transition>& out)
+{
+	// Modes 0 and 1: output goes HIGH once at terminal count and latches.
+	if (!counting) {
+		return;
+	}
+	if (phase_ms + duration_ms >= period_ms) {
+		const auto delay = period_ms - phase_ms;
+		Emit(OutputState::High, delay, out);
+		counting = false;
+		phase_ms = period_ms;
+	} else {
+		phase_ms += duration_ms;
+	}
+}
+
+void PitCounter::AdvanceStrobe(const float duration_ms, std::vector<Transition>& out)
+{
+	// Modes 4 and 5: a single one-clock LOW pulse at terminal count, then
+	// the output returns HIGH. Counting stops afterwards either way.
+	if (!counting) {
+		return;
+	}
+	if (phase_ms + duration_ms >= period_ms) {
+		const auto delay = period_ms - phase_ms;
+		Emit(OutputState::Low, delay, out);              // LOW strobe
+		Emit(OutputState::High, delay + MsPerTick, out); // return HIGH
+		counting = false;
+		phase_ms = period_ms;
+	} else {
+		phase_ms += duration_ms;
+	}
+}
+
+void PitCounter::AdvanceOscillator(float duration_ms,
+                                   std::vector<Transition>& out, const bool square)
+{
+	// Modes 2 (rate generator) and 3 (square wave) share the same two-phase
+	// structure: a HIGH segment of half_ms followed by a LOW segment until
+	// period_ms. They differ only in how a pending count reload is applied:
+	//   - Mode 2: reloads at the full-period boundary, and half_ms is fixed
+	//     at period_ms - one clock (the LOW segment is a single clock pulse).
+	//   - Mode 3: reloads at either half-period boundary, with an explicit
+	//     new_half_ms (a true square wave).
+	const bool active = square ? mode3_active : counting;
+	if (!active) {
+		return;
+	}
+
+	auto time_base = 0.0f;
+	while (duration_ms > 0.0f) {
+		if (phase_ms >= half_ms) {
+			// LOW segment, ending at the full-period boundary
+			if (phase_ms + duration_ms >= period_ms) {
+				const auto delay = period_ms - phase_ms;
+				time_base += delay;
+				duration_ms -= delay;
+				phase_ms  = 0.0f;
+				period_ms = new_period_ms;
+				half_ms = square ? new_half_ms
+				                 : std::max(period_ms - MsPerTick,
+				                            0.0f);
+				Emit(OutputState::High, time_base, out); // go HIGH
+			} else {
+				phase_ms += duration_ms;
+				duration_ms = 0.0f;
+			}
+		} else {
+			// HIGH segment, ending at the half-period boundary
+			if (phase_ms + duration_ms >= half_ms) {
+				const auto delay = half_ms - phase_ms;
+				time_base += delay;
+				duration_ms -= delay;
+				phase_ms = half_ms;
+				if (square) {
+					period_ms = new_period_ms;
+					half_ms   = new_half_ms;
+				}
+				Emit(OutputState::Low, time_base, out); // go LOW
+			} else {
+				phase_ms += duration_ms;
+				duration_ms = 0.0f;
+			}
+		}
+	}
+}
+
+std::vector<PitCounter::Transition> PitCounter::Advance(const float duration_ms)
+{
+	std::vector<Transition> out;
+
+	switch (mode) {
+	case PitMode::InterruptOnTerminalCount:
+	case PitMode::OneShot: AdvanceCountdown(duration_ms, out); break;
+
+	case PitMode::HardwareStrobe:
+	case PitMode::SoftwareStrobe: AdvanceStrobe(duration_ms, out); break;
+
+	case PitMode::RateGenerator:
+		AdvanceOscillator(duration_ms, out, /*square=*/false);
+		break;
+
+	case PitMode::SquareWave:
+		AdvanceOscillator(duration_ms, out, /*square=*/true);
+		break;
+
+	default: break;
+	}
+
+	return out;
+}

--- a/src/hardware/audio/private/pcspeaker_discrete.h
+++ b/src/hardware/audio/private/pcspeaker_discrete.h
@@ -24,7 +24,7 @@ public:
 	void SetFilterState(const FilterState filter_state) override;
 	bool TryParseAndSetCustomFilter(const std::string& filter_choice) override;
 	void SetCounter(const int cntr, const PitMode m) override;
-	void SetPITControl(const PitMode) override {}
+	void SetPITControl(const PitMode pit_mode) override;
 	void SetType(const PpiPortB& b) override;
 	void PicCallback(const int requested_frames) override;
 

--- a/src/hardware/audio/private/pcspeaker_impulse.h
+++ b/src/hardware/audio/private/pcspeaker_impulse.h
@@ -1,20 +1,23 @@
-// SPDX-FileSPDText:X Identifier: GPL-2.0-or-later
+// SPDX-FileCopyrightText:  2025-2026 The DOSBox Staging Team
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #ifndef DOSBOX_PCSPEAKER_IMPULSE_H
 #define DOSBOX_PCSPEAKER_IMPULSE_H
 
 #include "pcspeaker.h"
+#include "pcspeaker_pit.h"
 
 #include <array>
 #include <deque>
 #include <string>
+#include <vector>
 
 #include "audio/channel_names.h"
 #include "config/setup.h"
 #include "hardware/pic.h"
 #include "hardware/port.h"
 #include "misc/support.h"
+#include "utils/math_utils.h"
 
 class PcSpeakerImpulse final : public PcSpeaker {
 public:
@@ -23,87 +26,110 @@ public:
 
 	void SetFilterState(const FilterState filter_state) override;
 	bool TryParseAndSetCustomFilter(const std::string& filter_choice) override;
-	void SetCounter(const int cntr, const PitMode pit_mode) override;
+	void SetCounter(const int counter, const PitMode pit_mode) override;
 	void SetPITControl(const PitMode pit_mode) override;
 	void SetType(const PpiPortB& port_b) override;
 	void PicCallback(const int requested_frames) override;
 
 private:
-	void AddImpulse(float index, const int16_t amplitude);
-	void AddPITOutput(const float index);
-	void ForwardPIT(const float new_index);
-	float CalcImpulse(const double t) const;
-	void InitializeImpulseLUT();
+	void AddImpulse(const float index, const int16_t amplitude);
+	float CalcImpulse(double t) const;
+	void InitializeLut();
+	void ApplyTransitions(const std::vector<PitCounter::Transition>& transitions,
+	                      const float index_base, const bool speaker_enabled);
 
-	// Constants
-	static constexpr auto device_name = ChannelName::PcSpeaker;
-	static constexpr auto model_name  = "impulse";
+	// Wake, advance the PIT to the current position within this 1ms tick,
+	// emitting any transitions that occurred since the last sync. Returns the
+	// new position (PIC_TickIndex). Shared preamble of the public entry points.
+	float SyncPitToTick();
 
-	// Amplitude constants
+	// Output amplitude for a given speaker-enable and PIT output level.
+	static int16_t OutputAmplitude(const bool speaker_enabled,
+	                               const OutputState output);
 
-	// The impulse PWM scalar was manually adjusted to roughly match voltage
-	// levels recorded from a hardware PC speaker
-	// Ref:https://github.com/dosbox-staging/dosbox-staging/files/9494469/3.audio.samples.zip
-	static constexpr float pwm_scalar = 0.5f;
+	// Wake the channel and reset dedup state if we were sleeping. While
+	// asleep the mixer emits silence, so prev_amplitude must be reset to
+	// neutral on wake or AddImpulse may dedup-skip a legitimate emission.
+	// Call at the top of any public entry point that may produce impulses.
+	void HandleWakeUp();
 
-	static constexpr int16_t positive_amplitude = static_cast<int16_t>(
-	        Max16BitSampleValue * pwm_scalar);
+	static constexpr auto DeviceName = ChannelName::PcSpeaker;
+	static constexpr auto ModelName  = "impulse";
 
-	static constexpr int16_t negative_amplitude = -positive_amplitude;
-	static constexpr int16_t neutral_amplitude  = 0;
+	// Amplitude: manually tuned to roughly match hardware voltage levels.
+	// Ref:
+	// https://github.com/dosbox-staging/dosbox-staging/files/9494469/3.audio.samples.zip
+	static constexpr float PwmScalar = 0.5f;
 
-	static constexpr float ms_per_pit_tick = 1000.0f / PIT_TICK_RATE;
+	static constexpr int16_t PositiveAmplitude = static_cast<int16_t>(
+	        Max16BitSampleValue * PwmScalar);
+	static constexpr int16_t NegativeAmplitude = -PositiveAmplitude;
+	static constexpr int16_t NeutralAmplitude  = 0;
 
-	// Mixer channel constants
-	static constexpr auto sample_rate_hz     = 32000;
-	static constexpr auto sample_rate_per_ms = sample_rate_hz / 1000;
+	// Fixed sample rate; must be a multiple of 1000 so each 1ms PIC callback
+	// produces an exact integer number of samples (SampleRateHz / 1000).
+	static constexpr auto SampleRateHz    = 48000;
+	static constexpr auto SampleRatePerMs = SampleRateHz / 1000;
 
-	static constexpr auto minimum_counter = 2 * PIT_TICK_RATE / sample_rate_hz;
+	// Minimum PIT count representable at this sample rate (Nyquist)
+	static constexpr auto MinimumCounter = ceil_sdivide(2 * PIT_TICK_RATE,
+	                                                    SampleRateHz);
 
-	// must be greater than 0.0f
-	static constexpr float cutoff_margin = 0.2f;
+	// Reference sample rate of the original impulse model; the cutoff
+	// frequency is kept constant (not scaled with SampleRateHz) so the
+	// two models are tonally equivalent.
+	static constexpr auto ReferenceSampleRateHz = 32000.0;
+	static constexpr auto ReferenceCutoffMargin = 0.2;
+	static constexpr auto CutoffMargin = (SampleRateHz / ReferenceSampleRateHz) *
+	                                             (2.0 + ReferenceCutoffMargin) -
+	                                     2.0;
 
-	// Should be selected based on sampling rate
-	static constexpr float sinc_amplitude_fade     = 0.999f;
-	static constexpr auto sinc_filter_quality      = 100;
-	static constexpr auto sinc_oversampling_factor = 32;
+	static constexpr float SincAmplitudeFade = 0.999f;
 
-	static constexpr auto sinc_filter_width = sinc_filter_quality *
-	                                          sinc_oversampling_factor;
+	// Keep the same 3.125 ms impulse span as the former 32 kHz /
+	// 100-tap configuration.
+	static constexpr auto SincFilterDurationUs = 3125;
+	static constexpr auto SincFilterQuality =
+	        ceil_sdivide(SampleRateHz * SincFilterDurationUs, 1'000'000);
 
-	static constexpr float max_possible_pit_ms = 1320000.0f / PIT_TICK_RATE;
+	static constexpr auto SincOversamplingFactor = 32;
+	static constexpr auto SincLutSize = SincFilterQuality * SincOversamplingFactor;
 
-	// Compound types and containers
-	struct PitState {
-		// PIT starts in mode 3 (SquareWave) at ~903 Hz (pit_max) with
-		// positive amplitude
-		float max_ms            = max_possible_pit_ms;
-		float new_max_ms        = max_possible_pit_ms;
-		float half_ms           = max_possible_pit_ms / 2.0f;
-		float new_half_ms       = max_possible_pit_ms / 2.0f;
-		float index             = 0.0f;
-		float last_index        = 0.0f;
-		float mode1_pending_max = 0.0f;
+	// Undersampled mode 3: rapid reloads used as a noise source
+	static constexpr float MaxUndersampledReloadGapMs = 1.0f;
 
-		// PIT boolean state
-		bool mode1_waiting_for_counter = false;
-		bool mode1_waiting_for_trigger = true;
-		bool mode3_counting            = false;
+	PitCounter pit_counter = {};
 
-		PitMode mode = PitMode::SquareWave;
+	// Waveform accumulation buffer; large enough for one ms plus sinc tail.
+	// This stores fractional impulse contributions until they are integrated
+	// into output samples in PicCallback().
+	static constexpr auto WaveformSize = SincFilterQuality + SampleRatePerMs;
+	std::deque<float> waveform = {};
 
-		int16_t amplitude      = positive_amplitude;
-		int16_t prev_amplitude = negative_amplitude;
-	} pit = {};
+	std::array<float, SincLutSize> impulse_lut = {};
 
-	std::deque<float> waveform_deque = {};
+	// Position within current tick advanced so far (ms, 0..1)
+	float pit_last_index = 0.0f;
 
-	std::array<float, sinc_filter_width> impulse_lut = {};
+	// Running amplitude integrator
+	float accumulator = 0.0f;
 
-	PpiPortB prev_port_b = {};
-
+	// Silence tracking for channel sleep
 	int tally_of_silence = 0;
-};
 
+	// Port B state (speaker_output + timer2_gating) from the Intel 8255
+	// Programmable Peripheral Interface (PPI).
+	PpiPortB port_b = {};
+
+	// Undersampled mode 3 reload tracking
+	bool have_undersampled_reload = false;
+	float undersampled_reload_ms  = 0.0f;
+
+	// Amplitude at last impulse. Re-emitting an identical level would apply
+	// another impulse step at the same level and incorrectly bias loudness.
+	int16_t prev_amplitude = NeutralAmplitude;
+
+	std::vector<float> render_buf = {};
+};
 
 #endif // DOSBOX_PCSPEAKER_IMPULSE_H

--- a/src/hardware/audio/private/pcspeaker_pit.h
+++ b/src/hardware/audio/private/pcspeaker_pit.h
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText:  2025-2026 The DOSBox Staging Team
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#ifndef DOSBOX_PCSPEAKER_PIT_H
+#define DOSBOX_PCSPEAKER_PIT_H
+
+#include "hardware/timer.h"
+
+#include <vector>
+
+enum class OutputState { High, Low };
+
+// Pure hardware emulation of PIT counter 2 as wired to the PC speaker.
+//
+// Tracks output transitions in continuous time (milliseconds). Callers drive
+// it with WriteControl / WriteCount / EnableGate, interleaved with Advance()
+// calls to collect the transitions that occurred during each time window.
+//
+// All offsets in Transition are relative to the start of the Advance() call
+// that produced them.
+class PitCounter {
+public:
+	struct Transition {
+		float offset_ms    = 0.0f;
+		OutputState output = OutputState::High;
+	};
+
+	// Control word written. Output changes immediately; no count loaded yet.
+	std::vector<Transition> WriteControl(const PitMode mode);
+
+	// Count register written. May start counting depending on mode + gate.
+	std::vector<Transition> WriteCount(const int count);
+
+	// Gate signal changed (port B bit 0).
+	std::vector<Transition> EnableGate(const bool gate);
+
+	// Advance by duration_ms, returning transitions that occurred within.
+	std::vector<Transition> Advance(const float duration_ms);
+
+	// Stop counting without changing mode. Used when a count arrives that
+	// can't be represented (e.g. ultrasonic mode 3 reload).
+	void Invalidate();
+
+	OutputState GetOutputState() const
+	{
+		return output_state;
+	}
+
+	PitMode GetMode() const
+	{
+		return mode;
+	}
+
+	bool IsMode3Active() const
+	{
+		return mode3_active;
+	}
+
+	bool IsGateEnabled() const
+	{
+		return gate;
+	}
+
+private:
+	void Emit(const OutputState state, const float offset_ms,
+	          std::vector<Transition>& out);
+
+	// Per-mode Advance() helpers (dispatched on the canonical mode).
+	void AdvanceCountdown(const float duration_ms, std::vector<Transition>& out);
+	void AdvanceStrobe(const float duration_ms, std::vector<Transition>& out);
+	void AdvanceOscillator(float duration_ms, std::vector<Transition>& out,
+	                       const bool square);
+
+	// Modes 6 and 7 are hardware aliases of modes 2 and 3; fold them so the
+	// rest of the class only ever deals with RateGenerator / SquareWave.
+	static PitMode Canonical(const PitMode m);
+
+	// A programmed count of 0 reloads the full 16-bit range (65536 ticks).
+	static constexpr int MaxDecCount = 0x10000;
+
+	static constexpr float MsPerTick   = 1000.0f / PIT_TICK_RATE;
+	static constexpr float MaxPeriodMs = MsPerTick * MaxDecCount;
+
+	PitMode mode             = PitMode::SquareWave;
+	bool gate                = false;
+	OutputState output_state = OutputState::High;
+	bool counting            = false;
+
+	float phase_ms      = 0.0f;
+	float period_ms     = MaxPeriodMs;
+	float half_ms       = MaxPeriodMs / 2.0f;
+	float new_period_ms = MaxPeriodMs;
+	float new_half_ms   = MaxPeriodMs / 2.0f;
+
+	// Mode 1 (OneShot)
+	bool mode1_awaiting_count   = false;
+	bool mode1_awaiting_trigger = false;
+	float mode1_pending_ms      = 0.0f;
+
+	// Mode 3 (SquareWave): gate must have been high to begin oscillating
+	bool mode3_active = false;
+	// Set by Invalidate() so WriteCount can resume without resetting phase
+	bool mode3_retain_phase = false;
+};
+
+#endif // DOSBOX_PCSPEAKER_PIT_H

--- a/src/hardware/timer.cpp
+++ b/src/hardware/timer.cpp
@@ -66,10 +66,12 @@ struct PIT_Block {
 
 	uint16_t read_latch  = 0;
 	uint16_t write_latch = 0;
+	uint8_t status_latch = 0;
 
-	PitMode mode          = PitMode::Inactive;
-	AccessMode read_mode  = AccessMode::Latch;
-	AccessMode write_mode = AccessMode::Latch;
+	PitMode mode           = PitMode::Inactive;
+	AccessMode access_mode = AccessMode::Latch;
+	AccessMode read_mode   = AccessMode::Latch;
+	AccessMode write_mode  = AccessMode::Latch;
 
 	bool bcd               = false;
 	bool go_read_latch     = false;
@@ -124,11 +126,6 @@ constexpr auto& channel_2 = pit[2];
 
 static bool gate2;
 
-static uint8_t latched_timerstatus;
-// the timer status can not be overwritten until it is read or the timer was
-// reprogrammed.
-static bool latched_timerstatus_locked;
-
 const char* pit_mode_to_string(const PitMode mode)
 {
 	switch (mode) {
@@ -148,22 +145,23 @@ const char* pit_mode_to_string(const PitMode mode)
 
 // The maximum decimal count can go beyond 16-bit, beacuse a
 // count of zero was used to represent 65536 ticks.
-constexpr int32_t max_bcd_count = 9999;
-constexpr int32_t max_dec_count = 0x10000;
-constexpr int32_t get_max_count(const PIT_Block& channel)
+constexpr int32_t MaxBcdCount = 9999;
+constexpr int32_t MaxDecCount = 0x10000;
+
+// A programmed count of 0 represents one more tick than the max representable
+// value: 65536 in binary mode, 10000 in BCD mode.
+// Ref: https://wiki.osdev.org/Programmable_Interval_Timer
+constexpr int32_t ZeroBcdCount    = MaxBcdCount + 1;
+constexpr int32_t ZeroBinaryCount = MaxDecCount;
+constexpr int32_t get_zero_count_ticks(const PIT_Block& channel)
 {
-	return channel.bcd ? max_bcd_count : max_dec_count;
+	return channel.bcd ? ZeroBcdCount : ZeroBinaryCount;
 }
 
 constexpr int update_channel_delay(PIT_Block& channel)
 {
-	// Since the frequency can't be divided by 0 in a sane way, many
-	// implementations use 0 to represent the value 65536 (or 10000
-	// when programmed in BCD mode).
-	// Ref: https://wiki.osdev.org/Programmable_Interval_Timer
-	//
 	const auto freq_divider = channel.count ? channel.count
-	                                        : (get_max_count(channel) + 1);
+	                                        : get_zero_count_ticks(channel);
 
 	channel.delay = 1000.0 * freq_divider / PIT_TICK_RATE;
 	return freq_divider;
@@ -226,44 +224,36 @@ static bool counter_output(const PIT_Block& channel)
 }
 static void status_latch(PIT_Block& channel)
 {
-	// the timer status can not be overwritten until it is read or the timer
-	// was reprogrammed.
-	if (!latched_timerstatus_locked) {
-		latched_timerstatus = 0;
-		// Timer Status Word
-		// 0: BCD
-		// 1-3: Timer mode
-		// 4-5: read/load mode
-		// 6: "NULL" - this is 0 if "the counter value is in the
-		// counter" ;) should rarely be 1 (i.e. on exotic modes) 7: OUT
-		// - the logic level on the Timer output pin
-		if (channel.bcd) {
-			latched_timerstatus |= 0x1;
-		}
-
-		latched_timerstatus |= (static_cast<uint8_t>(channel.mode) & 7) << 1;
-
-		if (channel.read_mode == AccessMode::Latch ||
-		    channel.read_mode == AccessMode::Both) {
-			latched_timerstatus |= 0x30;
-		} else if (channel.read_mode == AccessMode::Low) {
-			latched_timerstatus |= 0x10;
-		} else if (channel.read_mode == AccessMode::High) {
-			latched_timerstatus |= 0x20;
-		}
-
-		if (counter_output(channel)) {
-			latched_timerstatus |= 0x80;
-		}
-		if (channel.mode_changed) {
-			latched_timerstatus |= 0x40;
-		}
-
-		// The first thing that is being read from this counter now is
-		// the counter status.
-		channel.counterstatus_set  = true;
-		latched_timerstatus_locked = true;
+	// The 8254 keeps one status latch per counter. Repeated status latch
+	// commands for the same counter are ignored until the latched status is
+	// read or the counter is reprogrammed.
+	if (channel.counterstatus_set) {
+		return;
 	}
+
+	channel.status_latch = 0;
+	// Timer Status Word
+	// 0: BCD
+	// 1-3: Timer mode
+	// 4-5: programmed read/load mode
+	// 6: NULL count
+	// 7: OUT pin state
+	if (channel.bcd) {
+		channel.status_latch |= 0x1;
+	}
+
+	channel.status_latch |= (static_cast<uint8_t>(channel.mode) & 7) << 1;
+	channel.status_latch |= static_cast<uint8_t>(channel.access_mode) << 4;
+
+	if (counter_output(channel)) {
+		channel.status_latch |= 0x80;
+	}
+	if (channel.mode_changed) {
+		channel.status_latch |= 0x40;
+	}
+
+	// The first thing read from this counter is now the counter status.
+	channel.counterstatus_set = true;
 }
 static void counter_latch(PIT_Block& channel)
 {
@@ -279,7 +269,7 @@ static void counter_latch(PIT_Block& channel)
 
 	auto save_read_latch = [&](double latch_time) {
 		// Latch is a 16-bit counter, wrap it to ensure it doesn't overflow
-		const auto wrapped = iround(latch_time) % UINT16_MAX;
+		const auto wrapped = iround(latch_time) & UINT16_MAX;
 		channel.read_latch = check_cast<uint16_t>(wrapped);
 	};
 
@@ -308,12 +298,11 @@ static void counter_latch(PIT_Block& channel)
 			if (channel.bcd) {
 				elapsed_ms = fmod(elapsed_ms,
 				                  period_of_1k_pit_ticks * 10000.0);
-				save_read_latch(max_bcd_count -
+				save_read_latch(MaxBcdCount -
 				                elapsed_ms * PIT_TICK_RATE_KHZ);
 			} else {
 				elapsed_ms = fmod(elapsed_ms,
-				                  period_of_1k_pit_ticks *
-				                          max_dec_count);
+				                  period_of_1k_pit_ticks * MaxDecCount);
 				save_read_latch(0xffff -
 				                elapsed_ms * PIT_TICK_RATE_KHZ);
 			}
@@ -361,6 +350,17 @@ static void counter_latch(PIT_Block& channel)
 	}
 }
 
+static void counter_latch_if_unlatched(PIT_Block& channel)
+{
+	// The 8254 ignores repeated count-latch commands for a counter until
+	// the previously latched count is read.
+	if (!channel.go_read_latch) {
+		return;
+	}
+
+	counter_latch(channel);
+}
+
 static void write_latch(io_port_t port, io_val_t value, io_width_t)
 {
 	const auto val         = check_cast<uint8_t>(value);
@@ -398,16 +398,16 @@ static void write_latch(io_port_t port, io_val_t value, io_width_t)
 	if (channel.write_mode != AccessMode::Latch) {
 
 		channel.count = channel.write_latch ? channel.write_latch
-		                                    : get_max_count(channel);
+		                                    : get_zero_count_ticks(channel);
 
 		if ((!channel.mode_changed) &&
 		    (channel.mode == PitMode::RateGenerator ||
 		     channel.mode == PitMode::RateGeneratorAlias) &&
 		    (channel_num == 0)) {
 			// In mode 2 writing another value has no direct
-			// effect on the count until the old one has run
-			// out. This might apply to other modes too.
-			// This is not fixed for PIT2 yet!!
+			// effect on the count until the old one has run out.
+			// For PIT2 (PC speaker) this deferral is handled
+			// inside PitCounter::WriteCount.
 			channel.update_count = true;
 			return;
 		}
@@ -456,9 +456,8 @@ static uint8_t read_latch(io_port_t port, io_width_t)
 	uint8_t ret = 0;
 
 	if (channel.counterstatus_set) {
-		channel.counterstatus_set  = false;
-		latched_timerstatus_locked = false;
-		ret                        = latched_timerstatus;
+		channel.counterstatus_set = false;
+		ret                       = channel.status_latch;
 	} else {
 		if (channel.go_read_latch) {
 			counter_latch(channel);
@@ -542,7 +541,7 @@ static void latch_single_channel(const uint8_t channel_num, const uint8_t val)
 	const ReadBackStatus rbs = {val};
 
 	if (rbs.access_mode.none()) {
-		counter_latch(channel);
+		counter_latch_if_unlatched(channel);
 		return;
 	}
 
@@ -553,18 +552,18 @@ static void latch_single_channel(const uint8_t channel_num, const uint8_t val)
 	counter_latch(channel);
 	channel.bcd = rbs.bcd_state;
 	if (channel.bcd) {
-		channel.count = std::min(channel.count, max_bcd_count);
+		channel.count = std::min(channel.count, MaxBcdCount);
 	}
 
 	// Timer is being reprogrammed, unlock the status
 	if (channel.counterstatus_set) {
-		channel.counterstatus_set  = false;
-		latched_timerstatus_locked = false;
+		channel.counterstatus_set = false;
 	}
 	channel.start         = PIC_FullIndex(); // for undocumented newmode
 	channel.go_read_latch = true;
 	channel.update_count  = false;
 	channel.counting      = false;
+	channel.access_mode   = static_cast<AccessMode>(rbs.access_mode.val());
 	channel.read_mode     = static_cast<AccessMode>(rbs.access_mode.val());
 	channel.write_mode    = static_cast<AccessMode>(rbs.access_mode.val());
 	channel.mode          = static_cast<PitMode>(rbs.pit_mode.val());
@@ -586,8 +585,6 @@ static void latch_single_channel(const uint8_t channel_num, const uint8_t val)
 		} else {
 			PIC_DeActivateIRQ(0);
 		}
-	} else if (channel_num == 2) {
-		PCSPEAKER_SetCounter(0, PitMode::SquareWave);
 	}
 	channel.mode_changed = true;
 	if (channel_num == 2) {
@@ -602,25 +599,26 @@ static void latch_all_channels(const uint8_t val)
 	// Latch multiple pit counters
 	if ((val & 0x20) == 0) {
 		if (val & 0x02) {
-			counter_latch(channel_0);
+			counter_latch_if_unlatched(channel_0);
 		}
 		if (val & 0x04) {
-			counter_latch(channel_1);
+			counter_latch_if_unlatched(channel_1);
 		}
 		if (val & 0x08) {
-			counter_latch(channel_2);
+			counter_latch_if_unlatched(channel_2);
 		}
 	}
 
 	// Status and values can be latched simultaneously
 	if ((val & 0x10) == 0) {
 		// Latch status words
-		// but only 1 status can be latched simultaneously
 		if (val & 0x02) {
 			status_latch(channel_0);
-		} else if (val & 0x04) {
+		}
+		if (val & 0x04) {
 			status_latch(channel_1);
-		} else if (val & 0x08) {
+		}
+		if (val & 0x08) {
 			status_latch(channel_2);
 		}
 	}
@@ -713,9 +711,11 @@ public:
 
 		// Initialize channel 0
 		channel_0.bcd               = false;
-		channel_0.count             = get_max_count(channel_0);
+		channel_0.count             = get_zero_count_ticks(channel_0);
 		channel_0.read_latch        = 0;
 		channel_0.write_latch       = 0;
+		channel_0.status_latch      = 0;
+		channel_0.access_mode       = AccessMode::Both;
 		channel_0.read_mode         = AccessMode::Both;
 		channel_0.write_mode        = AccessMode::Both;
 		channel_0.mode              = PitMode::SquareWave;
@@ -726,6 +726,8 @@ public:
 		// Initialize channel 1
 		channel_1.bcd               = false;
 		channel_1.count             = 18;
+		channel_1.status_latch      = 0;
+		channel_1.access_mode       = AccessMode::Low;
 		channel_1.read_mode         = AccessMode::Low;
 		channel_1.write_mode        = AccessMode::Both;
 		channel_1.mode              = PitMode::RateGenerator;
@@ -735,7 +737,9 @@ public:
 		// Initialize channel 2
 		channel_2.bcd               = false;
 		channel_2.count             = 1320;
-		channel_2.read_latch        = 1320;             // MadTv1
+		channel_2.read_latch        = 1320; // MadTv1
+		channel_2.status_latch      = 0;
+		channel_2.access_mode       = AccessMode::Both;
 		channel_2.read_mode         = AccessMode::Both; // Chuck Yeager
 		channel_2.write_mode        = AccessMode::Both;
 		channel_2.mode              = PitMode::SquareWave;
@@ -747,8 +751,7 @@ public:
 		update_channel_delay(channel_1);
 		update_channel_delay(channel_2);
 
-		latched_timerstatus_locked = false;
-		gate2                      = false;
+		gate2 = false;
 		PIC_AddEvent(PIT0_Event, channel_0.delay);
 	}
 	~TIMER()


### PR DESCRIPTION
# Description

Refactors the PC speaker `impulse` model implementation starting with a clean-room approach from the Intel 8254 data sheet for the PIT interaction, split off into its own state machine.

The actual DSP model is largely unchanged, with the notable exception of boosting from 32kHz to 48kHz, which was affecting digitized sound.

## Related issues

Fixes #3278
Fixes #3435
Resolves #3819 (yes, I'm ambitious and optimistic)

# Release notes

We've updated the existing PC speaker impulse model to be compatible with more games.

# Manual testing

Tested the following games:
- Impossible Mission II (death scream effect)
- Freddy Hardest in South Manhattan (opening music and menu sounds)
- Wolfenstein 3d (pc speaker for sound effects)
- Starflight 1 (wormhole effect)
- Spellcasting 101 (opening music)
- Space Quest 1 (music)
- Prince of Persia (music and effects, startup with `prince stdsnd`)
- Ultima 3 (startup screen sound effects)
- Budokan (intro and game music)
- Digger (game music and effects)

The change has been manually tested on:

- [ ] Windows
- [x] macOS
- [ ] Linux


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [x] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

