### PR TITLE
Send samples to Mixer::AddSamples in batches

### DIFF
--- a/src/hardware/audio/cms.cpp
+++ b/src/hardware/audio/cms.cpp
@@ -247,20 +247,26 @@ void Cms::AudioCallback(const int requested_frames)
 	}
 #endif
 
+	render_buf.clear();
+
 	auto frames_remaining = requested_frames;
 
-	// First, add any frames we've queued since the last callback
+	// Drain any cycle-accurate frames queued by RenderUpToNow
 	while (frames_remaining && fifo.size()) {
-		channel->AddSamples_sfloat(1, &fifo.front()[0]);
+		render_buf.push_back(fifo.front());
 		fifo.pop();
 		--frames_remaining;
 	}
-	// If the queue's run dry, render the remainder and sync-up our time datum
+	// Render the remainder
 	while (frames_remaining) {
-		auto frame = RenderFrame();
-		channel->AddSamples_sfloat(1, &frame[0]);
+		render_buf.emplace_back(RenderFrame());
 		--frames_remaining;
 	}
+
+	// Submit the whole batch at once so the speex resampler processes
+	// one block instead of one frame per call.
+	channel->AddSamples_sfloat(requested_frames,
+	                           reinterpret_cast<float*>(render_buf.data()));
 	last_rendered_ms = PIC_AtomicIndex();
 }
 

--- a/src/hardware/audio/cms.cpp
+++ b/src/hardware/audio/cms.cpp
@@ -265,8 +265,7 @@ void Cms::AudioCallback(const int requested_frames)
 
 	// Submit the whole batch at once so the speex resampler processes
 	// one block instead of one frame per call.
-	channel->AddSamples_sfloat(requested_frames,
-	                           reinterpret_cast<float*>(render_buf.data()));
+	channel->AddAudioFrames(render_buf);
 	last_rendered_ms = PIC_AtomicIndex();
 }
 

--- a/src/hardware/audio/imfc.cpp
+++ b/src/hardware/audio/imfc.cpp
@@ -5018,10 +5018,7 @@ void ym2151_device::sound_stream_update(const int requested_frames)
 		--frames_remaining;
 	}
 
-	// Submit the whole batch at once so the speex resampler processes
-	// one block instead of one frame per call.
-	audio_channel->AddSamples_sfloat(requested_frames,
-	                                 reinterpret_cast<float*>(render_buf.data()));
+	audio_channel->AddAudioFrames(render_buf);
 	last_rendered_ms = PIC_AtomicIndex();
 }
 

--- a/src/hardware/audio/imfc.cpp
+++ b/src/hardware/audio/imfc.cpp
@@ -3148,8 +3148,9 @@ private:
 
 	// Playback related
 	MixerChannelPtr audio_channel = nullptr;
-	std::queue<AudioFrame> fifo   = {};
-	double last_rendered_ms       = 0.0;
+	std::queue<AudioFrame> fifo        = {};
+	std::vector<AudioFrame> render_buf = {};
+	double last_rendered_ms            = 0.0;
 	double ms_per_render          = 0.0;
 
 	int tl_tab[TL_TAB_LEN]{};
@@ -5001,20 +5002,26 @@ void ym2151_device::sound_stream_update(const int requested_frames)
 	// if (fifo.size())
 	//	LOG_MSG("IMFC: Queued %2lu cycle-accurate frames", fifo.size());
 
+	render_buf.clear();
+
 	auto frames_remaining = requested_frames;
 
-	// First, send any frames we've queued since the last callback
+	// Drain any cycle-accurate frames queued by RenderUpToNow
 	while (frames_remaining && fifo.size()) {
-		audio_channel->AddSamples_sfloat(1, &fifo.front()[0]);
+		render_buf.push_back(fifo.front());
 		fifo.pop();
 		--frames_remaining;
 	}
-	// If the queue's run dry, render the remainder and sync-up our time datum
+	// Render the remainder
 	while (frames_remaining) {
-		const auto frame = RenderFrame();
-		audio_channel->AddSamples_sfloat(1, &frame[0]);
+		render_buf.emplace_back(RenderFrame());
 		--frames_remaining;
 	}
+
+	// Submit the whole batch at once so the speex resampler processes
+	// one block instead of one frame per call.
+	audio_channel->AddSamples_sfloat(requested_frames,
+	                                 reinterpret_cast<float*>(render_buf.data()));
 	last_rendered_ms = PIC_AtomicIndex();
 }
 

--- a/src/hardware/audio/innovation.cpp
+++ b/src/hardware/audio/innovation.cpp
@@ -209,25 +209,26 @@ void Innovation::AudioCallback(const int requested_frames)
 
 	std::lock_guard lock(mutex);
 
-	// if (fifo.size())
-	//	LOG_MSG("INNOVATION: Queued %2lu cycle-accurate frames",
-	// fifo.size());
+	render_buf.clear();
 
 	auto frames_remaining = requested_frames;
 
-	// First, send any frames we've queued since the last callback
+	// Drain any cycle-accurate frames queued by RenderUpToNow
 	while (frames_remaining && fifo.size()) {
-		channel->AddSamples_mfloat(1, &fifo.front());
+		render_buf.push_back(fifo.front());
 		fifo.pop();
 		--frames_remaining;
 	}
-	// If the queue's run dry, render the remainder and sync-up our time datum
+	// Render the remainder
 	while (frames_remaining) {
 		if (float frame = 0.0f; MaybeRenderFrame(frame)) {
-			channel->AddSamples_mfloat(1, &frame);
+			render_buf.push_back(frame);
 		}
 		--frames_remaining;
 	}
+
+	channel->AddSamples_mfloat(static_cast<int>(render_buf.size()),
+	                           render_buf.data());
 	last_rendered_ms = PIC_AtomicIndex();
 }
 

--- a/src/hardware/audio/opl.cpp
+++ b/src/hardware/audio/opl.cpp
@@ -459,8 +459,7 @@ void Opl::AudioCallback(const int requested_frames)
 		--frames_remaining;
 	}
 
-	channel->AddSamples_sfloat(requested_frames,
-	                           reinterpret_cast<float*>(render_buf.data()));
+	channel->AddAudioFrames(render_buf);
 	last_rendered_ms = PIC_AtomicIndex();
 }
 

--- a/src/hardware/audio/opl.cpp
+++ b/src/hardware/audio/opl.cpp
@@ -442,20 +442,25 @@ void Opl::AudioCallback(const int requested_frames)
 		        fifo.size());
 	}
 #endif
+
+	render_buf.clear();
+
 	auto frames_remaining = requested_frames;
 
-	// First, send any frames we've queued since the last callback
+	// Drain any cycle-accurate frames queued by RenderUpToNow
 	while (frames_remaining && fifo.size()) {
-		channel->AddSamples_sfloat(1, &fifo.front()[0]);
+		render_buf.push_back(fifo.front());
 		fifo.pop();
 		--frames_remaining;
 	}
-	// If the queue's run dry, render the remainder and sync-up our time datum
+	// Render the remainder
 	while (frames_remaining) {
-		const auto frame = RenderFrame();
-		channel->AddSamples_sfloat(1, &frame[0]);
+		render_buf.emplace_back(RenderFrame());
 		--frames_remaining;
 	}
+
+	channel->AddSamples_sfloat(requested_frames,
+	                           reinterpret_cast<float*>(render_buf.data()));
 	last_rendered_ms = PIC_AtomicIndex();
 }
 

--- a/src/hardware/audio/opl.h
+++ b/src/hardware/audio/opl.h
@@ -9,6 +9,7 @@
 #include <cmath>
 #include <memory>
 #include <queue>
+#include <vector>
 
 #include "ESFMu/esfm.h"
 #include "nuked/opl3.h"
@@ -121,6 +122,8 @@ private:
 	// Playback related
 	double last_rendered_ms = 0.0;
 	double ms_per_frame     = 0.0;
+
+	std::vector<AudioFrame> render_buf = {};
 
 	// Last selected address in the chip for the different modes
 	union {

--- a/src/hardware/audio/private/cms.h
+++ b/src/hardware/audio/private/cms.h
@@ -59,7 +59,8 @@ private:
 
 	std::unique_ptr<saa1099_device> devices[2] = {};
 
-	std::queue<AudioFrame> fifo = {};
+	std::queue<AudioFrame> fifo        = {};
+	std::vector<AudioFrame> render_buf = {};
 
 	std::mutex mutex = {};
 

--- a/src/hardware/audio/private/innovation.h
+++ b/src/hardware/audio/private/innovation.h
@@ -9,6 +9,7 @@
 #include <memory>
 #include <queue>
 #include <string>
+#include <vector>
 
 #include "residfp/SID.h"
 
@@ -42,6 +43,7 @@ private:
 
 	std::unique_ptr<reSIDfp::SID> service = {};
 	std::queue<float> fifo                = {};
+	std::vector<float> render_buf         = {};
 	std::mutex mutex                      = {};
 
 	// Initial configuration

--- a/src/hardware/audio/ps1audio.cpp
+++ b/src/hardware/audio/ps1audio.cpp
@@ -391,6 +391,7 @@ private:
 	MixerChannelPtr channel            = nullptr;
 	IO_WriteHandleObject write_handler = {};
 	std::queue<float> fifo             = {};
+	std::vector<float> render_buf      = {};
 	std::mutex mutex                   = {};
 	sn76496_device device;
 
@@ -510,20 +511,23 @@ void Ps1Synth::AudioCallback(const int requested_frames)
 	}
 #endif
 
+	render_buf.clear();
+
 	auto frames_remaining = requested_frames;
 
-	// First, send any frames we've queued since the last callback
+	// Drain any cycle-accurate frames queued by RenderUpToNow
 	while (frames_remaining && fifo.size()) {
-		channel->AddSamples_mfloat(1, &fifo.front());
+		render_buf.push_back(fifo.front());
 		fifo.pop();
 		--frames_remaining;
 	}
-	// If the queue's run dry, render the remainder and sync-up our time datum
+	// Render the remainder
 	while (frames_remaining) {
-		float sample = RenderSample();
-		channel->AddSamples_mfloat(1, &sample);
+		render_buf.emplace_back(RenderSample());
 		--frames_remaining;
 	}
+
+	channel->AddSamples_mfloat(requested_frames, render_buf.data());
 	last_rendered_ms = PIC_AtomicIndex();
 }
 

--- a/src/hardware/audio/tandy_sound.cpp
+++ b/src/hardware/audio/tandy_sound.cpp
@@ -76,6 +76,7 @@ private:
 	std::unique_ptr<sn76496_base_device> device = {};
 	std::queue<float> fifo                      = {};
 	std::mutex mutex                            = {};
+	std::vector<float> render_buf               = {};
 
 	// Static rate-related configuration
 	static constexpr auto RenderDivisor = 16;
@@ -574,20 +575,23 @@ void TandyPSG::AudioCallback(const int requested_frames)
 	}
 #endif
 
+	render_buf.clear();
+
 	auto frames_remaining = requested_frames;
 
-	// First, send any frames we've queued since the last callback
+	// Drain any cycle-accurate frames queued by RenderUpToNow
 	while (frames_remaining && fifo.size()) {
-		channel->AddSamples_mfloat(1, &fifo.front());
+		render_buf.push_back(fifo.front());
 		fifo.pop();
 		--frames_remaining;
 	}
-	// If the queue's run dry, render the remainder and sync-up our time datum
+	// Render the remainder
 	while (frames_remaining) {
-		float sample = RenderSample();
-		channel->AddSamples_mfloat(1, &sample);
+		render_buf.emplace_back(RenderSample());
 		--frames_remaining;
 	}
+
+	channel->AddSamples_mfloat(requested_frames, render_buf.data());
 	last_rendered_ms = PIC_AtomicIndex();
 }
 

--- a/src/libs/residfp/CMakeLists.txt
+++ b/src/libs/residfp/CMakeLists.txt
@@ -25,4 +25,10 @@ add_library(residfp STATIC
 target_include_directories(residfp SYSTEM PUBLIC ..)
 target_link_libraries(residfp PRIVATE project_headers)
 
+if (C_TARGET_CPU_ARM)
+  target_compile_definitions(residfp PRIVATE HAVE_ARM_NEON_H)
+elseif (C_TARGET_CPU_X86)
+  target_compile_definitions(residfp PRIVATE HAVE_EMMINTRIN_H)
+endif()
+
 disable_warnings(residfp)


### PR DESCRIPTION
# Description

Several audio callbacks were sending samples one-at-a-time to Mixer::AddSamples in a loop. This PR batches them up in a vector and sends them all at once, which greatly reduces the mutex churning in AddSamples in addition to plain call overhead.

There should be zero behavioral changes here.

Also enabled SIMD build options for reSIDfp.

# Manual testing

Ran many games and used macOS Instruments to verify performance improvements (% of time spent in ::AudioCallback functions) for the various devices:
- Innovation: Ultima VI
- IMFC: King's Quest IV
- CMS: Passport to Adventure
- OPL: Doom
- PS1: Police Quest 3
- Tandy: Space Quest 2

Also did a micro benchmark in Opl::AudioCallback with std::chrono. 

main:
```log
2026-05-31 21:38:07.709 | OPL: AudioCallback cumulative 31.119 ms over 53 calls; last interval 31.119 ms over 53 calls and 28107 frames
2026-05-31 21:38:08.711 | OPL: AudioCallback cumulative 70.781 ms over 148 calls; last interval 39.663 ms over 95 calls and 49892 frames
2026-05-31 21:38:13.736 | OPL: AudioCallback cumulative 77.408 ms over 159 calls; last interval 6.626 ms over 11 calls and 5834 frames
2026-05-31 21:38:14.738 | OPL: AudioCallback cumulative 121.452 ms over 254 calls; last interval 44.044 ms over 95 calls and 49892 frames
2026-05-31 21:38:15.741 | OPL: AudioCallback cumulative 176.153 ms over 348 calls; last interval 54.701 ms over 94 calls and 49849 frames
2026-05-31 21:38:16.745 | OPL: AudioCallback cumulative 231.365 ms over 442 calls; last interval 55.212 ms over 94 calls and 49848 frames
2026-05-31 21:38:17.746 | OPL: AudioCallback cumulative 290.465 ms over 536 calls; last interval 59.100 ms over 94 calls and 49849 frames
2026-05-31 21:38:18.749 | OPL: AudioCallback cumulative 349.810 ms over 630 calls; last interval 59.346 ms over 94 calls and 49848 frames
2026-05-31 21:38:19.751 | OPL: AudioCallback cumulative 405.468 ms over 724 calls; last interval 55.658 ms over 94 calls and 49849 frames
2026-05-31 21:38:20.755 | OPL: AudioCallback cumulative 472.670 ms over 818 calls; last interval 67.202 ms over 94 calls and 49849 frames
2026-05-31 21:38:21.756 | OPL: AudioCallback cumulative 537.671 ms over 912 calls; last interval 65.001 ms over 94 calls and 49848 frames
2026-05-31 21:38:22.759 | OPL: AudioCallback cumulative 599.627 ms over 1006 calls; last interval 61.955 ms over 94 calls and 49849 frames
2026-05-31 21:38:23.762 | OPL: AudioCallback cumulative 659.182 ms over 1100 calls; last interval 59.555 ms over 94 calls and 49848 frames
2026-05-31 21:38:24.765 | OPL: AudioCallback cumulative 716.007 ms over 1194 calls; last interval 56.825 ms over 94 calls and 49849 frames
2026-05-31 21:38:25.767 | OPL: AudioCallback cumulative 776.116 ms over 1288 calls; last interval 60.109 ms over 94 calls and 49848 frames
```

Branch:
```log
2026-05-31 21:36:07.262 | OPL: AudioCallback cumulative 20.658 ms over 52 calls; last interval 20.658 ms over 52 calls and 27577 frames
2026-05-31 21:36:08.265 | OPL: AudioCallback cumulative 53.278 ms over 147 calls; last interval 32.620 ms over 95 calls and 49892 frames
2026-05-31 21:36:17.000 | OPL: AudioCallback cumulative 57.063 ms over 157 calls; last interval 3.785 ms over 10 calls and 5304 frames
2026-05-31 21:36:18.003 | OPL: AudioCallback cumulative 111.186 ms over 252 calls; last interval 54.123 ms over 95 calls and 49892 frames
2026-05-31 21:36:19.006 | OPL: AudioCallback cumulative 153.315 ms over 346 calls; last interval 42.129 ms over 94 calls and 49849 frames
2026-05-31 21:36:20.008 | OPL: AudioCallback cumulative 199.876 ms over 440 calls; last interval 46.561 ms over 94 calls and 49848 frames
2026-05-31 21:36:21.011 | OPL: AudioCallback cumulative 252.893 ms over 534 calls; last interval 53.017 ms over 94 calls and 49849 frames
2026-05-31 21:36:22.014 | OPL: AudioCallback cumulative 303.667 ms over 628 calls; last interval 50.774 ms over 94 calls and 49848 frames
2026-05-31 21:36:23.017 | OPL: AudioCallback cumulative 359.171 ms over 722 calls; last interval 55.503 ms over 94 calls and 49849 frames
2026-05-31 21:36:24.019 | OPL: AudioCallback cumulative 413.134 ms over 816 calls; last interval 53.964 ms over 94 calls and 49849 frames
2026-05-31 21:36:25.022 | OPL: AudioCallback cumulative 466.646 ms over 910 calls; last interval 53.512 ms over 94 calls and 49848 frames
2026-05-31 21:36:26.025 | OPL: AudioCallback cumulative 515.197 ms over 1004 calls; last interval 48.551 ms over 94 calls and 49849 frames
2026-05-31 21:36:27.027 | OPL: AudioCallback cumulative 572.459 ms over 1098 calls; last interval 57.262 ms over 94 calls and 49848 frames
2026-05-31 21:36:28.030 | OPL: AudioCallback cumulative 630.073 ms over 1192 calls; last interval 57.614 ms over 94 calls and 49849 frames
2026-05-31 21:36:29.032 | OPL: AudioCallback cumulative 686.140 ms over 1286 calls; last interval 56.068 ms over 94 calls and 49848 frames
```

The change has been manually tested on:

- [ ] Windows
- [x] macOS
- [ ] Linux


# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

