### PR TITLE
Fix cold-start Sound Blaster digital audio latency

### DIFF
--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -2878,6 +2878,21 @@ static void generate_frames(const int frames_requested)
 		frames_added_this_tick += frames_requested;
 		break;
 	}
+	// Skip the silence-fill if DMA/DAC has never started in this session
+	// (the channel is only enabled inside the Dma and Dac cases below).
+	// Otherwise on SB16 and ESS - where init_speaker_state() forces
+	// sb.speaker_enabled = true at startup - we'd enqueue silence every
+	// PIC tick from process start, with nothing draining the queue (the
+	// mixer thread skips disabled channels). The queue ends up pre-filled
+	// with stale silence ahead of the game's first real audio, baking in
+	// tens of milliseconds of input-to-audio latency for the rest of the
+	// session. Matches the gating pattern used by GUS, LPT DAC, PS1,
+	// Tandy, PC Speaker and ReelMagic. The Tyrian-style brief DmaMasked
+	// dip is unaffected because that only happens after DMA has run.
+	if (!sb.chan->is_enabled) {
+		frames_added_this_tick += frames_requested;
+		break;
+	}
 	// Enqueue a tick's worth of silenced frames
 	// Some games (Tyrian for example) will switch to DmaMasked briefly (less than 5 ticks usually)
 	// We can't use AddSilence on the mixer thread as that asks for a blocksize of audio (usually over 10ms)


### PR DESCRIPTION
# Description

Fixes a permanent input-to-audio latency that affects every cold launch of an SB16-using game on 0.82.x. The same bug is reported in #4949 (Quazatron77 et al.) and matches the reporter's repro and workarounds exactly.

**The bug.** `sblaster_pic_callback` enqueues silence into `soundblaster_mixer_queue` from the moment SB initializes — but the mixer-thread consumer doesn't drain the queue until `sb.chan` is enabled, which only happens once a game actually starts DMA or DAC playback. On SB16 and ESS, `init_speaker_state()` forces `sb.speaker_enabled = true` at startup, so the producer fires unconditionally from SB-init onward. The queue accumulates stale silence ahead of the game's first real audio sample, baking that silence into the playback pipeline for the rest of the session.

**Why SB only.** Every other audio module on this branch — GUS, LPT DAC, PS1, Tandy, PC Speaker, ReelMagic — already gates its PIC tick producer on `channel->is_enabled`. SB is the lone exception. The MIDI handlers (FluidSynth, MT-32) sidestep the issue by bounding their queue to `2 × prebuffer_ms`, so any analogous accumulation is capped to the user's prebuffer setting. I checked all audio code paths in `src/hardware/` and `src/midi/` to confirm no other module needs the same change.

**Introduced by** [`6c029d2ab`](https://github.com/dosbox-staging/dosbox-staging/commit/6c029d2ab) ("Move mixer to seperate thread"), which introduced the producer/consumer-queue architecture for audio modules. Other modules were written with the is_enabled gate from the start; SB missed it.

**The fix.** Three new lines: skip the silence-fill in `generate_frames`' None/DmaPause/DmaMasked case when `sb.chan->is_enabled` is false. That gates the silence-fill to "after DMA/DAC has actually started" — which is the only scenario the silence-fill exists for (Tyrian briefly transitions to DmaMasked mid-playback). Cold-start, never-played-yet sessions no longer accumulate.

**OS-agnostic.** The bug lives in DOSBox's own queue/producer/consumer plumbing. Nothing OS-, SDL2- or backend-specific. The reporter saw it on Windows; I verified on macOS. Anyone on 0.82.x with `sbtype = sb16` (or `ess`) and a game that starts SB DMA within the first few seconds of session start is affected.

**`main` is not affected** because [`bf2c6a7a1`](https://github.com/dosbox-staging/dosbox-staging/commit/bf2c6a7a1) ("Use the Mixer's pull pattern in the Sound Blaster") rewrote the SB to the pull pattern, with the producer now properly gated on `channel->is_enabled` (`per_tick_callback` line 3231, `per_frame_callback` line 3265 in current `src/hardware/audio/soundblaster.cpp`) and a right-sized queue (`2 × FramesPerBlock`). The rewrite is too invasive to backport — this targeted gate is the minimal equivalent for the 0.82.x line.

## Related issues

- #4949

# Manual testing

Verified on macOS (Apple Silicon, Tahoe 26) with the reporter's exact config:

```ini
[mixer]
rate = 44100
blocksize = 512
prebuffer = 8
negotiate = false

[sblaster]
sbtype = sb16

[cpu]
core = dynamic
cpu_cycles = max
```

Instrumented `enqueue_frames()` and the SB mixer callback to log queue depth at every event. Drove the path with a minimal hand-written DOS `.COM` (76 lines of NASM) that programs auto-init 8-bit DMA at 22050 Hz and loops. Two scenarios — immediate-DMA cold start and 5 s delay before DMA. Both reproduce the user's reported pattern on 0.82.x without the fix; both are clean with the fix.

| scenario | queue at first dequeue | steady-state | verdict |
|---|---|---|---|
| **before fix**, immediate DMA | **95** | ~85–95 | latency baked in |
| **before fix**, 5 s delay then DMA | 128 (full, drops audio data) | ~100–120 | worse |
| **after fix**, immediate DMA | **6** | 0–10 | ✓ |
| **after fix**, 5 s delay then DMA | **15** | 0–15 | ✓ |
| sbpro2 control (speaker defaults off, bug shouldn't trigger) | 1 | 0–4 | ✓ same as fixed sb16 |

Reproduce locally:
```sh
meson setup build/release
meson compile -C build/release
# point at a config with [sblaster] sbtype = sb16 and any program that starts SB DMA
build/release/dosbox --conf <yourconf>
```

Spot-checked manually that:
- Tyrian-style brief DmaMasked transitions during playback still produce the silence-fill (the `is_enabled` check passes once DMA has run).
- The existing 5000-tick auto-cleanup logic still fires correctly when DMA stops.
- SB Pro and earlier (where `speaker_enabled` defaults to false) are unchanged — they always took the early `!sb.speaker_enabled` return anyway.

Did not run a sanitizer build; the change is a 3-line read of an existing atomic.

# Checklist

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.