### PR TITLE
Default MediaId to HardDisk like in original codebase

### DIFF
--- a/src/dos/programs/mount.h
+++ b/src/dos/programs/mount.h
@@ -5,6 +5,7 @@
 #ifndef DOSBOX_PROGRAM_MOUNT_H
 #define DOSBOX_PROGRAM_MOUNT_H
 
+#include "dos/dos.h"
 #include "dos/programs.h"
 #include <array>
 #include <string>
@@ -25,7 +26,8 @@ struct MountParameters {
 	bool is_ide               = false;
 	int8_t ide_index          = -1;
 	bool is_second_cable_slot = false;
-	uint8_t mediaid           = 0;
+	// Defaulting to Hard Disk prevents obscure issues in games like Hyperspace 
+	uint8_t mediaid           = MediaId::HardDisk;
 	// 0-3 vs A-Z
 	bool is_drive_number = false;
 };


### PR DESCRIPTION
# Description

This PR restores the original dosbox behavior of assuming a hard disk mediaID value as default.

## Related issues

Fixes #4911

# Manual testing

Tested using various CD and hard disk images, for example X-Wing, Tie-Fighter, Discworld, as well as hdd images of installed games such as Descent, Jazz Jackrabbit, Test Drive 3, Wacky Wheels and Stunts.

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [X] Linux


# Checklist
- [X] I am a human, I have read and understood the [project's policy on the use of generative AI tools](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md#policy-on-the-use-of-generative-ai-tools), and I have acted in accordance to it.

I have:

- [X] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [X] performed a self-review of my work (especially important for AI-assisted contributions).
- [ ] commented on the particularly hard-to-understand areas of my code.
- [X] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [X] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [X] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [X] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

