### PR TITLE
Fix linux.yml

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -116,13 +116,17 @@ jobs:
       - name: Set up CMake
         uses: lukka/get-cmake@591817e96fcad43505fb4eae36172462abb3a42e # v4.3.3
 
-<<<<<<< HEAD
-      - name: Install dependencies
-        run: |
-          export DEBIAN_FRONTEND=noninteractive
-          sudo apt-get update
-          sudo apt-get install -y $(cat extras/linux/ubuntu-24.04-packages.txt)
+      - name: Load apt package list
+        id:   apt_pkgs
+        run:  echo "list=$(tr '\n' ' ' < extras/linux/ubuntu-24.04-packages.txt)" >> "$GITHUB_OUTPUT"
 
+      # See linting.yml for notes on this action.
+      - name: Install apt dependencies
+        id:   apt_cache
+        uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # v1.6.0
+        with:
+          packages: ${{ steps.apt_pkgs.outputs.list }}
+          version:  "1.0"
 
       - name: Install GCC ${{ matrix.conf.compiler_version }} and switch alternative
         if: ${{ matrix.conf.cc == 'gcc' && matrix.conf.compiler_version != '13' }}
@@ -145,19 +149,6 @@ jobs:
           gcc --version
           g++ --version
 
-=======
-      - name: Load apt package list
-        id:   apt_pkgs
-        run:  echo "list=$(tr '\n' ' ' < extras/linux/ubuntu-22.04-packages.txt)" >> "$GITHUB_OUTPUT"
-
-      # Package list from extras/linux/ubuntu-22.04-packages.txt (also used outside CI).
-      - name: Install apt dependencies
-        id:   apt_cache
-        uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # v1.6.0
-        with:
-          packages: ${{ steps.apt_pkgs.outputs.list }}
-          version:  "1.0"
->>>>>>> 4f676a070 (ci: Cache apt packages with cache-apt-pkgs-action)
 
       - name: Report apt cache status
         run:  echo "apt cache hit:" "${{ steps.apt_cache.outputs.cache-hit || 'false' }}"


### PR DESCRIPTION
# Description

`linux.yml` had leftover diff markup and was failing.

# Manual testing

Ensured Linux CI produced artifacts.

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [ ] Linux


# Checklist

- [x] I am a human, I have read and understood the [project's policy on the use of generative AI tools](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md#policy-on-the-use-of-generative-ai-tools), and I have acted in accordance to it.

I have:

- [ ] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [ ] performed a self-review of my work (especially important for AI-assisted contributions).
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [ ] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

