### PR TITLE
Remove stray OPL3_ProcessSlotMaybeInline

### DIFF
--- a/src/libs/nuked/opl3.c
+++ b/src/libs/nuked/opl3.c
@@ -1125,34 +1125,6 @@ static void OPL3_ProcessSlot(opl3_slot *slot)
     OPL3_SlotGenerate(slot);
 }
 
-/* Inline pre-check for trivially-silent slots. Avoids the OPL3_ProcessSlot
- * function-call prologue (stmdb of 8 regs + 8 prologue loads + matching
- * ldmia) for the common case of a fully-attenuated, key-off, idle slot.
- * Mirrors the inner trivial branch of OPL3_ProcessSlot's existing fast path.
- *
- * Invariant: the six idempotent fields (fbmod, prout, eg_out, pg_reset,
- * eg_gen, pg_phase_out) are guaranteed to already be at their steady-silence
- * values whenever this short-circuit fires, because the transition INTO this
- * state always goes through OPL3_ProcessSlot, which writes them. No code path
- * outside ProcessSlot writes those fields, so they stay correct without
- * needing to be re-written each sample. */
-static inline void OPL3_ProcessSlotMaybeInline(opl3_slot *slot)
-{
-    if (!slot->key && slot->eg_rout == 0x1ff
-        && slot->slot_num != 13 && slot->slot_num != 16 && slot->slot_num != 17
-        && slot->channel->fb == 0 && slot->pg_inc == 0 && slot->out == 0
-        && *slot->mod == 0 && slot->eg_tl_ksl == 0 && *slot->trem == 0
-        && slot->pg_phase == 0 && slot->reg_vib == 0 && slot->reg_wf == 0)
-    {
-        opl3_chip *chip = slot->chip;
-        uint32_t noise = chip->noise;
-        uint8_t n_bit = ((noise >> 14) ^ noise) & 0x01;
-        chip->noise = (noise >> 1) | (n_bit << 22);
-        return;
-    }
-    OPL3_ProcessSlot(slot);
-}
-
 void OPL3_Generate4Ch(opl3_chip *chip, int16_t *buf4)
 {
     opl3_channel *channel;
@@ -1173,7 +1145,7 @@ void OPL3_Generate4Ch(opl3_chip *chip, int16_t *buf4)
     for (ii = 0; ii < 36; ii++)
 #endif
     {
-        OPL3_ProcessSlotMaybeInline(&chip->slot[ii]);
+        OPL3_ProcessSlot(&chip->slot[ii]);
     }
 
     mix[0] = mix[1] = 0;
@@ -1210,7 +1182,7 @@ void OPL3_Generate4Ch(opl3_chip *chip, int16_t *buf4)
 #if OPL_QUIRK_CHANNELSAMPLEDELAY
     for (ii = 15; ii < 18; ii++)
     {
-        OPL3_ProcessSlotMaybeInline(&chip->slot[ii]);
+        OPL3_ProcessSlot(&chip->slot[ii]);
     }
 #endif
 
@@ -1220,7 +1192,7 @@ void OPL3_Generate4Ch(opl3_chip *chip, int16_t *buf4)
 #if OPL_QUIRK_CHANNELSAMPLEDELAY
     for (ii = 18; ii < 33; ii++)
     {
-        OPL3_ProcessSlotMaybeInline(&chip->slot[ii]);
+        OPL3_ProcessSlot(&chip->slot[ii]);
     }
 #endif
 
@@ -1253,7 +1225,7 @@ void OPL3_Generate4Ch(opl3_chip *chip, int16_t *buf4)
 #if OPL_QUIRK_CHANNELSAMPLEDELAY
     for (ii = 33; ii < 36; ii++)
     {
-        OPL3_ProcessSlotMaybeInline(&chip->slot[ii]);
+        OPL3_ProcessSlot(&chip->slot[ii]);
     }
 #endif
 


### PR DESCRIPTION
# Description

The Nuked-OPL3-fast vendored in #4910 mistakenly contained an unrelated experimental optimization targeting RP2350. The OPL3_ProcessSlotMaybeInline wrapper is not part of released Nuked-OPL3-fast. On x86_64, that path is slightly worse. Restore direct OPL3_ProcessSlot calls to match the released fork. Identical output.

Sorry about this. I was doing too many things at once and confused myself and gave you guys an experimental branch.

## Related issues

#4910 


# Manual testing

Trivial change.

The change has been manually tested on:

- [X] Windows
- [ ] macOS
- [X] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

- [X] I am a human, I have read and understood the [project's policy on the use of generative AI tools](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md#policy-on-the-use-of-generative-ai-tools), and I have acted in accordance to it.

I have:

- [X] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [X] performed a self-review of my work (especially important for AI-assisted contributions).
- [X] commented on the particularly hard-to-understand areas of my code.
- [X] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [ ] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [X] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [X] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

