### PR TITLE
Reduce GUS frame processing overhead

### DIFF
--- a/src/hardware/audio/gus.cpp
+++ b/src/hardware/audio/gus.cpp
@@ -7,7 +7,6 @@
 #include <array>
 #include <iomanip>
 #include <memory>
-#include <queue>
 #include <string>
 #include <unistd.h>
 #include <vector>
@@ -521,11 +520,9 @@ void Gus::RenderUpToNow()
 		        std::floor(elapsed_ms / ms_per_render));
 		assert(num_elapsed_frames > 0);
 
-		// Enqueue in the FIFO that will be drained when the mixer pulls
-		// frames
-		for (auto& frame : RenderFrames(num_elapsed_frames)) {
-			fifo.emplace(frame);
-		}
+		// Append to the FIFO that will be drained when the mixer pulls frames
+		const auto& frames = RenderFrames(num_elapsed_frames);
+		fifo.insert(fifo.end(), frames.begin(), frames.end());
 		last_rendered_ms += num_elapsed_frames * ms_per_render;
 	}
 }
@@ -541,14 +538,15 @@ void Gus::PicCallback(const int num_requested_frames)
 
 	auto num_frames_remaining = num_requested_frames;
 
-	// First, send any frames we've queued since the last callback
-	while (num_frames_remaining && fifo.size()) {
-		AudioFrame frame = fifo.front();
-		fifo.pop();
-		output_queue.NonblockingEnqueue(std::move(frame));
-		--num_frames_remaining;
+	// Drain any pre-rendered cycle-accurate frames in a single bulk enqueue
+	if (!fifo.empty() && num_frames_remaining > 0) {
+		const auto num_from_fifo = std::min(num_frames_remaining,
+		                                    static_cast<int>(fifo.size()));
+		output_queue.NonblockingBulkEnqueue(fifo,
+		                                    static_cast<size_t>(num_from_fifo));
+		num_frames_remaining -= num_from_fifo;
 	}
-	// If the queue's run dry, render the remainder and sync-up our time datum
+	// Render any remaining frames needed
 	if (num_frames_remaining > 0) {
 		auto frames = RenderFrames(num_frames_remaining);
 		output_queue.NonblockingBulkEnqueue(frames, num_frames_remaining);
@@ -1116,6 +1114,8 @@ void Gus::Reset() noexcept
 
 	reset_register.data       = {};
 	mix_control_register.data = MixControlRegisterDefaultState;
+
+	fifo.clear();
 }
 
 static void gus_evict(Section* sec);

--- a/src/hardware/audio/private/gus.h
+++ b/src/hardware/audio/private/gus.h
@@ -5,8 +5,6 @@
 #ifndef DOSBOX_PRIVATE_GUS_H
 #define DOSBOX_PRIVATE_GUS_H
 
-#include <queue>
-
 #include "audio/mixer.h"
 #include "hardware/dma.h"
 #include "utils/bit_view.h"
@@ -319,7 +317,7 @@ private:
 	void WriteToRegister();
 
 	// Collections
-	std::queue<AudioFrame> fifo             = {};
+	std::vector<AudioFrame> fifo            = {};
 	vol_scalars_array_t vol_scalars         = {{}};
 	pan_scalars_array_t pan_scalars         = {{}};
 	ram_array_t ram                         = {};


### PR DESCRIPTION
# Description

I missed GUS when I did #4916 since it doesn't quite work the same way.

# Manual testing

Ran the usual GUS games and demos.

The change has been manually tested on:

- [ ] Windows
- [x] macOS
- [ ] Linux


# Checklist

- [x] I am a human, I have read and understood the [project's policy on the use of generative AI tools](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md#policy-on-the-use-of-generative-ai-tools), and I have acted in accordance to it.

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my work (especially important for AI-assisted contributions).
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

