### PR TITLE
Fix Sound Blaster output queue saturation from catch-up bursts

### DIFF
--- a/src/hardware/audio/soundblaster.cpp
+++ b/src/hardware/audio/soundblaster.cpp
@@ -8,6 +8,7 @@
 #include "private/gus.h"
 
 #include <array>
+#include <chrono>
 #include <cmath>
 #include <cstring>
 #include <iomanip>
@@ -35,6 +36,13 @@
 #include "utils/math_utils.h"
 #include "utils/rwqueue.h"
 #include "utils/string_utils.h"
+
+// Set to 1 to enable runtime SB queue tracing (`SB_INSTRUMENTATION`
+// LOG_MSG block printed every 5 wall-clock seconds and again at SB
+// shutdown) for diagnosing audio latency / dropout regressions in
+// `per_tick_callback`, `per_frame_callback` and MixerCallback. See
+// PR #4954 for the methodology.
+#define SB_DEBUG_INSTRUMENTATION 0
 
 constexpr uint8_t MixerIndex = 0x04;
 constexpr uint8_t MixerData  = 0x05;
@@ -1104,11 +1112,172 @@ static uint32_t read_dma_16bit(const uint32_t words_to_read,
 	return check_cast<uint32_t>(words_read);
 }
 
+#if SB_DEBUG_INSTRUMENTATION
+// Lock-free min/max/sum/count aggregator. All updates relaxed -- we
+// only care about the summary, not per-event ordering.
+struct SbStat {
+	std::atomic<uint64_t> sum{0};
+	std::atomic<uint64_t> count{0};
+	std::atomic<int64_t>  min{INT64_MAX};
+	std::atomic<int64_t>  max{INT64_MIN};
+
+	void Record(int64_t v)
+	{
+		sum.fetch_add(static_cast<uint64_t>(v), std::memory_order_relaxed);
+		count.fetch_add(1, std::memory_order_relaxed);
+		auto cur_min = min.load(std::memory_order_relaxed);
+		while (v < cur_min && !min.compare_exchange_weak(
+		                              cur_min, v,
+		                              std::memory_order_relaxed)) {}
+		auto cur_max = max.load(std::memory_order_relaxed);
+		while (v > cur_max && !max.compare_exchange_weak(
+		                              cur_max, v,
+		                              std::memory_order_relaxed)) {}
+	}
+
+	void Reset()
+	{
+		sum.store(0, std::memory_order_relaxed);
+		count.store(0, std::memory_order_relaxed);
+		min.store(INT64_MAX, std::memory_order_relaxed);
+		max.store(INT64_MIN, std::memory_order_relaxed);
+	}
+};
+
+// Latency proxy: queue depth observed by the producer / consumer at the
+// moment they arrived. Higher avg `queue_pre_deq` = higher input-to-audio
+// latency (the mixer plays frames from the front of a deeper queue).
+static SbStat sb_queue_pre_enq;
+static SbStat sb_queue_pre_deq;
+static SbStat sb_frames_needed_stat; // raw value (pre-`max(_, 1)`)
+
+static std::atomic<uint64_t> sb_enq_calls{0};
+static std::atomic<uint64_t> sb_enq_frames_wanted{0};
+// Frames the producer generated that NonblockingBulkEnqueue rejected
+// because the queue was at cap. NOT the same as "audio frames lost":
+// when the producer is ahead of wall-clock time (e.g. cycles=max)
+// these are emulated-future samples the mixer wouldn't have caught
+// up to anyway. Useful as a saturation indicator, not an audio-loss
+// indicator.
+static std::atomic<uint64_t> sb_enq_frames_rejected{0};
+static std::atomic<uint64_t> sb_perframe_calls{0};
+static std::atomic<uint64_t> sb_pertick_calls{0};
+static std::atomic<uint64_t> sb_deq_zero_depth{0}; // mixer arrived to empty queue
+// One-shot / sticky, never reset between periodic dumps.
+static std::atomic<int64_t>  sb_first_dma_qsize{-1};
+static std::atomic<bool>     sb_ff_observed{false};
+// Session-cumulative pre-dequeue depth (the latency proxy). Sticky --
+// each periodic dump reports the average over the whole session, so
+// the trend across the full run is visible alongside the per-window
+// snapshot.
+static std::atomic<uint64_t> sb_queue_pre_deq_cum_sum{0};
+static std::atomic<uint64_t> sb_queue_pre_deq_cum_count{0};
+// Most recent channel sample rate seen at dequeue. Cached so the
+// destructor's final summary can still print latency in milliseconds
+// after the channel has been torn down.
+static std::atomic<int>      sb_last_channel_rate_hz{0};
+
+static void log_sb_instrumentation_summary(const char* label)
+{
+	const auto fmt_stat = [](const SbStat& s) {
+		const auto n = s.count.load(std::memory_order_relaxed);
+		if (n == 0) {
+			return std::string("n=0");
+		}
+		char buf[128] = {};
+		std::snprintf(buf, sizeof(buf),
+		              "n=%llu min=%lld max=%lld avg=%.1f",
+		              static_cast<unsigned long long>(n),
+		              static_cast<long long>(s.min.load(
+		                      std::memory_order_relaxed)),
+		              static_cast<long long>(s.max.load(
+		                      std::memory_order_relaxed)),
+		              static_cast<double>(s.sum.load(
+		                      std::memory_order_relaxed)) /
+		                      static_cast<double>(n));
+		return std::string(buf);
+	};
+	LOG_MSG("SB_INSTRUMENTATION (%s) ==========", label);
+	LOG_MSG("  per_tick_callback calls   : %llu",
+	        (unsigned long long)sb_pertick_calls.load());
+	LOG_MSG("  per_frame_callback calls  : %llu",
+	        (unsigned long long)sb_perframe_calls.load());
+	LOG_MSG("  enqueue calls             : %llu",
+	        (unsigned long long)sb_enq_calls.load());
+	LOG_MSG("  frames wanted (sum)       : %llu",
+	        (unsigned long long)sb_enq_frames_wanted.load());
+	LOG_MSG("  frames rejected by queue  : %llu  (producer overran queue cap; NOT the same as audio loss)",
+	        (unsigned long long)sb_enq_frames_rejected.load());
+	LOG_MSG("  queue depth pre-enqueue   : %s",
+	        fmt_stat(sb_queue_pre_enq).c_str());
+	LOG_MSG("  queue depth pre-dequeue   : %s  (latency proxy)",
+	        fmt_stat(sb_queue_pre_deq).c_str());
+	{
+		const auto cum_n = sb_queue_pre_deq_cum_count.load(
+		        std::memory_order_relaxed);
+		if (cum_n > 0) {
+			const auto cum_sum = sb_queue_pre_deq_cum_sum.load(
+			        std::memory_order_relaxed);
+			const double cum_avg = static_cast<double>(cum_sum) /
+			                       static_cast<double>(cum_n);
+			const auto rate_hz = sb_last_channel_rate_hz.load(
+			        std::memory_order_relaxed);
+			if (rate_hz > 0) {
+				LOG_MSG("  avg latency (cumulative)  : %.1f frames = %.2f ms at %d Hz",
+				        cum_avg,
+				        cum_avg * 1000.0 / static_cast<double>(rate_hz),
+				        rate_hz);
+			} else {
+				LOG_MSG("  avg latency (cumulative)  : %.1f frames (rate unknown)",
+				        cum_avg);
+			}
+		} else {
+			LOG_MSG("  avg latency (cumulative)  : n=0");
+		}
+	}
+	LOG_MSG("  empty-queue at dequeue    : %llu  (underrun indicator)",
+	        (unsigned long long)sb_deq_zero_depth.load());
+	LOG_MSG("  frames_needed (raw)       : %s",
+	        fmt_stat(sb_frames_needed_stat).c_str());
+	const auto first = sb_first_dma_qsize.load(std::memory_order_relaxed);
+	LOG_MSG("  first-DMA queue depth     : %s  (sticky; non-zero => #4949-style pre-fill)",
+	        (first < 0 ? "(no DMA observed)"
+	                   : std::to_string(first).c_str()));
+	LOG_MSG("  fast-forward observed     : %s  (sticky)",
+	        sb_ff_observed.load(std::memory_order_relaxed) ? "yes" : "no");
+	LOG_MSG("==============================");
+
+	// Reset per-window counters so the next summary shows a fresh
+	// 5-second window. One-shots above (first-DMA queue depth, FF
+	// observed) intentionally stay sticky.
+	sb_pertick_calls.store(0, std::memory_order_relaxed);
+	sb_perframe_calls.store(0, std::memory_order_relaxed);
+	sb_enq_calls.store(0, std::memory_order_relaxed);
+	sb_enq_frames_wanted.store(0, std::memory_order_relaxed);
+	sb_enq_frames_rejected.store(0, std::memory_order_relaxed);
+	sb_deq_zero_depth.store(0, std::memory_order_relaxed);
+	sb_queue_pre_enq.Reset();
+	sb_queue_pre_deq.Reset();
+	sb_frames_needed_stat.Reset();
+}
+#endif
+
 static void enqueue_frames(std::vector<AudioFrame>& frames)
 {
 	assert(sblaster);
 	frames_added_this_tick += static_cast<int>(frames.size());
+#if SB_DEBUG_INSTRUMENTATION
+	const auto wanted = frames.size();
+	sb_queue_pre_enq.Record(
+	        static_cast<int64_t>(sblaster->output_queue.Size()));
+	const auto accepted = sblaster->output_queue.NonblockingBulkEnqueue(frames);
+	sb_enq_calls.fetch_add(1, std::memory_order_relaxed);
+	sb_enq_frames_wanted.fetch_add(wanted, std::memory_order_relaxed);
+	sb_enq_frames_rejected.fetch_add(wanted - accepted,
+	                                 std::memory_order_relaxed);
+#else
 	sblaster->output_queue.NonblockingBulkEnqueue(frames);
+#endif
 }
 
 static void play_dma_transfer(const uint32_t bytes_requested)
@@ -3194,6 +3363,22 @@ static void generate_frames(const int frames_requested)
 		break;
 
 	case DspMode::Dma: {
+#if SB_DEBUG_INSTRUMENTATION
+		// Capture queue depth at first DMA dispatch. On unfixed
+		// 0.82.x this would be at the queue cap (pre-filled with
+		// stale silence by the per-tick producer running before the
+		// channel was enabled). On main it should be 0: the
+		// `channel->is_enabled` gate at the top of per_tick_callback
+		// / per_frame_callback (added by e97988a3 "Use the Mixer's
+		// sleep feature in the Sound Blaster") suppresses the
+		// producer until DMA/DAC actually starts. See #4949.
+		int64_t expected = -1;
+		sb_first_dma_qsize.compare_exchange_strong(
+		        expected,
+		        static_cast<int64_t>(sblaster->output_queue.Size()),
+		        std::memory_order_relaxed);
+#endif
+
 		// This is a no-op if the channel is already running. DMA
 		// processing can go for some time using auto-init mode without
 		// having to send IO calls to the card; so we keep it awake when
@@ -3233,6 +3418,10 @@ static void per_tick_callback()
 		return;
 	}
 
+#if SB_DEBUG_INSTRUMENTATION
+	sb_pertick_calls.fetch_add(1, std::memory_order_relaxed);
+#endif
+
 	static float frame_counter = 0.0f;
 
 	frame_counter += std::max(static_cast<float>(sblaster->frames_needed.exchange(
@@ -3267,8 +3456,16 @@ static void per_frame_callback(uint32_t)
 		return;
 	}
 
-	int mixer_needs = std::max(
-	        sblaster->frames_needed.exchange(0, std::memory_order_acq_rel), 1);
+#if SB_DEBUG_INSTRUMENTATION
+	sb_perframe_calls.fetch_add(1, std::memory_order_relaxed);
+#endif
+
+	const int raw_frames_needed = sblaster->frames_needed.exchange(
+	        0, std::memory_order_acq_rel);
+#if SB_DEBUG_INSTRUMENTATION
+	sb_frames_needed_stat.Record(raw_frames_needed);
+#endif
+	int mixer_needs = std::max(raw_frames_needed, 1);
 
 	// Frames added this tick is only useful when we're in an underflow
 	// situation with the mixer. generate_frames() may not give us
@@ -3287,6 +3484,37 @@ void SoundBlaster::MixerCallback(const int frames_requested)
 	constexpr bool Stereo      = true;
 	constexpr bool SignedData  = true;
 	constexpr bool NativeOrder = true;
+
+#if SB_DEBUG_INSTRUMENTATION
+	{
+		const auto sz = output_queue.Size();
+		sb_queue_pre_deq.Record(static_cast<int64_t>(sz));
+		sb_queue_pre_deq_cum_sum.fetch_add(static_cast<uint64_t>(sz),
+		                                   std::memory_order_relaxed);
+		sb_queue_pre_deq_cum_count.fetch_add(1,
+		                                     std::memory_order_relaxed);
+		if (sz == 0) {
+			sb_deq_zero_depth.fetch_add(1, std::memory_order_relaxed);
+		}
+		sb_last_channel_rate_hz.store(channel->GetSampleRate(),
+		                              std::memory_order_relaxed);
+	}
+	if (MIXER_FastForwardModeEnabled()) {
+		sb_ff_observed.store(true, std::memory_order_relaxed);
+	}
+	// Periodic summary every 5 wall-clock seconds. The mixer thread is
+	// the only caller here, so a plain static + simple comparison is
+	// race-free.
+	{
+		using clock = std::chrono::steady_clock;
+		static auto last = clock::now();
+		const auto now = clock::now();
+		if (now - last >= std::chrono::seconds(5)) {
+			last = now;
+			log_sb_instrumentation_summary("periodic");
+		}
+	}
+#endif
 
 	// Fast forward mode can cause the mixer to get very far behind.
 	// In extreme cases, it can cause SoundBlaster code to integer overflow
@@ -3716,6 +3944,10 @@ SoundBlaster::~SoundBlaster()
 
 	// Stop SB DAC
 	LOG_MSG("%s: Shutting down", sb_log_prefix());
+
+#if SB_DEBUG_INSTRUMENTATION
+	log_sb_instrumentation_summary("final");
+#endif
 
 	output_queue.Stop();
 

--- a/src/hardware/audio/soundblaster.cpp
+++ b/src/hardware/audio/soundblaster.cpp
@@ -3413,11 +3413,6 @@ static void per_tick_callback()
 	assert(sblaster);
 	assert(sblaster->channel);
 
-	if (!sblaster->channel->is_enabled) {
-		callback_type.SetNone();
-		return;
-	}
-
 #if SB_DEBUG_INSTRUMENTATION
 	sb_pertick_calls.fetch_add(1, std::memory_order_relaxed);
 #endif
@@ -3450,11 +3445,6 @@ static void per_frame_callback(uint32_t)
 {
 	assert(sblaster);
 	assert(sblaster->channel);
-
-	if (!sblaster->channel->is_enabled) {
-		callback_type.SetNone();
-		return;
-	}
 
 #if SB_DEBUG_INSTRUMENTATION
 	sb_perframe_calls.fetch_add(1, std::memory_order_relaxed);
@@ -3862,6 +3852,16 @@ SoundBlaster::SoundBlaster(Section* conf)
 	                           DefaultPlaybackRateHz,
 	                           ChannelName::SoundBlasterDac,
 	                           channel_features);
+
+	// XXX (#4949 demo): start the per-tick producer immediately at SB
+	// init -- on release/0.82.x, sblaster_pic_callback is registered
+	// unconditionally during SB construction, so the silence-fill path
+	// in generate_frames begins running before any game has touched the
+	// card. Combined with the removed `is_enabled` gate at the top of
+	// per_tick_callback, this reproduces the user's cold-start latency
+	// (queue pre-fills with stale silence ahead of the first real
+	// audio). Reverted in the next commit.
+	callback_type.SetPerTick();
 
 	const std::string sb_filter_prefs = section->GetString("sb_filter");
 

--- a/src/hardware/audio/soundblaster.cpp
+++ b/src/hardware/audio/soundblaster.cpp
@@ -3413,6 +3413,11 @@ static void per_tick_callback()
 	assert(sblaster);
 	assert(sblaster->channel);
 
+	if (!sblaster->channel->is_enabled) {
+		callback_type.SetNone();
+		return;
+	}
+
 #if SB_DEBUG_INSTRUMENTATION
 	sb_pertick_calls.fetch_add(1, std::memory_order_relaxed);
 #endif
@@ -3445,6 +3450,11 @@ static void per_frame_callback(uint32_t)
 {
 	assert(sblaster);
 	assert(sblaster->channel);
+
+	if (!sblaster->channel->is_enabled) {
+		callback_type.SetNone();
+		return;
+	}
 
 #if SB_DEBUG_INSTRUMENTATION
 	sb_perframe_calls.fetch_add(1, std::memory_order_relaxed);
@@ -3852,16 +3862,6 @@ SoundBlaster::SoundBlaster(Section* conf)
 	                           DefaultPlaybackRateHz,
 	                           ChannelName::SoundBlasterDac,
 	                           channel_features);
-
-	// XXX (#4949 demo): start the per-tick producer immediately at SB
-	// init -- on release/0.82.x, sblaster_pic_callback is registered
-	// unconditionally during SB construction, so the silence-fill path
-	// in generate_frames begins running before any game has touched the
-	// card. Combined with the removed `is_enabled` gate at the top of
-	// per_tick_callback, this reproduces the user's cold-start latency
-	// (queue pre-fills with stale silence ahead of the first real
-	// audio). Reverted in the next commit.
-	callback_type.SetPerTick();
 
 	const std::string sb_filter_prefs = section->GetString("sb_filter");
 

--- a/src/hardware/audio/soundblaster.cpp
+++ b/src/hardware/audio/soundblaster.cpp
@@ -3424,9 +3424,22 @@ static void per_tick_callback()
 
 	static float frame_counter = 0.0f;
 
-	frame_counter += std::max(static_cast<float>(sblaster->frames_needed.exchange(
-	                                  0, std::memory_order_acq_rel)),
-	                          sblaster->channel->GetFramesPerTick());
+	// Advance at the channel's natural per-tick rate. PR #4175
+	// originally added a mixer-signalled catch-up burst here
+	// (`max(frames_needed, natural)`) to recover from underruns on slow
+	// hosts. In practice on fast hosts under `cpu_cycles = max` the
+	// producer already runs at or above the consumer rate, so those
+	// bursts pile on top of the natural rate and push the output queue
+	// to capacity; `NonblockingBulkEnqueue` silently truncates and
+	// audio frames are lost. We rely on the natural rate here,
+	// matching the per-tick pattern used by every other audio module
+	// on this branch (GUS, LPT DAC, PS1, Tandy, PC Speaker).
+	//
+	// per_frame_callback (Direct DAC and tiny auto-init DMA, e.g.
+	// Crystal Dream) still consults frames_needed -- per-frame
+	// production is paced at one frame per scheduled call, not one
+	// tick's worth, so the burst there does not pile on the same way.
+	frame_counter += sblaster->channel->GetFramesPerTick();
 	const int total_frames = ifloor(frame_counter);
 	frame_counter -= static_cast<float>(total_frames);
 

--- a/src/hardware/audio/soundblaster.cpp
+++ b/src/hardware/audio/soundblaster.cpp
@@ -3524,24 +3524,65 @@ static void per_tick_callback()
 
 	static float frame_counter = 0.0f;
 
-	// Advance at the channel's natural per-tick rate. PR #4175
-	// originally added a mixer-signalled catch-up burst here
-	// (`max(frames_needed, natural)`) to recover from underruns on slow
-	// hosts. In practice on fast hosts under `cpu_cycles = max` the
-	// producer already runs at or above the consumer rate, so those
-	// bursts pile on top of the natural rate and push the output queue
-	// to capacity; `NonblockingBulkEnqueue` silently truncates and
-	// audio frames are lost. We rely on the natural rate here,
-	// matching the per-tick pattern used by every other audio module
-	// on this branch (GUS, LPT DAC, PS1, Tandy, PC Speaker).
+	// Advance at the channel's natural per-tick rate.
+	frame_counter += sblaster->channel->GetFramesPerTick();
+	int total_frames = ifloor(frame_counter);
+	frame_counter -= static_cast<float>(total_frames);
+
+	// Burst-only-when-behind. PR #4175 originally took
+	// `max(frames_needed, natural)` every tick. On fast hosts under
+	// `cpu_cycles = max` that produced standing latency: the producer
+	// already ticks at or above the consumer rate, so any positive
+	// `frames_needed` (a single-shot reading from the most recent
+	// MixerCallback) was added on top of the natural rate and the
+	// queue ratcheted up towards its cap. On slow hosts the same
+	// override was what saved Tyrian / Duke3D from underrun stutter.
+	//
+	// The narrower gate here keeps the underrun protection while
+	// preventing the ratchet. Two conditions must both hold:
+	//
+	//   1. The mixer's most recent callback observed a shortfall
+	//      (`frames_needed > total_frames`, i.e. the queue was so
+	//      low that even one natural per-tick batch will not satisfy
+	//      the next mixer callback).
+	//
+	//   2. The queue is *currently* below one blocksize. That is the
+	//      depth needed to fulfil the next callback in one shot; if
+	//      we are already at or above it the natural per-tick rate
+	//      will keep the queue served and a burst would only deepen
+	//      it -- the exact mechanism behind the original regression.
+	//
+	// On a fast host with `cycles = max` condition 1 fires only in
+	// transients, and condition 2 acts as the brake that keeps those
+	// transients from compounding into standing latency. On a slow
+	// host where per-tick production cannot keep pace, both
+	// conditions fire together and the burst restores PR #4175's
+	// behaviour for the underrun path.
 	//
 	// per_frame_callback (Direct DAC and tiny auto-init DMA, e.g.
-	// Crystal Dream) still consults frames_needed -- per-frame
-	// production is paced at one frame per scheduled call, not one
-	// tick's worth, so the burst there does not pile on the same way.
-	frame_counter += sblaster->channel->GetFramesPerTick();
-	const int total_frames = ifloor(frame_counter);
-	frame_counter -= static_cast<float>(total_frames);
+	// Crystal Dream) keeps its existing `max(frames_needed, 1)`
+	// behaviour: per-frame production is paced at one frame per
+	// scheduled call rather than one tick's worth, so it does not
+	// pile on the same way.
+	//
+	const int raw_frames_needed =
+	        sblaster->frames_needed.exchange(0, std::memory_order_acq_rel);
+
+#if SB_DEBUG_INSTRUMENTATION
+	sb_frames_needed_stat.Record(raw_frames_needed);
+#endif
+
+	if (raw_frames_needed > total_frames) {
+		const int queue_depth = check_cast<int>(
+		        sblaster->output_queue.Size());
+
+		const int target_depth = iceil(
+		        sblaster->channel->GetFramesPerBlock());
+
+		if (queue_depth < target_depth) {
+			total_frames = raw_frames_needed;
+		}
+	}
 
 	while (frames_added_this_tick < total_frames) {
 		generate_frames(total_frames - frames_added_this_tick);

--- a/src/hardware/audio/soundblaster.cpp
+++ b/src/hardware/audio/soundblaster.cpp
@@ -11,7 +11,9 @@
 #include <chrono>
 #include <cmath>
 #include <cstring>
+#include <deque>
 #include <iomanip>
+#include <mutex>
 #include <optional>
 #include <string>
 #include <tuple>
@@ -1118,21 +1120,21 @@ static uint32_t read_dma_16bit(const uint32_t words_to_read,
 struct SbStat {
 	std::atomic<uint64_t> sum{0};
 	std::atomic<uint64_t> count{0};
-	std::atomic<int64_t>  min{INT64_MAX};
-	std::atomic<int64_t>  max{INT64_MIN};
+	std::atomic<int64_t> min{INT64_MAX};
+	std::atomic<int64_t> max{INT64_MIN};
 
 	void Record(int64_t v)
 	{
 		sum.fetch_add(static_cast<uint64_t>(v), std::memory_order_relaxed);
 		count.fetch_add(1, std::memory_order_relaxed);
 		auto cur_min = min.load(std::memory_order_relaxed);
-		while (v < cur_min && !min.compare_exchange_weak(
-		                              cur_min, v,
-		                              std::memory_order_relaxed)) {}
+		while (v < cur_min &&
+		       !min.compare_exchange_weak(cur_min, v, std::memory_order_relaxed)) {
+		}
 		auto cur_max = max.load(std::memory_order_relaxed);
-		while (v > cur_max && !max.compare_exchange_weak(
-		                              cur_max, v,
-		                              std::memory_order_relaxed)) {}
+		while (v > cur_max &&
+		       !max.compare_exchange_weak(cur_max, v, std::memory_order_relaxed)) {
+		}
 	}
 
 	void Reset()
@@ -1164,8 +1166,8 @@ static std::atomic<uint64_t> sb_perframe_calls{0};
 static std::atomic<uint64_t> sb_pertick_calls{0};
 static std::atomic<uint64_t> sb_deq_zero_depth{0}; // mixer arrived to empty queue
 // One-shot / sticky, never reset between periodic dumps.
-static std::atomic<int64_t>  sb_first_dma_qsize{-1};
-static std::atomic<bool>     sb_ff_observed{false};
+static std::atomic<int64_t> sb_first_dma_qsize{-1};
+static std::atomic<bool> sb_ff_observed{false};
 // Session-cumulative pre-dequeue depth (the latency proxy). Sticky --
 // each periodic dump reports the average over the whole session, so
 // the trend across the full run is visible alongside the per-window
@@ -1175,7 +1177,55 @@ static std::atomic<uint64_t> sb_queue_pre_deq_cum_count{0};
 // Most recent channel sample rate seen at dequeue. Cached so the
 // destructor's final summary can still print latency in milliseconds
 // after the channel has been torn down.
-static std::atomic<int>      sb_last_channel_rate_hz{0};
+static std::atomic<int> sb_last_channel_rate_hz{0};
+
+// End-to-end latency measurement: producer tags every Nth accepted
+// frame with a wall-clock timestamp; the mixer thread reports the
+// delta when that frame reaches the head of the queue and is pulled.
+// This is the direct equivalent of "tag each AudioFrame with an
+// incremental counter, then measure how long it takes to show up at
+// the dequeue side" (#4954 review feedback) without modifying
+// AudioFrame -- the queue is FIFO so the cumulative producer/consumer
+// frame indices identify the same frames the tags do.
+//
+// Caveats:
+// - Measures producer-side enqueue -> SB MixerCallback dequeue only.
+//   The downstream mixer-internal queue and the SDL output queue are
+//   NOT included; those add a roughly constant overhead on top, so
+//   the measurement is appropriate for comparing branches that only
+//   differ in the SB producer/queue behaviour.
+// - The consumer-side frame count is reconstructed from a FIFO
+//   identity rather than observed directly. Producer enqueue and
+//   counter-bump are two separate relaxed atomics, so the count can
+//   drift by up to one batch per callback in either direction.
+//   Individual measurements are therefore noisy; the periodic
+//   average is still meaningful for relative comparisons.
+static std::atomic<uint64_t> sb_producer_frames_total{0};
+static std::atomic<uint64_t> sb_consumer_frames_total{0};
+static SbStat sb_e2e_latency_us;
+
+struct SbPendingTag {
+	uint64_t target_consumer_idx             = 0;
+	std::chrono::steady_clock::time_point ts = {};
+};
+
+static std::mutex sb_tag_mutex;
+static std::deque<SbPendingTag> sb_pending_tags;
+
+// Frame index at which the next tag will be emitted. Producer-only;
+// updated under the same single-threaded path as enqueue_frames.
+static uint64_t sb_next_tag_at_frame = 0;
+
+// Coarse enough that the tagging path runs once per ~12 ms of audio
+// at 22050 Hz; fine enough that a 5 s window contains hundreds of
+// samples for averaging.
+static constexpr uint64_t SbTagIntervalFrames = 256;
+
+// Hard cap on outstanding tags so a stalled consumer (e.g. paused
+// mixer) cannot grow the queue unbounded. The oldest tag is dropped
+// when the cap is hit -- it would have produced a misleading
+// measurement anyway.
+static constexpr size_t SbPendingTagCap = 256;
 
 static void log_sb_instrumentation_summary(const char* label)
 {
@@ -1185,15 +1235,15 @@ static void log_sb_instrumentation_summary(const char* label)
 			return std::string("n=0");
 		}
 		char buf[128] = {};
-		std::snprintf(buf, sizeof(buf),
+		std::snprintf(buf,
+		              sizeof(buf),
 		              "n=%llu min=%lld max=%lld avg=%.1f",
 		              static_cast<unsigned long long>(n),
-		              static_cast<long long>(s.min.load(
-		                      std::memory_order_relaxed)),
-		              static_cast<long long>(s.max.load(
-		                      std::memory_order_relaxed)),
-		              static_cast<double>(s.sum.load(
-		                      std::memory_order_relaxed)) /
+		              static_cast<long long>(
+		                      s.min.load(std::memory_order_relaxed)),
+		              static_cast<long long>(
+		                      s.max.load(std::memory_order_relaxed)),
+		              static_cast<double>(s.sum.load(std::memory_order_relaxed)) /
 		                      static_cast<double>(n));
 		return std::string(buf);
 	};
@@ -1237,12 +1287,39 @@ static void log_sb_instrumentation_summary(const char* label)
 	}
 	LOG_MSG("  empty-queue at dequeue    : %llu  (underrun indicator)",
 	        (unsigned long long)sb_deq_zero_depth.load());
+	{
+		const auto n = sb_e2e_latency_us.count.load(std::memory_order_relaxed);
+		if (n == 0) {
+			LOG_MSG("  end-to-end latency        : n=0  (no tags consumed yet)");
+		} else {
+			const auto sum = sb_e2e_latency_us.sum.load(
+			        std::memory_order_relaxed);
+			const auto avg_us = static_cast<double>(sum) /
+			                    static_cast<double>(n);
+
+			LOG_MSG("  end-to-end latency        : n=%llu min=%lld us max=%lld us avg=%.1f us (= %.2f ms)  (producer-enqueue -> SB-mixer-dequeue)",
+			        (unsigned long long)n,
+			        (long long)sb_e2e_latency_us.min.load(
+			                std::memory_order_relaxed),
+			        (long long)sb_e2e_latency_us.max.load(
+			                std::memory_order_relaxed),
+			        avg_us,
+			        avg_us / 1000.0);
+		}
+
+		size_t pending = 0;
+		{
+			std::lock_guard<std::mutex> lock(sb_tag_mutex);
+			pending = sb_pending_tags.size();
+		}
+		LOG_MSG("  pending tags              : %llu",
+		        (unsigned long long)pending);
+	}
 	LOG_MSG("  frames_needed (raw)       : %s",
 	        fmt_stat(sb_frames_needed_stat).c_str());
 	const auto first = sb_first_dma_qsize.load(std::memory_order_relaxed);
 	LOG_MSG("  first-DMA queue depth     : %s  (sticky; non-zero => #4949-style pre-fill)",
-	        (first < 0 ? "(no DMA observed)"
-	                   : std::to_string(first).c_str()));
+	        (first < 0 ? "(no DMA observed)" : std::to_string(first).c_str()));
 	LOG_MSG("  fast-forward observed     : %s  (sticky)",
 	        sb_ff_observed.load(std::memory_order_relaxed) ? "yes" : "no");
 	LOG_MSG("==============================");
@@ -1259,6 +1336,7 @@ static void log_sb_instrumentation_summary(const char* label)
 	sb_queue_pre_enq.Reset();
 	sb_queue_pre_deq.Reset();
 	sb_frames_needed_stat.Reset();
+	sb_e2e_latency_us.Reset();
 }
 #endif
 
@@ -1268,13 +1346,35 @@ static void enqueue_frames(std::vector<AudioFrame>& frames)
 	frames_added_this_tick += static_cast<int>(frames.size());
 #if SB_DEBUG_INSTRUMENTATION
 	const auto wanted = frames.size();
-	sb_queue_pre_enq.Record(
-	        static_cast<int64_t>(sblaster->output_queue.Size()));
+	sb_queue_pre_enq.Record(static_cast<int64_t>(sblaster->output_queue.Size()));
 	const auto accepted = sblaster->output_queue.NonblockingBulkEnqueue(frames);
 	sb_enq_calls.fetch_add(1, std::memory_order_relaxed);
 	sb_enq_frames_wanted.fetch_add(wanted, std::memory_order_relaxed);
-	sb_enq_frames_rejected.fetch_add(wanted - accepted,
-	                                 std::memory_order_relaxed);
+	sb_enq_frames_rejected.fetch_add(wanted - accepted, std::memory_order_relaxed);
+
+	// End-to-end latency tagging. Bump the producer's cumulative
+	// frame counter by the number actually enqueued, then push a
+	// timestamped tag if we crossed the next tagging boundary. The
+	// tag targets the frame index that, once consumed, marks the
+	// end of the latency measurement window.
+	if (accepted > 0) {
+		const uint64_t prev_total = sb_producer_frames_total.fetch_add(
+		        accepted, std::memory_order_relaxed);
+		const uint64_t new_total = prev_total + accepted;
+
+		if (new_total >= sb_next_tag_at_frame) {
+			const SbPendingTag tag{new_total,
+			                       std::chrono::steady_clock::now()};
+
+			std::lock_guard<std::mutex> lock(sb_tag_mutex);
+			if (sb_pending_tags.size() >= SbPendingTagCap) {
+				sb_pending_tags.pop_front();
+			}
+			sb_pending_tags.push_back(tag);
+
+			sb_next_tag_at_frame = new_total + SbTagIntervalFrames;
+		}
+	}
 #else
 	sblaster->output_queue.NonblockingBulkEnqueue(frames);
 #endif
@@ -3473,8 +3573,8 @@ static void per_frame_callback(uint32_t)
 	sb_perframe_calls.fetch_add(1, std::memory_order_relaxed);
 #endif
 
-	const int raw_frames_needed = sblaster->frames_needed.exchange(
-	        0, std::memory_order_acq_rel);
+	const int raw_frames_needed =
+	        sblaster->frames_needed.exchange(0, std::memory_order_acq_rel);
 #if SB_DEBUG_INSTRUMENTATION
 	sb_frames_needed_stat.Record(raw_frames_needed);
 #endif
@@ -3504,8 +3604,7 @@ void SoundBlaster::MixerCallback(const int frames_requested)
 		sb_queue_pre_deq.Record(static_cast<int64_t>(sz));
 		sb_queue_pre_deq_cum_sum.fetch_add(static_cast<uint64_t>(sz),
 		                                   std::memory_order_relaxed);
-		sb_queue_pre_deq_cum_count.fetch_add(1,
-		                                     std::memory_order_relaxed);
+		sb_queue_pre_deq_cum_count.fetch_add(1, std::memory_order_relaxed);
 		if (sz == 0) {
 			sb_deq_zero_depth.fetch_add(1, std::memory_order_relaxed);
 		}
@@ -3519,9 +3618,9 @@ void SoundBlaster::MixerCallback(const int frames_requested)
 	// the only caller here, so a plain static + simple comparison is
 	// race-free.
 	{
-		using clock = std::chrono::steady_clock;
+		using clock      = std::chrono::steady_clock;
 		static auto last = clock::now();
-		const auto now = clock::now();
+		const auto now   = clock::now();
 		if (now - last >= std::chrono::seconds(5)) {
 			last = now;
 			log_sb_instrumentation_summary("periodic");
@@ -3541,8 +3640,61 @@ void SoundBlaster::MixerCallback(const int frames_requested)
 		                    std::memory_order_release);
 	}
 
+#if SB_DEBUG_INSTRUMENTATION
+	// Snapshot producer's cumulative count and queue depth on entry.
+	// Together with the post-pull values these let us compute exactly
+	// how many frames the pull consumed, even when the producer
+	// thread is enqueueing concurrently:
+	//   consumed = queue_before + (producer_after - producer_before)
+	//                           - queue_after
+	const uint64_t producer_before = sb_producer_frames_total.load(
+	        std::memory_order_relaxed);
+	const size_t queue_before_pull = output_queue.Size();
+#endif
+
 	MIXER_PullFromQueueCallback<SoundBlaster, AudioFrame, Stereo, SignedData, NativeOrder>(
 	        frames_requested, this);
+
+#if SB_DEBUG_INSTRUMENTATION
+	{
+		const uint64_t producer_after = sb_producer_frames_total.load(
+		        std::memory_order_relaxed);
+		const size_t queue_after_pull = output_queue.Size();
+		const uint64_t produced_during = producer_after - producer_before;
+
+		// Approximate consumed count from the FIFO identity. Not
+		// exact because enqueue_frames updates the queue and bumps
+		// sb_producer_frames_total as two separate relaxed atomics,
+		// so produced_during can lag the actual queue change. Errors
+		// are bounded by one batch per callback and average out over
+		// the periodic window. Clamp covers the negative-drift case.
+		const int64_t consumed_signed =
+		        static_cast<int64_t>(queue_before_pull) +
+		        static_cast<int64_t>(produced_during) -
+		        static_cast<int64_t>(queue_after_pull);
+
+		if (consumed_signed > 0) {
+			const uint64_t consumed = static_cast<uint64_t>(consumed_signed);
+			const uint64_t prev_consumer = sb_consumer_frames_total.fetch_add(
+			        consumed, std::memory_order_relaxed);
+			const uint64_t new_consumer = prev_consumer + consumed;
+
+			const auto now = std::chrono::steady_clock::now();
+			std::lock_guard<std::mutex> lock(sb_tag_mutex);
+			while (!sb_pending_tags.empty() &&
+			       sb_pending_tags.front().target_consumer_idx <=
+			               new_consumer) {
+				const auto& front = sb_pending_tags.front();
+				const auto delta_us =
+				        std::chrono::duration_cast<std::chrono::microseconds>(
+				                now - front.ts)
+				                .count();
+				sb_e2e_latency_us.Record(delta_us);
+				sb_pending_tags.pop_front();
+			}
+		}
+	}
+#endif
 }
 
 static SbType determine_sb_type(const std::string& pref)


### PR DESCRIPTION
# Description

Two SB bugs surfaced while investigating #4949. They turned out to be unrelated. This PR fixes one of them. The other is included for context and demonstrated via two commits in this branch so reviewers can checkout-and-reproduce.

## TL;DR

- **#4949 (cold-start latency)** is a 0.82.x bug. Already fixed on main by `e97988a3` ("Use the Mixer's sleep feature in the Sound Blaster"). This PR does not change that.
- **Catch-up burst latency under `cycles = max`** is a different bug, introduced on 0.83.x by PR #4175. This PR fixes it without regressing the PR #4175 or PR #4202 fixes.

## 0.82.x cold-start latency (#4949) — already fixed on main

On 0.82.x, `sblaster_pic_callback` is registered at SB construction and runs from process start, enqueueing silence into the SB output queue every PIC tick. The mixer thread doesn't drain the channel until the game enables it (which happens when DMA starts), so by the time the game's first DMA byte arrives the queue is already full of stale silence. The mixer plays that silence before reaching the game's audio — that's the latency the user reported.

Fixed on main by `e97988a3`, which adds a `channel->is_enabled` early-return at the top of `per_tick_callback` / `per_frame_callback`. The producer is gated off until the game wakes the channel, so no pre-fill.

Measured `first-DMA queue depth` (depth observed when the game dispatches its first DMA byte):

| Code state                              | Queue depth at first DMA |
| ---                                     | ---                      |
| `release/0.82.x` (unfixed)              | 128 (= cap on 0.82.x)    |
| `main` / this PR                        | 0                        |

Commit 2 (`Reproduce #4949 cold-start latency on main`) ports the 0.82.x behaviour to the main codebase so the bug can be observed here on a single checkout. Commit 3 reverts it.

## 0.83.x catch-up burst latency — the bug this PR fixes

`per_tick_callback` advances by `max(frames_needed, GetFramesPerTick())`. The `frames_needed` term was added by PR #4175 to let the producer burst-fill when the mixer underruns on slow hosts (Tyrian stutter, Duke3D 3DRealms screen). On a fast host under `cpu_cycles = max` the producer already ticks at or above the consumer rate, so the burst piles on top of the natural per-tick rate and the queue runs to its `2 × blocksize` cap. The mixer plays from the FRONT of the queue at wall-rate — a deeper queue means proportionally more input-to-audio latency. ~10–20 ms of standing latency was the user-visible symptom for any regular-DMA SB game.

The "frames rejected by the queue" counter is NOT the same as audio loss in this scenario — when the producer runs ahead of wall-clock time (cycles = max) the rejected frames are emulated-future samples the mixer wouldn't have caught up to anyway. The audible symptom is the latency.

### Fix

Drop the catch-up only from `per_tick_callback`. That path now matches what every other audio module on this branch does (GUS, LPT DAC, PS1, Tandy, PC Speaker — none of them burst).

`per_frame_callback` (Direct DAC and tiny auto-init DMA, e.g. Crystal Dream's 2-byte buffer) still consults `frames_needed` and bursts up to that count. Per-frame production is paced at one frame per scheduled call, so the burst doesn't compound the same way. PR #4175's intent is preserved for the modes that actually need it.

PR #4202's fast-forward guard on `frames_needed.store(...)` in `MixerCallback` is unchanged — still gates the integer-overflow / hang under FF.

## Instrumentation for verification

Behind a compile-time macro `SB_DEBUG_INSTRUMENTATION` in `soundblaster.cpp` (default `0`). Flip to `1` and rebuild — a summary block prints every 5 wall-clock seconds and again at SB shutdown:

    SB_INSTRUMENTATION (periodic) ==========
      per_tick_callback calls   : 5022
      per_frame_callback calls  : 0
      enqueue calls             : 5028
      frames wanted (sum)       : 110577
      frames rejected by queue  : 18   (producer overran queue cap; NOT the same as audio loss)
      queue depth pre-enqueue   : n=5028 min=12 max=505 avg=128.4
      queue depth pre-dequeue   : n=433 min=0 max=486 avg=171.1   (latency proxy)
      avg latency (cumulative)  : 188.8 frames = 8.68 ms at 21739 Hz
      empty-queue at dequeue    : 1    (underrun indicator)
      frames_needed (raw)       : n=0
      first-DMA queue depth     : 0    (sticky)
      fast-forward observed     : no   (sticky)
    ==============================

Per-window counters reset on each periodic dump so each block stands on its own; the cumulative latency, first-DMA depth, and FF flag are sticky across the session. Periodic-only, no per-event spam — that would skew the measurement (especially on Windows).

## Measured results

macOS arm64, debug build, M4 Pro host. `cycles=max`, regular DMA (the path this PR touches). 5-second-window averages over the steady state of a ~22-emulated-second run.

| Metric                              | Before fix          | After fix         |
| ---                                 | ---                 | ---               |
| `avg latency (cumulative)`          | ~365 frames ≈ 17 ms | ~188 frames ≈ 9 ms |
| `queue depth pre-deq` avg / max     | 365 / 505 (cap)     | 188 / ~490        |
| `frames rejected by queue` / 5 s    | 1400–1600           | 0–100             |
| `empty-queue at dequeue` / 5 s      | 0                   | 1–3               |

Latency is ~halved. The "empty-queue at dequeue" counter goes from 0 to 1–3 per 5 s with the fix — when the producer is no longer over-filling, the queue spends more time near its lower bound and occasional momentary empties show up in instrumentation. The default `prebuffer = 8 ms` absorbs these so they're not audible underruns; users on weak hosts can raise it if they observe glitches.

Crystal Dream (tiny DMA), Direct DAC, and fast-forward paths are unchanged because they don't go through `per_tick_callback`.



## Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

- [x] I am a human, I have read and understood the [project's policy on the use of generative AI tools](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md#policy-on-the-use-of-generative-ai-tools), and I have acted in accordance to it.

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/compile_commits.sh) that all my commits can be built.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.
