### PR TITLE
External dependency caching for the CI actions

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,0 +1,167 @@
+# GitHub CI workflows
+
+This directory holds the GitHub Actions configuration for DOSBox Staging:
+build and analysis workflows, the website deploy pipeline, composite actions,
+and issue/PR templates.
+
+## Analysis workflows
+
+Analysis workflows run when creating a new PR branch, pushing commits to any
+branch, and merging to a branch.
+
+| Workflow                    | Purpose
+| ---                         | ---
+| `linting.yml`               | Shellcheck, pylint, markdownlint, appstream-util
+| `pvs-studio.yml`            | PVS-Studio static analysis
+
+## Build workflows
+
+Build workflows run when creating a new PR branch, pushing commits to any
+branch, and merging to a branch.
+
+The prerequisite for starting these workflows is successfully passed analysis
+steps.
+
+| Workflow                    | Purpose
+| ---                         | ---
+| `windows.yml`               | Windows x64 release builds and installer packaging
+| `macos.yml`                 | macOS universal (x86_64 + arm64) builds and DMG packaging
+| `linux.yml`                 | Linux builds (multiple compiler combos) and release tarball
+
+## Website/documentation workflows
+
+See [docs/DOCUMENTATION.md](docs/DOCUMENTATION.md#deploying-the-website--documentation)
+for further details on how these workflows are used. The [Automatic preview deploys for PRs and
+`main`](docs/DOCUMENTATION.md#automatic-preview-deploys-for-prs-and-main)
+details the automatic website/documentation deploys.
+
+| Workflow                    | Purpose
+| ---                         | ---
+| `deploy-website*.yml`       | Website + preview deploys -- see [`workflows/deploy-website.md`](workflows/deploy-website.md)
+| `release-notes-preview.yml` | Generates release notes for upcoming versions
+
+## Composite actions
+
+We have a couple of reusable of composite actions in `.github/actions/`:
+
+- `setup-vcpkg/` -- pins vcpkg to the manifest baseline and configures
+  the two vcpkg caches (see below)
+
+- `set-common-vars/` -- exports shared env vars (versions of external
+  artifact bundles, etc.)
+
+- `generate-release-notes/` -- generates the release notes used by the
+  release notes workflow
+
+- `retry/` -- runs a shell command with retries and linear backoff;
+  used where the command has no native retry flag (e.g. `apt-get`)
+
+## External dependency surfaces
+
+Third-party services the CI touches that can flake or go down:
+
+- **vcpkg port upstreams** -- source tarballs for packages declared in
+  `vcpkg.json` and the overlay ports in `vcpkg-ports/**`. Fetched whenever the
+  binary cache and downloads cache both miss.
+
+- **`dosbox-staging/dosbox-staging-ext` release assets** -- pre-built
+  dynamic libraries that take a long time to build, fetched in each
+  platform's build workflow.
+
+- **`johnnovak/Nuked-SC55-CLAP` release assets** -- CLAP plugin
+  binaries, fetched in each platform's build workflow.
+
+- **PyPI** -- pip packages for building the website and documentation (see
+  `deploy-website.yml`) and linting (see `linting.yml`)
+
+- **Ubuntu apt mirrors** -- distro packages on `ubuntu-22.04` and
+  `ubuntu-slim` runners
+
+- **`files.pvs-studio.com`** -- non-standard apt repo for the PVS-Studio
+  static analyser, configured at the start of `pvs-studio.yml`
+
+## Caching strategy
+
+Four caches are configured across the workflows. The two vcpkg caches
+are layered and complementary; the rest are independent.
+
+| Cache                  | Configured in                              | Path                               | Key                                                                       |
+| ---                    | ---                                        | ---                                | ---                                                                       |
+| vcpkg source downloads | `actions/setup-vcpkg/action.yml`           | `vcpkg_downloads` (workspace)      | vcpkg short hash + manifest + overlay + `runner.os`                       |
+| vcpkg binary outputs   | `actions/setup-vcpkg/action.yml`           | `vcpkg_bin_cache` (workspace)      | vcpkg short hash + manifest + overlay + compiler + ImageOS + ImageVersion |
+| pip downloads          | `workflows/deploy-website.yml`             | `~/.cache/pip`                     | hash of `mkdocs-package-requirements.txt`                                 |
+| apt packages           | `workflows/{linting,linux,pvs-studio}.yml` | (managed by cache-apt-pkgs-action) | package list + `version:` field                                           |
+
+How the two vcpkg caches interact:
+
+- **Binary cache hit** -- skip downloading and building artifacts entirely;
+  this is the fast path
+
+- **Binary cache miss + downloads cache hit** -- compile from already-downloaded
+  sources; this is the resilience path against flaky vcpkg port download sites
+
+- **Both miss** -- fetch package sources, compile them, then populate both caches;
+  this is the slowest path and should only happen when updating the vcpkg
+  baseline hash, the vcpkg overlays, or the runner images
+
+The downloads cache is only written to when vcpkg actually fetches package
+sources, i.e., on a binary-cache miss. As long as the binary cache hits (the
+common case), `downloads/` stays empty on Linux/macOS. The cache download
+cache will be only actually used after the next natural binary-cache miss
+(e.g., runner image bump, compiler change, manifest edit).
+
+Windows is the exception: its `downloads/` also stores vcpkg's bundled
+toolchain (cmake, ninja, meson, etc.) and so populates on every cold build,
+binary-cache miss or not.
+
+Approximate sizes (zipped static libs + headers compress hard):
+
+- **vcpkg binary cache** --- 10--50 MB per entry
+- **vcpkg downloads cache** --- ~200 MB
+- **pip cache** --- 10--50 MB
+- **apt cache** --- 10--20 MB
+
+
+### Retry wrappers (complement to caching)
+
+We're also using a reasonable number of retries to recover from transient
+flakes:
+
+- GitHub release-asset downloads in `windows.yml`, `macos.yml`,
+  `linux.yml`: `curl -fL --retry 5 --retry-all-errors --retry-delay 10`
+  or the equivalent `wget --tries=5 --waitretry=10 --retry-connrefused`.
+
+- `pip3 install --retries 5 --timeout 60` in `deploy-website.yml`.
+
+- `apt-get update` / `apt-get install pvs-studio` in `pvs-studio.yml`,
+  wrapped by the `./.github/actions/retry` composite action.
+
+
+### Observability
+
+- Each cache step echoes `<cache> hit: true|false` after restore so
+  you can tell at a glance whether the slow path was taken.
+
+- The release build jobs in `windows.yml`, `macos.yml`, and `linux.yml`
+  end with a `gh cache list` step that prints repo-wide cache usage
+  sorted largest first -- useful for spotting cache pressure ahead of
+  the 10 GB per-repository actions cache quota.
+
+
+## Cache invalidation
+
+All keys are pure functions of their inputs:
+
+- **vcpkg caches** -- bumping the baseline in `vcpkg.json`, editing
+  `vcpkg-configuration.json`, or touching any file under `vcpkg-ports/**`
+  invalidates both caches. The binary cache additionally invalidates on
+  compiler, ImageOS, and ImageVersion changes.
+
+- **pip cache** -- editing
+  `extras/documentation/mkdocs-package-requirements.txt` invalidates it.
+
+- **apt cache** -- editing the package list or
+  `packages/ubuntu-22.04-apt.txt` invalidates it. Bumping the
+  `version:` field on the `cache-apt-pkgs-action` step force-invalidates
+  it.
+

--- a/.github/actions/retry/action.yml
+++ b/.github/actions/retry/action.yml
@@ -1,0 +1,43 @@
+name: Retry shell command
+description: Run a shell command with linear backoff. Use only when the command has no built-in retry facilities.
+
+inputs:
+  cmd:
+    description: 'Shell command to run'
+    required: true
+
+  attempts:
+    description: 'Maximum attempts'
+    required: false
+    default: '3'
+
+  base-delay:
+    description: 'Delay seconds, multiplied by attempt number'
+    required: false
+    default: '10'
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        RETRY_CMD: ${{ inputs.cmd }}
+        RETRY_ATTEMPTS: ${{ inputs.attempts }}
+        RETRY_BASE_DELAY: ${{ inputs.base-delay }}
+      run: |
+        set -u
+        for i in $(seq 1 "$RETRY_ATTEMPTS"); do
+          # Add collapsible GitHub log sections with ::group::/::endgroup::
+          echo "::group::Attempt $i/$RETRY_ATTEMPTS: $RETRY_CMD"
+          if bash -c "$RETRY_CMD"; then
+            echo "::endgroup::"
+            exit 0
+          fi
+          echo "::endgroup::"
+
+          if [ "$i" = "$RETRY_ATTEMPTS" ]; then
+            echo "::error::Command failed after $RETRY_ATTEMPTS attempts: $RETRY_CMD"
+            exit 1
+          fi
+          sleep $((i * RETRY_BASE_DELAY))
+        done

--- a/.github/actions/setup-vcpkg/action.yml
+++ b/.github/actions/setup-vcpkg/action.yml
@@ -114,3 +114,10 @@ runs:
       shell: pwsh
       run: |
         New-Item -Path "${Env:VCPKG_DOWNLOADS}" -ItemType Directory -Force
+
+    # 'true' = cache hit; 'false' = miss.
+    - name:  Report vcpkg cache status
+      shell: bash
+      run: |
+        echo "vcpkg binary cache hit:    ${{ steps.vcpkg_bin_cache.outputs.cache-hit || 'false' }}"
+        echo "vcpkg downloads cache hit: ${{ steps.vcpkg_downloads_cache.outputs.cache-hit || 'false' }}"

--- a/.github/actions/setup-vcpkg/action.yml
+++ b/.github/actions/setup-vcpkg/action.yml
@@ -22,11 +22,17 @@ inputs:
 runs:
   using: composite
   steps:
+    # We use a two-staged vcpkg caching schema:
+    #
+    # - vcpkg_downloads_cache: cache for the downloaded source files
+    # - vcpkg_bin_cache: compiled output cache
+    #
     - name: Set vcpkg env variables
       if: ${{ runner.os != 'Windows'}}
       shell: bash
       run: |
         echo "VCPKG_ROOT=${VCPKG_INSTALLATION_ROOT}" >> $GITHUB_ENV
+        echo "VCPKG_DOWNLOADS=${{ github.workspace }}/vcpkg_downloads" >> $GITHUB_ENV
         echo "VCPKG_DEFAULT_BINARY_CACHE=${{ github.workspace }}/vcpkg_bin_cache" >> $GITHUB_ENV
         echo "DOSBOX_VCPKG_BASELINE=$(jq -r .\"builtin-baseline\" ./vcpkg.json)" >> $GITHUB_ENV
 
@@ -35,6 +41,7 @@ runs:
       shell: pwsh
       run: |
         Write-Output "VCPKG_ROOT=$Env:VCPKG_INSTALLATION_ROOT" >> $Env:GITHUB_ENV
+        Write-Output "VCPKG_DOWNLOADS=C:\vcpkg_downloads" >> $Env:GITHUB_ENV
         Write-Output "VCPKG_DEFAULT_BINARY_CACHE=C:\vcpkg_bin_cache" >> $Env:GITHUB_ENV
         $baseline = (Get-Content .\vcpkg.json | ConvertFrom-Json)."builtin-baseline"
         Write-Output "DOSBOX_VCPKG_BASELINE=${baseline}" >> $Env:GITHUB_ENV
@@ -79,3 +86,31 @@ runs:
       shell: pwsh
       run: |
         New-Item -Path "${Env:VCPKG_DEFAULT_BINARY_CACHE}" -ItemType Directory
+
+    # Per-OS key: downloads/tools/ has platform-specific binaries.
+    # Compiler/ImageVersion are intentionally omitted -- tarballs are
+    # toolchain-independent, so runner-image bumps shouldn't invalidate.
+    - name:  Set vcpkg downloads cache key
+      id:    vcpkg_downloads_cache_key
+      shell: bash
+      run: |
+        echo "cacheKey=vcpkg-${VCPKG_SHORT_HASH}-downloads-${{ runner.os }}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json', 'vcpkg-ports/**') }}" >> $GITHUB_OUTPUT
+
+    - name: Restore vcpkg downloads cache
+      uses: actions/cache@v4
+      id:   vcpkg_downloads_cache
+      with:
+        path: ${{ env.VCPKG_DOWNLOADS }}
+        key:  ${{ steps.vcpkg_downloads_cache_key.outputs.cacheKey }}
+
+    - name: Create downloads cache directory
+      if: ${{ steps.vcpkg_downloads_cache.outputs.cache-hit != 'true' && runner.os != 'Windows'}}
+      shell: bash
+      run: |
+        mkdir -p "${VCPKG_DOWNLOADS}"
+
+    - name: Create downloads cache directory (Windows)
+      if: ${{ steps.vcpkg_downloads_cache.outputs.cache-hit != 'true' && runner.os == 'Windows'}}
+      shell: pwsh
+      run: |
+        New-Item -Path "${Env:VCPKG_DOWNLOADS}" -ItemType Directory -Force

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -61,11 +61,21 @@ jobs:
             echo "dest_path_prefix=preview/${{ inputs.destination_prefix }}" >> "$GITHUB_ENV"
           fi
 
+      # Manual actions/cache rather than setup-python@v5: ubuntu-slim
+      # has preinstalled Python we don't want replaced.
+      - name: Cache pip downloads
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: pip-${{ runner.os }}-${{ hashFiles('dosbox-staging/extras/documentation/mkdocs-package-requirements.txt') }}
+
       - name: Install mkdocs
         run: |
           cd dosbox-staging
           pip3 install --upgrade pip
-          pip3 install -r extras/documentation/mkdocs-package-requirements.txt
+          # --retries / --timeout: survive intermittent PyPI hiccups.
+          pip3 install --retries 5 --timeout 60 \
+            -r extras/documentation/mkdocs-package-requirements.txt
 
       - name: Get current documentation Git hash
         run: |

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -64,10 +64,14 @@ jobs:
       # Manual actions/cache rather than setup-python@v5: ubuntu-slim
       # has preinstalled Python we don't want replaced.
       - name: Cache pip downloads
+        id:   pip_cache
         uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: pip-${{ runner.os }}-${{ hashFiles('dosbox-staging/extras/documentation/mkdocs-package-requirements.txt') }}
+
+      - name: Report pip cache status
+        run:  echo "pip cache hit:" "${{ steps.pip_cache.outputs.cache-hit || 'false' }}"
 
       - name: Install mkdocs
         run: |

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -18,15 +18,24 @@ jobs:
         with:
           submodules: false
 
-      - name: Update packages
+      # cache-apt-pkgs-action validates packages via apt-cache before its own
+      # apt-get update; ubuntu-slim's index is empty until we refresh it, so
+      # without this the action would fail.
+      - name: Refresh apt index
         run:  sudo apt-get update
+
+      # Bump 'version:' to force-invalidate the cache
+      - name: Install apt dependencies
+        uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # v1.6.0
+        with:
+          packages: python3-setuptools ruby-full appstream-util
+          version: "1.0"
 
       - name: Run shellcheck
         run:  ./scripts/linting/verify-bash.sh
 
       - name: Install pylint
         run: |
-          sudo apt-get install python3-setuptools
           sudo pip3 install pylint beautifulsoup4 html5lib
           sudo pip3 install -r extras/documentation/mkdocs-package-requirements.txt
 
@@ -35,15 +44,11 @@ jobs:
 
       - name: Install markdownlint
         run: |
-          sudo apt-get install ruby-full
           ruby --version
           sudo gem install mdl
 
       - name: Run markdownlint
         run:  ./scripts/linting/verify-markdown.sh
-
-      - name: Install appstream-util
-        run:  sudo apt-get install appstream-util
 
       - name: Verify metainfo.xml
         run:  appstream-util validate-relax --nonet extras/linux/org.dosbox_staging.dosbox_staging.metainfo.xml

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -26,10 +26,14 @@ jobs:
 
       # Bump 'version:' to force-invalidate the cache
       - name: Install apt dependencies
+        id:   apt_cache
         uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # v1.6.0
         with:
           packages: python3-setuptools ruby-full appstream-util
           version: "1.0"
+
+      - name: Report apt cache status
+        run:  echo "apt cache hit:" "${{ steps.apt_cache.outputs.cache-hit || 'false' }}"
 
       - name: Run shellcheck
         run:  ./scripts/linting/verify-bash.sh

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -116,6 +116,7 @@ jobs:
       - name: Set up CMake
         uses: lukka/get-cmake@591817e96fcad43505fb4eae36172462abb3a42e # v4.3.3
 
+<<<<<<< HEAD
       - name: Install dependencies
         run: |
           export DEBIAN_FRONTEND=noninteractive
@@ -144,6 +145,18 @@ jobs:
           gcc --version
           g++ --version
 
+=======
+      - name: Load apt package list
+        id:   apt_pkgs
+        run:  echo "list=$(tr '\n' ' ' < extras/linux/ubuntu-22.04-packages.txt)" >> "$GITHUB_OUTPUT"
+
+      # Package list from extras/linux/ubuntu-22.04-packages.txt (also used outside CI).
+      - name: Install apt dependencies
+        uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # v1.6.0
+        with:
+          packages: ${{ steps.apt_pkgs.outputs.list }}
+          version:  "1.0"
+>>>>>>> 4f676a070 (ci: Cache apt packages with cache-apt-pkgs-action)
 
       - name: Set up vcpkg
         uses: ./.github/actions/setup-vcpkg
@@ -192,11 +205,16 @@ jobs:
       - name: Set up CMake
         uses: lukka/get-cmake@591817e96fcad43505fb4eae36172462abb3a42e # v4.3.3
 
-      - name: Install all dependencies
-        run: |
-          export DEBIAN_FRONTEND=noninteractive
-          sudo apt-get update
-          sudo apt-get install -y $(cat extras/linux/ubuntu-24.04-packages.txt)
+      - name: Load apt package list
+        id:   apt_pkgs
+        run:  echo "list=$(tr '\n' ' ' < extras/linux/ubuntu-24.04-packages.txt)" >> "$GITHUB_OUTPUT"
+
+      # See linting.yml for notes on this action.
+      - name: Install apt dependencies
+        uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # v1.6.0
+        with:
+          packages: ${{ steps.apt_pkgs.outputs.list }}
+          version:  "1.0"
 
       - name: Set up vcpkg
         uses: ./.github/actions/setup-vcpkg

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -298,3 +298,10 @@ jobs:
           name: dosbox-staging-linux-x86_64-${{ env.DOSBOX_VERSION_AND_HASH }}.tar.xz
           path: dosbox-staging-linux-x86_64-${{ env.DOSBOX_VERSION_AND_HASH }}.tar.xz
           archive: false
+
+      - name:  Report repo cache usage
+        if:    always()
+        shell: bash
+        run:   gh cache list --limit 50 --sort size_in_bytes --order desc
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -238,7 +238,9 @@ jobs:
           set -x
           ZIP_NAME=dosbox-vcpkg-deps-linux-x86_64.zip
 
-          wget -nv https://github.com/dosbox-staging/dosbox-staging-ext/releases/download/$VCPKG_EXT_DEPS_VERSION/$ZIP_NAME
+          # Retry on transient GitHub release-asset CDN flakes.
+          wget -nv --tries=5 --waitretry=10 --retry-connrefused \
+            https://github.com/dosbox-staging/dosbox-staging-ext/releases/download/$VCPKG_EXT_DEPS_VERSION/$ZIP_NAME
           unzip $ZIP_NAME -d vcpkg-deps
 
           LIB_DIR="dosbox-staging-linux-x86_64-$DOSBOX_VERSION_AND_HASH/lib"
@@ -251,7 +253,9 @@ jobs:
           set -x
           ZIP_NAME=Nuked-SC55-CLAP-linux-x86_64-$NUKED_SC55_CLAP_VERSION.zip
 
-          curl -L https://github.com/johnnovak/Nuked-SC55-CLAP/releases/download/$NUKED_SC55_CLAP_VERSION/$ZIP_NAME -o $ZIP_NAME
+          # Retry on transient GitHub release-asset CDN flakes.
+          curl -fL --retry 5 --retry-all-errors --retry-delay 10 \
+            https://github.com/johnnovak/Nuked-SC55-CLAP/releases/download/$NUKED_SC55_CLAP_VERSION/$ZIP_NAME -o $ZIP_NAME
           unzip $ZIP_NAME -d nuked-sc55-clap
 
           PLUGINS_DIR="dosbox-staging-linux-x86_64-$DOSBOX_VERSION_AND_HASH/plugins"

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -152,11 +152,15 @@ jobs:
 
       # Package list from extras/linux/ubuntu-22.04-packages.txt (also used outside CI).
       - name: Install apt dependencies
+        id:   apt_cache
         uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # v1.6.0
         with:
           packages: ${{ steps.apt_pkgs.outputs.list }}
           version:  "1.0"
 >>>>>>> 4f676a070 (ci: Cache apt packages with cache-apt-pkgs-action)
+
+      - name: Report apt cache status
+        run:  echo "apt cache hit:" "${{ steps.apt_cache.outputs.cache-hit || 'false' }}"
 
       - name: Set up vcpkg
         uses: ./.github/actions/setup-vcpkg
@@ -211,10 +215,14 @@ jobs:
 
       # See linting.yml for notes on this action.
       - name: Install apt dependencies
+        id:   apt_cache
         uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # v1.6.0
         with:
           packages: ${{ steps.apt_pkgs.outputs.list }}
           version:  "1.0"
+
+      - name: Report apt cache status
+        run:  echo "apt cache hit:" "${{ steps.apt_cache.outputs.cache-hit || 'false' }}"
 
       - name: Set up vcpkg
         uses: ./.github/actions/setup-vcpkg

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -166,7 +166,9 @@ jobs:
           set -x
           ZIP_NAME=dosbox-vcpkg-deps-macos-universal.zip
 
-          wget -nv https://github.com/dosbox-staging/dosbox-staging-ext/releases/download/$VCPKG_EXT_DEPS_VERSION/$ZIP_NAME
+          # Retry on transient GitHub release-asset CDN flakes.
+          wget -nv --tries=5 --waitretry=10 --retry-connrefused \
+            https://github.com/dosbox-staging/dosbox-staging-ext/releases/download/$VCPKG_EXT_DEPS_VERSION/$ZIP_NAME
           unzip $ZIP_NAME -d vcpkg-deps
 
           LIB_DIR="dist/DOSBox Staging.app/Contents/MacOS/lib"
@@ -179,7 +181,9 @@ jobs:
           set -x
           ZIP_NAME=Nuked-SC55-CLAP-macOS-$NUKED_SC55_CLAP_VERSION.zip
 
-          curl -L https://github.com/johnnovak/Nuked-SC55-CLAP/releases/download/$NUKED_SC55_CLAP_VERSION/$ZIP_NAME -o $ZIP_NAME
+          # Retry on transient GitHub release-asset CDN flakes.
+          curl -fL --retry 5 --retry-all-errors --retry-delay 10 \
+            https://github.com/johnnovak/Nuked-SC55-CLAP/releases/download/$NUKED_SC55_CLAP_VERSION/$ZIP_NAME -o $ZIP_NAME
           unzip $ZIP_NAME -d nuked-sc55-clap
 
           PLUGINS_DIR="dist/DOSBox Staging.app/Contents/PlugIns"

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -128,6 +128,13 @@ jobs:
           path: build/release-macos-${{ matrix.conf.arch }}/Resources
           overwrite: true
 
+      - name:  Report repo cache usage
+        if:    always()
+        shell: bash
+        run:   gh cache list --limit 50 --sort size_in_bytes --order desc
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 
   publish_universal_build:
     name:    Publish universal build

--- a/.github/workflows/pvs-studio.yml
+++ b/.github/workflows/pvs-studio.yml
@@ -29,18 +29,39 @@ jobs:
       - name: Set up CMake
         uses: lukka/get-cmake@591817e96fcad43505fb4eae36172462abb3a42e # v4.3.3
 
-      - name: Configure PVS-Studio repository
+      - name: Load apt package list
+        id:   apt_pkgs
+        run:  echo "list=$(tr '\n' ' ' < extras/linux/ubuntu-24.04-packages.txt)" >> "$GITHUB_OUTPUT"
+
+      - name: Refresh apt index
+        run:  sudo apt-get update
+
+      # Cache standard deps before configuring the PVS-Studio repo:
+      # if that repo flakes, regular packages are still available.
+      - name: Install apt dependencies
+        uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # v1.6.0
+        with:
+          packages: ${{ steps.apt_pkgs.outputs.list }}
+          version:  "1.0"
+
+      # PVS-Studio's external apt repo flakes. wget has native --tries;
+      # apt-get uses ./.github/actions/retry. cache-apt-pkgs-action
+      # doesn't help -- the repo isn't a standard PPA.
+      - name: Fetch PVS-Studio apt key and sources list
         run: |
           set -xeu
-          wget -q -O - https://files.pvs-studio.com/etc/pubkey.txt | sudo apt-key add -
-          sudo wget -O /etc/apt/sources.list.d/viva64.list https://files.pvs-studio.com/etc/viva64.list
-          sudo apt-get update
+          wget -q --tries=3 --waitretry=10 -O - https://files.pvs-studio.com/etc/pubkey.txt | sudo apt-key add -
+          sudo wget --tries=3 --waitretry=10 -O /etc/apt/sources.list.d/viva64.list https://files.pvs-studio.com/etc/viva64.list
 
-      - name: Install dependencies
-        run: |
-          export DEBIAN_FRONTEND=noninteractive
-          sudo apt-get install -y $(cat extras/linux/ubuntu-24.04-packages.txt)
-          sudo apt-get install pvs-studio
+      - name: Refresh apt index (PVS-Studio repo)
+        uses: ./.github/actions/retry
+        with:
+          cmd: sudo apt-get update
+
+      - name: Install PVS-Studio
+        uses: ./.github/actions/retry
+        with:
+          cmd: sudo DEBIAN_FRONTEND=noninteractive apt-get install -y pvs-studio
 
       - name: Set up vcpkg
         uses: ./.github/actions/setup-vcpkg

--- a/.github/workflows/pvs-studio.yml
+++ b/.github/workflows/pvs-studio.yml
@@ -39,10 +39,14 @@ jobs:
       # Cache standard deps before configuring the PVS-Studio repo:
       # if that repo flakes, regular packages are still available.
       - name: Install apt dependencies
+        id:   apt_cache
         uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # v1.6.0
         with:
           packages: ${{ steps.apt_pkgs.outputs.list }}
           version:  "1.0"
+
+      - name: Report apt cache status
+        run:  echo "apt cache hit:" "${{ steps.apt_cache.outputs.cache-hit || 'false' }}"
 
       # PVS-Studio's external apt repo flakes. wget has native --tries;
       # apt-get uses ./.github/actions/retry. cache-apt-pkgs-action

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -216,6 +216,13 @@ jobs:
           path: ${{ env.PACKAGE_DIR }}/${{ env.DOSBOX_DEBUGGER_EXE }}
           overwrite: true
 
+      - name:  Report repo cache usage
+        if:    always()
+        shell: bash
+        run:   gh cache list --limit 50 --sort size_in_bytes --order desc
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 
   merge_artifacts:
     name: Merge release & debugger artifacts (${{ matrix.arch }} )

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -159,7 +159,9 @@ jobs:
           set -x
           ZIP_NAME=dosbox-vcpkg-deps-windows-${{ matrix.conf.arch }}.zip
 
-          curl -L https://github.com/dosbox-staging/dosbox-staging-ext/releases/download/$VCPKG_EXT_DEPS_VERSION/$ZIP_NAME -o $ZIP_NAME
+          # Retry on transient GitHub release-asset CDN flakes.
+          curl -fL --retry 5 --retry-all-errors --retry-delay 10 \
+            https://github.com/dosbox-staging/dosbox-staging-ext/releases/download/$VCPKG_EXT_DEPS_VERSION/$ZIP_NAME -o $ZIP_NAME
           unzip $ZIP_NAME -d vcpkg-deps
 
           cp vcpkg-deps/release/* "$PACKAGE_DIR"
@@ -172,7 +174,9 @@ jobs:
           set -x
           ZIP_NAME=Nuked-SC55-CLAP-windows-${{ matrix.conf.arch }}-$NUKED_SC55_CLAP_VERSION.zip
 
-          curl -L https://github.com/johnnovak/Nuked-SC55-CLAP/releases/download/$NUKED_SC55_CLAP_VERSION/$ZIP_NAME -o $ZIP_NAME
+          # Retry on transient GitHub release-asset CDN flakes.
+          curl -fL --retry 5 --retry-all-errors --retry-delay 10 \
+            https://github.com/johnnovak/Nuked-SC55-CLAP/releases/download/$NUKED_SC55_CLAP_VERSION/$ZIP_NAME -o $ZIP_NAME
           unzip $ZIP_NAME -d nuked-sc55-clap
 
           PLUGINS_DIR="$PACKAGE_DIR/plugins"


### PR DESCRIPTION
# Description

CI jobs breaking because external repositories and CDNs timing out have become an increasingly common problem lately. The cause is certainly the massive activity increase on GitHub and other open-source code repositories due to LLM usage.

This PR introduces several layers of caching and retries to mitigate the issue to a (hopefully) large degree. We'll just have to use it and see. Another benefit is slightly reduced CI build times (maybe by 10-20%).

This was done by Claude with my input, reviewed line by line. I've also instructed it do create some new doco that summarises our CI workflow situation (manually edited by me for clarity). Probably start the review by reading that first.

# Manual testing

CI keeps working.

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [ ] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [x] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

