### PR TITLE
Fix GCC 16 compiler warning

### DIFF
--- a/src/dos/CMakeLists.txt
+++ b/src/dos/CMakeLists.txt
@@ -1,3 +1,14 @@
+# GCC 16 complains about disabled optimizations on this file
+# We have max-gcse-memory=300000 set globally but this file needs more
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  set_source_files_properties(
+    dos_locale_data.cpp
+    TARGET_DIRECTORY dosboxcommon
+    PROPERTIES
+    COMPILE_OPTIONS "--param;max-gcse-memory=600000"
+  )
+endif()
+
 target_sources(dosboxcommon PRIVATE
   cdrom.cpp
   cdrom_image.cpp


### PR DESCRIPTION
# Description

GCC 16 is throwing a warning about disabling optimizations due to not enough memory. Raise the limit for this single file. The global limit is 300000 which I would rather not double.

Alternative I considered is hiding the warning by passing `-Wno-disabled-optimization` but it didn't hurt build times too much to give it the extra memory and let it optimize.

## Related issues

#4860

# Manual testing

`touch src/dos/dos_locale_data.cpp` and rebuild to take some metrics on compiling this single file.

GCC 16.1.1 Main:
50 seconds
600MB RAM

GCC 16.1.1 This PR:
52 seconds
700MB RAM

Clang 22.1.6 (unchanged by this PR):
35 seconds
300MB RAM

This file contains some large-ish const `std::vector` and `std::map` data structures which have gotta be what's slowing this down.

Sidenote: I'm switching my default compiler to Clang after this. GCC has been a pain for me recently...

The change has been manually tested on (only relevant on Linux):

- [ ] Windows
- [ ] macOS
- [x] Linux

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

- [x] I am a human, I have read and understood the [project's policy on the use of generative AI tools](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md#policy-on-the-use-of-generative-ai-tools), and I have acted in accordance to it.

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my work (especially important for AI-assisted contributions).
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

