### PR TITLE
Add option to run the tests with the compile commits script

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -426,6 +426,13 @@ important for bisecting, and we strictly enforce it. You can simply just run
 `scripts/tools/compile-commits.sh` to compile all commits of the PR you're
 working on.
 
+Pass `--test` to also run the ctest suite after each commit compiles, or
+`--test-filter PATTERN` to run only the tests matching `PATTERN` (this implies
+`--test`). For example:
+
+    $ scripts/tools/compile-commits.sh debug-linux --test
+    $ scripts/tools/compile-commits.sh debug-linux --test-filter DOS_FilesTest
+
 
 ### clang-format
 

--- a/scripts/tools/compile-commits.sh
+++ b/scripts/tools/compile-commits.sh
@@ -20,6 +20,22 @@ restore_branch() {
 	git checkout "$CURRENT_BRANCH" &> /dev/null
 }
 
+print_failure() {
+	local REASON=$1
+	local COMMIT=$2
+	local TITLE=$3
+	local REPRO_CMD=$4
+
+	echo
+	echo -e "${RED}*** ERROR: $REASON:"
+	echo -e "    $COMMIT $TITLE"
+	echo
+	echo -e "    Execute the following to reproduce the failure:"
+	echo
+	echo -e "      git checkout -"
+	echo -e "      $REPRO_CMD${NC}"
+}
+
 compile_commit() {
 	local COMMIT
 	COMMIT=$1
@@ -54,42 +70,103 @@ compile_commit() {
 	if [[ $DO_CONFIGURE -eq 1 ]]; then
 		rm -rf $BUILD_DIR
 
-		if ! cmake --preset="$CMAKE_PRESET" >/dev/null; then
-			echo
-			echo -e "${RED}*** CMake configure failed for commit:"
-			echo -e "    $COMMIT $TITLE${NC}"
+		local CONFIGURE_CMD="cmake --preset=$CMAKE_PRESET"
+		if ! $CONFIGURE_CMD >/dev/null; then
+			print_failure "CMake configure failed for commit" \
+				"$COMMIT" "$TITLE" "$CONFIGURE_CMD"
 			restore_branch
 			exit 1
 		fi
 	fi
 
 	# Compile commit
-	if ! cmake --build --preset="$CMAKE_PRESET" >/dev/null; then
-		echo
-		echo -e "${RED}*** ERROR: Building commit failed:"
-		echo -e "    $COMMIT $TITLE"
-		echo
-		echo -e "    Execute the following to reproduce the failure:"
-		echo
-		echo -e "      git checkout -"
-		echo -e "      cmake --build --preset=$CMAKE_PRESET${NC}"
+	local BUILD_CMD="cmake --build --preset=$CMAKE_PRESET"
+	if ! $BUILD_CMD >/dev/null; then
+		print_failure "Building commit failed" \
+			"$COMMIT" "$TITLE" "$BUILD_CMD"
 		restore_branch
 		exit 1
 	fi
 }
 
-#-----------------------------------------------------------------------------
+run_tests() {
+	local COMMIT
+	COMMIT=$1
 
-if [ $# -lt 1 ] || [ $# -gt 2 ]; then
-	echo "Usage: compile-commits.sh CMAKE_PRESET [FROM_HASH]"
+	local TITLE
+	TITLE=$2
+
+	local CMD=(GTEST_COLOR=1 ctest -j 8 --preset "$CMAKE_PRESET")
+	if [[ -n $TEST_FILTER ]]; then
+		CMD+=(-R "$TEST_FILTER")
+	fi
+
+	if ! env "${CMD[@]}"; then
+		print_failure "Tests failed for commit" \
+			"$COMMIT" "$TITLE" "${CMD[*]}"
+		restore_branch
+		exit 1
+	fi
+}
+
+usage() {
+	echo "Usage: compile-commits.sh CMAKE_PRESET [FROM_HASH] [--test] [--test-filter PATTERN]"
 	echo
 	echo "If FROM_HASH is not specified, the script compiles all commits in the"
 	echo "current branch (assuming the parent branch is 'main')."
+	echo
+	echo "  --test                  Run the ctest suite after each commit compiles."
+	echo "  --test-filter PATTERN   Run only tests matching PATTERN (implies --test)."
 	exit 1
+}
+
+#-----------------------------------------------------------------------------
+
+RUN_TESTS=0
+TEST_FILTER=
+POSITIONAL=()
+
+while [[ $# -gt 0 ]]; do
+	case $1 in
+		--test)
+			RUN_TESTS=1
+			shift
+			;;
+
+		--test-filter)
+			if [[ -z ${2:-} ]]; then
+				echo "Error: --test-filter requires a PATTERN argument."
+				echo
+				usage
+			fi
+			RUN_TESTS=1
+			TEST_FILTER=$2
+			shift 2
+			;;
+
+		-h|--help)
+			usage
+			;;
+
+		--*)
+			echo "Error: unknown option: $1"
+			echo
+			usage
+			;;
+
+		*)
+			POSITIONAL+=("$1")
+			shift
+			;;
+	esac
+done
+
+if [[ ${#POSITIONAL[@]} -lt 1 || ${#POSITIONAL[@]} -gt 2 ]]; then
+	usage
 fi
 
-CMAKE_PRESET=$1
-FROM_HASH=$2
+CMAKE_PRESET=${POSITIONAL[0]}
+FROM_HASH=${POSITIONAL[1]:-}
 BUILD_DIR=build
 echo
 
@@ -115,6 +192,10 @@ do
 	printf "${YELLOW}[%2d/%2d] ${CYAN}%s${NC} %s" "$COMMIT_NO" "$NUM_COMMITS" "$COMMIT" "$TITLE"
 	echo
 	compile_commit "$COMMIT" "$TITLE"
+
+	if [[ $RUN_TESTS -eq 1 ]]; then
+		run_tests "$COMMIT" "$TITLE"
+	fi
 
 	(( COMMIT_NO++ ))
 done


### PR DESCRIPTION
# Description

Add support to the compile commits script to run all unit tests or just a subset specified via GTest filters.

# Manual testing

Works on macOS.

The change has been manually tested on:

- [ ] Windows
- [x] macOS
- [ ] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

- [x] I am a human, I have read and understood the [project's policy on the use of generative AI tools](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md#policy-on-the-use-of-generative-ai-tools), and I have acted in accordance to it.

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my work (especially important for AI-assisted contributions).
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [x] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

