### PR TITLE
Retry MkDocs build and git pushes via retry action

### DIFF
--- a/.github/actions/retry/action.yml
+++ b/.github/actions/retry/action.yml
@@ -16,6 +16,11 @@ inputs:
     required: false
     default: '10'
 
+  on-retry:
+    description: 'Shell command run after a failed attempt, before backoff sleep. Hook failures do not abort the retry.'
+    required: false
+    default: ''
+
 runs:
   using: composite
   steps:
@@ -24,6 +29,7 @@ runs:
         RETRY_CMD: ${{ inputs.cmd }}
         RETRY_ATTEMPTS: ${{ inputs.attempts }}
         RETRY_BASE_DELAY: ${{ inputs.base-delay }}
+        RETRY_ON_RETRY: ${{ inputs.on-retry }}
       run: |
         set -u
         for i in $(seq 1 "$RETRY_ATTEMPTS"); do
@@ -39,5 +45,12 @@ runs:
             echo "::error::Command failed after $RETRY_ATTEMPTS attempts: $RETRY_CMD"
             exit 1
           fi
+
+          if [ -n "$RETRY_ON_RETRY" ]; then
+            echo "::group::On-retry hook: $RETRY_ON_RETRY"
+            bash -c "$RETRY_ON_RETRY" || echo "::warning::on-retry hook failed (exit $?), continuing"
+            echo "::endgroup::"
+          fi
+
           sleep $((i * RETRY_BASE_DELAY))
         done

--- a/.github/workflows/deploy-website-preview-pr-cleanup.yml
+++ b/.github/workflows/deploy-website-preview-pr-cleanup.yml
@@ -54,19 +54,20 @@ jobs:
             git config user.email "<>"
             git rm -rf "$PREVIEW_DIR"
             git commit -m "Remove preview for PR #${PR_NUMBER}"
-
-            # Retry on non-fast-forward: a cancelled deploy for the same PR
-            # may still be mid-`git push` when we get here (cancel-in-progress
-            # is not synchronous). Rebase + retry ensures cleanup wins.
-            for i in 1 2 3; do
-              git push && break
-              git pull --rebase
-            done
-
             echo "cleaned=true" >> "$GITHUB_ENV"
           else
             echo "cleaned=false" >> "$GITHUB_ENV"
           fi
+
+      # Retry on non-fast-forward: a cancelled deploy for the same PR may
+      # still be mid-`git push` when we get here (cancel-in-progress is not
+      # synchronous). Rebase + retry ensures cleanup wins.
+      - name: Publish preview removal
+        if:   env.cleaned == 'true'
+        uses: ./.github/actions/retry
+        with:
+          cmd: git push
+          on-retry: git pull --rebase
 
       - name: Update sticky comment
         if: env.cleaned == 'true'

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -109,18 +109,27 @@ jobs:
               echo $FILES | xargs git rm -rf --
           fi
 
+      # The privacy plugin downloads every external URL referenced in the
+      # docs at build time; a transient 5xx from any source crashes the
+      # whole build. Retry the build itself; staging below cannot fail
+      # transiently and stays a plain `run:`.
       - name: Build documentation
+        uses: ./.github/actions/retry
+        with:
+          cmd: |
+            cd dosbox-staging.github.io
+            mkdocs build \
+              --config-file ../dosbox-staging/website/mkdocs.yml \
+              --site-dir $(pwd)/temp-out
+
+      - name: Stage built documentation
         run: |
           cd dosbox-staging.github.io
-          MKDOCS_SRC_PATH=../dosbox-staging/website/
-          TEMP_PATH=$(pwd)/temp-out
           DEST_PATH=$(pwd)/${{ env.dest_path_prefix }}
-
-          mkdocs build --config-file $MKDOCS_SRC_PATH/mkdocs.yml --site-dir $TEMP_PATH
-          mkdir -p $DEST_PATH
-          cp -rf $TEMP_PATH/* $DEST_PATH
-          rm -rf $TEMP_PATH
-          touch $DEST_PATH/.nojekyll
+          mkdir -p "$DEST_PATH"
+          cp -rf temp-out/* "$DEST_PATH"
+          rm -rf temp-out
+          touch "$DEST_PATH/.nojekyll"
 
       - name: Set up Git config
         run: |
@@ -128,7 +137,8 @@ jobs:
           git config user.name "GitHub Actions Bot"
           git config user.email "<>"
 
-      - name: Commit & publish new release
+      - name: Commit new release
+        id:   commit_release
         run: |
           cd dosbox-staging.github.io
           git add .
@@ -139,15 +149,23 @@ jobs:
           # website/**, so the workflow still fires).
           if git diff --cached --quiet; then
             echo "No changes to publish."
+            echo "publish=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           git commit -m "Deployed current website (${{ env.source_git_hash }})"
+          echo "publish=true" >> "$GITHUB_OUTPUT"
 
-          # Retry on non-fast-forward: a cancelled sibling run (cancel-in-progress
-          # is not synchronous) may land its push between our checkout and ours.
-          for i in 1 2 3; do
-            git push && break
+      # Retry on non-fast-forward: a cancelled sibling run (cancel-in-progress
+      # is not synchronous) may land its push between our checkout and ours.
+      - name: Publish new release
+        if:   steps.commit_release.outputs.publish == 'true'
+        uses: ./.github/actions/retry
+        with:
+          cmd: |
+            cd dosbox-staging.github.io
+            git push
+          on-retry: |
+            cd dosbox-staging.github.io
             git pull --rebase
-          done
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -164,13 +164,21 @@ jobs:
       - name: Log environment
         run: ./scripts/ci/log-env.sh
 
+      # Retried because the docs build (OPT_DOCUMENTATION=ON) downloads
+      # external assets via the MkDocs Material privacy plugin; a transient
+      # 5xx or DNS hiccup on any source crashes the whole build. Wrapping
+      # the entire step keeps the change minimal; the cmake build is
+      # incremental, so a docs-flake retry skips already-compiled artifacts.
       - name: Build
-        run: |
-          set -xo pipefail
-          export CC=${{ matrix.conf.cc }}
-          export CXX=${{ matrix.conf.cxx }}
-          cmake ${{ matrix.conf.cmake_flags }} -DOPT_DOCUMENTATION=ON --preset ${{ matrix.conf.cmake_preset }}
-          cmake --build --preset ${{ matrix.conf.cmake_preset }} 2>&1 | tee build.log
+        env:
+          CC:  ${{ matrix.conf.cc }}
+          CXX: ${{ matrix.conf.cxx }}
+        uses: ./.github/actions/retry
+        with:
+          cmd: |
+            set -xeo pipefail
+            cmake ${{ matrix.conf.cmake_flags }} -DOPT_DOCUMENTATION=ON --preset ${{ matrix.conf.cmake_preset }}
+            cmake --build --preset ${{ matrix.conf.cmake_preset }} 2>&1 | tee build.log
 
       - name: Run tests
         run: |
@@ -225,11 +233,18 @@ jobs:
       - name: Log environment
         run: ./scripts/ci/log-env.sh
 
+      # Retried because the docs build (OPT_DOCUMENTATION=ON) downloads
+      # external assets via the MkDocs Material privacy plugin; a transient
+      # 5xx or DNS hiccup on any source crashes the whole build. Wrapping
+      # the entire step keeps the change minimal; the cmake build is
+      # incremental, so a docs-flake retry skips already-compiled artifacts.
       - name: Build release
-        run: |
-          set -x
-          cmake -DOPT_DOCUMENTATION=ON --preset release-linux-vcpkg
-          cmake --build --preset release-linux-vcpkg
+        uses: ./.github/actions/retry
+        with:
+          cmd: |
+            set -xe
+            cmake -DOPT_DOCUMENTATION=ON --preset release-linux-vcpkg
+            cmake --build --preset release-linux-vcpkg
 
       - name: Dump workspace contents
         run: find $RUNNER_WORKSPACE

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -89,11 +89,18 @@ jobs:
       - name: Log environment
         run: arch -arch=${{ matrix.conf.arch }} ./scripts/ci/log-env.sh
 
+      # Retried because the docs build (OPT_DOCUMENTATION=ON) downloads
+      # external assets via the MkDocs Material privacy plugin; a transient
+      # 5xx or DNS hiccup on any source crashes the whole build. Wrapping
+      # the entire step keeps the change minimal; the cmake build is
+      # incremental, so a docs-flake retry skips already-compiled artifacts.
       - name: Build release
-        run: |
-          set -xo pipefail
-          cmake -DOPT_DOCUMENTATION=ON --preset release-macos-${{ matrix.conf.arch }}
-          cmake --build --preset release-macos-${{ matrix.conf.arch }} 2>&1 | tee build.log
+        uses: ./.github/actions/retry
+        with:
+          cmd: |
+            set -xeo pipefail
+            cmake -DOPT_DOCUMENTATION=ON --preset release-macos-${{ matrix.conf.arch }}
+            cmake --build --preset release-macos-${{ matrix.conf.arch }} 2>&1 | tee build.log
 
       - name: Run tests
         run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -101,12 +101,19 @@ jobs:
         shell: pwsh
         run:   .\scripts\ci\log-env.ps1
 
-      - name:  Build release
-        if:    ${{ !matrix.conf.debugger }}
-        shell: pwsh
-        run: |
-          cmake -DOPT_DOCUMENTATION=ON --preset release-windows
-          cmake --build --preset release-windows 2>&1 | Tee-Object -FilePath build.log
+      # Retried because the docs build (OPT_DOCUMENTATION=ON) downloads
+      # external assets via the MkDocs Material privacy plugin; a transient
+      # 5xx or DNS hiccup on any source crashes the whole build. Wrapping
+      # the entire step keeps the change minimal; the cmake build is
+      # incremental, so a docs-flake retry skips already-compiled artifacts.
+      - name: Build release
+        if:   ${{ !matrix.conf.debugger }}
+        uses: ./.github/actions/retry
+        with:
+          cmd: |
+            set -eo pipefail
+            cmake -DOPT_DOCUMENTATION=ON --preset release-windows
+            cmake --build --preset release-windows 2>&1 | tee build.log
 
       - name:  Run tests
         if:    ${{ !matrix.conf.debugger }}
@@ -114,12 +121,15 @@ jobs:
         run: |
           ctest -j 4 --preset release-windows 2>&1 | Tee-Object -FilePath tests.log
 
-      - name:  Build release with debugger
-        if:    ${{ matrix.conf.debugger }}
-        shell: pwsh
-        run: |
-          cmake -DOPT_DOCUMENTATION=ON --preset release-windows -DOPT_DEBUGGER=ON -DOPT_HEAVY_DEBUGGER=ON
-          cmake --build --preset release-windows 2>&1 | Tee-Object -FilePath build.log
+      # See the comment on "Build release" above re: why this is retried.
+      - name: Build release with debugger
+        if:   ${{ matrix.conf.debugger }}
+        uses: ./.github/actions/retry
+        with:
+          cmd: |
+            set -eo pipefail
+            cmake -DOPT_DOCUMENTATION=ON --preset release-windows -DOPT_DEBUGGER=ON -DOPT_HEAVY_DEBUGGER=ON
+            cmake --build --preset release-windows 2>&1 | tee build.log
 
       - name: Summarize warnings
         env:


### PR DESCRIPTION
# Description

Claude-assisted CI-resiliency improvement.

The MkDocs Material `privacy` plugin downloads every external URL referenced in the docs at build time (web fonts, images, JS). When a source returns a non-2xx the plugin logs a warning but keeps going; `copy_static_files` later crashes with `FileNotFoundError` because the asset never landed on disk. ]

We recently lost a Windows release build to a one-off 503 from `dosbox-staging.org` for `fluidsynth-listmidi.png`, and the first run of this PR lost the macOS x86_64 build to DNS resolution failures against `fonts.googleapis.com` and other external hosts.

This PR wraps every docs-building CI step with the existing local retry action so transient external-source flakes no longer fail the run.


# Manual testing

Verification is via CI on this PR.

# Checklist

- [x] I am a human, I have read and understood the [project's policy on the use of generative AI tools](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md#policy-on-the-use-of-generative-ai-tools), and I have acted in accordance to it.

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my work (especially important for AI-assisted contributions).
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [x] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.