### PR TITLE
Implement the pause feature properly

### DIFF
--- a/src/audio/README.md
+++ b/src/audio/README.md
@@ -1,0 +1,165 @@
+# Audio mixer overview
+
+This is an entry point for understanding the DOSBox Staging audio mixer. It
+describes the *pull model* the mixer is built on, how normal playback and
+capture flow through it, and the multithreading rules you must respect —
+especially around pause. For the details, read the code; this document is the
+map, not the territory.
+
+Key files:
+
+- `src/audio/mixer.cpp` / `src/audio/mixer.h` — the mixer thread, channels,
+  effects, capture feed, pause/mute, SDL device setup.
+- `src/audio/audio_frame.h` — `AudioFrame` (a stereo `{left, right}` float
+  sample).
+- `src/misc/rwqueue.cpp` — `RWQueue`, the bounded blocking queue everything is
+  paced by.
+- `src/midi/*.cpp` — the software synths (FluidSynth, MT-32, SoundCanvas),
+  each a mixer channel fed by its own renderer thread.
+
+
+## The mental model: a pull chain paced by one real clock
+
+There is exactly **one real clock in the system: the sound card.** SDL pulls a
+fixed number of sample frames off the mixer's output every real second (48000
+Hz, say — it's hardware, it never speeds up or slows down). Everything
+upstream is paced by *back-pressure* from that single consumer.
+
+Think of a **conveyor belt of fixed length** between each producer and
+consumer:
+
+```
+  emulated                mixer                      SDL / sound card
+  devices    ─push─▶  [ channel queues ] ─pull─▶  mixer thread ─push─▶ [ final_output ] ─pull─▶ SDL
+  (CPU thread)                                    (mix + effects)        (bounded queue)      (real-time)
+                                                        ▲
+  MIDI synth ─push─▶ [ audio_frame_fifo ] ─pull────────┘
+  renderer                (bounded queue)
+  (own thread)
+```
+
+Each belt (`RWQueue`) is **bounded and blocks when full**. So when SDL takes
+one block off `final_output`, the mixer thread can put one block on — and not
+before. The mixer, blocked on a full `final_output`, is therefore throttled to
+exactly real time. In turn the mixer draining a channel's queue lets that
+channel's producer run, and so on up the chain.
+
+**Real time propagates backwards through "the belt is full, wait your turn."**
+This is why there is almost no explicit timing code in the hot path: the
+queues *are* the clock. Keep this in mind — most of the subtle bugs in this
+subsystem come from a belt unexpectedly running empty and letting a producer
+sprint ahead of real time.
+
+## Threads
+
+| Thread | Role |
+|---|---|
+| **Emulator (main/CPU)** | Runs the DOS program and the emulated audio devices (Sound Blaster, GUS, OPL, PC Speaker, …). Pushes samples into channel queues, sends MIDI events, drives PIC timing. Also runs PIC tick handlers, including the capture drain. All pause-state changes happen here. |
+| **Mixer thread** (`mixer_thread_loop`) | The heart of the pull model. Each iteration pulls a block from every channel, mixes, applies effects and gain, feeds the capture queue, applies the pause/mute fade, and enqueues to `final_output`. |
+| **SDL audio callback** | Dequeues from `final_output` at the device rate and hands it to the OS. If the queue is short, SDL backfills the device with silence itself — we do **not** pad. |
+| **MIDI synth renderers** (one per active synth) | Each renders audio into its own `audio_frame_fifo` ahead of the mixer's consumption. Halted independently on pause (see below). |
+
+## Normal playback flow
+
+1. An emulated device produces samples on the **emulator thread** and hands
+   them to its `MixerChannel` (e.g. `AddSamples_*`), which buffers them.
+2. The **mixer thread** calls `mix_samples(blocksize)`: it pulls a block from
+   every channel (`channel->Mix()`), sums them into the master buffer, then
+   applies the master gain, reverb/chorus sends, high-pass filter and
+   compressor.
+3. The block is copied to the **capture feed** (see below) at full level.
+4. The pause/mute **fade** (`playback_gain`) is applied to the SDL-bound copy
+   only.
+5. The block is enqueued to `final_output`; the **SDL callback** pulls it out
+   at real time.
+
+Channels can be enabled/disabled and will "sleep" when idle to save work; a
+sleeping channel wakes when its device produces again.
+
+## Capture (WAV / video recording)
+
+Capture is a **tap on the mixer's output**, fed from inside `mix_samples()`:
+
+- It is taken **before the pause/mute fade** is applied, so recordings contain
+  full-level audio regardless of what the fade is doing to playback. What you
+  record is not affected by muting or by the resume fade-in.
+- Frames go into `capture_queue`, drained by `capture_callback()` — a PIC tick
+  handler on the emulator thread. It drains whatever is present and **never
+  zero-pads**; the two ends run on independent clocks, so momentary emptiness
+  is normal and is not spliced with silence.
+- The guiding criteria: **a capture made while pausing should be
+  bit-identical to one made without pausing.** Because `mix_samples()` does
+  not run while paused (see below), the capture simply freezes and resumes —
+  no frozen state and no pause-time silence leak into the file.
+
+## Pause and mute
+
+Two orthogonal notions of "go quiet":
+
+- **Mute** (`MixerMuteState`): `mix_samples()` keeps running (so capture is
+  still fed at full level); only the SDL-bound output is faded to silence.
+- **Pause** (`DOSBOX_IsPaused()`): the whole emulator freezes. The mixer
+  thread **short-circuits before `mix_samples()`**, so nothing is produced and
+  nothing is captured.
+
+To avoid clicks, pausing is **deferred until a short fade-out completes**. The
+pause FSM (see `dosbox.cpp` / `dosbox_pause_fsm.h`) parks in a *pending* state
+while `playback_gain` ramps to zero; only then does it flip to *paused* and
+halt the subsystems. During *pending*, everything still runs so the fade has
+real audio to work against.
+
+### Gotchas (this is where the bugs live)
+
+1. **Keep the belt full while paused.** If the mixer simply stopped feeding
+   `final_output` during pause, SDL would drain it empty; the device stays fed
+   (SDL backfills it with silence), but on resume nothing would back-pressure
+   the mixer, so it would sprint — producing blocks as fast as the CPU allows
+   until the queue refilled, each one also pushed into the capture feed with no
+   real time elapsed, stretching recordings by ~one bufferful per pause/resume
+   cycle.
+   Instead the paused mixer keeps enqueuing a blocksize of silence every
+   iteration via the **blocking** `final_output.BulkEnqueue()`. That keeps
+   SDL's whole pipeline fed and the mixer thread paced by SDL at real time for
+   the whole pause, so resume just continues — no empty belt, no catch-up
+   burst. The silence bypasses `mix_samples()`, so it is never captured.
+
+2. **Halt the synth renderers on pause.** A software synth's renderer runs
+   ahead of the mixer, filling its `audio_frame_fifo`. If it kept running while
+   paused it would advance the synth's clock and leak extra samples into the
+   next capture, so `MIDI_Pause()` parks it. While parked it stops its own
+   `audio_frame_fifo`, so a mixer `BulkDequeue()` racing the halt gets a short
+   read (silence-padded by the synth's `MixerCallback()`) instead of blocking
+   on an empty fifo — which is why the mixer needs no pause hook of its own and
+   the pause/resume order isn't load-bearing. See `set_subsystems_paused()` and
+   the synth `Render()` loops.
+
+3. The pause fade is gated on `playback_gain` actually reaching zero, not on a
+   wall-clock timer. `nosound` mode snaps the gain to target so the gate still
+   fires.
+
+## Multithreading rules
+
+- **`final_output` has exactly one producer (the mixer thread) and one
+  consumer (SDL).** Do not enqueue to it from anywhere else — the paused-state
+  silence-feed runs on the mixer thread precisely to keep this true.
+
+- **`playback_gain` is written only by the mixer thread.** It is atomic solely
+  so the pause FSM can read it to know when the fade finished.
+
+- **Take `mixer.mutex` only via `MIXER_LockMixerThread()` /
+  `MIXER_UnlockMixerThread…()`, never raw.** That protocol first *stops* the
+  channel queues, which unblocks the mixer thread from a `BulkDequeue()` so it
+  can release the mutex. A raw lock can deadlock: the main thread waits for
+  `mixer.mutex` while the mixer thread holds it inside a `BulkDequeue()`
+  waiting for samples only the main thread can produce. `mixer.mutex` is
+  recursive so nested lockers compose.
+
+- **Bounded queues block — mind who waits on whom.** A blocking
+  enqueue/dequeue is a place two threads rendezvous; if the other end is
+  parked (e.g. a halted synth renderer, or a paused mixer), a naive blocking
+  call there will hang. This is the root of the pause deadlocks, and of the
+  resume catch-up burst the paused silence-feed (gotcha 1) exists to prevent.
+
+- **Pause state is owned by the emulator thread.** Other threads may only
+  *read* it via the `DOSBOX_Is*()` queries; never store `pause_state`
+  off-thread.

--- a/src/audio/mixer.cpp
+++ b/src/audio/mixer.cpp
@@ -2909,70 +2909,111 @@ MixerMuteState MIXER_GetMuteState()
 	return mixer.mute_state.load(std::memory_order_acquire);
 }
 
-// User-driven path: pressing the mute hotkey (or invoking it remotely).
-// Trumps any `AutoMuted` state in effect -- once the user has decided, only
-// the user can clear it. Callers are responsible for the `no_sound` guard if
-// they want one (the hotkey handler logs a warning there).
-void MIXER_RequestUserMute()
+// Pure mute-transition policy; it maps (current state, request) to the next
+// state, or `nullopt` for a no-op.
+//
+// The `MIXER_Request*()` functions apply its result via `set_mute_state()`.
+//
+std::optional<MixerMuteState> MIXER_NextMuteState(const MixerMuteState current,
+                                                  const MuteRequest request)
 {
 	using enum MixerMuteState;
 
-	switch (mixer.mute_state.load(std::memory_order_acquire)) {
-	case Audible:
-	case AutoMuted: set_mute_state(UserMuted); break;
+	switch (request) {
+	case MuteRequest::UserMute:
+		// Trumps any AutoMuted state -- once the user has decided, only
+		// the user can clear it. Idempotent once user-muted.
+		//
+		switch (current) {
+		case Audible:
+		case AutoMuted: return UserMuted;
 
-	case UserMuted:
-		// already user-muted
+		case UserMuted: return {};
+
+		default: assertm(false, "Invalid MixerMuteState"); return {};
+		}
 		break;
+
+	case MuteRequest::UserUnmute:
+		// A user unmute clears either kind of mute -- the user is
+		// taking control regardless of how we got muted.
+		//
+		switch (current) {
+		case UserMuted:
+		case AutoMuted: return Audible;
+
+		case Audible: return {};
+
+		default: assertm(false, "Invalid MixerMuteState"); return {};
+		}
+		break;
+
+	case MuteRequest::AutoMute:
+		// Engages only from Audible; a user-mute survives focus loss
+		// and an existing auto-mute is idempotent.
+		//
+		switch (current) {
+		case Audible: return AutoMuted;
+
+		case UserMuted:
+		case AutoMuted: return {};
+
+		default: assertm(false, "Invalid MixerMuteState"); return {};
+		}
+		break;
+
+	case MuteRequest::AutoUnmute:
+		// Clears an auto-mute only; a user-mute must not be cleared by
+		// focus gain.
+		//
+		switch (current) {
+		case AutoMuted: return Audible;
+
+		case UserMuted:
+		case Audible: return {};
+
+		default: assertm(false, "Invalid MixerMuteState"); return {};
+		}
+		break;
+	}
+
+	return {};
+}
+
+// User-driven path: pressing the mute hotkey (or invoking it remotely).
+// Callers are responsible for the `no_sound` guard if they want one (the
+// hotkey handler logs a warning there).
+void MIXER_RequestUserMute()
+{
+	if (const auto next = MIXER_NextMuteState(MIXER_GetMuteState(),
+	                                          MuteRequest::UserMute)) {
+		set_mute_state(*next);
 	}
 }
 
 void MIXER_RequestUserUnmute()
 {
-	using enum MixerMuteState;
-
-	switch (mixer.mute_state.load(std::memory_order_acquire)) {
-	case UserMuted:
-	case AutoMuted:
-		// User-initiated unmute clears either kind of mute. We treat
-		// "user pressed unmute" as the user taking control regardless
-		// of which path got us here.
-		set_mute_state(Audible);
-		break;
-
-	case Audible:
-		// already audible
-		break;
+	if (const auto next = MIXER_NextMuteState(MIXER_GetMuteState(),
+	                                          MuteRequest::UserUnmute)) {
+		set_mute_state(*next);
 	}
 }
 
 // `mute_when_inactive` path: window lost focus.
 void MIXER_RequestAutoMute()
 {
-	using enum MixerMuteState;
-
-	switch (mixer.mute_state.load(std::memory_order_acquire)) {
-	case Audible: set_mute_state(AutoMuted); break;
-
-	case UserMuted:
-	case AutoMuted:
-		// UserMuted survives focus changes. AutoMuted is already in
-		// place. Both no-op.
-		break;
+	if (const auto next = MIXER_NextMuteState(MIXER_GetMuteState(),
+	                                          MuteRequest::AutoMute)) {
+		set_mute_state(*next);
 	}
 }
 
 // `mute_when_inactive` path: window regained focus.
 void MIXER_RequestAutoUnmute()
 {
-	using enum MixerMuteState;
-	switch (mixer.mute_state.load(std::memory_order_acquire)) {
-	case AutoMuted: set_mute_state(Audible); break;
-	case UserMuted:
-	case Audible:
-		// UserMuted must not be cleared by focus gain -- only the user
-		// can clear a user-mute. Audible is a no-op.
-		break;
+	if (const auto next = MIXER_NextMuteState(MIXER_GetMuteState(),
+	                                          MuteRequest::AutoUnmute)) {
+		set_mute_state(*next);
 	}
 }
 

--- a/src/audio/mixer.cpp
+++ b/src/audio/mixer.cpp
@@ -2081,7 +2081,8 @@ void MixerChannel::Sleeper::MaybeSleep()
 {
 	// A signed integer can a durration of ~24 days in milliseconds, which
 	// is surely more than enough.
-	const auto awake_for_ms = check_cast<int>(GetTicksSince(woken_at_ms));
+	const auto awake_for_ms = check_cast<int>(
+	        static_cast<int64_t>(PIC_AtomicIndex() - woken_at_pic_ms));
 
 	// Not enough time has passed.. .. try to sleep later
 	if (awake_for_ms < fadeout_or_sleep_after_ms) {
@@ -2108,9 +2109,9 @@ void MixerChannel::Sleeper::MaybeSleep()
 bool MixerChannel::Sleeper::WakeUp()
 {
 	// Always reset for another round of awakeness
-	woken_at_ms   = GetTicks();
-	fadeout_level = 1.0f;
-	had_signal    = false;
+	woken_at_pic_ms = PIC_AtomicIndex();
+	fadeout_level   = 1.0f;
+	had_signal      = false;
 
 	const auto was_sleeping = !channel.is_enabled;
 	if (was_sleeping) {

--- a/src/audio/mixer.cpp
+++ b/src/audio/mixer.cpp
@@ -211,6 +211,9 @@ struct MixerSettings {
 
 	bool is_manually_muted = false;
 
+	// State to restore on `MIXER_Resume()`. Written under `mutex`.
+	MixerState pre_pause_state = MixerState::On;
+
 	std::atomic<bool> fast_forward_mode = false;
 
 	std::recursive_mutex mutex = {};
@@ -2621,6 +2624,17 @@ static void mixer_thread_loop()
 	while (!mixer.thread_should_quit) {
 		std::unique_lock lock(mixer.mutex);
 
+		// Paused short-circuits BEFORE `mix_samples()` to keep frozen channel
+		// state out of the capture queue. Enqueue silence so SDL playback
+		// stays fed.
+		//
+		if (mixer.state == MixerState::Paused) {
+			lock.unlock();
+			mixer.output_buffer.assign(mixer.blocksize, AudioFrame{});
+			mixer.final_output.BulkEnqueue(mixer.output_buffer);
+			continue;
+		}
+
 		// This code is mostly for the fast-forward button (hold Alt + F12)
 		const double now         = PIC_AtomicIndex();
 		const double actual_time = now - last_mixed;
@@ -2720,13 +2734,15 @@ static void mixer_thread_loop()
 	case MixerState::NoSound: return "No sound";
 	case MixerState::On: return "On";
 	case MixerState::Muted: return "Mute";
+	case MixerState::Paused: return "Paused";
 	default: assertm(false, "Invalid MixerState"); return "";
 	}
 }
 
 static void set_mixer_state(const MixerState new_state)
 {
-	assert(new_state == MixerState::Muted || new_state == MixerState::On);
+	assert(new_state == MixerState::Muted || new_state == MixerState::On ||
+	       new_state == MixerState::Paused);
 
 #ifdef DEBUG_MIXER
 	LOG_MSG("MIXER: Changing mixer state from %s to '%s'",
@@ -2734,12 +2750,48 @@ static void set_mixer_state(const MixerState new_state)
 	        to_string(new_state));
 #endif
 
-	if (new_state == MixerState::Muted) {
-		// Clear out any audio in the queue to avoid a stutter on un-mute
+	if (new_state == MixerState::Muted || new_state == MixerState::Paused) {
+		// Clear queued audio so resume doesn't replay pre-pause samples.
+		// `capture_queue` is NOT cleared; it's a separate path for video
+		// capture that must drain in FIFO order for bit-identical output.
 		mixer.final_output.Clear();
 	}
 
 	mixer.state = new_state;
+}
+
+// `MIXER_Pause()` / `MIXER_Resume()` must go through MIXER_LockMixerThread,
+// NOt raw `mixer.mutex`, to compose with the queue-stop / queue-start
+// protocol every other mutator uses.
+//
+// The mixer thread can be blocked inside a channel handler's
+// `output_queue.BulkDequeue()` (e.g., SB, PC Speaker, GUS, etc.) waiting for
+// samples produced on the main thread. A raw lock would deadlock here: the
+// main thread is stuck waiting for `mixer.mutex`, while the mixer thread
+// holds `mixer.mutex` inside `BulkDequeue()` waiting for samples only the
+// main thread can produce. `NotifyLockMixer()`'s `Stop()` call unblocks
+// `BulkDequeue()` so the mixer thread can release the mutex.
+void MIXER_Pause()
+{
+	MIXER_LockMixerThread();
+
+	if (mixer.state != MixerState::Paused) {
+		mixer.pre_pause_state = mixer.state;
+		set_mixer_state(MixerState::Paused);
+	}
+
+	MIXER_UnlockMixerThread();
+}
+
+void MIXER_Resume()
+{
+	MIXER_LockMixerThread();
+
+	if (mixer.state == MixerState::Paused) {
+		set_mixer_state(mixer.pre_pause_state);
+	}
+
+	MIXER_UnlockMixerThread();
 }
 
 void MIXER_CloseAudioDevice()
@@ -3108,6 +3160,8 @@ bool MIXER_IsManuallyMuted()
 // Toggle the mixer on/off when a 'true' bool is passed in.
 static void handle_toggle_mute(const bool was_pressed)
 {
+	using enum MixerState;
+
 	// The "pressed" bool argument is used by the Mapper API, which sends a
 	// true-bool for key down events and a false-bool for key up events.
 	if (!was_pressed) {
@@ -3115,21 +3169,61 @@ static void handle_toggle_mute(const bool was_pressed)
 	}
 
 	switch (mixer.state) {
-	case MixerState::NoSound:
+	case NoSound:
 		LOG_WARNING("MIXER: Mute requested, but sound is disabled ('nosound' mode)");
 		break;
 
-	case MixerState::Muted:
+	case Muted:
 		MIXER_Unmute();
 		mixer.is_manually_muted = false;
 		break;
 
-	case MixerState::On:
+	case On:
 		MIXER_Mute();
 		mixer.is_manually_muted = true;
 		break;
 
-	default: break;
+	case Paused:
+		// We're paused. `MIXER_Pause()` saved the previous state for
+		// `MIXER_Resume()` to restore. Flip that saved state and the
+		// manual-mute flag here so resume picks up what the user just asked
+		// for. Also update external MIDI mute and the titlebar so the user
+		// sees the change right away.
+		//
+		// Lock the mixer thread while writing; the mixer thread reads
+		// `pre_pause_state` with the same lock held in `MIXER_Resume()`.
+		MIXER_LockMixerThread();
+
+		switch (mixer.pre_pause_state) {
+		case On:
+			mixer.pre_pause_state   = Muted;
+			mixer.is_manually_muted = true;
+
+			MIDI_Mute();
+			TITLEBAR_NotifyAudioMutedStatus(true);
+
+			LOG_MSG("MIXER: Muted audio output");
+			break;
+
+		case Muted:
+			mixer.pre_pause_state   = On;
+			mixer.is_manually_muted = false;
+
+			MIDI_Unmute();
+			TITLEBAR_NotifyAudioMutedStatus(false);
+
+			LOG_MSG("MIXER: Unmuted audio output");
+			break;
+
+		default:
+			// `pre_pause_state` is captured by `MIXER_Pause()` from
+			// the live state and only ever `On` or `Muted`.
+			assertm(false, "Invalid pre-pause MixerState");
+			break;
+		}
+
+		MIXER_UnlockMixerThread();
+		break;
 	};
 }
 

--- a/src/audio/mixer.cpp
+++ b/src/audio/mixer.cpp
@@ -2693,7 +2693,11 @@ static float apply_fade(std::vector<AudioFrame>& buffer, float gain,
 
 static void mixer_thread_loop()
 {
-	auto last_mixed = 0.0;
+	// Seed with the current emulated time so the first iteration's
+	// `actual_time` delta is ~zero. Without this, the `no_sound` catch-up
+	// below would size the very first block from `now - 0`, producing one
+	// oversized block at startup.
+	auto last_mixed = PIC_AtomicIndex();
 
 	// Fade gain owned entirely by this thread. Published to
 	// `mixer.playback_gain` at the end of each iteration so the PausePending
@@ -2727,10 +2731,8 @@ static void mixer_thread_loop()
 				         static_cast<double>(mixer.sample_rate_hz)) *
 				        1000.0;
 
-				std::this_thread::sleep_for(std::chrono::nanoseconds(
-				        static_cast<uint64_t>(
-				                expected_time *
-				                NanosecondsPerMillisecond)));
+				SDL_DelayPrecise(static_cast<uint64_t>(
+				        expected_time * NanosecondsPerMillisecond));
 				continue;
 			}
 
@@ -2756,11 +2758,21 @@ static void mixer_thread_loop()
 		// always request at least a blocksize worth of audio.
 		auto frames_requested = mixer.blocksize;
 
-		if (mixer.fast_forward_mode) {
-			// Flag is set only by the fast-forward hotkey handler.
-			// Usually this means the emulation core is running much
-			// faster than real-time. We must consume more audio to
-			// "catch up" but always request at least a blocksize.
+		if (mixer.fast_forward_mode || mixer.no_sound) {
+			// Two cases size the block from the elapsed emulated
+			// time instead of a fixed blocksize:
+			//
+			//  - Fast-forward: the emulation core runs much faster
+			//    than real-time, so we must consume more audio to
+			//    "catch up".
+			//
+			//  - `no_sound`: there's no SDL device applying
+			//    backpressure to pace us, so we anchor the block's
+			//    frame count to the emulated time that actually
+			//    elapsed. This keeps captures at the correct speed
+			//    regardless of how long the sleep below overshoots.
+			//
+			// Always request at least a blocksize.
 			frames_requested = std::max(
 			        mixer.blocksize,
 			        ifloor(actual_time * get_mixer_frames_per_tick()));
@@ -2783,9 +2795,8 @@ static void mixer_thread_loop()
 			                          std::memory_order_relaxed);
 
 			constexpr double NanosecondsPerMillisecond = 1000000.0;
-			std::this_thread::sleep_for(std::chrono::nanoseconds(
-			        static_cast<uint64_t>(expected_time *
-			                              NanosecondsPerMillisecond)));
+			SDL_DelayPrecise(static_cast<uint64_t>(
+			        expected_time * NanosecondsPerMillisecond));
 			continue;
 		}
 

--- a/src/audio/mixer.cpp
+++ b/src/audio/mixer.cpp
@@ -2794,6 +2794,11 @@ void MIXER_Resume()
 	MIXER_UnlockMixerThread();
 }
 
+void MIXER_ClearCaptureQueue()
+{
+	mixer.capture_queue.Clear();
+}
+
 void MIXER_CloseAudioDevice()
 {
 	TIMER_DelTickHandler(capture_callback);

--- a/src/audio/mixer.cpp
+++ b/src/audio/mixer.cpp
@@ -3023,46 +3023,6 @@ void MIXER_RequestAutoUnmute()
 	}
 }
 
-// `MIXER_Pause()` / `MIXER_Resume()` don't carry pause state of their own;
-// `DOSBOX_IsPaused()` is the single source of truth and the mixer thread
-// reads it directly at the top of its loop. These functions are just the
-// synchronization barrier: by the time `MIXER_Pause()` returns, the mixer
-// thread has finished any in-flight `mix_samples()` and is at a clean loop
-// boundary.
-//
-// The fade-in ramp doesn't need any queue clear here: the mixer thread
-// itself applies the ramp to `output_buffer` before enqueue, so
-// `final_output` is a continuous stream of appropriately-attenuated
-// samples with no boundary discontinuity for the fade to "miss".
-//
-// Both must go through `MIXER_LockMixerThread()` (NOT raw `mixer.mutex`!) to
-// compose with the queue-stop / queue-start protocol every other mutator
-// uses. The mixer thread can be blocked inside a channel handler's
-// `output_queue.BulkDequeue` (SB, PC Speaker, GUS, etc.) waiting for samples
-// produced on the main thread. A raw lock would deadlock here: the main
-// thread is stuck waiting for `mixer.mutex`, while the mixer thread holds
-// `mixer.mutex` inside `BulkDequeue()` waiting for samples only the main
-// thread can produce. `NotifyLockMixer()`'s `Stop()` unblocks `BulkDequeue()`
-// so the mixer thread can release the mutex.
-//
-// `MIDI_Pause()`/`MIDI_Resume()` do NOT take this lock. The synth
-// renderers stop their own `audio_frame_fifo` while parked, so a mixer
-// `BulkDequeue()` that races the halt short-reads instead of blocking on
-// it -- no cross-lock coordination with the pause path is needed. See
-// `set_subsystems_paused()` in dosbox.cpp.
-//
-void MIXER_Pause()
-{
-	MIXER_LockMixerThread();
-	MIXER_UnlockMixerThread();
-}
-
-void MIXER_Resume()
-{
-	MIXER_LockMixerThread();
-	MIXER_UnlockMixerThread();
-}
-
 void MIXER_ClearCaptureQueue()
 {
 	mixer.capture_queue.Clear();

--- a/src/audio/mixer.cpp
+++ b/src/audio/mixer.cpp
@@ -2722,8 +2722,10 @@ static void mixer_thread_loop()
 				continue;
 			}
 
-			// Enqueue silence to keep SDL fed. `playback_gain` is
-			// already 0 so no fade to apply.
+			// Keep `final_output` full with silence so the mixer
+			// stays paced by SDL; if it ran dry, the mixer would
+			// sprint on resume and stretch captures (see README.md
+			// gotcha 1). `playback_gain` is already 0, so no fade.
 			mixer.output_buffer.assign(mixer.blocksize, AudioFrame{});
 			mixer.final_output.BulkEnqueue(mixer.output_buffer);
 			continue;

--- a/src/audio/mixer.cpp
+++ b/src/audio/mixer.cpp
@@ -199,15 +199,20 @@ struct MixerSettings {
 	// per-block duration to simulate timing. Never changes after init.
 	bool no_sound = false;
 
-	// Mute FSM (see `MixerMuteState` in mixer.h). When non-Audible, the
-	// mixer still runs `mix_samples()` (so the capture queue IS fed at full
-	// level) but overwrites the SDL-bound buffer with silence.
+	// Mute FSM (see `MixerMuteState` in mixer.h). When non-Audible,
+	// `mix_samples()` still runs (so the capture queue IS fed at full level)
+	// and the fade below ramps the SDL-bound `output_buffer` toward zero
+	// before it reaches `final_output`.
 	std::atomic<MixerMuteState> mute_state = MixerMuteState::Audible;
 
-	// SDL-side fade-out/-in gain, ramped by `mixer_callback()` and
-	// polled by the PausePending FSM in dosbox.cpp (via
-	// `MIXER_GetPlaybackGain()`) to know when the fade-out has
-	// reached zero.
+	// Fade-out/-in gain, ramped by `mixer_thread_loop()` and polled by the
+	// PausePending FSM in dosbox.cpp (via `MIXER_GetPlaybackGain()`) to know
+	// when the fade-out has reached zero.
+	//
+	// Written ONLY by the mixer thread. Read by the mixer thread and by
+	// `pending_pause_tick_handler()`. Because there's a single writer there's
+	// no coordination hazard; the atomic exists purely to make the FSM's read
+	// well-defined.
 	std::atomic<float> playback_gain = 1.0f;
 
 	HighpassFilter highpass_filter = {};
@@ -2603,23 +2608,11 @@ static void capture_callback()
 	CAPTURE_AddAudioData(mixer.sample_rate_hz, num_frames, frames.data());
 }
 
-// Returns whether the SDL output buffer should currently be silenced.
-// Used both by the mixer thread (to silence `final_output` content under
-// mute) and by `mixer_callback()` (to drive the silence-edge gain ramp).
+// SDL playback callback. Just plays whatever the mixer thread has already
+// produced -- the silence-edge fade is applied by the mixer thread before
+// samples reach `final_output`, so this callback has nothing to do beyond
+// dequeue + shortfall-fill.
 //
-// Uses `DOSBOX_IsPauseRequested()` (not `DOSBOX_IsPaused()`) so the
-// fade-out ramp starts at the pause-request edge, not at the actual
-// pause. During the pending window the mixer thread and MIDI renderer
-// are still producing real audio -- that's what the fade attenuates
-// against, so it doesn't hit silence half-way through and click.
-//
-static bool mixer_should_silence_output()
-{
-	return DOSBOX_IsPauseRequested() ||
-	       (mixer.mute_state.load(std::memory_order_acquire) !=
-	        MixerMuteState::Audible);
-}
-
 static void SDLCALL mixer_callback([[maybe_unused]] void* userdata,
                                    SDL_AudioStream* stream, int bytes_requested,
                                    [[maybe_unused]] int total_bytes)
@@ -2649,61 +2642,6 @@ static void SDLCALL mixer_callback([[maybe_unused]] void* userdata,
 	// Satisfy any shortfall with silence
 	std::fill(output.begin() + frames_received, output.end(), AudioFrame{});
 
-	// Fades out the SDL audio between full and muted over a few ms to mask
-	// the discontinuity that would otherwise result in an audible click
-	// when muting. On resuming, we do the reverse, a fade-in.
-	//
-	// Applied here at the SDL boundary, NOT in `mix_samples()`, so the
-	// capture path stays at full level and the fades don't end up in the
-	// captured WAV/AVI audio.
-	//
-	const bool should_silence = mixer_should_silence_output();
-
-	// Read the shared gain into a local scratch so the per-frame ramp
-	// doesn't hammer the atomic; commit the final value at the bottom.
-	// The PausePending FSM in dosbox.cpp reads this via
-	// `MIXER_GetPlaybackGain()` to know when the fade-out has completed.
-	float playback_gain = mixer.playback_gain.load(std::memory_order_relaxed);
-	const float target_gain = should_silence ? 0.0f : 1.0f;
-
-	constexpr float SmoothingMs = 5.0f;
-
-	const float fade_step = 1.0f / (SmoothingMs *
-	                                static_cast<float>(mixer.sample_rate_hz) /
-	                                1000.0f);
-
-	// Fade-in is gated on actually receiving real samples from
-	// `final_output`. On the leave-silent edge we clear the queue (see
-	// `maybe_clear_final_output_on_unsilence`); if SDL polls before the
-	// mixer thread has had a chance to push fresh real audio, the buffer is
-	// silence-filled by the shortfall path above. Ramping gain up over that
-	// silence would hit 1.0 before any real audio arrives, and the first
-	// real sample behind the silence would land at full gain, resulting in
-	// an audible click. We hold the ramp at its current value until we see
-	// real samples.
-	//
-	// Fade-out has no such gating: when there's nothing to drain, gain just
-	// settles at 0 against whatever silence the mixer thread pushed, which
-	// is the desired end state.
-	//
-	const bool got_real_samples = (frames_received > 0);
-
-	for (auto& frame : output) {
-		frame *= playback_gain;
-
-		if (playback_gain < target_gain) {
-			if (got_real_samples) {
-				playback_gain = std::min(target_gain,
-				                         playback_gain + fade_step);
-			}
-		} else if (playback_gain > target_gain) {
-			playback_gain = std::max(target_gain,
-			                         playback_gain - fade_step);
-		}
-	}
-
-	mixer.playback_gain.store(playback_gain, std::memory_order_relaxed);
-
 	SDL_PutAudioStreamData(stream, output.data(), bytes_requested);
 }
 
@@ -2712,35 +2650,117 @@ float MIXER_GetPlaybackGain()
 	return mixer.playback_gain.load(std::memory_order_relaxed);
 }
 
+// Fades out the SDL `output_buffer` between full and muted over a few ms to
+// avoid clicks and pops when a non-zero sample is followed by 0.0 when
+// muting/pausing. On unmuting/resuming, we do the reverse, a fade-in.
+//
+// Applied here at the SDL boundary, NOT in `mix_samples()`, so the capture
+// path stays at full level and the fades don't end up in the captured WAV/AVI
+// audio.
+//
+// Uses `DOSBOX_IsPauseRequested()` (not `DOSBOX_IsPaused()`) so the fade-out
+// starts at the pause-request edge, NOT at the actual pause. During the
+// pending window, `mix_samples()` still runs and produces real audio --
+// that's what the fade attenuates against, so it doesn't hit silence half-way
+// through and click.
+//
+static constexpr float FadeSmoothingMs = 5.0f;
+
+static float compute_fade_step()
+{
+	return 1.0f / (FadeSmoothingMs *
+	               static_cast<float>(mixer.sample_rate_hz) / 1000.0f);
+}
+
+static float target_fade_gain()
+{
+	const bool should_silence = DOSBOX_IsPauseRequested() ||
+	                            (mixer.mute_state.load(std::memory_order_acquire) !=
+	                             MixerMuteState::Audible);
+
+	return should_silence ? 0.0f : 1.0f;
+}
+
+static float apply_fade(std::vector<AudioFrame>& buffer, float gain,
+                        const float target, const float step)
+{
+	for (auto& frame : buffer) {
+		frame *= gain;
+
+		if (gain < target) {
+			gain = std::min(target, gain + step);
+
+		} else if (gain > target) {
+			gain = std::max(target, gain - step);
+		}
+	}
+	return gain;
+}
+
 static void mixer_thread_loop()
 {
-	double last_mixed = 0.0;
+	auto last_mixed = 0.0;
+
+	// Fade gain owned entirely by this thread. Published to
+	// `mixer.playback_gain` at the end of each iteration so the PausePending
+	// FSM in dosbox.cpp can observe when the fade-out has completed.
+	//
+	auto playback_gain = mixer.playback_gain.load(std::memory_order_relaxed);
+
+	const auto fade_step = compute_fade_step();
+
 	while (!mixer.thread_should_quit) {
 		std::unique_lock lock(mixer.mutex);
 
-		// Paused short-circuits BEFORE `mix_samples()` to keep frozen channel
-		// state out of the capture queue. Enqueue silence so SDL playback
-		// stays fed.
+		// Paused short-circuits BEFORE `mix_samples()` to keep frozen
+		// channel state out of the capture queue (we want bit-identical
+		// captures compared to not pausing at all). At this point the
+		// fade-out has already completed (that's what triggered the
+		// Pending -> Paused transition), so `playback_gain` is already
+		// at 0 and no further ramp is needed here.
 		if (DOSBOX_IsPaused()) {
 			lock.unlock();
+
+			if (mixer.no_sound) {
+				// No SDL device, no consumer for
+				// `final_output`. Just sleep to simulate the
+				// per-block duration; skipping the enqueue avoids
+				// filling and blocking the queue.
+				constexpr double NanosecondsPerMillisecond = 1000000.0;
+
+				const auto expected_time =
+				        (static_cast<double>(mixer.blocksize) /
+				         static_cast<double>(mixer.sample_rate_hz)) *
+				        1000.0;
+
+				std::this_thread::sleep_for(std::chrono::nanoseconds(
+				        static_cast<uint64_t>(
+				                expected_time *
+				                NanosecondsPerMillisecond)));
+				continue;
+			}
+
+			// Enqueue silence to keep SDL fed. `playback_gain` is
+			// already 0 so no fade to apply.
 			mixer.output_buffer.assign(mixer.blocksize, AudioFrame{});
 			mixer.final_output.BulkEnqueue(mixer.output_buffer);
 			continue;
 		}
 
 		// This code is mostly for the fast-forward button (hold Alt + F12)
-		const double now         = PIC_AtomicIndex();
-		const double actual_time = now - last_mixed;
-		const double expected_time = (static_cast<double>(mixer.blocksize) /
-		                              static_cast<double>(mixer.sample_rate_hz)) *
-		                             1000.0;
+		const auto now         = PIC_AtomicIndex();
+		const auto actual_time = now - last_mixed;
+
+		const auto expected_time = (static_cast<double>(mixer.blocksize) /
+		                            static_cast<double>(mixer.sample_rate_hz)) *
+		                           1000.0;
 		last_mixed = now;
 
 		// "Underflow" is not a concern since moving to a threaded
 		// mixer. If the CPU is running slower than real-time, the audio
 		// drivers will naturally slow down the audio. Therefore, we can
 		// always request at least a blocksize worth of audio.
-		int frames_requested = mixer.blocksize;
+		auto frames_requested = mixer.blocksize;
 
 		if (mixer.fast_forward_mode) {
 			// Flag is set only by the fast-forward hotkey handler.
@@ -2760,31 +2780,18 @@ static void mixer_thread_loop()
 
 		if (mixer.no_sound) {
 			// SDL callback is not running. Mixed sound gets
-			// discarded. Sleep for the expected duration to
-			// simulate the time it would have taken to playback the
-			// audio.
+			// discarded. Snap `playback_gain` to target so the
+			// PausePending FSM can transition immediately (there's
+			// no audible fade to wait for). Then sleep to simulate
+			// the per-block duration.
+			playback_gain = target_fade_gain();
+			mixer.playback_gain.store(playback_gain,
+			                          std::memory_order_relaxed);
+
 			constexpr double NanosecondsPerMillisecond = 1000000.0;
-
-			const auto nap_time = static_cast<uint64_t>(
-			        expected_time * NanosecondsPerMillisecond);
-
-			std::this_thread::sleep_for(
-			        std::chrono::nanoseconds(nap_time));
-			continue;
-		}
-
-		if (mixer.mute_state.load(std::memory_order_acquire) !=
-		    MixerMuteState::Audible) {
-
-			// Mute path: `mix_samples()` already ran and the
-			// capture queue is fed at full level (mute should not
-			// silence captures). Overwrite the SDL-bound buffer
-			// with silence before it reaches `final_output`.
-			//
-			mixer.output_buffer.clear();
-			mixer.output_buffer.resize(mixer.blocksize);
-
-			mixer.final_output.BulkEnqueue(mixer.output_buffer);
+			std::this_thread::sleep_for(std::chrono::nanoseconds(
+			        static_cast<uint64_t>(expected_time *
+			                              NanosecondsPerMillisecond)));
 			continue;
 		}
 
@@ -2792,7 +2799,7 @@ static void mixer_thread_loop()
 		// calculated frames_requested. That variable could have changed
 		// by now but we need to always squash down to a blocksize of
 		// audio.
-		const bool audio_needs_squashing = frames_requested > mixer.blocksize;
+		const auto audio_needs_squashing = frames_requested > mixer.blocksize;
 
 		auto& to_mix = audio_needs_squashing ? mixer.fast_forward_buffer
 		                                     : mixer.output_buffer;
@@ -2806,13 +2813,13 @@ static void mixer_thread_loop()
 			mixer.fast_forward_buffer.clear();
 			mixer.fast_forward_buffer.reserve(mixer.blocksize);
 
-			const float index_add = static_cast<float>(frames_requested) /
-			                        static_cast<float>(mixer.blocksize);
+			const auto index_add = static_cast<float>(frames_requested) /
+			                       static_cast<float>(mixer.blocksize);
 
-			float float_index = 0.0f;
+			auto float_index = 0.0f;
 
-			for (int i = 0; i < mixer.blocksize; ++i) {
-				const size_t src_index = std::min(
+			for (auto i = 0; i < mixer.blocksize; ++i) {
+				const auto src_index = std::min(
 				        check_cast<size_t>(iroundf(float_index)),
 				        mixer.output_buffer.size() - 1);
 
@@ -2824,6 +2831,18 @@ static void mixer_thread_loop()
 		}
 
 		assert(to_mix.size() == static_cast<size_t>(mixer.blocksize));
+
+		// Apply the fade ramp to the SDL-bound buffer. Mute is folded
+		// into the target: when `mute != Audible`, target=0, so the
+		// buffer content is smoothly attenuated to silence. Capture
+		// already happened at full level inside `mix_samples()`.
+		playback_gain = apply_fade(to_mix,
+		                           playback_gain,
+		                           target_fade_gain(),
+		                           fade_step);
+
+		mixer.playback_gain.store(playback_gain, std::memory_order_relaxed);
+
 		mixer.final_output.BulkEnqueue(to_mix);
 	}
 }
@@ -2837,26 +2856,6 @@ static void mixer_thread_loop()
 	}
 	assertm(false, "Invalid MixerMuteState");
 	return "";
-}
-
-// Drop any silence the mixer thread queued into `final_output` while we were
-// silent so the fade-in ramp in `mixer_callback()` (silent->Audible edge)
-// lifts gain from 0.0 to 1.0 against the next fresh real audio rather than
-// against the queued silence. Otherwise gain hits 1.0 over the silence, the
-// first real sample lands at full gain, and we get the click the fade was
-// supposed to mask. `capture_queue` is NOT cleared; that's a separate path
-// with its own FIFO invariant.
-//
-// On the way INTO a silent state we intentionally do NOT clear -- any
-// pre-silent real audio still queued drains naturally as SDL pulls, and
-// `mixer_callback()` applies its gain ramp to those samples before they reach
-// the host.
-static void maybe_clear_final_output_on_unsilence(const bool was_silent,
-                                                  const bool will_be_silent)
-{
-	if (was_silent && !will_be_silent) {
-		mixer.final_output.Clear();
-	}
 }
 
 static void set_mute_state(const MixerMuteState new_state)
@@ -2875,48 +2874,33 @@ static void set_mute_state(const MixerMuteState new_state)
 	const bool was_audible     = (prev_state == MixerMuteState::Audible);
 	const bool will_be_audible = (new_state == MixerMuteState::Audible);
 
-	// Only the Audible<->non-Audible edge matters for the SDL fade and for
-	// MIDI/titlebar coordination. UserMuted<->AutoMuted is a pure
-	// bookkeeping change -- the listener experiences continuous silence.
+	// Only the Audible<->non-Audible edge matters for MIDI / titlebar
+	// coordination. UserMuted<->AutoMuted is a pure bookkeeping change
+	// -- the listener experiences continuous silence.
 	//
 	const bool audible_edge = (was_audible != will_be_audible);
 
 	mixer.mute_state.store(new_state, std::memory_order_release);
 
 	if (audible_edge) {
-		// Mute is just one source of silence; pause is the other. The
-		// fade-in clear only matters when the COMBINED silence
-		// condition flips from true to false, so factor in pause too.
-		const bool paused         = DOSBOX_IsPaused();
-		const bool was_silent     = !was_audible || paused;
-		const bool will_be_silent = !will_be_audible || paused;
-
-		maybe_clear_final_output_on_unsilence(was_silent, will_be_silent);
-
 		// Skip MIDI updates when a pause is in effect (Pending or
 		// Paused). MIDI is managed by `MIDI_Pause()` / `MIDI_Resume()`
-		// around the pause boundaries -- touching it here while paused
-		// would send volume-restore to external MIDI and revive
-		// hanging notes on an unmute mid-pause.
+		// around the pause boundaries. If we touched MIDI here while
+		// paused, unmuting mid-pause would send volume-restore to
+		// external MIDI and revive hanging notes; muting mid-pause
+		// would double-mute (harmless) or worse mismatch the state
+		// `MIDI_Resume()` expects on the way out.
 		//
-		const bool touch_midi = !DOSBOX_IsPauseRequested();
-
-		if (will_be_audible) {
-			if (touch_midi) {
+		if (!DOSBOX_IsPauseRequested()) {
+			if (will_be_audible) {
 				MIDI_Unmute();
-			}
-			TITLEBAR_NotifyAudioMutedStatus(false);
-
-			LOG_MSG("MIXER: Unmuted audio output");
-
-		} else {
-			if (touch_midi) {
+			} else {
 				MIDI_Mute();
 			}
-			TITLEBAR_NotifyAudioMutedStatus(true);
-
-			LOG_MSG("MIXER: Muted audio output");
 		}
+		TITLEBAR_NotifyAudioMutedStatus(!will_be_audible);
+		LOG_MSG("MIXER: %s audio output",
+		        will_be_audible ? "Unmuted" : "Muted");
 	}
 }
 
@@ -2997,9 +2981,12 @@ void MIXER_RequestAutoUnmute()
 // reads it directly at the top of its loop. These functions are just the
 // synchronization barrier: by the time `MIXER_Pause()` returns, the mixer
 // thread has finished any in-flight `mix_samples()` and is at a clean loop
-// boundary; `MIXER_Resume()` additionally clears `final_output` if the
-// listener is now audible (so the fade-in ramps against fresh real audio
-// rather than the silence the mixer thread queued during pause).
+// boundary.
+//
+// The fade-in ramp doesn't need any queue clear here: the mixer thread
+// itself applies the ramp to `output_buffer` before enqueue, so
+// `final_output` is a continuous stream of appropriately-attenuated
+// samples with no boundary discontinuity for the fade to "miss".
 //
 // Both must go through `MIXER_LockMixerThread()` (NOT raw `mixer.mutex`!) to
 // compose with the queue-stop / queue-start protocol every other mutator
@@ -3026,20 +3013,6 @@ void MIXER_Pause()
 void MIXER_Resume()
 {
 	MIXER_LockMixerThread();
-
-	// Callers (`set_subsystems_paused()`) only invoke this on a
-	// Paused -> Running edge, so we always know we were silent due to
-	// pause. If mute is also non-Audible we stay silent and skip the
-	// clear (else we'd nuke the silence the mixer thread is queueing
-	// to keep SDL fed); if mute is Audible the listener is going back
-	// to audible and we drop the queued silence so the fade-in ramps
-	// against fresh real audio.
-	const bool will_be_silent = (mixer.mute_state.load(std::memory_order_acquire) !=
-	                             MixerMuteState::Audible);
-
-	constexpr auto WasSilent = true;
-	maybe_clear_final_output_on_unsilence(WasSilent, will_be_silent);
-
 	MIXER_UnlockMixerThread();
 }
 

--- a/src/audio/mixer.cpp
+++ b/src/audio/mixer.cpp
@@ -204,6 +204,12 @@ struct MixerSettings {
 	// level) but overwrites the SDL-bound buffer with silence.
 	std::atomic<MixerMuteState> mute_state = MixerMuteState::Audible;
 
+	// SDL-side fade-out/-in gain, ramped by `mixer_callback()` and
+	// polled by the PausePending FSM in dosbox.cpp (via
+	// `MIXER_GetPlaybackGain()`) to know when the fade-out has
+	// reached zero.
+	std::atomic<float> playback_gain = 1.0f;
+
 	HighpassFilter highpass_filter = {};
 	Compressor compressor          = {};
 	bool do_compressor             = false;
@@ -2600,9 +2606,16 @@ static void capture_callback()
 // Returns whether the SDL output buffer should currently be silenced.
 // Used both by the mixer thread (to silence `final_output` content under
 // mute) and by `mixer_callback()` (to drive the silence-edge gain ramp).
+//
+// Uses `DOSBOX_IsPauseRequested()` (not `DOSBOX_IsPaused()`) so the
+// fade-out ramp starts at the pause-request edge, not at the actual
+// pause. During the pending window the mixer thread and MIDI renderer
+// are still producing real audio -- that's what the fade attenuates
+// against, so it doesn't hit silence half-way through and click.
+//
 static bool mixer_should_silence_output()
 {
-	return DOSBOX_IsPaused() ||
+	return DOSBOX_IsPauseRequested() ||
 	       (mixer.mute_state.load(std::memory_order_acquire) !=
 	        MixerMuteState::Audible);
 }
@@ -2646,8 +2659,12 @@ static void SDLCALL mixer_callback([[maybe_unused]] void* userdata,
 	//
 	const bool should_silence = mixer_should_silence_output();
 
-	static float playback_gain = 1.0f;
-	const float target_gain    = should_silence ? 0.0f : 1.0f;
+	// Read the shared gain into a local scratch so the per-frame ramp
+	// doesn't hammer the atomic; commit the final value at the bottom.
+	// The PausePending FSM in dosbox.cpp reads this via
+	// `MIXER_GetPlaybackGain()` to know when the fade-out has completed.
+	float playback_gain = mixer.playback_gain.load(std::memory_order_relaxed);
+	const float target_gain = should_silence ? 0.0f : 1.0f;
 
 	constexpr float SmoothingMs = 5.0f;
 
@@ -2685,7 +2702,14 @@ static void SDLCALL mixer_callback([[maybe_unused]] void* userdata,
 		}
 	}
 
+	mixer.playback_gain.store(playback_gain, std::memory_order_relaxed);
+
 	SDL_PutAudioStreamData(stream, output.data(), bytes_requested);
+}
+
+float MIXER_GetPlaybackGain()
+{
+	return mixer.playback_gain.load(std::memory_order_relaxed);
 }
 
 static void mixer_thread_loop()

--- a/src/audio/mixer.cpp
+++ b/src/audio/mixer.cpp
@@ -2616,6 +2616,56 @@ static void SDLCALL mixer_callback([[maybe_unused]] void* userdata,
 	// Satisfy any shortfall with silence
 	std::fill(output.begin() + frames_received, output.end(), AudioFrame{});
 
+	// Fades out the SDL audio between full and muted over a few ms to mask
+	// the discontinuity that would otherwise result in an audible click
+	// when muting. On resuming, we do the reverse, a fade-in.
+	//
+	// Applied here at the SDL boundary, NOT in `mix_samples()`, so the
+	// capture path stays at full level and the fades don't end up in the
+	// captured WAV/AVI audio.
+	//
+	const auto state = mixer.state.load(std::memory_order_relaxed);
+
+	const bool should_silence = (state == MixerState::Paused ||
+	                             state == MixerState::Muted);
+
+	static float playback_gain  = 1.0f;
+	const float target_gain     = should_silence ? 0.0f : 1.0f;
+	constexpr float SmoothingMs = 5.0f;
+
+	const float fade_step = 1.0f / (SmoothingMs *
+	                                static_cast<float>(mixer.sample_rate_hz) /
+	                                1000.0f);
+
+	// Fade-in is gated on actually receiving real samples from
+	// `final_output`. When resuming, `set_mixer_state()` clears the queue;
+	// if SDL polls before the mixer thread has had a chance to push fresh
+	// real audio, the buffer is silence-filled by the shortfall path above.
+	// Ramping gain up over that silence would hit 1.0 before any real audio
+	// arrives, and the first real sample behind the silence would land at
+	// full gain, resulting in a click. We hold the ramp at its current
+	// value until we see real samples.
+	//
+	// Fade-out has no such gating: when there's nothing to drain, gain just
+	// settles at 0.0 against whatever silence the mixer thread pushed,
+	// which is the desired end state.
+	//
+	const bool got_real_samples = (frames_received > 0);
+
+	for (auto& frame : output) {
+		frame *= playback_gain;
+
+		if (playback_gain < target_gain) {
+			if (got_real_samples) {
+				playback_gain = std::min(target_gain,
+				                         playback_gain + fade_step);
+			}
+		} else if (playback_gain > target_gain) {
+			playback_gain = std::max(target_gain,
+			                         playback_gain - fade_step);
+		}
+	}
+
 	SDL_PutAudioStreamData(stream, output.data(), bytes_requested);
 }
 

--- a/src/audio/mixer.cpp
+++ b/src/audio/mixer.cpp
@@ -2893,14 +2893,26 @@ static void set_mute_state(const MixerMuteState new_state)
 
 		maybe_clear_final_output_on_unsilence(was_silent, will_be_silent);
 
+		// Skip MIDI updates when a pause is in effect (Pending or
+		// Paused). MIDI is managed by `MIDI_Pause()` / `MIDI_Resume()`
+		// around the pause boundaries -- touching it here while paused
+		// would send volume-restore to external MIDI and revive
+		// hanging notes on an unmute mid-pause.
+		//
+		const bool touch_midi = !DOSBOX_IsPauseRequested();
+
 		if (will_be_audible) {
-			MIDI_Unmute();
+			if (touch_midi) {
+				MIDI_Unmute();
+			}
 			TITLEBAR_NotifyAudioMutedStatus(false);
 
 			LOG_MSG("MIXER: Unmuted audio output");
 
 		} else {
-			MIDI_Mute();
+			if (touch_midi) {
+				MIDI_Mute();
+			}
 			TITLEBAR_NotifyAudioMutedStatus(true);
 
 			LOG_MSG("MIXER: Muted audio output");

--- a/src/audio/mixer.cpp
+++ b/src/audio/mixer.cpp
@@ -2544,19 +2544,6 @@ static void mix_samples(const int frames_requested)
 			        static_cast<int16_t>(host_to_le16(right)));
 		}
 
-		if (mixer.capture_queue.Size() + mixer.capture_buffer.size() >
-		    mixer.capture_queue.MaxCapacity()) {
-
-			// We're producing more audio than the capture is
-			// consuming. This usually happens when the main thread
-			// is being slowed down by video encoding (e.g., slow
-			// host CPU or using zlib rather than zlib_ng). Not
-			// ideal as this results in an audible "skip forward".
-			// Without this, it's a complete stuttery mess though so
-			// it's the lesser of two evils.
-			//
-			mixer.capture_queue.Clear();
-		}
 		mixer.capture_queue.NonblockingBulkEnqueue(mixer.capture_buffer);
 	}
 

--- a/src/audio/mixer.cpp
+++ b/src/audio/mixer.cpp
@@ -288,6 +288,12 @@ bool MIXER_FastForwardModeEnabled()
 // (mostly on device init/destroy and in the MIXER command line program).
 // Individual channels also have a mutex which can be safely aquired without
 // stopping these queues.
+//
+// NOTE: The queue `Stop()`/`Start()` protocol is not nesting-safe: a nested
+// lock/unlock pair would `Start()` the queues on the inner unlock while the
+// outer lock is still held. All current callers take the lock sequentially
+// (never nested), and the queue producers are non-blocking, so this is
+// harmless today -- but don't nest these calls.
 void MIXER_LockMixerThread()
 {
 	PCSPEAKER_NotifyLockMixer();
@@ -726,8 +732,8 @@ void MIXER_DeregisterChannel(MixerChannelPtr& channel_to_remove)
 	MIXER_UnlockMixerThread();
 }
 
-MixerChannelPtr MIXER_AddChannel(MIXER_Handler handler,
-                                 const int sample_rate_hz, const std::string& name,
+MixerChannelPtr MIXER_AddChannel(MIXER_Handler handler, const int sample_rate_hz,
+                                 const std::string& name,
                                  const std::set<ChannelFeature>& features)
 {
 	// We allow 0 for the UseMixerRate special value
@@ -739,7 +745,9 @@ MixerChannelPtr MIXER_AddChannel(MIXER_Handler handler,
 
 	const auto chan_rate_hz = chan->GetSampleRate();
 	if (chan_rate_hz == mixer.sample_rate_hz) {
-		LOG_MSG("%s: Operating at %d Hz without resampling", name.c_str(), chan_rate_hz);
+		LOG_MSG("%s: Operating at %d Hz without resampling",
+		        name.c_str(),
+		        chan_rate_hz);
 	} else {
 		LOG_MSG("%s: Operating at %d Hz and %s to the output rate",
 		        name.c_str(),
@@ -2182,8 +2190,8 @@ void MixerChannel::AddSamples(const int num_frames, const Type* data)
 			assert(s.pos >= 0.0f && s.pos <= 1.0f);
 			AudioFrame lerped_frame = {};
 			lerped_frame.left       = std::lerp(s.last_frame.left,
-			                                    curr_frame.left,
-			                                    s.pos);
+                                                      curr_frame.left,
+                                                      s.pos);
 
 			lerped_frame.right = std::lerp(s.last_frame.right,
 			                               curr_frame.right,
@@ -2612,7 +2620,7 @@ static void SDLCALL mixer_callback([[maybe_unused]] void* userdata,
 	constexpr int BytesPerAudioFrame = sizeof(AudioFrame);
 
 	const auto frames_requested = check_cast<size_t>(bytes_requested /
-	                                                  BytesPerAudioFrame);
+	                                                 BytesPerAudioFrame);
 
 	// Mac OSX has been observed to be problematic if we ever block inside
 	// SDL's callback. This ensures that we do not block waiting for more
@@ -2624,7 +2632,7 @@ static void SDLCALL mixer_callback([[maybe_unused]] void* userdata,
 	output.resize(frames_requested);
 
 	const auto frames_received = mixer.final_output.BulkDequeue(output.data(),
-	                                                             frames_to_dequeue);
+	                                                            frames_to_dequeue);
 	// Satisfy any shortfall with silence
 	std::fill(output.begin() + frames_received, output.end(), AudioFrame{});
 
@@ -2638,8 +2646,8 @@ static void SDLCALL mixer_callback([[maybe_unused]] void* userdata,
 	//
 	const bool should_silence = mixer_should_silence_output();
 
-	static float playback_gain  = 1.0f;
-	const float target_gain     = should_silence ? 0.0f : 1.0f;
+	static float playback_gain = 1.0f;
+	const float target_gain    = should_silence ? 0.0f : 1.0f;
 
 	constexpr float SmoothingMs = 5.0f;
 
@@ -2967,8 +2975,11 @@ void MIXER_RequestAutoUnmute()
 // thread can produce. `NotifyLockMixer()`'s `Stop()` unblocks `BulkDequeue()`
 // so the mixer thread can release the mutex.
 //
-// !!! ORDER MATTERS relative to MIDI_Pause/Resume. See the comments on
-// `set_subsystems_paused` in dosbox.cpp. !!!
+// `MIDI_Pause()`/`MIDI_Resume()` do NOT take this lock. The synth
+// renderers stop their own `audio_frame_fifo` while parked, so a mixer
+// `BulkDequeue()` that races the halt short-reads instead of blocking on
+// it -- no cross-lock coordination with the pause path is needed. See
+// `set_subsystems_paused()` in dosbox.cpp.
 //
 void MIXER_Pause()
 {
@@ -3046,7 +3057,9 @@ static bool init_sdl_sound(const int requested_sample_rate_hz,
 
 	// Open the audio device
 	if (!SDL_InitSubSystem(SDL_INIT_AUDIO)) {
-		LOG_ERR("SDL: Failed to init SDL audio subsystem: %s", SDL_GetError());
+		LOG_ERR("SDL: Failed to init SDL audio subsystem: %s",
+		        SDL_GetError());
+
 		return false;
 	}
 
@@ -3100,7 +3113,7 @@ static bool init_sdl_sound(const int requested_sample_rate_hz,
 
 	// Set these mixer values after we've passed all error points.
 	mixer.sample_rate_hz = obtained_sample_rate_hz;
-	mixer.blocksize = obtained_blocksize;
+	mixer.blocksize      = obtained_blocksize;
 
 	const auto driver_name = SDL_GetCurrentAudioDriver();
 	const auto playback_name = SDL_GetAudioDeviceName(mixer.sdl_device);
@@ -3109,8 +3122,8 @@ static bool init_sdl_sound(const int requested_sample_rate_hz,
 	// Did SDL negotiate a different playback rate?
 	if (obtained_sample_rate_hz != requested_sample_rate_hz) {
 		LOG_WARNING("MIXER: SDL negotiated the requested sample rate of %d to %d Hz",
-		         requested_sample_rate_hz,
-		         obtained_sample_rate_hz);
+		            requested_sample_rate_hz,
+		            obtained_sample_rate_hz);
 
 		set_section_property_value("mixer",
 		                           "rate",

--- a/src/audio/mixer.cpp
+++ b/src/audio/mixer.cpp
@@ -2611,7 +2611,7 @@ static void capture_callback()
 // SDL playback callback. Just plays whatever the mixer thread has already
 // produced -- the silence-edge fade is applied by the mixer thread before
 // samples reach `final_output`, so this callback has nothing to do beyond
-// dequeue + shortfall-fill.
+// dequeuing what's available; SDL backfills any shortfall with silence.
 //
 static void SDLCALL mixer_callback([[maybe_unused]] void* userdata,
                                    SDL_AudioStream* stream, int bytes_requested,
@@ -2630,19 +2630,13 @@ static void SDLCALL mixer_callback([[maybe_unused]] void* userdata,
 
 	// Mac OSX has been observed to be problematic if we ever block inside
 	// SDL's callback. This ensures that we do not block waiting for more
-	// audio. If the queue has run dry, we write what we have available and
-	// the rest of the request is silence.
+	// audio. If the queue has run dry, we write what we have available.
 	const auto frames_to_dequeue = std::min(mixer.final_output.Size(),
 	                                        frames_requested);
 
-	output.resize(frames_requested);
+	const auto frames_received = mixer.final_output.BulkDequeue(output, frames_to_dequeue);
 
-	const auto frames_received = mixer.final_output.BulkDequeue(output.data(),
-	                                                            frames_to_dequeue);
-	// Satisfy any shortfall with silence
-	std::fill(output.begin() + frames_received, output.end(), AudioFrame{});
-
-	SDL_PutAudioStreamData(stream, output.data(), bytes_requested);
+	SDL_PutAudioStreamData(stream, output.data(), check_cast<int>(frames_received) * BytesPerAudioFrame);
 }
 
 float MIXER_GetPlaybackGain()

--- a/src/audio/mixer.cpp
+++ b/src/audio/mixer.cpp
@@ -194,7 +194,15 @@ struct MixerSettings {
 	SDL_AudioDeviceID sdl_device = 0;
 	SDL_AudioStream* sdl_stream  = nullptr;
 
-	std::atomic<MixerState> state = {};
+	// Config-time flag from the `nosound` setting. If set, there is no SDL
+	// audio device and the mixer thread just sleeps for the expected
+	// per-block duration to simulate timing. Never changes after init.
+	bool no_sound = false;
+
+	// Mute FSM (see `MixerMuteState` in mixer.h). When non-Audible, the
+	// mixer still runs `mix_samples()` (so the capture queue IS fed at full
+	// level) but overwrites the SDL-bound buffer with silence.
+	std::atomic<MixerMuteState> mute_state = MixerMuteState::Audible;
 
 	HighpassFilter highpass_filter = {};
 	Compressor compressor          = {};
@@ -208,11 +216,6 @@ struct MixerSettings {
 
 	ChorusSettings chorus = {};
 	bool do_chorus        = false;
-
-	bool is_manually_muted = false;
-
-	// State to restore on `MIXER_Resume()`. Written under `mutex`.
-	MixerState pre_pause_state = MixerState::On;
 
 	std::atomic<bool> fast_forward_mode = false;
 
@@ -2586,9 +2589,18 @@ static void capture_callback()
 	CAPTURE_AddAudioData(mixer.sample_rate_hz, num_frames, frames.data());
 }
 
+// Returns whether the SDL output buffer should currently be silenced.
+// Used both by the mixer thread (to silence `final_output` content under
+// mute) and by `mixer_callback()` (to drive the silence-edge gain ramp).
+static bool mixer_should_silence_output()
+{
+	return DOSBOX_IsPaused() ||
+	       (mixer.mute_state.load(std::memory_order_acquire) !=
+	        MixerMuteState::Audible);
+}
+
 static void SDLCALL mixer_callback([[maybe_unused]] void* userdata,
-                                   SDL_AudioStream* stream,
-                                   int bytes_requested,
+                                   SDL_AudioStream* stream, int bytes_requested,
                                    [[maybe_unused]] int total_bytes)
 {
 	if (bytes_requested <= 0) {
@@ -2624,13 +2636,11 @@ static void SDLCALL mixer_callback([[maybe_unused]] void* userdata,
 	// capture path stays at full level and the fades don't end up in the
 	// captured WAV/AVI audio.
 	//
-	const auto state = mixer.state.load(std::memory_order_relaxed);
-
-	const bool should_silence = (state == MixerState::Paused ||
-	                             state == MixerState::Muted);
+	const bool should_silence = mixer_should_silence_output();
 
 	static float playback_gain  = 1.0f;
 	const float target_gain     = should_silence ? 0.0f : 1.0f;
+
 	constexpr float SmoothingMs = 5.0f;
 
 	const float fade_step = 1.0f / (SmoothingMs *
@@ -2638,17 +2648,18 @@ static void SDLCALL mixer_callback([[maybe_unused]] void* userdata,
 	                                1000.0f);
 
 	// Fade-in is gated on actually receiving real samples from
-	// `final_output`. When resuming, `set_mixer_state()` clears the queue;
-	// if SDL polls before the mixer thread has had a chance to push fresh
-	// real audio, the buffer is silence-filled by the shortfall path above.
-	// Ramping gain up over that silence would hit 1.0 before any real audio
-	// arrives, and the first real sample behind the silence would land at
-	// full gain, resulting in a click. We hold the ramp at its current
-	// value until we see real samples.
+	// `final_output`. On the leave-silent edge we clear the queue (see
+	// `maybe_clear_final_output_on_unsilence`); if SDL polls before the
+	// mixer thread has had a chance to push fresh real audio, the buffer is
+	// silence-filled by the shortfall path above. Ramping gain up over that
+	// silence would hit 1.0 before any real audio arrives, and the first
+	// real sample behind the silence would land at full gain, resulting in
+	// an audible click. We hold the ramp at its current value until we see
+	// real samples.
 	//
 	// Fade-out has no such gating: when there's nothing to drain, gain just
-	// settles at 0.0 against whatever silence the mixer thread pushed,
-	// which is the desired end state.
+	// settles at 0 against whatever silence the mixer thread pushed, which
+	// is the desired end state.
 	//
 	const bool got_real_samples = (frames_received > 0);
 
@@ -2678,8 +2689,7 @@ static void mixer_thread_loop()
 		// Paused short-circuits BEFORE `mix_samples()` to keep frozen channel
 		// state out of the capture queue. Enqueue silence so SDL playback
 		// stays fed.
-		//
-		if (mixer.state == MixerState::Paused) {
+		if (DOSBOX_IsPaused()) {
 			lock.unlock();
 			mixer.output_buffer.assign(mixer.blocksize, AudioFrame{});
 			mixer.final_output.BulkEnqueue(mixer.output_buffer);
@@ -2716,7 +2726,7 @@ static void mixer_thread_loop()
 
 		lock.unlock();
 
-		if (mixer.state == MixerState::NoSound) {
+		if (mixer.no_sound) {
 			// SDL callback is not running. Mixed sound gets
 			// discarded. Sleep for the expected duration to
 			// simulate the time it would have taken to playback the
@@ -2729,9 +2739,16 @@ static void mixer_thread_loop()
 			std::this_thread::sleep_for(
 			        std::chrono::nanoseconds(nap_time));
 			continue;
+		}
 
-		} else if (mixer.state == MixerState::Muted) {
-			// SDL callback remains active. Enqueue silence.
+		if (mixer.mute_state.load(std::memory_order_acquire) !=
+		    MixerMuteState::Audible) {
+
+			// Mute path: `mix_samples()` already ran and the
+			// capture queue is fed at full level (mute should not
+			// silence captures). Overwrite the SDL-bound buffer
+			// with silence before it reaches `final_output`.
+			//
 			mixer.output_buffer.clear();
 			mixer.output_buffer.resize(mixer.blocksize);
 
@@ -2779,58 +2796,183 @@ static void mixer_thread_loop()
 	}
 }
 
-[[maybe_unused]] static const char* to_string(const MixerState s)
+[[maybe_unused]] static const char* to_string(const MixerMuteState s)
 {
 	switch (s) {
-	case MixerState::NoSound: return "No sound";
-	case MixerState::On: return "On";
-	case MixerState::Muted: return "Mute";
-	case MixerState::Paused: return "Paused";
-	default: assertm(false, "Invalid MixerState"); return "";
+	case MixerMuteState::Audible: return "Audible";
+	case MixerMuteState::UserMuted: return "UserMuted";
+	case MixerMuteState::AutoMuted: return "AutoMuted";
+	}
+	assertm(false, "Invalid MixerMuteState");
+	return "";
+}
+
+// Drop any silence the mixer thread queued into `final_output` while we were
+// silent so the fade-in ramp in `mixer_callback()` (silent->Audible edge)
+// lifts gain from 0.0 to 1.0 against the next fresh real audio rather than
+// against the queued silence. Otherwise gain hits 1.0 over the silence, the
+// first real sample lands at full gain, and we get the click the fade was
+// supposed to mask. `capture_queue` is NOT cleared; that's a separate path
+// with its own FIFO invariant.
+//
+// On the way INTO a silent state we intentionally do NOT clear -- any
+// pre-silent real audio still queued drains naturally as SDL pulls, and
+// `mixer_callback()` applies its gain ramp to those samples before they reach
+// the host.
+static void maybe_clear_final_output_on_unsilence(const bool was_silent,
+                                                  const bool will_be_silent)
+{
+	if (was_silent && !will_be_silent) {
+		mixer.final_output.Clear();
 	}
 }
 
-static void set_mixer_state(const MixerState new_state)
+static void set_mute_state(const MixerMuteState new_state)
 {
-	assert(new_state == MixerState::Muted || new_state == MixerState::On ||
-	       new_state == MixerState::Paused);
+	const auto prev_state = mixer.mute_state.load(std::memory_order_acquire);
+	if (prev_state == new_state) {
+		return;
+	}
 
 #ifdef DEBUG_MIXER
-	LOG_MSG("MIXER: Changing mixer state from %s to '%s'",
-	        to_string(mixer.state),
+	LOG_MSG("MIXER: Changing mute state from %s to '%s'",
+	        to_string(prev_state),
 	        to_string(new_state));
 #endif
 
-	if (new_state == MixerState::Muted || new_state == MixerState::Paused) {
-		// Clear queued audio so resume doesn't replay pre-pause samples.
-		// `capture_queue` is NOT cleared; it's a separate path for video
-		// capture that must drain in FIFO order for bit-identical output.
-		mixer.final_output.Clear();
-	}
+	const bool was_audible     = (prev_state == MixerMuteState::Audible);
+	const bool will_be_audible = (new_state == MixerMuteState::Audible);
 
-	mixer.state = new_state;
+	// Only the Audible<->non-Audible edge matters for the SDL fade and for
+	// MIDI/titlebar coordination. UserMuted<->AutoMuted is a pure
+	// bookkeeping change -- the listener experiences continuous silence.
+	//
+	const bool audible_edge = (was_audible != will_be_audible);
+
+	mixer.mute_state.store(new_state, std::memory_order_release);
+
+	if (audible_edge) {
+		// Mute is just one source of silence; pause is the other. The
+		// fade-in clear only matters when the COMBINED silence
+		// condition flips from true to false, so factor in pause too.
+		const bool paused         = DOSBOX_IsPaused();
+		const bool was_silent     = !was_audible || paused;
+		const bool will_be_silent = !will_be_audible || paused;
+
+		maybe_clear_final_output_on_unsilence(was_silent, will_be_silent);
+
+		if (will_be_audible) {
+			MIDI_Unmute();
+			TITLEBAR_NotifyAudioMutedStatus(false);
+
+			LOG_MSG("MIXER: Unmuted audio output");
+
+		} else {
+			MIDI_Mute();
+			TITLEBAR_NotifyAudioMutedStatus(true);
+
+			LOG_MSG("MIXER: Muted audio output");
+		}
+	}
 }
 
-// `MIXER_Pause()` / `MIXER_Resume()` must go through MIXER_LockMixerThread,
-// NOt raw `mixer.mutex`, to compose with the queue-stop / queue-start
-// protocol every other mutator uses.
+MixerMuteState MIXER_GetMuteState()
+{
+	return mixer.mute_state.load(std::memory_order_acquire);
+}
+
+// User-driven path: pressing the mute hotkey (or invoking it remotely).
+// Trumps any `AutoMuted` state in effect -- once the user has decided, only
+// the user can clear it. Callers are responsible for the `no_sound` guard if
+// they want one (the hotkey handler logs a warning there).
+void MIXER_RequestUserMute()
+{
+	using enum MixerMuteState;
+
+	switch (mixer.mute_state.load(std::memory_order_acquire)) {
+	case Audible:
+	case AutoMuted: set_mute_state(UserMuted); break;
+
+	case UserMuted:
+		// already user-muted
+		break;
+	}
+}
+
+void MIXER_RequestUserUnmute()
+{
+	using enum MixerMuteState;
+
+	switch (mixer.mute_state.load(std::memory_order_acquire)) {
+	case UserMuted:
+	case AutoMuted:
+		// User-initiated unmute clears either kind of mute. We treat
+		// "user pressed unmute" as the user taking control regardless
+		// of which path got us here.
+		set_mute_state(Audible);
+		break;
+
+	case Audible:
+		// already audible
+		break;
+	}
+}
+
+// `mute_when_inactive` path: window lost focus.
+void MIXER_RequestAutoMute()
+{
+	using enum MixerMuteState;
+
+	switch (mixer.mute_state.load(std::memory_order_acquire)) {
+	case Audible: set_mute_state(AutoMuted); break;
+
+	case UserMuted:
+	case AutoMuted:
+		// UserMuted survives focus changes. AutoMuted is already in
+		// place. Both no-op.
+		break;
+	}
+}
+
+// `mute_when_inactive` path: window regained focus.
+void MIXER_RequestAutoUnmute()
+{
+	using enum MixerMuteState;
+	switch (mixer.mute_state.load(std::memory_order_acquire)) {
+	case AutoMuted: set_mute_state(Audible); break;
+	case UserMuted:
+	case Audible:
+		// UserMuted must not be cleared by focus gain -- only the user
+		// can clear a user-mute. Audible is a no-op.
+		break;
+	}
+}
+
+// `MIXER_Pause()` / `MIXER_Resume()` don't carry pause state of their own;
+// `DOSBOX_IsPaused()` is the single source of truth and the mixer thread
+// reads it directly at the top of its loop. These functions are just the
+// synchronization barrier: by the time `MIXER_Pause()` returns, the mixer
+// thread has finished any in-flight `mix_samples()` and is at a clean loop
+// boundary; `MIXER_Resume()` additionally clears `final_output` if the
+// listener is now audible (so the fade-in ramps against fresh real audio
+// rather than the silence the mixer thread queued during pause).
 //
-// The mixer thread can be blocked inside a channel handler's
-// `output_queue.BulkDequeue()` (e.g., SB, PC Speaker, GUS, etc.) waiting for
-// samples produced on the main thread. A raw lock would deadlock here: the
-// main thread is stuck waiting for `mixer.mutex`, while the mixer thread
-// holds `mixer.mutex` inside `BulkDequeue()` waiting for samples only the
-// main thread can produce. `NotifyLockMixer()`'s `Stop()` call unblocks
-// `BulkDequeue()` so the mixer thread can release the mutex.
+// Both must go through `MIXER_LockMixerThread()` (NOT raw `mixer.mutex`!) to
+// compose with the queue-stop / queue-start protocol every other mutator
+// uses. The mixer thread can be blocked inside a channel handler's
+// `output_queue.BulkDequeue` (SB, PC Speaker, GUS, etc.) waiting for samples
+// produced on the main thread. A raw lock would deadlock here: the main
+// thread is stuck waiting for `mixer.mutex`, while the mixer thread holds
+// `mixer.mutex` inside `BulkDequeue()` waiting for samples only the main
+// thread can produce. `NotifyLockMixer()`'s `Stop()` unblocks `BulkDequeue()`
+// so the mixer thread can release the mutex.
+//
+// !!! ORDER MATTERS relative to MIDI_Pause/Resume. See the comments on
+// `set_subsystems_paused` in dosbox.cpp. !!!
+//
 void MIXER_Pause()
 {
 	MIXER_LockMixerThread();
-
-	if (mixer.state != MixerState::Paused) {
-		mixer.pre_pause_state = mixer.state;
-		set_mixer_state(MixerState::Paused);
-	}
-
 	MIXER_UnlockMixerThread();
 }
 
@@ -2838,9 +2980,18 @@ void MIXER_Resume()
 {
 	MIXER_LockMixerThread();
 
-	if (mixer.state == MixerState::Paused) {
-		set_mixer_state(mixer.pre_pause_state);
-	}
+	// Callers (`set_subsystems_paused()`) only invoke this on a
+	// Paused -> Running edge, so we always know we were silent due to
+	// pause. If mute is also non-Audible we stay silent and skip the
+	// clear (else we'd nuke the silence the mixer thread is queueing
+	// to keep SDL fed); if mute is Audible the listener is going back
+	// to audible and we drop the queued silence so the fade-in ramps
+	// against fresh real audio.
+	const bool will_be_silent = (mixer.mute_state.load(std::memory_order_acquire) !=
+	                             MixerMuteState::Audible);
+
+	constexpr auto WasSilent = true;
+	maybe_clear_final_output_on_unsilence(WasSilent, will_be_silent);
 
 	MIXER_UnlockMixerThread();
 }
@@ -3058,8 +3209,7 @@ void MIXER_Init()
 	// Initialize the 8-bit to 16-bit lookup table
 	fill_8to16_lut();
 
-	const auto mixer_state = section->GetBool("nosound") ? MixerState::NoSound
-	                                                     : MixerState::On;
+	const auto requested_no_sound = section->GetBool("nosound");
 
 	auto set_no_sound = [&] {
 		assert(mixer.sdl_device == 0);
@@ -3067,7 +3217,7 @@ void MIXER_Init()
 
 		LOG_MSG("MIXER: Sound output disabled ('nosound' mode)");
 
-		mixer.state = MixerState::NoSound;
+		mixer.no_sound = true;
 		set_section_property_value("mixer", "nosound", "on");
 	};
 
@@ -3078,7 +3228,7 @@ void MIXER_Init()
 	const auto blocksize   = parse_blocksize(section);
 	mixer.blocksize        = blocksize.value_or(DefaultBlocksize);
 
-	if (mixer_state == MixerState::NoSound) {
+	if (requested_no_sound) {
 		set_no_sound();
 
 	} else {
@@ -3091,7 +3241,8 @@ void MIXER_Init()
 			// We never use SDL's pause feature. Instead we write silence when we mute the audio.
 			SDL_SetAudioStreamGetCallback(mixer.sdl_stream, mixer_callback, nullptr);
 
-			set_mixer_state(MixerState::On);
+			// `mute_state` defaults to Audible and `paused`
+			// defaults to false; nothing more to set here.
 		} else {
 			set_no_sound();
 		}
@@ -3186,101 +3337,34 @@ static void notify_mixer_setting_updated(SectionProp& section,
 	MIXER_UnlockMixerThread();
 }
 
-void MIXER_Mute()
-{
-	if (mixer.state == MixerState::On) {
-		set_mixer_state(MixerState::Muted);
-		MIDI_Mute();
-
-		TITLEBAR_NotifyAudioMutedStatus(true);
-		LOG_MSG("MIXER: Muted audio output");
-	}
-}
-
-void MIXER_Unmute()
-{
-	if (mixer.state == MixerState::Muted) {
-		set_mixer_state(MixerState::On);
-		MIDI_Unmute();
-
-		TITLEBAR_NotifyAudioMutedStatus(false);
-		LOG_MSG("MIXER: Unmuted audio output");
-	}
-}
-
-bool MIXER_IsManuallyMuted()
-{
-	return mixer.is_manually_muted;
-}
-
-// Toggle the mixer on/off when a 'true' bool is passed in.
+// Mute hotkey handler.
+//
+// Toggle semantics: audible -> mute, any-muted -> audible. We do NOT upgrade
+// `AutoMuted` to `UserMuted` here; a user pressing the hotkey while
+// focus-loss has silenced the mixer is asking for sound, not asking to
+// "double-down" on the silence. (The FSM does support that upgrade via
+// `MIXER_RequestUserMute()` directly, for callers that genuinely want it,
+// e.g., a future HTTP API command.)
 static void handle_toggle_mute(const bool was_pressed)
 {
-	using enum MixerState;
-
 	// The "pressed" bool argument is used by the Mapper API, which sends a
 	// true-bool for key down events and a false-bool for key up events.
 	if (!was_pressed) {
 		return;
 	}
 
-	switch (mixer.state) {
-	case NoSound:
-		LOG_WARNING("MIXER: Mute requested, but sound is disabled ('nosound' mode)");
-		break;
+	if (mixer.no_sound) {
+		LOG_WARNING(
+		        "MIXER: Mute requested, but sound is disabled "
+		        "('nosound' mode)");
+		return;
+	}
 
-	case Muted:
-		MIXER_Unmute();
-		mixer.is_manually_muted = false;
-		break;
-
-	case On:
-		MIXER_Mute();
-		mixer.is_manually_muted = true;
-		break;
-
-	case Paused:
-		// We're paused. `MIXER_Pause()` saved the previous state for
-		// `MIXER_Resume()` to restore. Flip that saved state and the
-		// manual-mute flag here so resume picks up what the user just asked
-		// for. Also update external MIDI mute and the titlebar so the user
-		// sees the change right away.
-		//
-		// Lock the mixer thread while writing; the mixer thread reads
-		// `pre_pause_state` with the same lock held in `MIXER_Resume()`.
-		MIXER_LockMixerThread();
-
-		switch (mixer.pre_pause_state) {
-		case On:
-			mixer.pre_pause_state   = Muted;
-			mixer.is_manually_muted = true;
-
-			MIDI_Mute();
-			TITLEBAR_NotifyAudioMutedStatus(true);
-
-			LOG_MSG("MIXER: Muted audio output");
-			break;
-
-		case Muted:
-			mixer.pre_pause_state   = On;
-			mixer.is_manually_muted = false;
-
-			MIDI_Unmute();
-			TITLEBAR_NotifyAudioMutedStatus(false);
-
-			LOG_MSG("MIXER: Unmuted audio output");
-			break;
-
-		default:
-			// `pre_pause_state` is captured by `MIXER_Pause()` from
-			// the live state and only ever `On` or `Muted`.
-			assertm(false, "Invalid pre-pause MixerState");
-			break;
-		}
-
-		MIXER_UnlockMixerThread();
-		break;
-	};
+	if (MIXER_GetMuteState() == MixerMuteState::Audible) {
+		MIXER_RequestUserMute();
+	} else {
+		MIXER_RequestUserUnmute();
+	}
 }
 
 static void init_mixer_config_settings(SectionProp& sec_prop)

--- a/src/audio/mixer.cpp
+++ b/src/audio/mixer.cpp
@@ -2674,7 +2674,7 @@ static float compute_fade_step()
 
 static float target_fade_gain()
 {
-	const bool should_silence = DOSBOX_IsPauseRequested() ||
+	const auto should_silence = DOSBOX_IsPauseRequested() ||
 	                            (mixer.mute_state.load(std::memory_order_acquire) !=
 	                             MixerMuteState::Audible);
 
@@ -2871,14 +2871,14 @@ static void set_mute_state(const MixerMuteState new_state)
 	        to_string(new_state));
 #endif
 
-	const bool was_audible     = (prev_state == MixerMuteState::Audible);
-	const bool will_be_audible = (new_state == MixerMuteState::Audible);
+	const auto was_audible     = (prev_state == MixerMuteState::Audible);
+	const auto will_be_audible = (new_state == MixerMuteState::Audible);
 
 	// Only the Audible<->non-Audible edge matters for MIDI / titlebar
 	// coordination. UserMuted<->AutoMuted is a pure bookkeeping change
 	// -- the listener experiences continuous silence.
 	//
-	const bool audible_edge = (was_audible != will_be_audible);
+	const auto audible_edge = (was_audible != will_be_audible);
 
 	mixer.mute_state.store(new_state, std::memory_order_release);
 

--- a/src/audio/mixer.cpp
+++ b/src/audio/mixer.cpp
@@ -2597,13 +2597,19 @@ static void SDLCALL mixer_callback([[maybe_unused]] void* userdata,
 
 	// Mac OSX has been observed to be problematic if we ever block inside
 	// SDL's callback. This ensures that we do not block waiting for more
-	// audio. If the queue has run dry, we write what we have available.
+	// audio. If the queue has run dry, we write what we have available and
+	// the rest of the request is silence.
 	const auto frames_to_dequeue = std::min(mixer.final_output.Size(),
 	                                        frames_requested);
 
-	const auto frames_received = mixer.final_output.BulkDequeue(output, frames_to_dequeue);
+	output.resize(frames_requested);
 
-	SDL_PutAudioStreamData(stream, output.data(), check_cast<int>(frames_received) * BytesPerAudioFrame);
+	const auto frames_received = mixer.final_output.BulkDequeue(output.data(),
+	                                                             frames_to_dequeue);
+	// Satisfy any shortfall with silence
+	std::fill(output.begin() + frames_received, output.end(), AudioFrame{});
+
+	SDL_PutAudioStreamData(stream, output.data(), bytes_requested);
 }
 
 static void mixer_thread_loop()

--- a/src/audio/mixer.cpp
+++ b/src/audio/mixer.cpp
@@ -2708,17 +2708,16 @@ static void mixer_thread_loop()
 	const auto fade_step = compute_fade_step();
 
 	while (!mixer.thread_should_quit) {
-		std::unique_lock lock(mixer.mutex);
-
 		// Paused short-circuits BEFORE `mix_samples()` to keep frozen
 		// channel state out of the capture queue (we want bit-identical
 		// captures compared to not pausing at all). At this point the
 		// fade-out has already completed (that's what triggered the
 		// Pending -> Paused transition), so `playback_gain` is already
 		// at 0 and no further ramp is needed here.
+		//
+		// `DOSBOX_IsPaused()` is a lock-free atomic read; we take
+		// `mixer.mutex` (below) only for `mix_samples()`.
 		if (DOSBOX_IsPaused()) {
-			lock.unlock();
-
 			if (mixer.no_sound) {
 				// No SDL device, no consumer for
 				// `final_output`. Just sleep to simulate the
@@ -2742,6 +2741,8 @@ static void mixer_thread_loop()
 			mixer.final_output.BulkEnqueue(mixer.output_buffer);
 			continue;
 		}
+
+		std::unique_lock lock(mixer.mutex);
 
 		// This code is mostly for the fast-forward button (hold Alt + F12)
 		const auto now         = PIC_AtomicIndex();

--- a/src/audio/mixer.cpp
+++ b/src/audio/mixer.cpp
@@ -2541,40 +2541,43 @@ static void mix_samples(const int frames_requested)
 	}
 }
 
-// Run in the main thread by a PIC Callback
+// Run in the main thread by a PIC Callback. Drains whatever's currently in
+// the capture queue; never zero-pads. `mix_samples()` produces in
+// ~`blocksize` bursts paced by SDL, while this callback is paced by
+// emulator ticks -- two independent clocks. The queue can be momentarily
+// empty when the consumer wakes up before the producer (most visibly across
+// a pause/resume edge); padding with silence would splice zero samples into
+// the captured WAV / AVI audio track. The producer catches up on its next
+// iteration and FIFO ordering keeps capture bit-identical to a
+// continuously-running capture.
+//
+// AVI side effect: 01wb audio chunks per 00dc video frame become bursty
+// rather than uniform -- some video frames get an oversized audio chunk,
+// others get none. Total sample count and the audio stream's reported rate
+// are unchanged, and modern demuxers (VLC, ffmpeg-based players, mpv) sync
+// on sample/frame counts rather than chunk interleaving, so playback is
+// correct. Restoring uniform per-tick chunks would require a smoothing
+// buffer here with a prebuffer to absorb producer jitter; not worth the
+// complexity since no demuxer in current use cares.
 static void capture_callback()
 {
 	if (!(CAPTURE_IsCapturingAudio() || CAPTURE_IsCapturingVideo())) {
 		return;
 	}
 
-	static float frame_counter = 0.0f;
-	frame_counter += get_mixer_frames_per_tick();
-
-	const int num_frames = ifloor(frame_counter);
-	assert(num_frames > 0);
-
-	frame_counter -= static_cast<float>(num_frames);
-
-	const int num_samples = num_frames * 2;
-
-	// We can't block waiting on the mixer thread
-	// Some mixer channels block waiting on the main thread and this would
-	// deadlock
 	static std::vector<int16_t> frames = {};
 	frames.clear();
 
-	const int samples_available = check_cast<int>(mixer.capture_queue.Size());
-	const int samples_requested = std::min(num_samples, samples_available);
-
-	if (samples_requested > 0) {
-		mixer.capture_queue.BulkDequeue(frames,
-		                                std::min(num_samples,
-		                                         samples_available));
+	const auto samples_available = mixer.capture_queue.Size();
+	if (samples_available == 0) {
+		return;
 	}
 
-	// Fill with silence if needed
-	frames.resize(num_samples);
+	mixer.capture_queue.BulkDequeue(frames, samples_available);
+
+	constexpr auto SamplesPerFrame = 2;
+	const auto num_frames = check_cast<uint32_t>(samples_available /
+	                                             SamplesPerFrame);
 
 	CAPTURE_AddAudioData(mixer.sample_rate_hz, num_frames, frames.data());
 }

--- a/src/audio/mixer.h
+++ b/src/audio/mixer.h
@@ -54,8 +54,8 @@ using MIXER_Handler = std::function<void(int frames)>;
 //   UserMuted  -> AutoMuted    user-mute survives focus changes
 //   UserMuted  -> any via RequestAutoUnmute
 //
-// Pause is orthogonal -- see `MIXER_Pause()` / `MIXER_Resume()`. The mixer
-// is silent if EITHER `DOSBOX_IsPaused()` OR `mute_state != Audible`. The
+// Pause is orthogonal to mute. The mixer is silent if EITHER
+// `DOSBOX_IsPaused()` OR `mute_state != Audible`. The
 // two axes don't share state, so toggling mute during pause is just a
 // normal mute transition.
 //
@@ -538,26 +538,6 @@ void MIXER_RequestUserUnmute();
 // both -- user-initiated mute trumps focus changes.
 void MIXER_RequestAutoMute();
 void MIXER_RequestAutoUnmute();
-
-// Pause synchronization barrier. The mixer reads `DOSBOX_IsPaused()`
-// directly at the top of its loop, so these don't mutate any mixer-side
-// state -- they just serialize against in-flight `mix_samples()`. By
-// the time `MIXER_Pause()` returns, the mixer thread is at a clean loop
-// boundary.
-//
-// Pause is orthogonal to mute: the mixer output is silent if either is
-// in effect (via the silence-edge fade in `mixer_thread_loop()`). Pause
-// additionally short-circuits `mix_samples()` so the capture queue
-// isn't fed during pause; mute lets `mix_samples()` run and folds mute
-// into the fade target, so captures stay full-volume while SDL output
-// smoothly attenuates to silence.
-//
-// !!! PAUSE ORDER MATTERS relative to MIDI_Pause/Resume (halt the synth
-// renderer first); resume order does not. See `set_subsystems_paused` in
-// dosbox.cpp before reordering callers. !!!
-//
-void MIXER_Pause();
-void MIXER_Resume();
 
 // Current fade-out/-in gain (0.0 = silent, 1.0 = full). Updated by the
 // mixer thread on each iteration. Read by the PausePending FSM in

--- a/src/audio/mixer.h
+++ b/src/audio/mixer.h
@@ -521,17 +521,18 @@ void MIXER_RequestUserUnmute();
 void MIXER_RequestAutoMute();
 void MIXER_RequestAutoUnmute();
 
-// Pause synchronization barrier. The mixer reads `DOSBOX_IsPaused()` directly
-// at the top of its loop, so these don't mutate any mixer-side state -- they
-// just serialize against in-flight `mix_samples()`. By the time
-// `MIXER_Pause()` returns the mixer thread is at a clean loop boundary;
-// `MIXER_Resume()` additionally clears `final_output` so the silence-edge
-// fade-in ramps against fresh real audio.
+// Pause synchronization barrier. The mixer reads `DOSBOX_IsPaused()`
+// directly at the top of its loop, so these don't mutate any mixer-side
+// state -- they just serialize against in-flight `mix_samples()`. By
+// the time `MIXER_Pause()` returns, the mixer thread is at a clean loop
+// boundary.
 //
-// Pause is orthogonal to mute: the mixer is silent on the SDL side if either
-// is in effect. Pause additionally short-circuits `mix_samples()` so the
-// capture queue isn't fed during pause; mute lets `mix_samples()` run and
-// overwrites only the SDL-bound buffer, so captures stay full-volume.
+// Pause is orthogonal to mute: the mixer output is silent if either is
+// in effect (via the silence-edge fade in `mixer_thread_loop()`). Pause
+// additionally short-circuits `mix_samples()` so the capture queue
+// isn't fed during pause; mute lets `mix_samples()` run and folds mute
+// into the fade target, so captures stay full-volume while SDL output
+// smoothly attenuates to silence.
 //
 // !!! PAUSE ORDER MATTERS relative to MIDI_Pause/Resume (halt the synth
 // renderer first); resume order does not. See `set_subsystems_paused` in
@@ -540,11 +541,11 @@ void MIXER_RequestAutoUnmute();
 void MIXER_Pause();
 void MIXER_Resume();
 
-// Current SDL-side fade-out/-in gain (0.0 = silent, 1.0 = full). Updated
-// by `mixer_callback()` on each SDL callback. Read by the PausePending
-// FSM in dosbox.cpp to know when a fade-out has completed, so it can
-// hand off to the actually-paused state at the exact moment the
-// audible fade reaches zero.
+// Current fade-out/-in gain (0.0 = silent, 1.0 = full). Updated by the
+// mixer thread on each iteration. Read by the PausePending FSM in
+// dosbox.cpp to know when a fade-out has completed, so it can hand off
+// to the actually-paused state at the exact moment the audible fade
+// reaches zero.
 float MIXER_GetPlaybackGain();
 
 void MIXER_LockMixerThread();

--- a/src/audio/mixer.h
+++ b/src/audio/mixer.h
@@ -34,7 +34,42 @@
 // 48000 Hz, that's 48 frames.
 using MIXER_Handler = std::function<void(int frames)>;
 
-enum class MixerState { NoSound, On, Muted, Paused };
+// Mute FSM. Mirrors the structure of `DOSBOX_PauseState` in dosbox.h; two
+// distinct mute causes (user / focus-loss) with overlapping behaviour but
+// separate ownership of the transition.
+//
+// Transitions:
+//   Audible    -> UserMuted    `MIXER_RequestUserMute()`
+//   Audible    -> AutoMuted    `MIXER_RequestAutoMute()`
+//   UserMuted  -> Audible      `MIXER_RequestUserUnmute()`
+//
+//   AutoMuted  -> Audible      `MIXER_RequestAutoUnmute()` /
+//                              `MIXER_RequestUserUnmute()`
+//
+//   AutoMuted  -> UserMuted    `MIXER_RequestUserMute()` (upgrade)
+//
+// No-ops (intentional):
+//
+//   UserMuted  -> AutoMuted    user-mute survives focus changes
+//   UserMuted  -> any via RequestAutoUnmute
+//
+// Pause is orthogonal -- see `MIXER_Pause()` / `MIXER_Resume()`. The mixer
+// is silent if EITHER `DOSBOX_IsPaused()` OR `mute_state != Audible`. The
+// two axes don't share state, so toggling mute during pause is just a
+// normal mute transition.
+//
+enum class MixerMuteState {
+	// Output flows normally to SDL.
+	Audible,
+
+	// User toggled the via the hotkey or the HTTP API.
+	// Survives focus changes; only the user can clear it.
+	UserMuted,
+
+	// `mute_when_inactive` kicked in on focus loss.
+	// Cleared automatically on focus gain.
+	AutoMuted
+};
 
 static constexpr int MixerBufferByteSize = 16 * 1024;
 static constexpr int MixerBufferMask     = MixerBufferByteSize - 1;
@@ -473,12 +508,35 @@ bool MIXER_FastForwardModeEnabled();
 const AudioFrame MIXER_GetMasterVolume();
 void MIXER_SetMasterVolume(const AudioFrame gain);
 
-void MIXER_Mute();
-void MIXER_Unmute();
+// Mute FSM. See the comment on `MixerMuteState` above for the state graph
+// and the rationale for orthogonal pause / mute states.
+MixerMuteState MIXER_GetMuteState();
 
-// Enter `MixerState::Paused` (mixer thread short-circuits before
-// `mix_samples()`). Acquires `mixer.mutex`; on return any in-flight mix is
-// over. Captures the pre-pause state so `MIXER_Resume()` can restore it.
+// User-driven hotkey path. Overrides any AutoMuted state in effect.
+void MIXER_RequestUserMute();
+void MIXER_RequestUserUnmute();
+
+// `mute_when_inactive` focus-loss / focus-gain path. UserMuted survives
+// both -- user-initiated mute trumps focus changes.
+void MIXER_RequestAutoMute();
+void MIXER_RequestAutoUnmute();
+
+// Pause synchronization barrier. The mixer reads `DOSBOX_IsPaused()` directly
+// at the top of its loop, so these don't mutate any mixer-side state -- they
+// just serialize against in-flight `mix_samples()`. By the time
+// `MIXER_Pause()` returns the mixer thread is at a clean loop boundary;
+// `MIXER_Resume()` additionally clears `final_output` so the silence-edge
+// fade-in ramps against fresh real audio.
+//
+// Pause is orthogonal to mute: the mixer is silent on the SDL side if either
+// is in effect. Pause additionally short-circuits `mix_samples()` so the
+// capture queue isn't fed during pause; mute lets `mix_samples()` run and
+// overwrites only the SDL-bound buffer, so captures stay full-volume.
+//
+// !!! PAUSE ORDER MATTERS relative to MIDI_Pause/Resume (halt the synth
+// renderer first); resume order does not. See `set_subsystems_paused` in
+// dosbox.cpp before reordering callers. !!!
+//
 void MIXER_Pause();
 void MIXER_Resume();
 
@@ -491,10 +549,6 @@ void MIXER_CloseAudioDevice();
 // `Off` to `Pending` so the mixer thread still sees `Off` and isn't
 // enqueueing fresh samples that this call would wipe.
 void MIXER_ClearCaptureQueue();
-
-// Return true if the mixer was explicitly muted by the user (as opposed to
-// auto-muted when `mute_when_inactive` is enabled).
-bool MIXER_IsManuallyMuted();
 
 CrossfeedPreset MIXER_GetCrossfeedPreset();
 void MIXER_SetCrossfeedPreset(const CrossfeedPreset new_preset);

--- a/src/audio/mixer.h
+++ b/src/audio/mixer.h
@@ -34,7 +34,7 @@
 // 48000 Hz, that's 48 frames.
 using MIXER_Handler = std::function<void(int frames)>;
 
-enum class MixerState { NoSound, On, Muted };
+enum class MixerState { NoSound, On, Muted, Paused };
 
 static constexpr int MixerBufferByteSize = 16 * 1024;
 static constexpr int MixerBufferMask     = MixerBufferByteSize - 1;
@@ -471,6 +471,12 @@ void MIXER_SetMasterVolume(const AudioFrame gain);
 
 void MIXER_Mute();
 void MIXER_Unmute();
+
+// Enter `MixerState::Paused` (mixer thread short-circuits before
+// `mix_samples()`). Acquires `mixer.mutex`; on return any in-flight mix is
+// over. Captures the pre-pause state so `MIXER_Resume()` can restore it.
+void MIXER_Pause();
+void MIXER_Resume();
 
 void MIXER_LockMixerThread();
 void MIXER_UnlockMixerThread();

--- a/src/audio/mixer.h
+++ b/src/audio/mixer.h
@@ -63,7 +63,7 @@ enum class MixerMuteState {
 	// Output flows normally to SDL.
 	Audible,
 
-	// User toggled the via the hotkey or the HTTP API.
+	// User toggled the mute via the hotkey or the HTTP API.
 	// Survives focus changes; only the user can clear it.
 	UserMuted,
 
@@ -78,7 +78,7 @@ enum class MuteRequest {
 	UserMute,
 	UserUnmute,
 
-	// Intenet coming from the `mute_when_inactive` focus loss / gain path.
+	// Intent coming from the `mute_when_inactive` focus loss / gain path.
 	AutoMute,
 	AutoUnmute
 };

--- a/src/audio/mixer.h
+++ b/src/audio/mixer.h
@@ -13,6 +13,7 @@
 #include <map>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <set>
 #include <string>
 #include <utility>
@@ -69,6 +70,17 @@ enum class MixerMuteState {
 	// `mute_when_inactive` kicked in on focus loss.
 	// Cleared automatically on focus gain.
 	AutoMuted
+};
+
+// Intent signals that drive the mute FSM.
+enum class MuteRequest {
+	// Intent coming from the hotkey invocations / HTTP API
+	UserMute,
+	UserUnmute,
+
+	// Intenet coming from the `mute_when_inactive` focus loss / gain path.
+	AutoMute,
+	AutoUnmute
 };
 
 static constexpr int MixerBufferByteSize = 16 * 1024;
@@ -511,6 +523,12 @@ void MIXER_SetMasterVolume(const AudioFrame gain);
 // Mute FSM. See the comment on `MixerMuteState` above for the state graph
 // and the rationale for orthogonal pause / mute states.
 MixerMuteState MIXER_GetMuteState();
+
+// Pure mute-transition policy: the next state for `request` in `current`, or
+// `nullopt` if the request is a no-op there. No side effects -- the
+// `MIXER_Request*()` functions below apply its result.
+std::optional<MixerMuteState> MIXER_NextMuteState(MixerMuteState current,
+                                                  MuteRequest request);
 
 // User-driven hotkey path. Overrides any AutoMuted state in effect.
 void MIXER_RequestUserMute();

--- a/src/audio/mixer.h
+++ b/src/audio/mixer.h
@@ -482,6 +482,12 @@ void MIXER_LockMixerThread();
 void MIXER_UnlockMixerThread();
 void MIXER_CloseAudioDevice();
 
+// Drop any leftover audio samples sitting in the capture queue between
+// recording sessions. Must be called BEFORE flipping a capture state from
+// `Off` to `Pending` so the mixer thread still sees `Off` and isn't
+// enqueueing fresh samples that this call would wipe.
+void MIXER_ClearCaptureQueue();
+
 // Return true if the mixer was explicitly muted by the user (as opposed to
 // auto-muted when `mute_when_inactive` is enabled).
 bool MIXER_IsManuallyMuted();

--- a/src/audio/mixer.h
+++ b/src/audio/mixer.h
@@ -34,9 +34,9 @@
 // 48000 Hz, that's 48 frames.
 using MIXER_Handler = std::function<void(int frames)>;
 
-// Mute FSM. Mirrors the structure of `DOSBOX_PauseState` in dosbox.h; two
-// distinct mute causes (user / focus-loss) with overlapping behaviour but
-// separate ownership of the transition.
+// Mute FSM. Mirrors the structure of the pause FSM in `src/dosbox.cpp` --
+// two distinct mute causes (user / focus-loss) with overlapping behaviour
+// but separate ownership of the transition.
 //
 // Transitions:
 //   Audible    -> UserMuted    `MIXER_RequestUserMute()`

--- a/src/audio/mixer.h
+++ b/src/audio/mixer.h
@@ -323,7 +323,7 @@ public:
 		static constexpr auto DefaultWaitMs = 500;
 		static constexpr auto MaxWaitMs     = 5000;
 
-		AudioFrame last_frame          = {};
+		AudioFrame last_frame = {};
 		// Wakeup timestamp in PIC (emulator) milliseconds, not wall
 		// clock. The mixer pauses with `DOSBOX_IsPaused()`; PIC time
 		// freezes with it. Using `GetTicks()` would count the pause as
@@ -484,8 +484,8 @@ private:
 
 using MixerChannelPtr = std::shared_ptr<MixerChannel>;
 
-MixerChannelPtr MIXER_AddChannel(MIXER_Handler handler,
-                                 const int sample_rate_hz, const std::string& name,
+MixerChannelPtr MIXER_AddChannel(MIXER_Handler handler, const int sample_rate_hz,
+                                 const std::string& name,
                                  const std::set<ChannelFeature>& features);
 
 MixerChannelPtr MIXER_FindChannel(const char* name);
@@ -539,6 +539,13 @@ void MIXER_RequestAutoUnmute();
 //
 void MIXER_Pause();
 void MIXER_Resume();
+
+// Current SDL-side fade-out/-in gain (0.0 = silent, 1.0 = full). Updated
+// by `mixer_callback()` on each SDL callback. Read by the PausePending
+// FSM in dosbox.cpp to know when a fade-out has completed, so it can
+// hand off to the actually-paused state at the exact moment the
+// audible fade reaches zero.
+float MIXER_GetPlaybackGain();
 
 void MIXER_LockMixerThread();
 void MIXER_UnlockMixerThread();

--- a/src/audio/mixer.h
+++ b/src/audio/mixer.h
@@ -289,7 +289,11 @@ public:
 		static constexpr auto MaxWaitMs     = 5000;
 
 		AudioFrame last_frame          = {};
-		int64_t woken_at_ms            = {};
+		// Wakeup timestamp in PIC (emulator) milliseconds, not wall
+		// clock. The mixer pauses with `DOSBOX_IsPaused()`; PIC time
+		// freezes with it. Using `GetTicks()` would count the pause as
+		// "awake" and force a fade-out / sleep on resume.
+		double woken_at_pic_ms         = {};
 		float fadeout_level            = {};
 		float fadeout_decrement_per_ms = {};
 		int fadeout_or_sleep_after_ms  = {};

--- a/src/capture/capture.cpp
+++ b/src/capture/capture.cpp
@@ -13,6 +13,7 @@
 #include "private/capture_midi.h"
 #include "private/capture_video.h"
 
+#include "audio/mixer.h"
 #include "config/config.h"
 #include "config/setup.h"
 #include "dosbox.h"
@@ -354,6 +355,15 @@ void CAPTURE_StartVideoCapture()
 {
 	switch (capture.state.video) {
 	case CaptureState::Off:
+		// Audio and video share the mixer's capture queue. If neither is
+		// currently capturing, drop any stale samples left behind by the
+		// previous session before flipping to `Pending`; `mix_samples()`
+		// still sees `Off` here and won't enqueue fresh samples that the
+		// clear would wipe.
+		//
+		if (capture.state.audio == CaptureState::Off) {
+			MIXER_ClearCaptureQueue();
+		}
 		capture.state.video = CaptureState::Pending;
 
 		TITLEBAR_NotifyVideoCaptureStatus(true);
@@ -464,6 +474,12 @@ static void handle_capture_audio_event(bool pressed)
 
 	switch (capture.state.audio) {
 	case CaptureState::Off:
+		// See `CAPTURE_StartVideoCapture()` for why we clear the queue
+		// only when no other capture stream is already keeping it active.
+		//
+		if (capture.state.video == CaptureState::Off) {
+			MIXER_ClearCaptureQueue();
+		}
 		capture.state.audio = CaptureState::Pending;
 		if (DOSBOX_IsPaused()) {
 			LOG_MSG("CAPTURE: Preparing to capture audio output; "

--- a/src/capture/capture.cpp
+++ b/src/capture/capture.cpp
@@ -15,6 +15,7 @@
 
 #include "config/config.h"
 #include "config/setup.h"
+#include "dosbox.h"
 #include "dosbox_config.h"
 #include "gui/mapper.h"
 #include "gui/titlebar.h"
@@ -354,8 +355,15 @@ void CAPTURE_StartVideoCapture()
 	switch (capture.state.video) {
 	case CaptureState::Off:
 		capture.state.video = CaptureState::Pending;
+
 		TITLEBAR_NotifyVideoCaptureStatus(true);
+
+		if (DOSBOX_IsPaused()) {
+			LOG_MSG("CAPTURE: Preparing to capture video output; "
+					"capturing will start once unpaused");
+		}
 		break;
+
 	case CaptureState::Pending:
 	case CaptureState::InProgress:
 		LOG_WARNING("CAPTURE: Already capturing video output");
@@ -369,17 +377,22 @@ void CAPTURE_StopVideoCapture()
 	case CaptureState::Off:
 		LOG_WARNING("CAPTURE: Not capturing video output");
 		break;
+
 	case CaptureState::Pending:
-		// It's very hard to hit this branch; handling it for
-		// completeness only
-		LOG_MSG("CAPTURE: Cancelling pending video output capture");
 		capture.state.video = CaptureState::Off;
+
 		TITLEBAR_NotifyVideoCaptureStatus(false);
+
+		LOG_MSG("CAPTURE: Stopped capturing video output "
+		        "(no frames were written)");
 		break;
+
 	case CaptureState::InProgress:
 		capture_video_finalise();
 		capture.state.video = CaptureState::Off;
+
 		TITLEBAR_NotifyVideoCaptureStatus(false);
+
 		LOG_MSG("CAPTURE: Stopped capturing video output");
 	}
 }
@@ -451,19 +464,24 @@ static void handle_capture_audio_event(bool pressed)
 
 	switch (capture.state.audio) {
 	case CaptureState::Off:
-		// Capturing the audio output will start in the next few
-		// milliseconds when CAPTURE_AddAudioData is called
 		capture.state.audio = CaptureState::Pending;
+		if (DOSBOX_IsPaused()) {
+			LOG_MSG("CAPTURE: Preparing to capture audio output; "
+			        "capturing will start with the next audio frame");
+		}
 		break;
+
 	case CaptureState::Pending:
-		// It's practically impossible to hit this branch; handling it
-		// for completeness only
 		capture.state.audio = CaptureState::Off;
-		LOG_MSG("CAPTURE: Cancelled pending audio output capture");
+
+		LOG_MSG("CAPTURE: Stopped capturing audio output "
+		        "(no audio was written)");
 		break;
+
 	case CaptureState::InProgress:
 		capture_audio_finalise();
 		capture.state.audio = CaptureState::Off;
+
 		LOG_MSG("CAPTURE: Stopped capturing audio output");
 		break;
 	}
@@ -485,14 +503,18 @@ static void handle_capture_midi_event(bool pressed)
 		LOG_MSG("CAPTURE: Preparing to capture MIDI output; "
 		        "capturing will start on the first MIDI message");
 		break;
+
 	case CaptureState::Pending:
 		capture.state.midi = CaptureState::Off;
-		LOG_MSG("CAPTURE: Stopped capturing MIDI output before any "
-		        "MIDI message was output (no MIDI file has been created)");
+
+		LOG_MSG("CAPTURE: Stopped capturing MIDI output "
+		        "(no MIDI messages were written)");
 		break;
+
 	case CaptureState::InProgress:
 		capture_midi_finalise();
 		capture.state.midi = CaptureState::Off;
+
 		LOG_MSG("CAPTURE: Stopped capturing MIDI output");
 		break;
 	}

--- a/src/capture/capture_video.cpp
+++ b/src/capture/capture_video.cpp
@@ -9,6 +9,7 @@
 
 #include <cassert>
 #include <cmath>
+#include <cstring>
 
 #include "hardware/memory.h"
 #include "misc/support.h"
@@ -16,8 +17,50 @@
 
 static constexpr auto NumSampleFramesInBuffer = 16 * 1024;
 
-static constexpr auto SampleFrameSize  = 4;
+static constexpr auto SampleFrameSizeBytes = 4;
 static constexpr auto NumAudioChannels = 2;
+
+// The mixer delivers captured audio to us in producer-paced bursts, while
+// `capture_video_add_frame()` runs per emulated video frame; these are two
+// independent clocks. Dumping every sample buffered since the last frame into
+// a single `01wb` chunk therefore can yields wildly uneven per-frame audio.
+//
+// Instead, we meter a fixed per-frame target out of the buffer and hold this
+// many sample frames in reserve, so short-term producer jitter is absorbed by
+// the reserve and the emitted chunks stay uniform. The cost is a constant
+// audio-behind-video interleave offset of roughly this many frames, which
+// demuxers reconcile from the stream's sample/frame counts. Sized well above
+// the mixer blocksize (1024 by default) and well below the 16K buffer
+// capacity so we neither underrun on jitter nor risk the overflow drop in
+// `capture_video_add_audio_data()`.
+static constexpr int AudioPrebufferFrames = 4 * 1024;
+
+// Captured-audio resync (surplus shedding)
+// ========================================
+//
+// A host too slow to emulate in real time makes the mixer (paced by the wall
+// clock, to feed the audio device) produce more audio than the video timeline
+// (paced by emulated time) can hold. The excess piles up in the buffer above
+// the prebuffer set-point. We periodically "shed" that surplus so the
+// captured audio stays locked to the video (this is a "controlled skip
+// forward") and crossfade each cut to avoid audible clicks.
+
+// Minimum spacing between sheds, in video frames. Every shed is a crossfade
+// seam; shedding on every frame (typically up to 50 to 70 times per second)
+// sounds choppy, so we let the surplus accumulate and cut less often. So we
+// do larger but fewer skips which sound better. A minimum spacing of 7 frames
+// gives the best overall results that works well enough for fast-paced music,
+// too (we could use a higher value for slower paces music).
+static constexpr int AudioResyncIntervalVideoFrames = 7;
+
+// Don't shed a surplus smaller than this. Keeps normal producer jitter (which
+// the prebuffer already absorbs) from triggering needless cuts, so captures
+// on a fast-enough host stay pristine. ~21 ms at 48 kHz.
+static constexpr int AudioResyncMinSurplusFrames = 1024;
+
+// Frames blended across each cut to smooth the skip-forward. ~2.7 ms for 48
+// kHz audio in 70 Hz VGA modes.
+static constexpr int AudioResyncCrossfadeFrames = 128;
 
 static constexpr auto AviHeaderSize = 500;
 
@@ -38,11 +81,29 @@ static struct {
 	uint32_t index_used        = 0;
 
 	struct {
+		// Unit model: this buffer and every count derived from it are
+		// measured in audio *sample frames* -- one L+R pair of
+		// `NumAudioChannels` samples. `SampleFrameSizeBytes` converts a
+		// frame count to bytes; names ending in `VideoFrames` count
+		// emulated video frames instead.
 		int16_t buf[NumSampleFramesInBuffer][NumAudioChannels] = {};
 
-		uint32_t sample_rate     = 0;
-		uint32_t buf_frames_used = 0;
-		uint32_t bytes_written   = 0;
+		uint32_t sample_rate         = 0;
+		uint32_t num_buffered_frames = 0;
+		uint32_t bytes_written       = 0;
+
+		// Fractional per-frame emit target; carries the sub-frame
+		// remainder (and any unmet demand from an underrun) between
+		// video frames. See `AudioPrebufferFrames`.
+		double frame_credit = 0.0;
+
+		// False until the reserve has first filled to
+		// `AudioPrebufferFrames`; gates the start of metered output.
+		bool is_primed = false;
+
+		// Video frames since the last surplus shed; gates the resync
+		// cadence. See `AudioResyncIntervalVideoFrames`.
+		int num_video_frames_since_resync = 0;
 	} audio = {};
 } video = {};
 
@@ -119,6 +180,98 @@ static void add_avi_chunk(const char* tag, const uint32_t size,
 	host_writed(index + 12, size);
 }
 
+// Writes the first `num_sample_frames` sample frames from the audio buffer as
+// a single `01wb` AVI chunk, then shifts any remaining frames down to the
+// front of the buffer. A no-op when `num_sample_frames` is zero.
+static void write_audio_chunk(const int num_sample_frames)
+{
+	assert(num_sample_frames <=
+	       static_cast<int>(video.audio.num_buffered_frames));
+
+	if (num_sample_frames == 0) {
+		return;
+	}
+
+	add_avi_chunk("01wb",
+	              num_sample_frames * SampleFrameSizeBytes,
+	              video.audio.buf,
+	              0);
+
+	video.audio.bytes_written += num_sample_frames * SampleFrameSizeBytes;
+
+	// Slide the frames we didn't write down to the front so the next chunk
+	// starts at index 0.
+	const int num_remaining_frames = static_cast<int>(
+	                                         video.audio.num_buffered_frames) -
+	                                 num_sample_frames;
+
+	if (num_remaining_frames > 0) {
+		memmove(video.audio.buf,
+		        video.audio.buf[num_sample_frames],
+		        num_remaining_frames * SampleFrameSizeBytes);
+	}
+	video.audio.num_buffered_frames = num_remaining_frames;
+}
+
+// Sheds `num_frames_to_drop` sample frames from the front of the audio buffer
+// to pull the captured audio back in step with the video timeline (see
+// `AudioResyncIntervalVideoFrames`). Excising a run of frames outright would
+// click, so we instead crossfade the retained head into the audio just past
+// the cut: over `num_crossfade_frames` frames we fade the kept audio out
+// (weight `1 - blend_weight`) while fading in the audio `num_frames_to_drop`
+// frames later (weight `blend_weight`). `blend_weight` runs
+// `(frame + 1) / (num_crossfade_frames + 1)` -- the `+ 1`s keep it strictly
+// between 0 and 1 so neither source is fully cut off at a seam. Then the tail
+// is shifted down. Net effect: a smooth skip-forward of `num_frames_to_drop`
+// frames.
+static void drop_audio_surplus_with_crossfade(const int num_frames_to_drop)
+{
+	if (num_frames_to_drop == 0) {
+		return;
+	}
+
+	// Keep the fade region inside the dropped run so the fade-out and
+	// fade-in sources never overlap.
+	const int num_crossfade_frames = (AudioResyncCrossfadeFrames < num_frames_to_drop)
+	                                       ? AudioResyncCrossfadeFrames
+	                                       : num_frames_to_drop;
+
+	// The dropped run plus the run we blend into must both be present.
+	assert(static_cast<int>(video.audio.num_buffered_frames) >=
+	       num_frames_to_drop + num_crossfade_frames);
+
+	for (int frame = 0; frame < num_crossfade_frames; ++frame) {
+		const auto blend_weight = static_cast<float>(frame + 1) /
+		                          static_cast<float>(num_crossfade_frames + 1);
+
+		for (int channel = 0; channel < NumAudioChannels; ++channel) {
+			const auto fade_out_sample = static_cast<float>(
+			        video.audio.buf[frame][channel]);
+
+			const auto fade_in_sample = static_cast<float>(
+			        video.audio.buf[num_frames_to_drop + frame][channel]);
+
+			video.audio.buf[frame][channel] = clamp_to_int16(
+			        iroundf(fade_out_sample * (1.0f - blend_weight) +
+			                fade_in_sample * blend_weight));
+		}
+	}
+
+	// Slide the untouched tail up so it sits directly behind the blended
+	// head, closing the gap the skipped frames left behind.
+	const int tail_start_frame = num_frames_to_drop + num_crossfade_frames;
+	const int num_tail_frames = static_cast<int>(video.audio.num_buffered_frames) -
+	                            tail_start_frame;
+
+	if (num_tail_frames > 0) {
+		memmove(video.audio.buf[num_crossfade_frames],
+		        video.audio.buf[tail_start_frame],
+		        num_tail_frames * SampleFrameSizeBytes);
+	}
+
+	video.audio.num_buffered_frames -= num_frames_to_drop;
+}
+
 void capture_video_finalise()
 {
 	if (!video.handle) {
@@ -127,6 +280,11 @@ void capture_video_finalise()
 	if (video.codec) {
 		video.codec->FinishVideo();
 	}
+
+	// Flush all audio still held back by the per-frame prebuffer so the
+	// stream contains every produced sample. Must run before the header is
+	// built below, which reads `bytes_written` as the audio stream length.
+	write_audio_chunk(video.audio.num_buffered_frames);
 
 	uint8_t avi_header[AviHeaderSize];
 	uint32_t header_pos = 0;
@@ -229,17 +387,17 @@ void capture_video_finalise()
 	AVIOUTd(4); /* Scale */
 
 	/* Rate, actual rate is scale/rate */
-	AVIOUTd(video.audio.sample_rate * SampleFrameSize);
+	AVIOUTd(video.audio.sample_rate * SampleFrameSizeBytes);
 	AVIOUTd(0); /* Start */
 
 	if (!video.audio.sample_rate) {
 		video.audio.sample_rate = 1;
 	}
 
-	AVIOUTd(video.audio.bytes_written / SampleFrameSize); /* Length */
+	AVIOUTd(video.audio.bytes_written / SampleFrameSizeBytes); /* Length */
 	AVIOUTd(0);               /* SuggestedBufferSize */
 	AVIOUTd(~0);              /* Quality */
-	AVIOUTd(SampleFrameSize); /* SampleSize */
+	AVIOUTd(SampleFrameSizeBytes); /* SampleSize */
 	AVIOUTd(0);               /* Frame */
 	AVIOUTd(0);               /* Frame */
 
@@ -249,7 +407,7 @@ void capture_video_finalise()
 	AVIOUTw(1);                       /* Format, WAVE_ZMBV_FORMAT_PCM */
 	AVIOUTw(2);                       /* Number of channels */
 	AVIOUTd(video.audio.sample_rate); /* SamplesPerSec */
-	AVIOUTd(video.audio.sample_rate * SampleFrameSize); /* AvgBytesPerSec*/
+	AVIOUTd(video.audio.sample_rate * SampleFrameSizeBytes); /* AvgBytesPerSec*/
 	AVIOUTw(4);                                         /* BlockAlign */
 	AVIOUTw(16);                                        /* BitsPerSample */
 
@@ -284,6 +442,11 @@ void capture_video_finalise()
 	video.handle = nullptr;
 }
 
+// Buffers freshly captured audio delivered by the capture pipeline until
+// `capture_video_add_frame()` meters it back out one video frame at a time. The
+// buffer is fixed-size: if it is already full we copy only what fits and drop
+// the remainder -- a last-resort overflow valve that the resync shedding (see
+// the `AudioResync*` constants) is designed to keep us clear of.
 void capture_video_add_audio_data(const uint32_t sample_rate,
                                   const uint32_t num_sample_frames,
                                   const int16_t* sample_frames)
@@ -291,16 +454,19 @@ void capture_video_add_audio_data(const uint32_t sample_rate,
 	if (!video.handle) {
 		return;
 	}
-	auto frames_left = NumSampleFramesInBuffer - video.audio.buf_frames_used;
+
+	// Take the smaller of the buffer's free space and the incoming count;
+	// any excess beyond the free space is dropped.
+	auto frames_left = NumSampleFramesInBuffer - video.audio.num_buffered_frames;
 	if (frames_left > num_sample_frames) {
 		frames_left = num_sample_frames;
 	}
 
-	memcpy(&video.audio.buf[video.audio.buf_frames_used],
+	memcpy(&video.audio.buf[video.audio.num_buffered_frames],
 	       sample_frames,
-	       frames_left * SampleFrameSize);
+	       frames_left * SampleFrameSizeBytes);
 
-	video.audio.buf_frames_used += frames_left;
+	video.audio.num_buffered_frames += frames_left;
 	video.audio.sample_rate = sample_rate;
 }
 
@@ -332,10 +498,14 @@ static void create_avi_file(const uint16_t width, const uint16_t height,
 		fputc(0, video.handle);
 	}
 
-	video.frames                = 0;
-	video.written               = 0;
-	video.audio.buf_frames_used = 0;
-	video.audio.bytes_written   = 0;
+	video.frames  = 0;
+	video.written = 0;
+
+	video.audio.num_buffered_frames           = 0;
+	video.audio.bytes_written                 = 0;
+	video.audio.frame_credit                  = 0.0;
+	video.audio.is_primed                     = false;
+	video.audio.num_video_frames_since_resync = 0;
 }
 
 // Performs some transforms on the passed down rendered image to make sure
@@ -487,16 +657,76 @@ void capture_video_add_frame(const RenderedImage& image, const float frames_per_
 	add_avi_chunk("00dc", written, video.buf.data(), codec_flags & 1 ? 0x10 : 0x0);
 	video.frames++;
 
-	//		LOG_MSG("CAPTURE: Frame %d video %d audio
-	//%d",video.frames, written, video.audio_buf_frames_used *4 );
-	if (video.audio.buf_frames_used) {
-		add_avi_chunk("01wb",
-		              video.audio.buf_frames_used * SampleFrameSize,
-		              video.audio.buf,
-		              0);
+	// Meter audio out evenly across video frames instead of dumping every
+	// sample that arrived since the last frame into one `01wb` chunk. We
+	// hold back a reserve (`AudioPrebufferFrames`) and emit a fixed
+	// per-frame target, so bursty producer output is smoothed into uniform
+	// chunks.
+	if (!video.audio.is_primed) {
+		if (video.audio.num_buffered_frames < AudioPrebufferFrames) {
+			// Still building the reserve; nothing to emit yet.
+			return;
+		}
+		video.audio.is_primed = true;
+	}
 
-		video.audio.bytes_written += video.audio.buf_frames_used *
-		                             SampleFrameSize;
-		video.audio.buf_frames_used = 0;
+	// One video frame spans `1 / frames_per_second` seconds, which at the
+	// capture sample rate is this many audio sample frames. Accumulate it
+	// as a running credit and emit whole frames only, carrying the
+	// fractional remainder forward so the audio rate stays exact over time.
+	video.audio.frame_credit += static_cast<double>(video.audio.sample_rate) /
+	                            video.frames_per_second;
+
+	int num_audio_frames_to_write = ifloor(video.audio.frame_credit);
+
+	// Underrun (reserve exhausted by a long producer stall): emit whatever
+	// is available rather than padding with silence, keeping the captured
+	// stream bit-identical to what was produced. The unmet demand stays in
+	// `frame_credit` and drains once the producer catches up.
+	if (num_audio_frames_to_write >
+	    static_cast<int>(video.audio.num_buffered_frames)) {
+		num_audio_frames_to_write = static_cast<int>(
+		        video.audio.num_buffered_frames);
+	}
+
+	video.audio.frame_credit -= num_audio_frames_to_write;
+	write_audio_chunk(num_audio_frames_to_write);
+
+	// Shed accumulated surplus to keep the captured audio locked to the
+	// (emulated-time) video timeline. See the `AudioResync*` constants.
+	++video.audio.num_video_frames_since_resync;
+
+	// The surplus is whatever sits above the steady-state reserve; only this
+	// excess is eligible to be shed (the reserve itself is never touched).
+	const int num_surplus_frames =
+	        (video.audio.num_buffered_frames > AudioPrebufferFrames)
+	                ? static_cast<int>(video.audio.num_buffered_frames -
+	                                   AudioPrebufferFrames)
+	                : 0;
+
+	// Force an early shed well before the buffer's hard capacity (at around
+	// ~75% capacity) so a very slow host can't overrun it (and hit the drop
+	// in `capture_video_add_audio_data()`) between scheduled sheds.
+	const auto is_buffer_near_full = video.audio.num_buffered_frames >
+	                                 (NumSampleFramesInBuffer * 3) / 4;
+
+	const auto is_resync_due = video.audio.num_video_frames_since_resync >=
+	                           AudioResyncIntervalVideoFrames;
+
+	if (num_surplus_frames >= AudioResyncMinSurplusFrames &&
+	    (is_resync_due || is_buffer_near_full)) {
+
+		[[maybe_unused]] const int num_video_frames_waited =
+		        video.audio.num_video_frames_since_resync;
+
+		drop_audio_surplus_with_crossfade(num_surplus_frames);
+		video.audio.num_video_frames_since_resync = 0;
+
+		LOG_DEBUG("CAPTURE: Audio resync after %d frames%s -- shed %d sample frames, buffer now %u (target %d)",
+		          num_video_frames_waited,
+		          is_buffer_near_full ? " (buffer pressure)" : "",
+		          num_surplus_frames,
+		          video.audio.num_buffered_frames,
+		          AudioPrebufferFrames);
 	}
 }

--- a/src/capture/capture_video.cpp
+++ b/src/capture/capture_video.cpp
@@ -495,8 +495,8 @@ void capture_video_add_frame(const RenderedImage& image, const float frames_per_
 		              video.audio.buf,
 		              0);
 
-		video.audio.bytes_written = video.audio.buf_frames_used *
-		                            SampleFrameSize;
+		video.audio.bytes_written += video.audio.buf_frames_used *
+		                             SampleFrameSize;
 		video.audio.buf_frames_used = 0;
 	}
 }

--- a/src/capture/image/image_capturer.cpp
+++ b/src/capture/image/image_capturer.cpp
@@ -7,6 +7,7 @@
 #include <string>
 
 #include "config/setup.h"
+#include "dosbox.h"
 #include "misc/std_filesystem.h"
 #include "utils/checks.h"
 #include "utils/string_utils.h"
@@ -194,12 +195,41 @@ ImageSaver& ImageCapturer::GetNextImageSaver()
 	return image_savers[current_image_saver_index];
 }
 
+// During pause, `RENDER_EndUpdate()` doesn't fire, so the normal vertical
+// retrace-driven `MaybeCaptureImage()` drain never runs and the request stays
+// in `Pending` forever (rendered-only captures would also hit a stale
+// `rendered_path` from a prior non-paused capture).
+//
+// Drive the drain synchronously here using the source latch via
+// `RENDER_GetCurrentImage()`; each press allocates its own index inside
+// `MaybeCaptureImage()` so repeated capture actions produce distinct indexed
+// files. No effect outside pause.
+//
+void ImageCapturer::MaybeDrainOnPause()
+{
+	if (!DOSBOX_IsPaused()) {
+		return;
+	}
+
+	// If no frame has been completed yet (e.g., pause activated during
+	// startup before the first VGA scanout), the latched image is empty and
+	// there's nothing to capture.
+	const auto image = RENDER_GetCurrentImage();
+	if (!image.image_data) {
+		return;
+	}
+
+	MaybeCaptureImage(image);
+}
+
 void ImageCapturer::RequestRawCapture()
 {
 	if (state.raw != CaptureState::Off) {
 		return;
 	}
+
 	state.raw = CaptureState::Pending;
+	MaybeDrainOnPause();
 }
 
 void ImageCapturer::RequestUpscaledCapture()
@@ -207,7 +237,9 @@ void ImageCapturer::RequestUpscaledCapture()
 	if (state.upscaled != CaptureState::Off) {
 		return;
 	}
+
 	state.upscaled = CaptureState::Pending;
+	MaybeDrainOnPause();
 }
 
 void ImageCapturer::RequestRenderedCapture()
@@ -215,7 +247,9 @@ void ImageCapturer::RequestRenderedCapture()
 	if (state.rendered != CaptureState::Off) {
 		return;
 	}
+
 	state.rendered = CaptureState::Pending;
+	MaybeDrainOnPause();
 }
 
 void ImageCapturer::RequestGroupedCapture()
@@ -224,4 +258,5 @@ void ImageCapturer::RequestGroupedCapture()
 		return;
 	}
 	state.grouped = CaptureState::Pending;
+	MaybeDrainOnPause();
 }

--- a/src/capture/image/image_capturer.h
+++ b/src/capture/image/image_capturer.h
@@ -99,6 +99,8 @@ private:
 	void ConfigureGroupedMode(const std::string& prefs);
 
 	ImageSaver& GetNextImageSaver();
+
+	void MaybeDrainOnPause();
 };
 
 #endif // DOSBOX_IMAGE_CAPTURER_H

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -12,7 +12,6 @@
 #include <cstring>
 #include <limits>
 #include <memory>
-#include <mutex>
 
 #ifdef WIN32
 #ifndef WIN32_LEAN_AND_MEAN
@@ -152,21 +151,20 @@ void Null_Init([[maybe_unused]] Section* sec)
 // applies the result. That policy is the single source of truth for what
 // each event does; it is exhaustively unit tested in isolation.
 //
-// THREADING: every mutator runs on the main (emulation) thread -- hotkeys
-// and window events via the SDL event loop, HTTP commands via the
-// webserver bridge's `ProcessRequests()`, and the pending-transition
-// handler via the PIC ticker. The request helpers read `pause_state`
-// without holding `pause_state_mutex` before transitioning, so the mutex
-// alone would NOT make concurrent requesters correct (racy requests would
-// trip the `is_valid_transition()` guard rather than corrupt state). Keep
-// it that way: other threads may only *read* the state, via the
-// `DOSBOX_Is*()` query functions.
+// THREADING: `pause_state` has a single writer, the main (emulation) thread.
+// Every mutator runs there: hotkeys and window events via the SDL event loop,
+// HTTP commands via the webserver bridge's `ProcessRequests()`, and the
+// pending-transition handler via the PIC ticker. All other threads (the mixer
+// and MIDI renderer threads) only *read* the state, via the `DOSBOX_Is*()`
+// query functions. With a single writer no lock is needed; the atomic exists
+// purely to make those cross-thread reads well-defined.
 //
 // The `PauseState` and `PauseEvent` enums and the pure `NextPauseState()`
 // transition table live in `dosbox_pause_fsm.h`.
 // ---------------------------------------------------------------------------
 
-static std::mutex pause_state_mutex;
+// Single writer (the main thread; see THREADING above).
+// All other threads read only.
 static std::atomic<PauseState> pause_state{PauseState::Running};
 
 static const char* to_string(const PauseState s)
@@ -197,9 +195,8 @@ static bool is_paused_state(const PauseState s)
 
 // Structural guard for the application layer: which edges the FSM permits at
 // all. Every state produced by `NextPauseState()` satisfies this, plus the
-// unconditional force-to-`Running` used on shutdown. `set_pause_state_locked()`
-// asserts on it to catch a bad direct store or a race between an unlocked
-// request read and the locked write.
+// unconditional force-to-`Running` used on shutdown. `set_pause_state()`
+// asserts on it to catch a bad direct store.
 static bool is_valid_transition(const PauseState from, const PauseState to)
 {
 	using enum PauseState;
@@ -345,7 +342,7 @@ bool DOSBOX_IsPauseRequested()
 	return get_pause_state() != PauseState::Running;
 }
 
-// Subsystem pause hook driven by the FSM. Called by `set_pause_state_locked()`
+// Subsystem pause hook driven by the FSM. Called by `set_pause_state()`
 // only on the actually-paused edge, so it never fires redundantly. Mapper UI
 // doesn't go through here -- it pauses audio via MIXER_LockMixerThread directly
 // in mapper.cpp, which composes correctly with this path because both agree on
@@ -396,18 +393,10 @@ static void set_subsystems_paused(const bool paused)
 	}
 }
 
-static void set_pause_state_locked(const PauseState new_state);
-
+// Applies a validated pause-state transition and drives the subsystem hooks.
+// Only ever called on the main thread (see THREADING above), so nothing has
+// to serialise concurrent transitions.
 static void set_pause_state(const PauseState new_state)
-{
-	const std::lock_guard lock(pause_state_mutex);
-	set_pause_state_locked(new_state);
-}
-
-// Common transition body. Must be called with `pause_state_mutex` held --
-// this lets `pending_pause_tick_handler()` re-enter without racing an
-// in-flight user-requested transition.
-static void set_pause_state_locked(const PauseState new_state)
 {
 	using enum PauseState;
 
@@ -495,14 +484,9 @@ static void pending_pause_tick_handler()
 		return;
 	}
 
-	const std::lock_guard lock(pause_state_mutex);
-
-	// Re-check under the lock in case the state moved between the
-	// unlocked fast-path checks and now (e.g. the user resumed during
-	// the fade).
 	if (const auto next = NextPauseState(pause_state.load(),
 	                                     PauseEvent::FadeComplete)) {
-		set_pause_state_locked(*next);
+		set_pause_state(*next);
 	}
 }
 

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -164,8 +164,29 @@ PauseState DOSBOX_GetPauseState()
 	return pause_state.load();
 }
 
-// Forward decl; body lives next to the `ticks` struct it operates on.
-static void rebase_wall_clock_on_resume();
+// Idempotent subsystem pause hook driven by the FSM. Mapper UI doesn't go
+// through here -- it pauses audio via `MIXER_LockMixerThread()` directly in
+// `mapper.cpp`, which composes correctly with this path because both agree on
+// `mixer.mutex`.
+//
+static void set_subsystems_paused(const bool paused)
+{
+	static bool audio_paused = false;
+	if (paused == audio_paused) {
+		return;
+	}
+	audio_paused = paused;
+	if (paused) {
+		MIXER_Pause();
+	} else {
+		MIXER_Resume();
+	}
+}
+
+static void update_subsystem_pause_state()
+{
+	set_subsystems_paused(DOSBOX_IsPaused());
+}
 
 void DOSBOX_SetPauseState(const PauseState new_state)
 {
@@ -194,6 +215,8 @@ void DOSBOX_SetPauseState(const PauseState new_state)
 	if (was_paused && now_running) {
 		rebase_wall_clock_on_resume();
 	}
+
+	update_subsystem_pause_state();
 
 	LOG_MSG("DOSBOX: Pause %s -> %s",
 	        to_string(prev),

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -78,10 +78,10 @@
 #include "webserver/bridge.h"
 #include "webserver/webserver.h"
 
-MachineType machine   = MachineType::None;
-SvgaType    svga_type = SvgaType::None;
+MachineType machine = MachineType::None;
+SvgaType svga_type  = SvgaType::None;
 
-static LoopHandler * loop;
+static LoopHandler* loop;
 
 static struct {
 	int64_t remain    = {};
@@ -121,7 +121,8 @@ void DOSBOX_SetTicksScheduled(const int64_t ticks_scheduled)
 	ticks.scheduled = ticks_scheduled;
 }
 
-void Null_Init([[maybe_unused]] Section *sec) {
+void Null_Init([[maybe_unused]] Section* sec)
+{
 	// do nothing
 }
 
@@ -210,20 +211,33 @@ bool DOSBOX_IsPaused()
 // mapper.cpp, which composes correctly with this path because both agree on
 // mixer.mutex.
 //
-// !!! ORDERING IS CRITICAL. !!!
+// !!! PAUSE ORDERING IS CRITICAL; resume ordering is not. !!!
 //
 // The MIDI software synths (FluidSynth, MT-32, SoundCanvas) each run a
 // renderer thread that fills an `audio_frame_fifo` ahead of the mixer's
-// consumption. If the mixer stops draining BEFORE the renderer halts, or the
-// renderer wakes BEFORE the mixer starts draining, the renderer rushes to
-// fill the fifo headroom and the synth's internal clock advances by up to one
-// mixer pull (potentially up to 21 ms with common buffer sizes) per cycle.
-// Those extra samples reach the capture queue on resume and "stretch" the
-// captured music by N * ~21 ms over N pause/resume cycles.
+// consumption.
 //
-// Therefore, on pause, we must halt the *renderer* FIRST. On resume, we must
-// wake the *mixer* FIRST. Do NOT swap these without understanding what you're
-// doing!
+// On PAUSE: halt the renderer FIRST. If the mixer halted first, the
+// still-running renderer would rush to fill the fifo headroom that
+// opens up, advancing the synth's internal clock by up to one mixer
+// pull (~21 ms) per cycle. Those extra samples reach the capture queue
+// on resume and stretch captured music by N * ~21 ms over N
+// pause/resume cycles.
+//
+// The renderers stop their own `audio_frame_fifo` while parked (see the
+// synth `Render()` loops), so a mixer `BulkDequeue()` that races the
+// halt gets a short read -- silence-padded by the synth's
+// `MixerCallback()` -- instead of blocking on the empty-but-running
+// queue. That block (`mix_samples()` stuck mid-`BulkDequeue()` waiting
+// for a halted renderer while holding `mixer.mutex`) was the
+// pause/resume deadlock; the fifo stop removes it. `MIDI_Pause()` and
+// `MIDI_Resume()` therefore need no `MIXER_LockMixerThread()` coverage.
+//
+// On RESUME: order no longer matters for correctness. Even if the mixer
+// races into `mix_samples()` before the renderer wakes, its
+// `BulkDequeue()` short-reads on the stopped fifo rather than blocking
+// on a still-parked renderer. We wake the renderer first anyway,
+// mirroring the pause path.
 //
 static void set_subsystems_paused(const bool paused)
 {
@@ -231,7 +245,9 @@ static void set_subsystems_paused(const bool paused)
 	if (paused == audio_paused) {
 		return;
 	}
+
 	audio_paused = paused;
+
 	if (paused) {
 		// MIDI first so the synth renderer stops before the mixer
 		// stops draining.
@@ -239,10 +255,11 @@ static void set_subsystems_paused(const bool paused)
 		MIXER_Pause();
 
 	} else {
-		// MIXER first so the mixer drains the pre-pause buffered
-		// audio before the renderer wakes and refills the headroom.
-		MIXER_Resume();
+		// Order-independent now: the stopped fifo makes a racing
+		// mixer `BulkDequeue()` short-read instead of deadlocking.
+		// Wake the renderer first anyway, mirroring the pause path.
 		MIDI_Resume();
+		MIXER_Resume();
 	}
 }
 
@@ -623,7 +640,8 @@ static void increase_ticks()
 					         (ratio_not_removed +
 					          1024.0 / (static_cast<double>(ratio)));
 
-					new_cycle_max = static_cast<int>(CPU_CycleMax * r + 1);
+					new_cycle_max = static_cast<int>(
+					        CPU_CycleMax * r + 1);
 				} else {
 					auto ratio_with_removed = static_cast<int64_t>(
 					        ((static_cast<double>(ratio) - 1024.0) *
@@ -762,10 +780,12 @@ static void DOSBOX_UnlockSpeed(bool pressed)
 		MIXER_EnableFastForwardMode();
 
 		if (CPU_CycleAutoAdjust) {
-			autoadjust = true;
+			autoadjust          = true;
 			CPU_CycleAutoAdjust = false;
 			CPU_CycleMax /= 3;
-			if (CPU_CycleMax<1000) CPU_CycleMax=1000;
+			if (CPU_CycleMax < 1000) {
+				CPU_CycleMax = 1000;
+			}
 		}
 	} else {
 		LOG_MSG("Fast Forward OFF");
@@ -773,7 +793,7 @@ static void DOSBOX_UnlockSpeed(bool pressed)
 		MIXER_DisableFastForwardMode();
 
 		if (autoadjust) {
-			autoadjust = false;
+			autoadjust          = false;
 			CPU_CycleAutoAdjust = true;
 		}
 	}
@@ -783,7 +803,8 @@ void DOSBOX_SetMachineTypeFromConfig(SectionProp& section)
 {
 	const auto arguments = &control->arguments;
 	if (!arguments->machine.empty()) {
-		//update value in config (else no matching against suggested values
+		// update value in config (else no matching against suggested
+		// values
 		section.HandleInputLine(std::string("machine=") + arguments->machine);
 	}
 
@@ -822,7 +843,7 @@ void DOSBOX_SetMachineTypeFromConfig(SectionProp& section)
 		int10.vesa_nolfb = true;
 	} else if (machine_str == "vesa_oldvbe") {
 
-		svga_type = SvgaType::S3;
+		svga_type         = SvgaType::S3;
 		int10.vesa_oldvbe = true;
 
 	} else if (machine_str == "svga_et3000") {
@@ -1089,8 +1110,8 @@ static void notify_dosbox_setting_updated(const SectionProp& section,
 		VGA_SetRefreshRateMode(section.GetString("dos_rate"));
 
 	} else if (prop_name == "shell_config_shortcuts") {
-		// No need to re-init anything; the setting is always queried when
-		// executing a command.
+		// No need to re-init anything; the setting is always queried
+		// when executing a command.
 	}
 }
 

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -618,6 +618,13 @@ void DOSBOX_RunMachine()
 void DOSBOX_RequestShutdown()
 {
 	is_shutdown_requested.store(true, std::memory_order_relaxed);
+
+	// Force-resume so `paused_tick()` exits and subsystem teardown happens
+	// from a known-running state. Without this, teardown would block on
+	// the mixer / synth threads that are parked in their pause hooks.
+	if (DOSBOX_IsPaused()) {
+		DOSBOX_SetPauseState(PauseState::Running);
+	}
 }
 
 bool DOSBOX_IsShutdownRequested()

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -288,9 +288,40 @@ void DOSBOX_RequestUserResume()
 	case UserPaused: DOSBOX_SetPauseState(Running); break;
 
 	case Running:
+	case AutoPaused: break;
+
+	default: assertm(false, "Invalid PauseState value");
+	}
+}
+
+void DOSBOX_RequestAutoPause()
+{
+	using enum PauseState;
+
+	switch (DOSBOX_GetPauseState()) {
+	case Running: DOSBOX_SetPauseState(AutoPaused); break;
+
+	case UserPaused:
 	case AutoPaused:
-		// only the focus handler resumes auto-pauses
+		// user-pause survives auto signals; auto-pause is idempotent
 		break;
+
+	default: assertm(false, "Invalid PauseState value");
+	}
+}
+
+void DOSBOX_RequestAutoResume()
+{
+	using enum PauseState;
+
+	switch (DOSBOX_GetPauseState()) {
+	case AutoPaused: DOSBOX_SetPauseState(Running); break;
+
+	case Running:
+	case UserPaused:
+		// never auto-resume a user pause
+		break;
+
 	default: assertm(false, "Invalid PauseState value");
 	}
 }

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -430,7 +430,7 @@ static void set_pause_state_locked(const PauseState new_state)
 	}
 
 	if (!is_valid_transition(prev_state, new_state)) {
-		LOG_WARNING("DOSBOX: Invalid pause transition %s -> %s",
+		LOG_WARNING("DOSBOX: Invalid pause transition %s -> %s", //-V510
 		            to_string(prev_state),
 		            to_string(new_state));
 

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -342,54 +342,17 @@ bool DOSBOX_IsPauseRequested()
 	return get_pause_state() != PauseState::Running;
 }
 
-// Subsystem pause hook driven by the FSM. Called by `set_pause_state()`
-// only on the actually-paused edge, so it never fires redundantly. Mapper UI
-// doesn't go through here -- it pauses audio via MIXER_LockMixerThread directly
-// in mapper.cpp, which composes correctly with this path because both agree on
-// mixer.mutex.
-//
-// !!! PAUSE ORDERING IS CRITICAL; resume ordering is not. !!!
-//
-// The MIDI software synths (FluidSynth, MT-32, SoundCanvas) each run a
-// renderer thread that fills an `audio_frame_fifo` ahead of the mixer's
-// consumption.
-//
-// On PAUSE: halt the renderer FIRST. If the mixer halted first, the
-// still-running renderer would rush to fill the fifo headroom that
-// opens up, advancing the synth's internal clock by up to one mixer
-// pull (~21 ms) per cycle. Those extra samples reach the capture queue
-// on resume and stretch captured music by N * ~21 ms over N
-// pause/resume cycles.
-//
-// The renderers stop their own `audio_frame_fifo` while parked (see the
-// synth `Render()` loops), so a mixer `BulkDequeue()` that races the
-// halt gets a short read -- silence-padded by the synth's
-// `MixerCallback()` -- instead of blocking on the empty-but-running
-// queue. That block (`mix_samples()` stuck mid-`BulkDequeue()` waiting
-// for a halted renderer while holding `mixer.mutex`) was the
-// pause/resume deadlock; the fifo stop removes it. `MIDI_Pause()` and
-// `MIDI_Resume()` therefore need no `MIXER_LockMixerThread()` coverage.
-//
-// On RESUME: order no longer matters for correctness. Even if the mixer
-// races into `mix_samples()` before the renderer wakes, its
-// `BulkDequeue()` short-reads on the stopped fifo rather than blocking
-// on a still-parked renderer. We wake the renderer first anyway,
-// mirroring the pause path.
-//
+// Subsystem pause hook driven by the FSM. Called by `set_pause_state()` only
+// on the actually-paused edge. The mixer needs no hook here -- it reads
+// `DOSBOX_IsPaused()` at the top of its loop and skips `mix_samples()` while
+// paused. Only the MIDI synth renderers have to be actively halted, so their
+// internal clock doesn't advance while paused (see `MIDI_Pause()`).
 static void set_subsystems_paused(const bool paused)
 {
 	if (paused) {
-		// MIDI first so the synth renderer stops before the mixer
-		// stops draining.
 		MIDI_Pause();
-		MIXER_Pause();
-
 	} else {
-		// Order-independent now: the stopped fifo makes a racing
-		// mixer `BulkDequeue()` short-read instead of deadlocking.
-		// Wake the renderer first anyway, mirroring the pause path.
 		MIDI_Resume();
-		MIXER_Resume();
 	}
 }
 

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -39,6 +39,7 @@
 #include "gui/common.h"
 #include "gui/mapper.h"
 #include "gui/render/render.h"
+#include "gui/titlebar.h"
 #include "hardware/audio/gus.h"
 #include "hardware/audio/imfc.h"
 #include "hardware/audio/innovation.h"
@@ -74,8 +75,8 @@
 #include "shell/autoexec.h"
 #include "shell/shell.h"
 #include "utils/math_utils.h"
-#include "webserver/webserver.h"
 #include "webserver/bridge.h"
+#include "webserver/webserver.h"
 
 MachineType machine   = MachineType::None;
 SvgaType    svga_type = SvgaType::None;
@@ -192,37 +193,56 @@ static void update_subsystem_pause_state()
 
 void DOSBOX_SetPauseState(const PauseState new_state)
 {
-	const std::lock_guard lock(pause_state_mutex);
+	using enum PauseState;
 
-	const auto prev = pause_state.load();
-	if (prev == new_state) {
-		return;
+	bool was_paused  = false;
+	bool now_running = false;
+	PauseState prev  = Running;
+
+	{
+		const std::lock_guard lock(pause_state_mutex);
+
+		prev = pause_state.load();
+		if (prev == new_state) {
+			return;
+		}
+
+		if (!is_valid_transition(prev, new_state)) {
+			LOG_WARNING("DOSBOX: Invalid pause transition %s -> %s",
+			            to_string(prev),
+			            to_string(new_state));
+
+			assertm(false, "Invalid PauseState transition");
+			return;
+		}
+
+		was_paused  = (prev == UserPaused || prev == FocusLossPaused);
+		now_running = (new_state == Running);
+
+		pause_state.store(new_state);
+
+		if (was_paused && now_running) {
+			rebase_wall_clock_on_resume();
+		}
+
+		update_subsystem_pause_state();
 	}
 
-	if (!is_valid_transition(prev, new_state)) {
-		LOG_WARNING("DOSBOX: Invalid pause transition %s -> %s",
-		            to_string(prev),
-		            to_string(new_state));
+	// Log pause state and refresh the titlebar only on user-visible
+	// transitions: pause becoming active or resumed.
+	const bool now_paused = (new_state == UserPaused ||
+	                         new_state == FocusLossPaused);
 
-		assert(false);
-		return;
+	if (now_paused != was_paused) {
+		TITLEBAR_RefreshTitle();
 	}
 
-	const bool was_paused  = (prev == PauseState::UserPaused ||
-                                 prev == PauseState::FocusLossPaused);
-	const bool now_running = (new_state == PauseState::Running);
+	if (now_paused && !was_paused) {
+		LOG_MSG("DOSBOX: Paused");
 
-	pause_state.store(new_state);
-
-	if (was_paused && now_running) {
-		rebase_wall_clock_on_resume();
+	} else if (was_paused && now_running) {
+		LOG_MSG("DOSBOX: Resumed");
 	}
-
-	update_subsystem_pause_state();
-
-	LOG_MSG("DOSBOX: Pause %s -> %s",
-	        to_string(prev),
-	        to_string(new_state));
 }
 
 void DOSBOX_RequestUserPause()

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -143,7 +143,7 @@ static const char* to_string(const PauseState s)
 	switch (s) {
 	case Running: return "Running";
 	case UserPaused: return "UserPaused";
-	case FocusLossPaused: return "FocusLossPaused";
+	case AutoPaused: return "AutoPaused";
 	default: assertm(false, "Invalid PauseState value"); return "";
 	}
 }
@@ -153,9 +153,9 @@ static bool is_valid_transition(const PauseState from, const PauseState to)
 	using enum PauseState;
 
 	switch (from) {
-	case Running: return (to == UserPaused || to == FocusLossPaused);
+	case Running: return (to == UserPaused || to == AutoPaused);
 	case UserPaused: return (to == Running);
-	case FocusLossPaused: return (to == Running || to == UserPaused);
+	case AutoPaused: return (to == Running || to == UserPaused);
 	default: assertm(false, "Invalid PauseState value"); return false;
 	}
 }
@@ -236,7 +236,7 @@ void DOSBOX_SetPauseState(const PauseState new_state)
 			return;
 		}
 
-		was_paused  = (prev == UserPaused || prev == FocusLossPaused);
+		was_paused  = (prev == UserPaused || prev == AutoPaused);
 		now_running = (new_state == Running);
 
 		pause_state.store(new_state);
@@ -248,10 +248,9 @@ void DOSBOX_SetPauseState(const PauseState new_state)
 		update_subsystem_pause_state();
 	}
 
-	// Log pause state and refresh the titlebar only on user-visible
-	// transitions: pause becoming active or resumed.
-	const bool now_paused = (new_state == UserPaused ||
-	                         new_state == FocusLossPaused);
+	// Log pause and refresh the titlebar only on user-visible edges: pause
+	// becoming active or fully resumed.
+	const bool now_paused = (new_state == UserPaused || new_state == AutoPaused);
 
 	if (now_paused != was_paused) {
 		TITLEBAR_RefreshTitle();
@@ -271,7 +270,7 @@ void DOSBOX_RequestUserPause()
 
 	switch (DOSBOX_GetPauseState()) {
 	case Running: DOSBOX_SetPauseState(UserPaused); break;
-	case FocusLossPaused: DOSBOX_SetPauseState(UserPaused); break;
+	case AutoPaused: DOSBOX_SetPauseState(UserPaused); break;
 
 	case UserPaused:
 		// already user-paused
@@ -289,10 +288,9 @@ void DOSBOX_RequestUserResume()
 	case UserPaused: DOSBOX_SetPauseState(Running); break;
 
 	case Running:
-	case FocusLossPaused:
-		// only the focus handler resumes focus-loss pauses
+	case AutoPaused:
+		// only the focus handler resumes auto-pauses
 		break;
-
 	default: assertm(false, "Invalid PauseState value");
 	}
 }

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -318,7 +318,7 @@ std::optional<PauseState> NextPauseState(const PauseState current,
 
 static PauseState get_pause_state()
 {
-	return pause_state.load();
+	return pause_state.load(std::memory_order_relaxed);
 }
 
 bool DOSBOX_IsRunning()
@@ -425,7 +425,7 @@ static void set_pause_state(const PauseState new_state)
 	const auto request_edge = (now_pause_requested != was_pause_requested);
 	const auto actual_edge  = (now_paused_actual != was_paused_actual);
 
-	pause_state.store(new_state);
+	pause_state.store(new_state, std::memory_order_relaxed);
 
 	if (was_paused_actual && now_running) {
 		rebase_wall_clock_on_resume();

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -133,9 +133,16 @@ void Null_Init([[maybe_unused]] Section* sec)
 // user-initiated pause survives the auto-pausing (on focus loss); only the
 // auto-pausing can be auto-cleared.
 //
-// `AutoPaused` upgrades to `UserPaused` if the user activates pause mode
-// while auto-paused -- it shouldn't auto-resume on focus gain after that. The
-// reverse never happens.
+// The pending states exist to give the SDL-side fade-out enough real audio
+// to work against. Without them, when pause was requested with a
+// nearly-drained `final_output` buffer (low prebuffer config, host CPU
+// contention, right after fast-forward), the fade would hit silence
+// midway and click. During pending we keep producing real audio, so the
+// fade always has ~5 ms of it to attenuate.
+//
+// Resume has no equivalent pending state because the fade-in works "for
+// free": on `MIXER_Resume()`, the mixer immediately starts producing real
+// audio and the SDL-side fade-in ramps against it.
 //
 // All transitions go through `set_pause_state()` (validated against
 // `is_valid_transition()`). Public callers express intent via the four
@@ -156,11 +163,37 @@ enum class PauseState {
 	// Emulator running normally.
 	Running,
 
-	// User-initiated pause (via hotkey or HTTP API call).
+	// User has been requested (via hotkey or HTTP API call) but the audio
+	// fade-out that starts when pausing has been initiated is still in
+	// progress (takes ~5 ms to complete).
+	//
+	// The emulator core, mixer, MIDI renderer, and capture path all still run
+	// normally -- this is what supplies the audio the fade-out attenuates.
+	//
+	// `pending_pause_tick_handler()` on the PIC 1 kHz ticker watches for
+	// the fade to reach zero (`MIXER_GetPlaybackGain() == 0`) and then
+	// transitions us into the actually-paused `UserPaused` state.
+	UserPausePending,
+
+	// Same as `UserPausePending`, just we enter this state on auto-pause from
+	// window focus loss (when the `pause_when_inactive` conf setting is
+	// enabled). Transitions to `AutoPaused` on fade-out completion.
+	//
+	// Gets "upgraded" to `UserPausePending` if the user activates pause mode
+	// while auto-pausing is pending -- it shouldn't auto-resume on focus gain
+	// after that. This can only be done via the HTTP API. The reverse never
+	// happens.
+	AutoPausePending,
+
+	// User-initiated pause is active.
 	UserPaused,
 
-	// Auto-pause from window focus loss; only the focus-gain handler resumes
-	// this, leaving user-pauses alone.
+	// Auto-pause initiated from window focus loss is active; only the
+	// focus-gain handler resumes this, leaving user-pauses alone.
+	//
+	// Gets "upgraded" to `UserPaused` if the user activates pause mode while
+	// auto-paused -- it shouldn't auto-resume on focus gain after that. This
+	// can only be done via the HTTP API. The reverse never happens.
 	AutoPaused,
 };
 
@@ -173,10 +206,23 @@ static const char* to_string(const PauseState s)
 
 	switch (s) {
 	case Running: return "Running";
+	case UserPausePending: return "UserPausePending";
+	case AutoPausePending: return "AutoPausePending";
 	case UserPaused: return "UserPaused";
 	case AutoPaused: return "AutoPaused";
+
 	default: assertm(false, "Invalid PauseState value"); return "";
 	}
+}
+
+static bool is_pending_state(const PauseState s)
+{
+	return s == PauseState::UserPausePending || s == PauseState::AutoPausePending;
+}
+
+static bool is_paused_state(const PauseState s)
+{
+	return s == PauseState::UserPaused || s == PauseState::AutoPaused;
 }
 
 static bool is_valid_transition(const PauseState from, const PauseState to)
@@ -184,9 +230,15 @@ static bool is_valid_transition(const PauseState from, const PauseState to)
 	using enum PauseState;
 
 	switch (from) {
-	case Running: return (to == UserPaused || to == AutoPaused);
+	case Running: return (to == UserPausePending || to == AutoPausePending);
+	case UserPausePending: return (to == UserPaused || to == Running);
+
+	case AutoPausePending:
+		return (to == AutoPaused || to == Running || to == UserPausePending);
+
 	case UserPaused: return (to == Running);
 	case AutoPaused: return (to == Running || to == UserPaused);
+
 	default: assertm(false, "Invalid PauseState value"); return false;
 	}
 }
@@ -203,6 +255,17 @@ bool DOSBOX_IsRunning()
 
 bool DOSBOX_IsPaused()
 {
+	// Only the actually-paused states -- pending states still have the
+	// emulator core, mixer, and MIDI renderer running so the SDL fade
+	// has audio to work against. See the FSM header comment.
+	return is_paused_state(get_pause_state());
+}
+
+bool DOSBOX_IsPauseRequested()
+{
+	// True for any non-Running state (pending or paused). Callers that
+	// want "user has asked to pause" semantics -- e.g. the SDL fade
+	// trigger, or the shutdown force-resume -- use this.
 	return get_pause_state() != PauseState::Running;
 }
 
@@ -268,56 +331,104 @@ static void update_subsystem_pause_state()
 	set_subsystems_paused(DOSBOX_IsPaused());
 }
 
+static void set_pause_state_locked(const PauseState new_state);
+
 static void set_pause_state(const PauseState new_state)
+{
+	const std::lock_guard lock(pause_state_mutex);
+	set_pause_state_locked(new_state);
+}
+
+// Common transition body. Must be called with `pause_state_mutex` held --
+// this lets `pending_pause_tick_handler()` re-enter without racing an
+// in-flight user-requested transition.
+static void set_pause_state_locked(const PauseState new_state)
 {
 	using enum PauseState;
 
-	bool was_paused  = false;
-	bool now_running = false;
-	PauseState prev  = Running;
-
-	{
-		const std::lock_guard lock(pause_state_mutex);
-
-		prev = pause_state.load();
-		if (prev == new_state) {
-			return;
-		}
-
-		if (!is_valid_transition(prev, new_state)) {
-			LOG_WARNING("DOSBOX: Invalid pause transition %s -> %s",
-			            to_string(prev),
-			            to_string(new_state));
-
-			assertm(false, "Invalid PauseState transition");
-			return;
-		}
-
-		was_paused  = (prev == UserPaused || prev == AutoPaused);
-		now_running = (new_state == Running);
-
-		pause_state.store(new_state);
-
-		if (was_paused && now_running) {
-			rebase_wall_clock_on_resume();
-		}
-
-		update_subsystem_pause_state();
+	const PauseState prev = pause_state.load();
+	if (prev == new_state) {
+		return;
 	}
 
-	// Log pause and refresh the titlebar only on user-visible edges: pause
-	// becoming active or fully resumed.
-	const bool now_paused = (new_state == UserPaused || new_state == AutoPaused);
+	if (!is_valid_transition(prev, new_state)) {
+		LOG_WARNING("DOSBOX: Invalid pause transition %s -> %s",
+		            to_string(prev),
+		            to_string(new_state));
 
-	if (now_paused != was_paused) {
+		assertm(false, "Invalid PauseState transition");
+		return;
+	}
+
+	const bool was_paused_actual   = is_paused_state(prev);
+	const bool was_pause_requested = (prev != Running);
+
+	const bool now_paused_actual   = is_paused_state(new_state);
+	const bool now_pause_requested = (new_state != Running);
+	const bool now_running         = (new_state == Running);
+
+	pause_state.store(new_state);
+
+	if (was_paused_actual && now_running) {
+		rebase_wall_clock_on_resume();
+	}
+
+	update_subsystem_pause_state();
+
+	// Log + refresh the titlebar on user-visible edges. Titlebar
+	// refresh fires at the request edge (pending) for immediate
+	// feedback -- the fade is imperceptible visually but the pause
+	// indicator should update instantly. Log fires at the actual-pause
+	// edge so it reflects when subsystems really halted.
+	if (now_pause_requested != was_pause_requested) {
 		TITLEBAR_RefreshTitle();
 	}
 
-	if (now_paused && !was_paused) {
+	if (now_paused_actual && !was_paused_actual) {
 		LOG_MSG("DOSBOX: Paused");
 
-	} else if (was_paused && now_running) {
+	} else if (was_paused_actual && now_running) {
 		LOG_MSG("DOSBOX: Resumed");
+	}
+}
+
+// Drives the `*Pending` -> `*Paused` transition. Runs on the emulator
+// thread via PIC's 1 kHz ticker so it fires from a context that's safe
+// to call `MIXER_LockMixerThread()` from (unlike, say, an
+// `SDL_AddTimer` on the SDL timer thread which is a different thread
+// than the mixer thread but still an unsafe caller in principle).
+//
+// The transition is gated on the SDL fade actually completing --
+// `MIXER_GetPlaybackGain()` reflects the ramp maintained by the SDL
+// callback, so we hand off to the actually-paused state exactly when
+// the audible fade-out reaches zero, not on a wall-clock deadline. No
+// timeout fallback: the fade completing IS the signal.
+//
+static void pending_pause_tick_handler()
+{
+	using enum PauseState;
+
+	// Fast path: not in a pending state, nothing to do. This runs
+	// 1000 times a second regardless, so keep it cheap.
+	if (!is_pending_state(get_pause_state())) {
+		return;
+	}
+
+	if (MIXER_GetPlaybackGain() > 0.0f) {
+		return;
+	}
+
+	const std::lock_guard lock(pause_state_mutex);
+
+	// Re-check under the lock in case the state moved between the
+	// unlocked fast-path checks and now (e.g. the user resumed during
+	// the fade).
+	const auto s = pause_state.load();
+	if (s == UserPausePending) {
+		set_pause_state_locked(UserPaused);
+
+	} else if (s == AutoPausePending) {
+		set_pause_state_locked(AutoPaused);
 	}
 }
 
@@ -325,12 +436,22 @@ void DOSBOX_RequestUserPause()
 {
 	using enum PauseState;
 
+	// Never engage a new pause once shutdown has been requested --
+	// `DOSBOX_RequestShutdown()` force-resumes so teardown runs from a
+	// known-running state, and a late pause request must not undo that
+	// between the shutdown request and the main loop exiting.
+	if (DOSBOX_IsShutdownRequested()) {
+		return;
+	}
+
 	switch (get_pause_state()) {
-	case Running: set_pause_state(UserPaused); break;
+	case Running: set_pause_state(UserPausePending); break;
+	case AutoPausePending: set_pause_state(UserPausePending); break;
 	case AutoPaused: set_pause_state(UserPaused); break;
 
+	case UserPausePending:
 	case UserPaused:
-		// already user-paused
+		// already user-paused (or pending)
 		break;
 
 	default: assertm(false, "Invalid PauseState value");
@@ -342,9 +463,11 @@ void DOSBOX_RequestUserResume()
 	using enum PauseState;
 
 	switch (get_pause_state()) {
+	case UserPausePending: set_pause_state(Running); break;
 	case UserPaused: set_pause_state(Running); break;
 
 	case Running:
+	case AutoPausePending:
 	case AutoPaused:
 		// only the auto-resume path resumes auto-pauses
 		break;
@@ -357,10 +480,18 @@ void DOSBOX_RequestAutoPause()
 {
 	using enum PauseState;
 
-	switch (get_pause_state()) {
-	case Running: set_pause_state(AutoPaused); break;
+	// Never engage a new pause after a shutdown request; see
+	// `DOSBOX_RequestUserPause()`.
+	if (DOSBOX_IsShutdownRequested()) {
+		return;
+	}
 
+	switch (get_pause_state()) {
+	case Running: set_pause_state(AutoPausePending); break;
+
+	case UserPausePending:
 	case UserPaused:
+	case AutoPausePending:
 	case AutoPaused:
 		// user-pause survives auto signals; auto-pause is idempotent
 		break;
@@ -374,9 +505,11 @@ void DOSBOX_RequestAutoResume()
 	using enum PauseState;
 
 	switch (get_pause_state()) {
+	case AutoPausePending: set_pause_state(Running); break;
 	case AutoPaused: set_pause_state(Running); break;
 
 	case Running:
+	case UserPausePending:
 	case UserPaused:
 		// never auto-resume a user pause
 		break;
@@ -476,6 +609,19 @@ static Bitu normal_loop()
 			if (ticks.remain > 0) {
 				TIMER_AddTick();
 				--ticks.remain;
+
+				// `pending_pause_tick_handler()` may have just
+				// engaged the pause inside `TIMER_AddTick()`.
+				// Bail out right away instead of emulating the
+				// rest of the tick budget (up to 20 ms):
+				// subsystems are already parked, so a MIDI
+				// burst in that window could fill the synth's
+				// `work_fifo` and deadlock the main thread on
+				// its blocking enqueue (the consumer -- the synth
+				// renderer thread -- was just halted).
+				if (DOSBOX_IsPaused()) {
+					return 0;
+				}
 			} else {
 				increase_ticks();
 				return 0;
@@ -751,7 +897,9 @@ void DOSBOX_RequestShutdown()
 	// Force-resume so `paused_tick()` exits and subsystem teardown happens
 	// from a known-running state. Without this, teardown would block on
 	// the mixer / synth threads that are parked in their pause hooks.
-	if (DOSBOX_IsPaused()) {
+	// Covers pending states too so the fade-out timer doesn't fire into
+	// a subsystem that's already tearing down.
+	if (DOSBOX_IsPauseRequested()) {
 		set_pause_state(PauseState::Running);
 	}
 }
@@ -1088,6 +1236,10 @@ void DOSBOX_Init()
 	PROGRAMS_Init();
 	TIMER_Init();
 	CMOS_Init();
+
+	// Register the PIC-tick handler that completes pending pauses once
+	// the SDL fade-out has reached zero. See `pending_pause_tick_handler`.
+	TIMER_AddTickHandler(pending_pause_tick_handler);
 }
 
 void DOSBOX_Destroy()

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -178,7 +178,9 @@ static void set_subsystems_paused(const bool paused)
 	audio_paused = paused;
 	if (paused) {
 		MIXER_Pause();
+		MIDI_Pause();
 	} else {
+		MIDI_Resume();
 		MIXER_Resume();
 	}
 }

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -170,6 +170,21 @@ PauseState DOSBOX_GetPauseState()
 // `mapper.cpp`, which composes correctly with this path because both agree on
 // `mixer.mutex`.
 //
+// !!! ORDERING IS CRITICAL. !!!
+//
+// The MIDI software synths (FluidSynth, MT-32, SoundCanvas) each run a
+// renderer thread that fills an `audio_frame_fifo` ahead of the mixer's
+// consumption. If the mixer stops draining BEFORE the renderer halts, or the
+// renderer wakes BEFORE the mixer starts draining, the renderer rushes to
+// fill the fifo headroom and the synth's internal clock advances by up to one
+// mixer pull (potentially up to 21 ms with common buffer sizes) per cycle.
+// Those extra samples reach the capture queue on resume and "stretch" the
+// captured music by N * ~21 ms over N pause/resume cycles.
+//
+// Therefore, on pause, we must halt the *renderer* FIRST. On resume, we must
+// wake the *mixer* FIRST. Do NOT swap these without understanding what you're
+// doing!
+//
 static void set_subsystems_paused(const bool paused)
 {
 	static bool audio_paused = false;
@@ -178,11 +193,16 @@ static void set_subsystems_paused(const bool paused)
 	}
 	audio_paused = paused;
 	if (paused) {
-		MIXER_Pause();
+		// MIDI first so the synth renderer stops before the mixer
+		// stops draining.
 		MIDI_Pause();
+		MIXER_Pause();
+
 	} else {
-		MIDI_Resume();
+		// MIXER first so the mixer drains the pre-pause buffered
+		// audio before the renderer wakes and refills the headroom.
 		MIXER_Resume();
+		MIDI_Resume();
 	}
 }
 

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -186,12 +186,13 @@ static const char* to_string(const PauseState s)
 
 static bool is_pending_state(const PauseState s)
 {
-	return s == PauseState::UserPausePending || s == PauseState::AutoPausePending;
+	return (s == PauseState::UserPausePending ||
+	        s == PauseState::AutoPausePending);
 }
 
 static bool is_paused_state(const PauseState s)
 {
-	return s == PauseState::UserPaused || s == PauseState::AutoPaused;
+	return (s == PauseState::UserPaused || s == PauseState::AutoPaused);
 }
 
 // Structural guard for the application layer: which edges the FSM permits at
@@ -380,6 +381,7 @@ bool DOSBOX_IsPauseRequested()
 static void set_subsystems_paused(const bool paused)
 {
 	static bool audio_paused = false;
+
 	if (paused == audio_paused) {
 		return;
 	}
@@ -421,26 +423,27 @@ static void set_pause_state_locked(const PauseState new_state)
 {
 	using enum PauseState;
 
-	const PauseState prev = pause_state.load();
-	if (prev == new_state) {
+	const auto prev_state = pause_state.load();
+
+	if (prev_state == new_state) {
 		return;
 	}
 
-	if (!is_valid_transition(prev, new_state)) {
+	if (!is_valid_transition(prev_state, new_state)) {
 		LOG_WARNING("DOSBOX: Invalid pause transition %s -> %s",
-		            to_string(prev),
+		            to_string(prev_state),
 		            to_string(new_state));
 
 		assertm(false, "Invalid PauseState transition");
 		return;
 	}
 
-	const bool was_paused_actual   = is_paused_state(prev);
-	const bool was_pause_requested = (prev != Running);
+	const auto was_paused_actual   = is_paused_state(prev_state);
+	const auto was_pause_requested = (prev_state != Running);
 
-	const bool now_paused_actual   = is_paused_state(new_state);
-	const bool now_pause_requested = (new_state != Running);
-	const bool now_running         = (new_state == Running);
+	const auto now_paused_actual   = is_paused_state(new_state);
+	const auto now_pause_requested = (new_state != Running);
+	const auto now_running         = (new_state == Running);
 
 	pause_state.store(new_state);
 

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -140,9 +140,9 @@ void Null_Init([[maybe_unused]] Section* sec)
 // midway and click. During pending we keep producing real audio, so the
 // fade always has ~5 ms of it to attenuate.
 //
-// Resume has no equivalent pending state because the fade-in works "for
-// free": on `MIXER_Resume()`, the mixer immediately starts producing real
-// audio and the SDL-side fade-in ramps against it.
+// Resume has no equivalent pending state because the fade-in works for
+// free: on resume the mixer thread immediately starts producing real
+// audio and ramps the fade-in gain up over it, in-buffer.
 //
 // All transitions go through `set_pause_state()` (validated against
 // `is_valid_transition()`). Public callers express intent via the four
@@ -185,11 +185,12 @@ enum class PauseState {
 	// happens.
 	AutoPausePending,
 
-	// User-initiated pause is active.
+	// User-initiated pause is fully engaged (subsystems halted).
 	UserPaused,
 
-	// Auto-pause initiated from window focus loss is active; only the
-	// focus-gain handler resumes this, leaving user-pauses alone.
+	// Auto-paused when the window lost focus (if the `pause_when_inactive`
+	// conf setting is enabled); only the auto-resume path clears this,
+	// leaving user-pauses alone.
 	//
 	// Gets "upgraded" to `UserPaused` if the user activates pause mode while
 	// auto-paused -- it shouldn't auto-resume on focus gain after that. This
@@ -256,16 +257,16 @@ bool DOSBOX_IsRunning()
 bool DOSBOX_IsPaused()
 {
 	// Only the actually-paused states -- pending states still have the
-	// emulator core, mixer, and MIDI renderer running so the SDL fade
-	// has audio to work against. See the FSM header comment.
+	// emulator core, mixer, and MIDI renderer running so the fade has
+	// audio to work against. See the FSM header comment.
 	return is_paused_state(get_pause_state());
 }
 
 bool DOSBOX_IsPauseRequested()
 {
 	// True for any non-Running state (pending or paused). Callers that
-	// want "user has asked to pause" semantics -- e.g. the SDL fade
-	// trigger, or the shutdown force-resume -- use this.
+	// want "user has asked to pause" semantics -- e.g. the fade trigger,
+	// or the shutdown force-resume -- use this.
 	return get_pause_state() != PauseState::Running;
 }
 
@@ -398,15 +399,17 @@ static void set_pause_state_locked(const PauseState new_state)
 
 // Drives the `*Pending` -> `*Paused` transition. Runs on the emulator
 // thread via PIC's 1 kHz ticker so it fires from a context that's safe
-// to call `MIXER_LockMixerThread()` from (unlike, say, an
-// `SDL_AddTimer` on the SDL timer thread which is a different thread
-// than the mixer thread but still an unsafe caller in principle).
+// to call `MIXER_LockMixerThread()` from.
 //
-// The transition is gated on the SDL fade actually completing --
-// `MIXER_GetPlaybackGain()` reflects the ramp maintained by the SDL
-// callback, so we hand off to the actually-paused state exactly when
+// The transition is gated on the fade actually completing --
+// `MIXER_GetPlaybackGain()` reflects the ramp maintained by the mixer
+// thread, so we hand off to the actually-paused state exactly when
 // the audible fade-out reaches zero, not on a wall-clock deadline. No
-// timeout fallback: the fade completing IS the signal.
+// timeout fallback: the fade completing IS the signal. Nosound-mode
+// works too because the mixer thread snaps the gain directly to
+// target when it hits the `no_sound` sleep path -- the FSM sees 0
+// immediately and transitions without waiting for a non-existent
+// audible fade.
 //
 static void pending_pause_tick_handler()
 {
@@ -1242,7 +1245,7 @@ void DOSBOX_Init()
 	CMOS_Init();
 
 	// Register the PIC-tick handler that completes pending pauses once
-	// the SDL fade-out has reached zero. See `pending_pause_tick_handler`.
+	// the fade-out has reached zero. See `pending_pause_tick_handler`.
 	TIMER_AddTickHandler(pending_pause_tick_handler);
 }
 

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -345,9 +345,10 @@ bool DOSBOX_IsPauseRequested()
 	return get_pause_state() != PauseState::Running;
 }
 
-// Idempotent subsystem pause hook driven by the FSM. Mapper UI doesn't go
-// through here -- it pauses audio via MIXER_LockMixerThread directly in
-// mapper.cpp, which composes correctly with this path because both agree on
+// Subsystem pause hook driven by the FSM. Called by `set_pause_state_locked()`
+// only on the actually-paused edge, so it never fires redundantly. Mapper UI
+// doesn't go through here -- it pauses audio via MIXER_LockMixerThread directly
+// in mapper.cpp, which composes correctly with this path because both agree on
 // mixer.mutex.
 //
 // !!! PAUSE ORDERING IS CRITICAL; resume ordering is not. !!!
@@ -380,14 +381,6 @@ bool DOSBOX_IsPauseRequested()
 //
 static void set_subsystems_paused(const bool paused)
 {
-	static bool audio_paused = false;
-
-	if (paused == audio_paused) {
-		return;
-	}
-
-	audio_paused = paused;
-
 	if (paused) {
 		// MIDI first so the synth renderer stops before the mixer
 		// stops draining.
@@ -401,11 +394,6 @@ static void set_subsystems_paused(const bool paused)
 		MIDI_Resume();
 		MIXER_Resume();
 	}
-}
-
-static void update_subsystem_pause_state()
-{
-	set_subsystems_paused(DOSBOX_IsPaused());
 }
 
 static void set_pause_state_locked(const PauseState new_state);
@@ -445,13 +433,21 @@ static void set_pause_state_locked(const PauseState new_state)
 	const auto now_pause_requested = (new_state != Running);
 	const auto now_running         = (new_state == Running);
 
+	const auto request_edge = (now_pause_requested != was_pause_requested);
+	const auto actual_edge  = (now_paused_actual != was_paused_actual);
+
 	pause_state.store(new_state);
 
 	if (was_paused_actual && now_running) {
 		rebase_wall_clock_on_resume();
 	}
 
-	update_subsystem_pause_state();
+	// Halt / wake the subsystems only when the actually-paused status
+	// flips; the FSM guarantees this edge fires exactly once per pause
+	// and once per resume.
+	if (actual_edge) {
+		set_subsystems_paused(now_paused_actual);
+	}
 
 	// Refresh the titlebar on both the pause-request edge (so any UI
 	// that reflects "pause pending" updates instantly on user input)
@@ -459,9 +455,6 @@ static void set_pause_state_locked(const PauseState new_state)
 	// indicator -- driven by `DOSBOX_IsPaused()` -- flips). Log only
 	// on the actually-paused edge so it reflects when subsystems
 	// really halted.
-	const auto request_edge = (now_pause_requested != was_pause_requested);
-	const auto actual_edge  = (now_paused_actual != was_paused_actual);
-
 	if (request_edge || actual_edge) {
 		TITLEBAR_RefreshTitle();
 	}

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -4,12 +4,15 @@
 
 #include "dosbox.h"
 
+#include <atomic>
+#include <cassert>
 #include <chrono>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <limits>
 #include <memory>
+#include <mutex>
 
 #ifdef WIN32
 #ifndef WIN32_LEAN_AND_MEAN
@@ -107,11 +110,127 @@ void Null_Init([[maybe_unused]] Section *sec) {
 	// do nothing
 }
 
+// ---------------------------------------------------------------------------
+// Pause state machine. All transitions go through `DOSBOX_SetPauseState()`
+// (validated against `is_valid_transition()`).
+//
+// Callers that want "user pressed the pause / resume button" semantics
+// use `DOSBOX_RequestUserPause()` / `DOSBOX_RequestUserResume()`.
+// ---------------------------------------------------------------------------
+
+static std::mutex pause_state_mutex        = {};
+static std::atomic<PauseState> pause_state = PauseState::Running;
+
+static const char* to_string(const PauseState s)
+{
+	using enum PauseState;
+
+	switch (s) {
+	case Running: return "Running";
+	case UserPaused: return "UserPaused";
+	case FocusLossPaused: return "FocusLossPaused";
+	default: assertm(false, "Invalid PauseState value"); return "";
+	}
+}
+
+static bool is_valid_transition(const PauseState from, const PauseState to)
+{
+	using enum PauseState;
+
+	switch (from) {
+	case Running: return (to == UserPaused || to == FocusLossPaused);
+	case UserPaused: return (to == Running);
+	case FocusLossPaused: return (to == Running || to == UserPaused);
+	default: assertm(false, "Invalid PauseState value"); return false;
+	}
+}
+
+PauseState DOSBOX_GetPauseState()
+{
+	return pause_state.load();
+}
+
+void DOSBOX_SetPauseState(const PauseState new_state)
+{
+	const std::lock_guard lock(pause_state_mutex);
+
+	const auto prev = pause_state.load();
+	if (prev == new_state) {
+		return;
+	}
+
+	if (!is_valid_transition(prev, new_state)) {
+		LOG_WARNING("DOSBOX: Invalid pause transition %s -> %s",
+		            to_string(prev),
+		            to_string(new_state));
+
+		assert(false);
+		return;
+	}
+
+	pause_state.store(new_state);
+
+	LOG_MSG("DOSBOX: Pause %s -> %s",
+	        to_string(prev),
+	        to_string(new_state));
+}
+
+void DOSBOX_RequestUserPause()
+{
+	using enum PauseState;
+
+	switch (DOSBOX_GetPauseState()) {
+	case Running: DOSBOX_SetPauseState(UserPaused); break;
+	case FocusLossPaused: DOSBOX_SetPauseState(UserPaused); break;
+
+	case UserPaused:
+		// already user-paused
+		break;
+
+	default: assertm(false, "Invalid PauseState value");
+	}
+}
+
+void DOSBOX_RequestUserResume()
+{
+	using enum PauseState;
+
+	switch (DOSBOX_GetPauseState()) {
+	case UserPaused: DOSBOX_SetPauseState(Running); break;
+
+	case Running:
+	case FocusLossPaused:
+		// only the focus handler resumes focus-loss pauses
+		break;
+
+	default: assertm(false, "Invalid PauseState value");
+	}
+}
+
+// CPU-thread tick body while paused. Minimal skeleton; subsequent commits
+// will pump frame presentation, host events, the mapper, and the
+// webserver bridge here.
+//
+static Bitu paused_tick()
+{
+	if (DOSBOX_IsShutdownRequested()) {
+		return 1;
+	}
+
+	constexpr uint64_t one_ms_ns = 1'000'000;
+	SDL_DelayPrecise(one_ms_ns);
+	return 0;
+}
+
 // forward declaration
 static void increase_ticks();
 
 static Bitu normal_loop()
 {
+	if (DOSBOX_IsPaused()) {
+		return paused_tick();
+	}
+
 	Bits ret;
 
 	while (true) {

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -91,6 +91,20 @@ static struct {
 	bool locked       = {};
 } ticks = {};
 
+// Reset wall-clock accounting on resume so `increase_ticks()` doesn't see
+// a multi-second gap from before pause and try to "catch up" by running
+// tens of seconds of emulation in a burst. PIC time is frozen across
+// pause; only the wall-clock counters need this rebase.
+//
+static void rebase_wall_clock_on_resume()
+{
+	ticks.last      = GetTicks();
+	ticks.remain    = 0;
+	ticks.added     = 0;
+	ticks.done      = 0;
+	ticks.scheduled = 0;
+}
+
 int64_t DOSBOX_GetTicksDone()
 {
 	return ticks.done;
@@ -150,6 +164,9 @@ PauseState DOSBOX_GetPauseState()
 	return pause_state.load();
 }
 
+// Forward decl; body lives next to the `ticks` struct it operates on.
+static void rebase_wall_clock_on_resume();
+
 void DOSBOX_SetPauseState(const PauseState new_state)
 {
 	const std::lock_guard lock(pause_state_mutex);
@@ -168,7 +185,15 @@ void DOSBOX_SetPauseState(const PauseState new_state)
 		return;
 	}
 
+	const bool was_paused  = (prev == PauseState::UserPaused ||
+                                 prev == PauseState::FocusLossPaused);
+	const bool now_running = (new_state == PauseState::Running);
+
 	pause_state.store(new_state);
+
+	if (was_paused && now_running) {
+		rebase_wall_clock_on_resume();
+	}
 
 	LOG_MSG("DOSBOX: Pause %s -> %s",
 	        to_string(prev),

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -575,6 +575,15 @@ static void DOSBOX_UnlockSpeed(bool pressed)
 {
 	static bool autoadjust = false;
 
+	// Fast-forward requires PIC + CPU to be running. It's the one feature
+	// whose trigger is suppressed during pause; everything else (mapper,
+	// screenshot, capture, fullscreen, window resize, shader auto-switch,
+	// config reload) keeps working.
+	if (pressed && !DOSBOX_IsRunning()) {
+		LOG_MSG("Fast Forward is unavailable while paused");
+		return;
+	}
+
 	if (pressed) {
 		LOG_MSG("Fast Forward ON");
 		ticks.locked = true;

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -375,12 +375,16 @@ static void set_pause_state_locked(const PauseState new_state)
 
 	update_subsystem_pause_state();
 
-	// Log + refresh the titlebar on user-visible edges. Titlebar
-	// refresh fires at the request edge (pending) for immediate
-	// feedback -- the fade is imperceptible visually but the pause
-	// indicator should update instantly. Log fires at the actual-pause
-	// edge so it reflects when subsystems really halted.
-	if (now_pause_requested != was_pause_requested) {
+	// Refresh the titlebar on both the pause-request edge (so any UI
+	// that reflects "pause pending" updates instantly on user input)
+	// and on the actually-paused edge (which is when the paused
+	// indicator -- driven by `DOSBOX_IsPaused()` -- flips). Log only
+	// on the actually-paused edge so it reflects when subsystems
+	// really halted.
+	const auto request_edge = (now_pause_requested != was_pause_requested);
+	const auto actual_edge  = (now_paused_actual != was_paused_actual);
+
+	if (request_edge || actual_edge) {
 		TITLEBAR_RefreshTitle();
 	}
 

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -253,6 +253,8 @@ static Bitu paused_tick()
 		Webserver::Bridge::Instance().ProcessRequests();
 	}
 
+	MAPPER_RunPending();
+
 	constexpr uint64_t one_ms_ns = 1'000'000;
 	SDL_DelayPrecise(one_ms_ns);
 	return 0;
@@ -312,6 +314,8 @@ static Bitu normal_loop()
 			if (GFX_GetPresentationMode() == PresentationMode::HostRate) {
 				GFX_MaybePresentFrame();
 			}
+
+			MAPPER_RunPending();
 
 			if (!GFX_PollAndHandleEvents()) {
 				return 0;

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -207,14 +207,25 @@ void DOSBOX_RequestUserResume()
 	}
 }
 
-// CPU-thread tick body while paused. Minimal skeleton; subsequent commits
-// will pump frame presentation, host events, the mapper, and the
-// webserver bridge here.
+// CPU-thread tick handler paused. Keeps presentation, host input pump,
+// mapper, and webserver bridge alive so hotkeys (fullscreen toggle,
+// screenshot, mapper, capture start/stop, config reload) and remote
+// commands keep working while the emulator core is frozen.
 //
 static Bitu paused_tick()
 {
 	if (DOSBOX_IsShutdownRequested()) {
 		return 1;
+	}
+
+	GFX_MaybePresentFrame();
+
+	if (!GFX_PollAndHandleEvents()) {
+		return 0;
+	}
+
+	if (WEBSERVER_IsEnabled()) {
+		Webserver::Bridge::Instance().ProcessRequests();
 	}
 
 	constexpr uint64_t one_ms_ns = 1'000'000;

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -400,7 +400,7 @@ static void set_pause_state(const PauseState new_state)
 {
 	using enum PauseState;
 
-	const auto prev_state = pause_state.load();
+	const auto prev_state = get_pause_state();
 
 	if (prev_state == new_state) {
 		return;
@@ -484,7 +484,7 @@ static void pending_pause_tick_handler()
 		return;
 	}
 
-	if (const auto next = NextPauseState(pause_state.load(),
+	if (const auto next = NextPauseState(get_pause_state(),
 	                                     PauseEvent::FadeComplete)) {
 		set_pause_state(*next);
 	}

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -126,15 +126,45 @@ void Null_Init([[maybe_unused]] Section *sec) {
 }
 
 // ---------------------------------------------------------------------------
-// Pause state machine. All transitions go through `DOSBOX_SetPauseState()`
-// (validated against `is_valid_transition()`).
+// Pause state machine
 //
-// Callers that want "user pressed the pause / resume button" semantics
-// use `DOSBOX_RequestUserPause()` / `DOSBOX_RequestUserResume()`.
+// Mirrors the structure of `MixerMuteState` in `audio/mixer.h` --
+// user-initiated pause survives the auto-pausing (on focus loss); only the
+// auto-pausing can be auto-cleared.
+//
+// `AutoPaused` upgrades to `UserPaused` if the user activates pause mode
+// while auto-paused -- it shouldn't auto-resume on focus gain after that. The
+// reverse never happens.
+//
+// All transitions go through `set_pause_state()` (validated against
+// `is_valid_transition()`). Public callers express intent via the four
+// `DOSBOX_Request{User,Auto}{Pause,Resume}()` API functions.
+//
+// THREADING: every mutator runs on the main (emulation) thread -- hotkeys
+// and window events via the SDL event loop, HTTP commands via the
+// webserver bridge's `ProcessRequests()`, and the pending-transition
+// handler via the PIC ticker. The request helpers read `pause_state`
+// without holding `pause_state_mutex` before transitioning, so the mutex
+// alone would NOT make concurrent requesters correct (racy requests would
+// trip the `is_valid_transition()` guard rather than corrupt state). Keep
+// it that way: other threads may only *read* the state, via the
+// `DOSBOX_Is*()` query functions.
 // ---------------------------------------------------------------------------
 
-static std::mutex pause_state_mutex        = {};
-static std::atomic<PauseState> pause_state = PauseState::Running;
+enum class PauseState {
+	// Emulator running normally.
+	Running,
+
+	// User-initiated pause (via hotkey or HTTP API call).
+	UserPaused,
+
+	// Auto-pause from window focus loss; only the focus-gain handler resumes
+	// this, leaving user-pauses alone.
+	AutoPaused,
+};
+
+static std::mutex pause_state_mutex;
+static std::atomic<PauseState> pause_state{PauseState::Running};
 
 static const char* to_string(const PauseState s)
 {
@@ -160,15 +190,25 @@ static bool is_valid_transition(const PauseState from, const PauseState to)
 	}
 }
 
-PauseState DOSBOX_GetPauseState()
+static PauseState get_pause_state()
 {
 	return pause_state.load();
 }
 
+bool DOSBOX_IsRunning()
+{
+	return get_pause_state() == PauseState::Running;
+}
+
+bool DOSBOX_IsPaused()
+{
+	return get_pause_state() != PauseState::Running;
+}
+
 // Idempotent subsystem pause hook driven by the FSM. Mapper UI doesn't go
-// through here -- it pauses audio via `MIXER_LockMixerThread()` directly in
-// `mapper.cpp`, which composes correctly with this path because both agree on
-// `mixer.mutex`.
+// through here -- it pauses audio via MIXER_LockMixerThread directly in
+// mapper.cpp, which composes correctly with this path because both agree on
+// mixer.mutex.
 //
 // !!! ORDERING IS CRITICAL. !!!
 //
@@ -211,7 +251,7 @@ static void update_subsystem_pause_state()
 	set_subsystems_paused(DOSBOX_IsPaused());
 }
 
-void DOSBOX_SetPauseState(const PauseState new_state)
+static void set_pause_state(const PauseState new_state)
 {
 	using enum PauseState;
 
@@ -268,9 +308,9 @@ void DOSBOX_RequestUserPause()
 {
 	using enum PauseState;
 
-	switch (DOSBOX_GetPauseState()) {
-	case Running: DOSBOX_SetPauseState(UserPaused); break;
-	case AutoPaused: DOSBOX_SetPauseState(UserPaused); break;
+	switch (get_pause_state()) {
+	case Running: set_pause_state(UserPaused); break;
+	case AutoPaused: set_pause_state(UserPaused); break;
 
 	case UserPaused:
 		// already user-paused
@@ -284,11 +324,13 @@ void DOSBOX_RequestUserResume()
 {
 	using enum PauseState;
 
-	switch (DOSBOX_GetPauseState()) {
-	case UserPaused: DOSBOX_SetPauseState(Running); break;
+	switch (get_pause_state()) {
+	case UserPaused: set_pause_state(Running); break;
 
 	case Running:
-	case AutoPaused: break;
+	case AutoPaused:
+		// only the auto-resume path resumes auto-pauses
+		break;
 
 	default: assertm(false, "Invalid PauseState value");
 	}
@@ -298,8 +340,8 @@ void DOSBOX_RequestAutoPause()
 {
 	using enum PauseState;
 
-	switch (DOSBOX_GetPauseState()) {
-	case Running: DOSBOX_SetPauseState(AutoPaused); break;
+	switch (get_pause_state()) {
+	case Running: set_pause_state(AutoPaused); break;
 
 	case UserPaused:
 	case AutoPaused:
@@ -314,8 +356,8 @@ void DOSBOX_RequestAutoResume()
 {
 	using enum PauseState;
 
-	switch (DOSBOX_GetPauseState()) {
-	case AutoPaused: DOSBOX_SetPauseState(Running); break;
+	switch (get_pause_state()) {
+	case AutoPaused: set_pause_state(Running); break;
 
 	case Running:
 	case UserPaused:
@@ -692,7 +734,7 @@ void DOSBOX_RequestShutdown()
 	// from a known-running state. Without this, teardown would block on
 	// the mixer / synth threads that are parked in their pause hooks.
 	if (DOSBOX_IsPaused()) {
-		DOSBOX_SetPauseState(PauseState::Running);
+		set_pause_state(PauseState::Running);
 	}
 }
 

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -35,6 +35,7 @@
 #include "dos/dos.h"
 #include "dos/dos_locale.h"
 #include "dos/programs.h"
+#include "dosbox_pause_fsm.h"
 #include "fpu/fpu.h"
 #include "gui/common.h"
 #include "gui/mapper.h"
@@ -146,7 +147,10 @@ void Null_Init([[maybe_unused]] Section* sec)
 //
 // All transitions go through `set_pause_state()` (validated against
 // `is_valid_transition()`). Public callers express intent via the four
-// `DOSBOX_Request{User,Auto}{Pause,Resume}()` API functions.
+// `DOSBOX_Request{User,Auto}{Pause,Resume}()` API functions, each of which
+// consults the pure `NextPauseState()` policy in `dosbox_pause_fsm.h` and
+// applies the result. That policy is the single source of truth for what
+// each event does; it is exhaustively unit tested in isolation.
 //
 // THREADING: every mutator runs on the main (emulation) thread -- hotkeys
 // and window events via the SDL event loop, HTTP commands via the
@@ -157,46 +161,10 @@ void Null_Init([[maybe_unused]] Section* sec)
 // trip the `is_valid_transition()` guard rather than corrupt state). Keep
 // it that way: other threads may only *read* the state, via the
 // `DOSBOX_Is*()` query functions.
+//
+// The `PauseState` and `PauseEvent` enums and the pure `NextPauseState()`
+// transition table live in `dosbox_pause_fsm.h`.
 // ---------------------------------------------------------------------------
-
-enum class PauseState {
-	// Emulator running normally.
-	Running,
-
-	// User has been requested (via hotkey or HTTP API call) but the audio
-	// fade-out that starts when pausing has been initiated is still in
-	// progress (takes ~5 ms to complete).
-	//
-	// The emulator core, mixer, MIDI renderer, and capture path all still run
-	// normally -- this is what supplies the audio the fade-out attenuates.
-	//
-	// `pending_pause_tick_handler()` on the PIC 1 kHz ticker watches for
-	// the fade to reach zero (`MIXER_GetPlaybackGain() == 0`) and then
-	// transitions us into the actually-paused `UserPaused` state.
-	UserPausePending,
-
-	// Same as `UserPausePending`, just we enter this state on auto-pause from
-	// window focus loss (when the `pause_when_inactive` conf setting is
-	// enabled). Transitions to `AutoPaused` on fade-out completion.
-	//
-	// Gets "upgraded" to `UserPausePending` if the user activates pause mode
-	// while auto-pausing is pending -- it shouldn't auto-resume on focus gain
-	// after that. This can only be done via the HTTP API. The reverse never
-	// happens.
-	AutoPausePending,
-
-	// User-initiated pause is fully engaged (subsystems halted).
-	UserPaused,
-
-	// Auto-paused when the window lost focus (if the `pause_when_inactive`
-	// conf setting is enabled); only the auto-resume path clears this,
-	// leaving user-pauses alone.
-	//
-	// Gets "upgraded" to `UserPaused` if the user activates pause mode while
-	// auto-paused -- it shouldn't auto-resume on focus gain after that. This
-	// can only be done via the HTTP API. The reverse never happens.
-	AutoPaused,
-};
 
 static std::mutex pause_state_mutex;
 static std::atomic<PauseState> pause_state{PauseState::Running};
@@ -226,6 +194,11 @@ static bool is_paused_state(const PauseState s)
 	return s == PauseState::UserPaused || s == PauseState::AutoPaused;
 }
 
+// Structural guard for the application layer: which edges the FSM permits at
+// all. Every state produced by `NextPauseState()` satisfies this, plus the
+// unconditional force-to-`Running` used on shutdown. `set_pause_state_locked()`
+// asserts on it to catch a bad direct store or a race between an unlocked
+// request read and the locked write.
 static bool is_valid_transition(const PauseState from, const PauseState to)
 {
 	using enum PauseState;
@@ -242,6 +215,107 @@ static bool is_valid_transition(const PauseState from, const PauseState to)
 
 	default: assertm(false, "Invalid PauseState value"); return false;
 	}
+}
+
+// Pure pause-transition policy; it just maps (current state, event) to the
+// next state, or `nullopt` for a no-op.
+//
+// The `DOSBOX_Request*()` API and `pending_pause_tick_handler()` below apply
+// its result. Exhaustively unit tested in `dosbox_pause_fsm_tests.cpp`.
+//
+std::optional<PauseState> NextPauseState(const PauseState current,
+                                         const PauseEvent event)
+{
+	using enum PauseState;
+
+	switch (event) {
+	case PauseEvent::UserPause:
+		// User pause trumps auto: it engages from Running, upgrades a
+		// pending/engaged auto-pause, and is idempotent once user-paused.
+		//
+		switch (current) {
+		case Running: return UserPausePending;
+		case AutoPausePending: return UserPausePending;
+		case AutoPaused: return UserPaused;
+
+		case UserPausePending:
+		case UserPaused: return {};
+
+		default:
+			assertm(false, "Invalid PauseState value");
+			return {};
+		}
+		break;
+
+	case PauseEvent::UserResume:
+		// Only clears a user pause; auto-pauses are left for auto-resume.
+		//
+		switch (current) {
+		case UserPausePending: return Running;
+		case UserPaused: return Running;
+
+		case Running:
+		case AutoPausePending:
+		case AutoPaused: return {};
+
+		default:
+			assertm(false, "Invalid PauseState value");
+			return {};
+		}
+		break;
+
+	case PauseEvent::AutoPause:
+		// Engages only from Running; a user-pause survives it and an
+		// existing auto-pause is idempotent.
+		switch (current) {
+		case Running: return AutoPausePending;
+
+		case UserPausePending:
+		case UserPaused:
+		case AutoPausePending:
+		case AutoPaused: return {};
+
+		default:
+			assertm(false, "Invalid PauseState value");
+			return {};
+		}
+		break;
+
+	case PauseEvent::AutoResume:
+		// Clears an auto-pause only; never resumes a user pause.
+		//
+		switch (current) {
+		case AutoPausePending: return Running;
+		case AutoPaused: return Running;
+
+		case Running:
+		case UserPausePending:
+		case UserPaused: return {};
+
+		default:
+			assertm(false, "Invalid PauseState value");
+			return {};
+		}
+		break;
+
+	case PauseEvent::FadeComplete:
+		// The audio fade-out reached zero -- engage the pending pause.
+		switch (current) {
+		case UserPausePending: return UserPaused;
+		case AutoPausePending: return AutoPaused;
+
+		case Running:
+		case UserPaused:
+		case AutoPaused: return {};
+
+		default:
+			assertm(false, "Invalid PauseState value");
+			return {};
+		}
+		break;
+	}
+
+	return {};
 }
 
 static PauseState get_pause_state()
@@ -430,19 +504,14 @@ static void pending_pause_tick_handler()
 	// Re-check under the lock in case the state moved between the
 	// unlocked fast-path checks and now (e.g. the user resumed during
 	// the fade).
-	const auto s = pause_state.load();
-	if (s == UserPausePending) {
-		set_pause_state_locked(UserPaused);
-
-	} else if (s == AutoPausePending) {
-		set_pause_state_locked(AutoPaused);
+	if (const auto next = NextPauseState(pause_state.load(),
+	                                     PauseEvent::FadeComplete)) {
+		set_pause_state_locked(*next);
 	}
 }
 
 void DOSBOX_RequestUserPause()
 {
-	using enum PauseState;
-
 	// Never engage a new pause once shutdown has been requested --
 	// `DOSBOX_RequestShutdown()` force-resumes so teardown runs from a
 	// known-running state, and a late pause request must not undo that
@@ -451,77 +520,39 @@ void DOSBOX_RequestUserPause()
 		return;
 	}
 
-	switch (get_pause_state()) {
-	case Running: set_pause_state(UserPausePending); break;
-	case AutoPausePending: set_pause_state(UserPausePending); break;
-	case AutoPaused: set_pause_state(UserPaused); break;
-
-	case UserPausePending:
-	case UserPaused:
-		// already user-paused (or pending)
-		break;
-
-	default: assertm(false, "Invalid PauseState value");
+	if (const auto next = NextPauseState(get_pause_state(),
+	                                     PauseEvent::UserPause)) {
+		set_pause_state(*next);
 	}
 }
 
 void DOSBOX_RequestUserResume()
 {
-	using enum PauseState;
-
-	switch (get_pause_state()) {
-	case UserPausePending: set_pause_state(Running); break;
-	case UserPaused: set_pause_state(Running); break;
-
-	case Running:
-	case AutoPausePending:
-	case AutoPaused:
-		// only the auto-resume path resumes auto-pauses
-		break;
-
-	default: assertm(false, "Invalid PauseState value");
+	if (const auto next = NextPauseState(get_pause_state(),
+	                                     PauseEvent::UserResume)) {
+		set_pause_state(*next);
 	}
 }
 
 void DOSBOX_RequestAutoPause()
 {
-	using enum PauseState;
-
 	// Never engage a new pause after a shutdown request; see
 	// `DOSBOX_RequestUserPause()`.
 	if (DOSBOX_IsShutdownRequested()) {
 		return;
 	}
 
-	switch (get_pause_state()) {
-	case Running: set_pause_state(AutoPausePending); break;
-
-	case UserPausePending:
-	case UserPaused:
-	case AutoPausePending:
-	case AutoPaused:
-		// user-pause survives auto signals; auto-pause is idempotent
-		break;
-
-	default: assertm(false, "Invalid PauseState value");
+	if (const auto next = NextPauseState(get_pause_state(),
+	                                     PauseEvent::AutoPause)) {
+		set_pause_state(*next);
 	}
 }
 
 void DOSBOX_RequestAutoResume()
 {
-	using enum PauseState;
-
-	switch (get_pause_state()) {
-	case AutoPausePending: set_pause_state(Running); break;
-	case AutoPaused: set_pause_state(Running); break;
-
-	case Running:
-	case UserPausePending:
-	case UserPaused:
-		// never auto-resume a user pause
-		break;
-
-	default: assertm(false, "Invalid PauseState value");
+	if (const auto next = NextPauseState(get_pause_state(),
+	                                     PauseEvent::AutoResume)) {
+		set_pause_state(*next);
 	}
 }
 

--- a/src/dosbox.h
+++ b/src/dosbox.h
@@ -47,52 +47,22 @@ void DOSBOX_RequestShutdown();
 
 bool DOSBOX_IsShutdownRequested();
 
-enum class PauseState {
-	// Emulator running normally.
-	Running,
+// Pause API. The emulator is either running or paused. Pause requests come
+// from two sources: the user (via hotkeys or the HTTP API), and host-window
+// inactivity (when `pause_when_inactive` conf setting is enabled).
+//
+// We express only *intent* via these API calls; the actuall implements
+// decides the appropriate course of action (e.g., user pause trumps
+// auto-pausing, and auto-resume never resumes a user pause).
+//
+bool DOSBOX_IsRunning();
+bool DOSBOX_IsPaused();
 
-	// User-initiated pause (via hotkey or HTTP API call).
-	UserPaused,
-
-	// Auto-pause from window focus loss; only the focus-gain handler resumes
-	// this, leaving user-pauses alone.
-	//
-	// This gets "upgraded" to `UserPaused` if we receive a pause HTTP
-	// API call while focus-loss-paused (you can't do this via hotkey
-	// interactions; window must get the focus first which will unpause).
-	AutoPaused,
-};
-
-PauseState DOSBOX_GetPauseState();
-void DOSBOX_SetPauseState(PauseState new_state);
-
-// User-driven pause / resume intent (via hotkey or HTTP API call).
 void DOSBOX_RequestUserPause();
 void DOSBOX_RequestUserResume();
 
-// Auto-driven pause / resume intent. Focus-loss / focus-gain handlers
-// route through these so they don't have to encode FSM policy at the
-// call site.
-//
-// `DOSBOX_RequestAutoPause()`: `Running` -> `AutoPaused`. No-op when
-// already user-paused (user pauses survive auto signals) or already
-// auto-paused.
-//
-// `DOSBOX_RequestAutoResume()`: `AutoPaused` -> `Running`. No-op
-// otherwise; never auto-resumes a user pause.
-//
 void DOSBOX_RequestAutoPause();
 void DOSBOX_RequestAutoResume();
-
-inline bool DOSBOX_IsRunning()
-{
-	return (DOSBOX_GetPauseState() == PauseState::Running);
-}
-
-inline bool DOSBOX_IsPaused()
-{
-	return (DOSBOX_GetPauseState() != PauseState::Running);
-}
 
 // The E_Exit function throws an exception to quit. Call it in unexpected
 // circumstances.

--- a/src/dosbox.h
+++ b/src/dosbox.h
@@ -48,8 +48,9 @@ void DOSBOX_RequestShutdown();
 bool DOSBOX_IsShutdownRequested();
 
 // Pause API. The emulator is either running or paused. Pause requests come
-// from two sources: the user (via hotkeys or the HTTP API), and host-window
-// inactivity (when `pause_when_inactive` conf setting is enabled).
+// from the user (via hotkeys today; an HTTP API pause endpoint is planned
+// but not yet implemented) and from host-window inactivity (when the
+// `pause_when_inactive` conf setting is enabled).
 //
 // We express only *intent* via these API calls; the actual implementation
 // decides the appropriate course of action (e.g., user pause trumps

--- a/src/dosbox.h
+++ b/src/dosbox.h
@@ -70,6 +70,20 @@ void DOSBOX_SetPauseState(PauseState new_state);
 void DOSBOX_RequestUserPause();
 void DOSBOX_RequestUserResume();
 
+// Auto-driven pause / resume intent. Focus-loss / focus-gain handlers
+// route through these so they don't have to encode FSM policy at the
+// call site.
+//
+// `DOSBOX_RequestAutoPause()`: `Running` -> `AutoPaused`. No-op when
+// already user-paused (user pauses survive auto signals) or already
+// auto-paused.
+//
+// `DOSBOX_RequestAutoResume()`: `AutoPaused` -> `Running`. No-op
+// otherwise; never auto-resumes a user pause.
+//
+void DOSBOX_RequestAutoPause();
+void DOSBOX_RequestAutoResume();
+
 inline bool DOSBOX_IsRunning()
 {
 	return (DOSBOX_GetPauseState() == PauseState::Running);

--- a/src/dosbox.h
+++ b/src/dosbox.h
@@ -47,6 +47,39 @@ void DOSBOX_RequestShutdown();
 
 bool DOSBOX_IsShutdownRequested();
 
+enum class PauseState {
+	// Emulator running normally.
+	Running,
+
+	// User-initiated pause (via hotkey or HTTP API call).
+	UserPaused,
+
+	// Auto-pause from window focus loss; only the focus-gain handler resumes
+	// this, leaving user-pauses alone.
+	//
+	// This gets "upgraded" to `UserPaused` if we receive a pause HTTP
+	// API call while focus-loss-paused (you can't do this via hotkey
+	// interactions; window must get the focus first which will unpause).
+	FocusLossPaused,
+};
+
+PauseState DOSBOX_GetPauseState();
+void DOSBOX_SetPauseState(PauseState new_state);
+
+// User-driven pause / resume intent (via hotkey or HTTP API call).
+void DOSBOX_RequestUserPause();
+void DOSBOX_RequestUserResume();
+
+inline bool DOSBOX_IsRunning()
+{
+	return (DOSBOX_GetPauseState() == PauseState::Running);
+}
+
+inline bool DOSBOX_IsPaused()
+{
+	return (DOSBOX_GetPauseState() != PauseState::Running);
+}
+
 // The E_Exit function throws an exception to quit. Call it in unexpected
 // circumstances.
 [[noreturn]] void E_Exit(const char *message, ...)

--- a/src/dosbox.h
+++ b/src/dosbox.h
@@ -58,6 +58,14 @@ bool DOSBOX_IsShutdownRequested();
 bool DOSBOX_IsRunning();
 bool DOSBOX_IsPaused();
 
+// True whenever a pause has been requested but not necessarily engaged
+// yet -- covers the SDL fade-out pending window as well as the actually-
+// paused states. Callers that want "user has asked to pause" semantics
+// (e.g. the mixer's fade-to-silence trigger) use this. Callers that care
+// about subsystem state (mixer thread's silence path, capture skip) use
+// `DOSBOX_IsPaused()` instead.
+bool DOSBOX_IsPauseRequested();
+
 void DOSBOX_RequestUserPause();
 void DOSBOX_RequestUserResume();
 

--- a/src/dosbox.h
+++ b/src/dosbox.h
@@ -60,7 +60,7 @@ enum class PauseState {
 	// This gets "upgraded" to `UserPaused` if we receive a pause HTTP
 	// API call while focus-loss-paused (you can't do this via hotkey
 	// interactions; window must get the focus first which will unpause).
-	FocusLossPaused,
+	AutoPaused,
 };
 
 PauseState DOSBOX_GetPauseState();

--- a/src/dosbox.h
+++ b/src/dosbox.h
@@ -51,7 +51,7 @@ bool DOSBOX_IsShutdownRequested();
 // from two sources: the user (via hotkeys or the HTTP API), and host-window
 // inactivity (when `pause_when_inactive` conf setting is enabled).
 //
-// We express only *intent* via these API calls; the actuall implements
+// We express only *intent* via these API calls; the actual implementation
 // decides the appropriate course of action (e.g., user pause trumps
 // auto-pausing, and auto-resume never resumes a user pause).
 //

--- a/src/dosbox_pause_fsm.h
+++ b/src/dosbox_pause_fsm.h
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText:  2026-2026 The DOSBox Staging Team
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#ifndef DOSBOX_PAUSE_FSM_H
+#define DOSBOX_PAUSE_FSM_H
+
+#include <optional>
+
+// Pure pause-transition policy, split out from the side-effecting
+// application layer in `dosbox.cpp` so the decision table can be unit
+// tested in isolation. The threading, subsystem hooks, and the mutex all
+// live in `dosbox.cpp`; only the "given this state and this event, what
+// happens" logic lives here, and it is free of side effects and globals.
+
+enum class PauseState {
+	// Emulator running normally.
+	Running,
+
+	// A user pause (via hotkey or HTTP API) has been requested but the
+	// audio fade-out that starts on pause is still in progress (~5 ms).
+	//
+	// The emulator core, mixer, MIDI renderer, and capture path all still
+	// run normally -- that's what supplies the audio the fade-out
+	// attenuates. Transitions to `UserPaused` on fade-out completion.
+	UserPausePending,
+
+	// Same as `UserPausePending`, but entered on auto-pause from window
+	// focus loss (when the `pause_when_inactive` conf setting is enabled).
+	// Transitions to `AutoPaused` on fade-out completion.
+	//
+	// Gets "upgraded" to `UserPausePending` if the user activates pause
+	// mode while auto-pausing is pending -- it shouldn't auto-resume on
+	// focus gain after that. The reverse never happens.
+	AutoPausePending,
+
+	// User-initiated pause is fully engaged (subsystems halted).
+	UserPaused,
+
+	// Auto-paused when the window lost focus (if the `pause_when_inactive`
+	// conf setting is enabled); only the auto-resume path clears this,
+	// leaving user-pauses alone.
+	//
+	// Gets "upgraded" to `UserPaused` if the user activates pause mode
+	// while auto-paused -- it shouldn't auto-resume on focus gain after
+	// that. The reverse never happens.
+	AutoPaused,
+};
+
+// Intent signals that drive the pause FSM.
+enum class PauseEvent {
+	// These map to user/auto pause/resume events (`DOSBOX_Request*()` API in
+	// `dosbox.cpp`)
+	UserPause,
+	UserResume,
+	AutoPause,
+	AutoResume,
+
+	// Raised once the audio fade-out reaches zero, engaging a pending pause
+	FadeComplete,
+};
+
+// Gets the next state for `event` in `current`, or `nullopt` if the event is
+// a no-op in that state.
+std::optional<PauseState> NextPauseState(PauseState current, PauseEvent event);
+
+#endif // DOSBOX_PAUSE_FSM_H

--- a/src/gui/mapper.cpp
+++ b/src/gui/mapper.cpp
@@ -2992,24 +2992,36 @@ void MAPPER_LosingFocus() {
 	}
 }
 
-void MAPPER_RunEvent(uint32_t /*val*/)
+static std::atomic<bool> mapper_run_pending = false;
+
+void MAPPER_Run(bool pressed)
 {
-	// Clear buffer
-	KEYBOARD_ClrBuffer();           
-	
-	// Release any keys pressed (buffer gets filled again).
-	GFX_LosingFocus();		
-
-	MAPPER_DisplayUI();
-}
-
-void MAPPER_Run(bool pressed) {
+	// Each key press calls this twice: once on key-down with `pressed`
+	// set to true, and once on key-up with `pressed` set to false. Skip
+	// the key-down so the mapper opens once per press, not twice.
 	if (pressed) {
 		return;
 	}
 
-	// In case mapper deletes the key object that ran it
-	PIC_AddEvent(MAPPER_RunEvent,0);	
+	// Deferred via an atomic flag rather than `PIC_AddEvent()`. PIC time is
+	// frozen during pause, so a PIC-scheduled event never fires while paused
+	// and the hotkey would be silently dropped. `MAPPER_RunPending()` is
+	// drained from both `normal_loop()`'s idle branch and `paused_tick()`.
+	mapper_run_pending.store(true);
+}
+
+void MAPPER_RunPending()
+{
+	if (!mapper_run_pending.exchange(false)) {
+		return;
+	}
+	// Clear buffer
+	KEYBOARD_ClrBuffer();
+
+	// Release any keys pressed (buffer gets filled again).
+	GFX_LosingFocus();
+
+	MAPPER_DisplayUI();
 }
 
 SDL_Surface* SDL_SetVideoMode_Wrap(int width,int height,int bpp,uint32_t flags);

--- a/src/gui/mapper.cpp
+++ b/src/gui/mapper.cpp
@@ -2992,7 +2992,7 @@ void MAPPER_LosingFocus() {
 	}
 }
 
-static std::atomic<bool> mapper_run_pending = false;
+static bool mapper_run_pending = false;
 
 void MAPPER_Run(bool pressed)
 {
@@ -3003,18 +3003,22 @@ void MAPPER_Run(bool pressed)
 		return;
 	}
 
-	// Deferred via an atomic flag rather than `PIC_AddEvent()`. PIC time is
-	// frozen during pause, so a PIC-scheduled event never fires while paused
-	// and the hotkey would be silently dropped. `MAPPER_RunPending()` is
+	// Deferred via a flag rather than `PIC_AddEvent()`. PIC time is frozen
+	// during pause, so a PIC-scheduled event never fires while paused and
+	// the hotkey would be silently dropped. `MAPPER_RunPending()` is
 	// drained from both `normal_loop()`'s idle branch and `paused_tick()`.
-	mapper_run_pending.store(true);
+	// Both this setter and the drain run on the main thread, so the flag
+	// needs no synchronisation.
+	mapper_run_pending = true;
 }
 
 void MAPPER_RunPending()
 {
-	if (!mapper_run_pending.exchange(false)) {
+	if (!mapper_run_pending) {
 		return;
 	}
+	mapper_run_pending = false;
+
 	// Clear buffer
 	KEYBOARD_ClrBuffer();
 

--- a/src/gui/mapper.h
+++ b/src/gui/mapper.h
@@ -55,6 +55,12 @@ void MAPPER_AddHandler(MAPPER_Handler *handler,
 
 void MAPPER_BindKeys(Section *sec);
 void MAPPER_Run(bool pressed);
+
+// Open the mapper UI if a previous MAPPER_Run latched a request. Drained
+// from normal_loop's idle branch and from paused_tick so the mapper hotkey
+// works during pause (the prior PIC_AddEvent deferral didn't fire then).
+void MAPPER_RunPending();
+
 void MAPPER_DisplayUI();
 void MAPPER_LosingFocus();
 

--- a/src/gui/private/sdl_gui.h
+++ b/src/gui/private/sdl_gui.h
@@ -96,7 +96,6 @@ struct SDL_Block {
 	float dpi_scale    = 1.0f;
 	bool is_fullscreen = false;
 
-	bool is_paused           = false;
 	bool mute_when_inactive  = false;
 	bool pause_when_inactive = false;
 

--- a/src/gui/render/render.cpp
+++ b/src/gui/render/render.cpp
@@ -284,40 +284,56 @@ static void halt_render()
 	render.active             = false;
 }
 
-static void handle_capture_frame()
+// Returns a non-owning view into the latched source frame
+// (`render.last_complete_source`) -- never the live `render.scale.cache`,
+// so callers can't see a torn mid-scanout state. When deinterlacing is on,
+// the returned image is the deinterlacer's output (either in-place over the
+// latch for 32-bit BGRX, or in the deinterlacer's internal decode buffer
+// for other pixel formats).
+//
+// `image_data` is null until the first complete frame has been latched;
+// callers must check.
+//
+// Callers that need to outlive the next latched frame must deep-copy.
+//
+RenderedImage RENDER_GetCurrentImage()
 {
 	RenderedImage image = {};
 
-	image.params = render.src;
-	image.pitch  = render.scale.cache_pitch;
+	if (!render.last_complete_source.valid) {
+		return image;
+	}
 
-	image.image_data = reinterpret_cast<uint8_t*>(render.scale.cache.data());
+	image.params = render.last_complete_source.src;
+	image.pitch  = render.last_complete_source.pitch;
 
-	image.palette = render.palette.rgb;
+	image.image_data = reinterpret_cast<uint8_t*>(
+	        render.last_complete_source.cache.data());
 
-	const auto frames_per_second = static_cast<float>(render.fps);
+	image.palette = render.last_complete_source.palette.rgb;
 
 	if (is_deinterlacing()) {
-		// The pixel data in the returned new image points either to the
-		// input image's data (for 32-bit BGRX images), or to the
-		// deinterlacer's internal decode buffer (for any other pixel
-		// format). We *must not* call `free()` on `new_image` in either
-		// case as it doesn't own these pixel data buffers.
-		//
-		auto new_image = render.deinterlacer->Deinterlace(
-		        image, render.deinterlacing_strength);
-
-		// The image capturer will create its own deep copy the rendered
-		// image (and thus of the pixel data), and will free it when
-		// it's done with it.
-		//
-		// The video capturer doesn't create a copy, and consequently
-		// doesn't free the rendered image either.
-		CAPTURE_AddFrame(new_image, frames_per_second);
-
-	} else {
-		CAPTURE_AddFrame(image, frames_per_second);
+		return render.deinterlacer->Deinterlace(image,
+		                                        render.deinterlacing_strength);
 	}
+	return image;
+}
+
+static void handle_capture_frame()
+{
+	const auto image = RENDER_GetCurrentImage();
+	if (!image.image_data) {
+		return;
+	}
+
+	// The image capturer will create its own deep copy of the rendered
+	// image (and thus of the pixel data), and will free it when it's done
+	// with it.
+	//
+	// The video capturer doesn't create a copy, and consequently doesn't
+	// free the rendered image either.
+	//
+	CAPTURE_AddFrame(image, static_cast<float>(render.fps));
 }
 
 static void deinterlace_rendered_output()

--- a/src/gui/render/render.cpp
+++ b/src/gui/render/render.cpp
@@ -379,10 +379,11 @@ static void latch_last_complete_source()
 	            render.scale.cache.data(),
 	            bytes);
 
-	render.last_complete_source.src     = render.src;
-	render.last_complete_source.palette = render.palette;
-	render.last_complete_source.pitch   = render.scale.cache_pitch;
-	render.last_complete_source.valid   = true;
+	render.last_complete_source.src       = render.src;
+	render.last_complete_source.palette   = render.palette;
+	render.last_complete_source.pitch     = render.scale.cache_pitch;
+	render.last_complete_source.valid     = true;
+	render.last_complete_source.populated = true;
 }
 
 void RENDER_EndUpdate(const bool abort)
@@ -417,6 +418,84 @@ void RENDER_EndUpdate(const bool abort)
 
 	render.render_in_progress = false;
 	render.updating_frame     = false;
+}
+
+// Repaint the held frame at the current render geometry without
+// waiting for a fresh `VGA` scanout. Called from `GFX_ResetScreen()`
+// during pause to handle window-event recreates (resize, fullscreen
+// toggle, mapper close, DPI change).
+//
+// Two concrete cases drive the row mapping below. In both, the user
+// pauses, resizes the window, and the auto-shader picks a different
+// shader on the new canvas size:
+//
+//   1. `crt-hyllian` -> `sharp`. The double-scan -> single-scan flip
+//      retoggles `VGA` scan-doubling: latched cache holds 400 rows
+//      (each `VGA` line emitted twice), `render.src.height` is now
+//      200. We feed every other latched row.
+//
+//   2. `sharp` -> `crt-hyllian`. Single -> double: latched has 200,
+//      `render.src.height` is now 400. We feed each latched row twice.
+//
+// A resize that stays within the same shader family (e.g. an
+// `crt-hyllian` preset switch from 1400p to 4k) keeps the height and
+// runs the loop as a 1:1 copy.
+//
+// Pause-only: the `VGA` palette is CPU-driven and frozen across pause,
+// so the live `render.palette` still matches the latched palette.
+// Outside pause this breaks.
+//
+void RENDER_RescaleLastFrame()
+{
+	if (!render.last_complete_source.populated || !render.active) {
+		return;
+	}
+	if (render.last_complete_source.src.width != render.src.width ||
+	    render.last_complete_source.src.pixel_format != render.src.pixel_format) {
+		return;
+	}
+
+	const auto latched_height = render.last_complete_source.src.height;
+	const auto render_height  = render.src.height;
+
+	// Heights must match one of: 1:1 (same-family resize), latched is
+	// double (case 1 above), or render is double (case 2). Anything
+	// else is an actual `VGA` mode change -- impossible during pause
+	// since the emulated CPU is frozen, so just bail.
+	if (latched_height != render_height && latched_height != render_height * 2 &&
+	    latched_height * 2 != render_height) {
+		return;
+	}
+
+	// Tear down any in-flight scanout cleanly so `RENDER_StartUpdate()`
+	// below can take ownership. `abort = true` skips capture and the
+	// latch update -- both correct: we'd be re-latching the same data
+	// we're about to drive through.
+	if (render.render_in_progress) {
+		RENDER_EndUpdate(true);
+	}
+
+	// Force every line as changed so the scaler rewrites the full
+	// output (otherwise the per-line diff cache may skip lines).
+	render.scale.clear_cache = true;
+
+	if (!RENDER_StartUpdate()) {
+		return;
+	}
+
+	const auto pitch     = render.last_complete_source.pitch;
+	const auto* row_base = reinterpret_cast<const uint8_t*>(
+	        render.last_complete_source.cache.data());
+
+	// Pick the latched row to feed for each output row. The ratio
+	// `latched_height / render_height` is one of {1/1, 2/1, 1/2} per
+	// the check above, so `latched_y` always lands on an integer row.
+	for (int y = 0; y < render_height; ++y) {
+		const auto latched_y = (y * latched_height) / render_height;
+		RENDER_DrawLine(row_base + latched_y * pitch);
+	}
+
+	RENDER_EndUpdate(false);
 }
 
 static SectionProp& get_render_section()
@@ -557,9 +636,11 @@ void RENDER_SetSize(const ImageInfo& image_info, const double frames_per_second)
 {
 	halt_render();
 
-	// Source dimensions or pixel format may change; the latched frame is
-	// only meaningful at the dimensions it was captured at. Drop it and let
-	// the next `RENDER_EndUpdate(false)` re-populate it.
+	// Drop `valid` -- the latched bytes describe the previous source
+	// geometry, so screenshots / video capture must wait for a fresh
+	// `RENDER_EndUpdate(false)` to re-latch. Keep `populated`: the
+	// cache bytes survive (fixed-size embedded array) and
+	// `RENDER_RescaleLastFrame()` adapts them to the new geometry.
 	render.last_complete_source.valid = false;
 
 	if (image_info.width == 0 || image_info.height == 0 ||

--- a/src/gui/render/render.cpp
+++ b/src/gui/render/render.cpp
@@ -348,6 +348,27 @@ static void deinterlace_rendered_output()
 	render.deinterlacer->Deinterlace(image, render.deinterlacing_strength);
 }
 
+// Latch the just-finished frame's source pixels into
+// `render.last_complete_source` so screenshots / video capture and pause-time
+// re-scale can read a clean, complete frame instead of the live
+// `render.scale.cache` (which can be in the middle of an update during a
+// scanout).
+//
+static void latch_last_complete_source()
+{
+	const auto bytes = static_cast<size_t>(render.scale.cache_pitch) *
+	                   static_cast<size_t>(render.src.height);
+
+	std::memcpy(render.last_complete_source.cache.data(),
+	            render.scale.cache.data(),
+	            bytes);
+
+	render.last_complete_source.src     = render.src;
+	render.last_complete_source.palette = render.palette;
+	render.last_complete_source.pitch   = render.scale.cache_pitch;
+	render.last_complete_source.valid   = true;
+}
+
 void RENDER_EndUpdate(const bool abort)
 {
 	if (!render.render_in_progress) {
@@ -355,6 +376,13 @@ void RENDER_EndUpdate(const bool abort)
 	}
 
 	RENDER_DrawLine = empty_line_handler;
+
+	// Latch the just-finished frame before any consumer (capture,
+	// deinterlace) runs, so anything that reads via the latch sees the fresh
+	// frame, not the previous one.
+	if (!abort) {
+		latch_last_complete_source();
+	}
 
 	// Aborted scanouts (vertical retrace cleanup, `VGA_KillDrawing()`) leave
 	// a half-filled cache. Very rarely, such a frame could end up in the
@@ -512,6 +540,11 @@ static void render_callback(GFX_CallbackFunctions_t function)
 void RENDER_SetSize(const ImageInfo& image_info, const double frames_per_second)
 {
 	halt_render();
+
+	// Source dimensions or pixel format may change; the latched frame is
+	// only meaningful at the dimensions it was captured at. Drop it and let
+	// the next `RENDER_EndUpdate(false)` re-populate it.
+	render.last_complete_source.valid = false;
 
 	if (image_info.width == 0 || image_info.height == 0 ||
 	    image_info.width > ScalerMaxWidth ||

--- a/src/gui/render/render.cpp
+++ b/src/gui/render/render.cpp
@@ -348,7 +348,7 @@ static void deinterlace_rendered_output()
 	render.deinterlacer->Deinterlace(image, render.deinterlacing_strength);
 }
 
-void RENDER_EndUpdate([[maybe_unused]] bool abort)
+void RENDER_EndUpdate(const bool abort)
 {
 	if (!render.render_in_progress) {
 		return;
@@ -356,7 +356,11 @@ void RENDER_EndUpdate([[maybe_unused]] bool abort)
 
 	RENDER_DrawLine = empty_line_handler;
 
-	if (CAPTURE_IsCapturingImage() || CAPTURE_IsCapturingVideo()) {
+	// Aborted scanouts (vertical retrace cleanup, `VGA_KillDrawing()`) leave
+	// a half-filled cache. Very rarely, such a frame could end up in the
+	// video or image captures, resulting in random garbage.
+	//
+	if (!abort && (CAPTURE_IsCapturingImage() || CAPTURE_IsCapturingVideo())) {
 		handle_capture_frame();
 	}
 

--- a/src/gui/render/render.cpp
+++ b/src/gui/render/render.cpp
@@ -401,11 +401,20 @@ void RENDER_EndUpdate(const bool abort)
 		latch_last_complete_source();
 	}
 
-	// Aborted scanouts (vertical retrace cleanup, `VGA_KillDrawing()`) leave
-	// a half-filled cache. Very rarely, such a frame could end up in the
-	// video or image captures, resulting in random garbage.
+	// Two gates on captures:
 	//
-	if (!abort && (CAPTURE_IsCapturingImage() || CAPTURE_IsCapturingVideo())) {
+	//   * `!abort`: Aborted scanouts (vertical retrace cleanup,
+	//     `VGA_KillDrawing()`) leave a half-filled cache. Very rarely, such
+	//     a frame could end up in the video or image captures, resulting in
+	//     random garbage.
+	//
+	//   * `DOSBOX_IsRunning()`: synthetic frames produced by
+	//     `RENDER_RescaleLastFrame()` during a pause must not pollute an
+	//     active video capture.
+	//
+	if (!abort && DOSBOX_IsRunning() &&
+	    (CAPTURE_IsCapturingImage() || CAPTURE_IsCapturingVideo())) {
+
 		handle_capture_frame();
 	}
 

--- a/src/gui/render/render.h
+++ b/src/gui/render/render.h
@@ -107,6 +107,25 @@ struct Render {
 		int y_scale = 0;
 	} scale = {};
 
+	// Source-pixel snapshot of the last completed frame. Deep-copied from
+	// `scale.cache` at the end of every successful `RENDER_EndUpdate(false)`.
+	//
+	// Used as a clean source for screenshots and video capture, so consumers
+	// don't read the live, possibly mid-frame `scale.cache`, and as the input
+	// for `RENDER_RescaleLastFrame()` after a pause-time recreate.
+	struct {
+		alignas(uint64_t)
+		        std::array<uint32_t, ScalerMaxWidth * ScalerMaxHeight> cache = {};
+
+		ImageInfo src         = {};
+		RenderPalette palette = {};
+
+		int pitch = 0;
+
+		// `false` until the first frame has been latched.
+		bool valid = false;
+	} last_complete_source = {};
+
 	RenderPalette palette = {};
 
 	uint32_t* dest = nullptr;

--- a/src/gui/render/render.h
+++ b/src/gui/render/render.h
@@ -283,6 +283,13 @@ void RENDER_SetSize(const ImageInfo& image_info, const double frames_per_second)
 bool RENDER_StartUpdate();
 void RENDER_EndUpdate(bool abort);
 
+// Returns the last completed source-pixel frame as a non-owning
+// `RenderedImage`. Never returns a torn mid-scanout view -- the live
+// `render.scale.cache` is private to the scaler. `image_data` is null
+// until the first complete frame has been latched (e.g. right after a
+// video mode change); callers must check.
+RenderedImage RENDER_GetCurrentImage();
+
 void RENDER_SetPalette(const uint8_t entry, const uint8_t red,
                        const uint8_t green, const uint8_t blue);
 

--- a/src/gui/render/render.h
+++ b/src/gui/render/render.h
@@ -122,8 +122,22 @@ struct Render {
 
 		int pitch = 0;
 
-		// `false` until the first frame has been latched.
+		// `true` when the latched data matches `render.src` exactly
+		// (width, height, pixel format). Reset by `RENDER_SetSize()`,
+		// so e.g. a pause-time scan-doubling toggle (`crt-hyllian` ->
+		// `sharp` and back) drops it to false.
+		// `RENDER_GetCurrentImage()` gates on this so screenshots /
+		// video capture never pick up a frame at the previous geometry.
 		bool valid = false;
+
+		// `true` once any frame has ever been latched. *Not* reset by
+		// `RENDER_SetSize()` -- the cache lives in a fixed-size array
+		// embedded in this struct, so the bytes survive that reset.
+		// `RENDER_RescaleLastFrame()` reads via this flag during
+		// pause-time recreates: with no scanout coming to repopulate
+		// the latch, the held bytes are the only source we can
+		// replay through the freshly-configured scaler.
+		bool populated = false;
 	} last_complete_source = {};
 
 	RenderPalette palette = {};
@@ -289,6 +303,12 @@ void RENDER_EndUpdate(bool abort);
 // until the first complete frame has been latched (e.g. right after a
 // video mode change); callers must check.
 RenderedImage RENDER_GetCurrentImage();
+
+// Rescale the latched source frame at the current output dimensions and
+// run it through `RENDER_EndUpdate(false)` so the renderer's
+// `last_framebuf` is refreshed. No effect on VGA timing or PIC -- the
+// emulator core stays paused. No-op if no frame has been latched yet.
+void RENDER_RescaleLastFrame();
 
 void RENDER_SetPalette(const uint8_t entry, const uint8_t red,
                        const uint8_t green, const uint8_t blue);

--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -2122,8 +2122,8 @@ int GFX_GetUserSdlEventId(DosBoxSdlEvent event)
 }
 
 // Focus-loss / focus-gain hook. Routes window-focus events into the FSM:
-// loss requests a `FocusLossPaused`; gain resumes IFF the current pause is
-// a focus-loss one (user-initiated pauses survive focus changes -- the FSM
+// loss requests an `AutoPaused`; gain resumes IFF the current pause is
+// an auto one (user-initiated pauses survive focus changes -- the FSM
 // encodes that).
 //
 static void handle_pause_when_inactive(const SDL_Event& event)
@@ -2137,14 +2137,14 @@ static void handle_pause_when_inactive(const SDL_Event& event)
 		KEYBOARD_ClrBuffer();
 
 		if (DOSBOX_GetPauseState() == Running) {
-			DOSBOX_SetPauseState(FocusLossPaused);
+			DOSBOX_SetPauseState(AutoPaused);
 		}
 		break;
 
 	case SDL_EVENT_WINDOW_FOCUS_GAINED:
 	case SDL_EVENT_WINDOW_RESTORED:
 	case SDL_EVENT_WINDOW_EXPOSED: {
-		if (DOSBOX_GetPauseState() == FocusLossPaused) {
+		if (DOSBOX_GetPauseState() == AutoPaused) {
 			DOSBOX_SetPauseState(Running);
 		}
 		if (event.type == SDL_EVENT_WINDOW_FOCUS_GAINED) {
@@ -2508,7 +2508,7 @@ bool GFX_PollAndHandleEvents()
 			// and focus gain (`FOCUS_GAINED` / `RESTORED` /
 			// `EXPOSED`, which return `true`). Bailing on
 			// `handling_finished` before this point would skip the
-			// focus-gain side and leave `FocusLossPaused` stuck.
+			// focus-gain side and leave `AutoPaused` stuck.
 			if (sdl.pause_when_inactive) {
 				handle_pause_when_inactive(event);
 			}

--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -1617,8 +1617,10 @@ static void apply_active_settings()
 {
 	MOUSE_NotifyWindowActive(true);
 
-	if (sdl.mute_when_inactive && !MIXER_IsManuallyMuted()) {
-		MIXER_Unmute();
+	if (sdl.mute_when_inactive) {
+		// No-op if the user has manually muted -- the mute FSM
+		// preserves UserMuted across focus changes.
+		MIXER_RequestAutoUnmute();
 	}
 
 	// At least on some platforms grabbing the keyboard has to be repeated
@@ -1631,7 +1633,9 @@ static void apply_inactive_settings()
 	MOUSE_NotifyWindowActive(false);
 
 	if (sdl.mute_when_inactive) {
-		MIXER_Mute();
+		// No-op if the user has manually muted -- the mute FSM
+		// preserves UserMuted; AutoMuted layers under it logically.
+		MIXER_RequestAutoMute();
 	}
 }
 

--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -328,6 +328,18 @@ void GFX_ResetScreen()
 
 	VGA_SetupDrawing(0);
 	GFX_Start();
+
+	// While paused, we are not producing fresh frames, so the just recreated
+	// renderer would draw a blank or stale stretched framebuffer until
+	// resume. Drive a synthetic rescale of the latched last completed source
+	// frame at the new dimensions, then present immediately so the held frame
+	// shows correctly after viewport dimension updates (resizing the window,
+	// fullscreen/windowed toggle, etc.)
+	//
+	if (DOSBOX_IsPaused()) {
+		RENDER_RescaleLastFrame();
+		GFX_MaybePresentFrame();
+	}
 }
 
 static bool is_vsync_enabled()

--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -288,7 +288,7 @@ void GFX_RequestExit(const bool pressed)
 		DOSBOX_RequestUserPause();
 	}
 
-	// Titlebar refresh happens inside `DOSBOX_SetPauseState()` on the
+	// Titlebar refresh happens inside the pause FSM on the
 	// `Paused`/`Running` transition.
 }
 
@@ -2226,8 +2226,7 @@ static bool handle_sdl_windowevent(const SDL_Event& event)
 		// Framebuffer); therefore we rely on the FOCUS_GAINED event to
 		// catch window startup and size toggles.
 
-		const bool focus_gained = (event.type ==
-		                           SDL_EVENT_WINDOW_FOCUS_GAINED);
+		const bool focus_gained = (event.type == SDL_EVENT_WINDOW_FOCUS_GAINED);
 		on_window_active(focus_gained);
 
 		if (sdl.draw.callback) {
@@ -2350,9 +2349,9 @@ static bool handle_sdl_windowevent(const SDL_Event& event)
 	// case SDL_WINDOWEVENT_TAKE_FOCUS:
 	// 	log_window_event("SDL: Window is being offered a focus");
 
-	// 	focus_input();
-	// 	on_window_active(/* focus_gained = */ true);
-	// 	return true;
+		// 	focus_input();
+		// 	on_window_active(/* focus_gained = */ true);
+		// 	return true;
 
 	case SDL_EVENT_WINDOW_HIT_TEST:
 		log_window_event(

--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -282,7 +282,14 @@ void GFX_RequestExit(const bool pressed)
 		return;
 	}
 
-	if (DOSBOX_IsPaused()) {
+	// Toggle on the requested state, not the actual one. During the
+	// pending fade-out window `DOSBOX_IsPaused()` is still false, so
+	// keying off it would map a second press to another (no-op) pause
+	// request. Keying off the request lets a quick second press cancel
+	// the pause during the fade, and guarantees the hotkey can always
+	// exit a pending pause even if the fade never completes (e.g. the
+	// mixer thread wedged on a stalled audio device).
+	if (DOSBOX_IsPauseRequested()) {
 		DOSBOX_RequestUserResume();
 	} else {
 		DOSBOX_RequestUserPause();

--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -390,6 +390,18 @@ void GFX_ResetScreen()
 
 	CPU_ResetAutoAdjust();
 
+	// The callback's `update_viewport()` may have triggered an auto-shader
+	// switch (e.g. resize crossed the scan-doubling threshold while the
+	// mapper was open). Push the new shader's `force_single_scan` into
+	// `vga.draw.scan_doubling_allowed` here so the `VGA_SetupDrawing()` call
+	// below sees it, otherwise `render.src.height` will stay wrong.
+	//
+	// This matters even while paused: `RENDER_RescaleLastFrame()` below reads
+	// `render.src.height` as its destination height for the height
+	// doubling/halving of the last latched frame. Stale height will mean
+	// stride mismatch, resulting in garbage output.
+	RENDER_SetScanAndPixelDoubling();
+
 	VGA_SetupDrawing(0);
 	GFX_Start();
 }

--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -301,76 +301,28 @@ static bool is_unpause_event(const SDL_Event event, const KeyPressState unpause_
 	return event.key.key == DefaultKey && (event.key.mod & DefaultMod);
 }
 
+// Thin wrapper around the FSM. The state machine + `paused_tick()` in
+// `dosbox.cpp` own the actual pause loop; here we just translate the
+// hotkey press into the right transition.
+//
 [[maybe_unused]] static void pause_emulation(bool pressed)
 {
 	if (!pressed) {
 		return;
 	}
 
-	// Bit of a hack but this is the key that was used to pause so let's
-	// also check it to unpause. We should really be relying on
-	// MAPPER_CheckEvent() but that is not possible inside this janky pause
-	// loop.
-	// TODO: In the future, re-work pause logic so we use the main event
-	// loop all the time.
-	const auto unpause_key = MAPPER_GetLastKeyPressed();
+	if (DOSBOX_IsPaused()) {
+		DOSBOX_RequestUserResume();
+	} else {
+		DOSBOX_RequestUserPause();
+	}
 
-	const auto inkeymod = SDL_GetModState();
-
-	sdl.is_paused = true;
 	TITLEBAR_RefreshTitle();
-
-	SDL_Event event;
-
-	while (SDL_PollEvent(&event)) {
-		// flush event queue.
-	}
-
-	// Prevent the mixer from running while in our pause loop
-	// Muting is not ideal for some sound devices such as GUS that loop
-	// samples This also saves CPU time by not rendering samples we're not
-	// going to play anyway
-	MIXER_LockMixerThread();
-
-	// NOTE: This is one of the few places where we use SDL key codes with
-	// SDL 2.0, rather than scan codes. Is that the correct behavior?
-	while (sdl.is_paused && !DOSBOX_IsShutdownRequested()) {
-		// since we're not polling, CPU usage drops to 0.
-		SDL_WaitEvent(&event);
-
-		switch (event.type) {
-		case SDL_EVENT_QUIT: GFX_RequestExit(true); break;
-
-		case SDL_EVENT_WINDOW_RESTORED:
-			// We may need to re-create a texture and more
-			GFX_ResetScreen();
-			break;
-
-		case SDL_EVENT_KEY_DOWN:
-			if (is_unpause_event(event, unpause_key)) {
-				const auto outkeymod = event.key.mod;
-				if (inkeymod != outkeymod) {
-					KEYBOARD_ClrBuffer();
-					MAPPER_LosingFocus();
-					// Not perfect if the pressed Alt key is
-					// switched, but then we have to insert
-					// the keys into the mapper or
-					// create/rewrite the event and push it.
-					// Which is tricky due to possible use
-					// of scancodes.
-				}
-				sdl.is_paused = false;
-				TITLEBAR_RefreshTitle();
-				break;
-			}
-		}
-	}
-	MIXER_UnlockMixerThread();
 }
 
 bool GFX_IsPaused()
 {
-	return sdl.is_paused;
+	return DOSBOX_IsPaused();
 }
 
 void GFX_Stop()

--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -1613,8 +1613,46 @@ static void set_keyboard_capture()
 	}
 }
 
-static void apply_active_settings()
+// Window-inactive coordinator. Single entry point for everything that
+// should happen when the host window loses focus.
+static void on_window_inactive()
 {
+	MOUSE_NotifyWindowActive(false);
+
+	if (sdl.mute_when_inactive) {
+		// No-op if the user has manually muted
+		MIXER_RequestAutoMute();
+	}
+	if (sdl.pause_when_inactive) {
+		KEYBOARD_ClrBuffer();
+		DOSBOX_RequestAutoPause();
+	}
+}
+
+// Window-active coordinator.
+//
+// `focus_gained` is true for the FOCUS_GAINED SDL window event and false for
+// WINDOW_RESTORED" and WINDOW_EXPOSED. Only FOCUS_GAINED re-applies host-side
+// state (keyboard grab, mouse-active, and auto-unmute).
+//
+// Pause auto-resume runs on all three events, so a minimized/uncovered window
+// comes back up.
+//
+static void on_window_active(const bool focus_gained)
+{
+	if (sdl.pause_when_inactive) {
+		DOSBOX_RequestAutoResume();
+
+		// ALT can stick on focus loss -- `paused_tick` doesn't
+		// process key events normally, so release on the "user is
+		// back" edge regardless of which active-event got us here.
+		KEYBOARD_AddKey(KBD_leftalt, false);
+		KEYBOARD_AddKey(KBD_rightalt, false);
+	}
+	if (!focus_gained) {
+		return;
+	}
+
 	MOUSE_NotifyWindowActive(true);
 
 	if (sdl.mute_when_inactive) {
@@ -1626,17 +1664,6 @@ static void apply_active_settings()
 	// At least on some platforms grabbing the keyboard has to be repeated
 	// each time we regain focus
 	set_keyboard_capture();
-}
-
-static void apply_inactive_settings()
-{
-	MOUSE_NotifyWindowActive(false);
-
-	if (sdl.mute_when_inactive) {
-		// No-op if the user has manually muted -- the mute FSM
-		// preserves UserMuted; AutoMuted layers under it logically.
-		MIXER_RequestAutoMute();
-	}
 }
 
 static void restart_hotkey_handler([[maybe_unused]] bool pressed)
@@ -1915,7 +1942,8 @@ void GFX_InitAndStartGui()
 	set_minimum_window_size();
 
 	// Assume focus on startup
-	apply_active_settings();
+	constexpr auto FocusGained = true;
+	on_window_active(FocusGained);
 
 	RENDER_SetShaderWithFallback();
 
@@ -2121,42 +2149,10 @@ int GFX_GetUserSdlEventId(DosBoxSdlEvent event)
 	return sdl.start_event_id + enum_val(event);
 }
 
-// Focus-loss / focus-gain hook. Routes window-focus events into the FSM
-// via the idempotent auto-request helpers; they encode the policy that
-// user-initiated pauses survive focus changes, so we don't have to.
-//
-static void handle_pause_when_inactive(const SDL_Event& event)
-{
-	switch (event.type) {
-	case SDL_EVENT_WINDOW_FOCUS_LOST:
-	case SDL_EVENT_WINDOW_MINIMIZED:
-		apply_inactive_settings();
-		KEYBOARD_ClrBuffer();
-		DOSBOX_RequestAutoPause();
-		break;
-
-	case SDL_EVENT_WINDOW_FOCUS_GAINED:
-	case SDL_EVENT_WINDOW_RESTORED:
-	case SDL_EVENT_WINDOW_EXPOSED: {
-		DOSBOX_RequestAutoResume();
-
-		if (event.type == SDL_EVENT_WINDOW_FOCUS_GAINED) {
-			apply_active_settings();
-		}
-		// Release ALT keys; ALT can stick on focus loss.
-		KEYBOARD_AddKey(KBD_leftalt, false);
-		KEYBOARD_AddKey(KBD_rightalt, false);
-		break;
-	}
-
-	default: break;
-	}
-}
-
 static bool handle_sdl_windowevent(const SDL_Event& event)
 {
 	switch (event.type) {
-	case SDL_EVENT_WINDOW_RESTORED:
+	case SDL_EVENT_WINDOW_RESTORED: {
 		log_window_event("SDL: Window has been restored");
 
 		// We may need to re-create a texture and more on Android.
@@ -2174,7 +2170,11 @@ static bool handle_sdl_windowevent(const SDL_Event& event)
 		}
 #endif
 		focus_input();
+
+		constexpr auto FocusGained = false;
+		on_window_active(FocusGained);
 		return true;
+	}
 
 	case SDL_EVENT_WINDOW_RESIZED: {
 		// Window dimensions in logical coordinates
@@ -2212,11 +2212,9 @@ static bool handle_sdl_windowevent(const SDL_Event& event)
 
 	case SDL_EVENT_WINDOW_FOCUS_GAINED:
 		log_window_event("SDL: Window has gained keyboard focus");
-
-		apply_active_settings();
 		[[fallthrough]];
 
-	case SDL_EVENT_WINDOW_EXPOSED:
+	case SDL_EVENT_WINDOW_EXPOSED: {
 		log_window_event("SDL: Window has been exposed and should be redrawn");
 
 		// TODO: below is not consistently true :( seems incorrect on
@@ -2228,17 +2226,26 @@ static bool handle_sdl_windowevent(const SDL_Event& event)
 		// Framebuffer); therefore we rely on the FOCUS_GAINED event to
 		// catch window startup and size toggles.
 
+		const bool focus_gained = (event.type ==
+		                           SDL_EVENT_WINDOW_FOCUS_GAINED);
+		on_window_active(focus_gained);
+
 		if (sdl.draw.callback) {
 			sdl.draw.callback(GFX_CallbackRedraw);
 		}
 		focus_input();
 		return true;
+	}
 
 	case SDL_EVENT_WINDOW_FOCUS_LOST:
 		log_window_event("SDL: Window has lost keyboard focus");
 
-		apply_inactive_settings();
+		// `GFX_LosingFocus()` deactivates mapper events, which can
+		// enqueue key-up scancodes; `on_window_inactive()`'s
+		// `KEYBOARD_ClrBuffer` must run after that so pause starts
+		// with an empty keyboard buffer.
 		GFX_LosingFocus();
+		on_window_inactive();
 		return false;
 
 	case SDL_EVENT_WINDOW_MOUSE_ENTER:
@@ -2326,7 +2333,7 @@ static bool handle_sdl_windowevent(const SDL_Event& event)
 	case SDL_EVENT_WINDOW_MINIMIZED:
 		log_window_event("SDL: Window has been minimized");
 
-		apply_inactive_settings();
+		on_window_inactive();
 		return false;
 
 	case SDL_EVENT_WINDOW_MAXIMIZED:
@@ -2344,7 +2351,7 @@ static bool handle_sdl_windowevent(const SDL_Event& event)
 	// 	log_window_event("SDL: Window is being offered a focus");
 
 	// 	focus_input();
-	// 	apply_active_settings();
+	// 	on_window_active(/* focus_gained = */ true);
 	// 	return true;
 
 	case SDL_EVENT_WINDOW_HIT_TEST:
@@ -2494,18 +2501,7 @@ bool GFX_PollAndHandleEvents()
 		}
 
 		if (is_window_event(event)) {
-			const auto handling_finished = handle_sdl_windowevent(event);
-
-			// Pause-when-inactive must run for BOTH focus loss
-			// (`FOCUS_LOST` / `MINIMIZED`, which return `false`)
-			// and focus gain (`FOCUS_GAINED` / `RESTORED` /
-			// `EXPOSED`, which return `true`). Bailing on
-			// `handling_finished` before this point would skip the
-			// focus-gain side and leave `AutoPaused` stuck.
-			if (sdl.pause_when_inactive) {
-				handle_pause_when_inactive(event);
-			}
-			if (handling_finished) {
+			if (handle_sdl_windowevent(event)) {
 				continue;
 			}
 		}

--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -2121,32 +2121,25 @@ int GFX_GetUserSdlEventId(DosBoxSdlEvent event)
 	return sdl.start_event_id + enum_val(event);
 }
 
-// Focus-loss / focus-gain hook. Routes window-focus events into the FSM:
-// loss requests an `AutoPaused`; gain resumes IFF the current pause is
-// an auto one (user-initiated pauses survive focus changes -- the FSM
-// encodes that).
+// Focus-loss / focus-gain hook. Routes window-focus events into the FSM
+// via the idempotent auto-request helpers; they encode the policy that
+// user-initiated pauses survive focus changes, so we don't have to.
 //
 static void handle_pause_when_inactive(const SDL_Event& event)
 {
-	using enum PauseState;
-
 	switch (event.type) {
 	case SDL_EVENT_WINDOW_FOCUS_LOST:
 	case SDL_EVENT_WINDOW_MINIMIZED:
 		apply_inactive_settings();
 		KEYBOARD_ClrBuffer();
-
-		if (DOSBOX_GetPauseState() == Running) {
-			DOSBOX_SetPauseState(AutoPaused);
-		}
+		DOSBOX_RequestAutoPause();
 		break;
 
 	case SDL_EVENT_WINDOW_FOCUS_GAINED:
 	case SDL_EVENT_WINDOW_RESTORED:
 	case SDL_EVENT_WINDOW_EXPOSED: {
-		if (DOSBOX_GetPauseState() == AutoPaused) {
-			DOSBOX_SetPauseState(Running);
-		}
+		DOSBOX_RequestAutoResume();
+
 		if (event.type == SDL_EVENT_WINDOW_FOCUS_GAINED) {
 			apply_active_settings();
 		}

--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -288,7 +288,8 @@ void GFX_RequestExit(const bool pressed)
 		DOSBOX_RequestUserPause();
 	}
 
-	TITLEBAR_RefreshTitle();
+	// Titlebar refresh happens inside `DOSBOX_SetPauseState()` on the
+	// `Paused`/`Running` transition.
 }
 
 bool GFX_IsPaused()
@@ -2121,7 +2122,6 @@ static void handle_pause_when_inactive(const SDL_Event& event)
 
 		if (DOSBOX_GetPauseState() == Running) {
 			DOSBOX_SetPauseState(FocusLossPaused);
-			TITLEBAR_RefreshTitle();
 		}
 		break;
 
@@ -2130,7 +2130,6 @@ static void handle_pause_when_inactive(const SDL_Event& event)
 	case SDL_EVENT_WINDOW_EXPOSED: {
 		if (DOSBOX_GetPauseState() == FocusLossPaused) {
 			DOSBOX_SetPauseState(Running);
-			TITLEBAR_RefreshTitle();
 		}
 		if (event.type == SDL_EVENT_WINDOW_FOCUS_GAINED) {
 			apply_active_settings();

--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -272,35 +272,6 @@ void GFX_RequestExit(const bool pressed)
 	}
 }
 
-static bool is_unpause_event(const SDL_Event event, const KeyPressState unpause_key)
-{
-	if (event.type != SDL_EVENT_KEY_DOWN) {
-		return false;
-	}
-
-	if (event.key.key == unpause_key.key) {
-		// These are the only mods we're going to care about.
-		// Others mods include caps lock and num lock which we should not look at.
-		constexpr SDL_Keymod ModMask = SDL_Keymod(SDL_KMOD_CTRL | SDL_KMOD_SHIFT |
-		                                          SDL_KMOD_ALT | SDL_KMOD_GUI);
-		const auto unpause_mod = SDL_Keymod(unpause_key.mod & ModMask);
-		if ((event.key.mod & unpause_mod) == unpause_mod) {
-			return true;
-		}
-	}
-
-	// Also check previously hard-coded Alt+Pause on Windows/Linux
-	// and Command+P on Mac to ensure we don't have regressions.
-	#if defined(MACOSX)
-	constexpr SDL_Keymod DefaultMod  = SDL_KMOD_GUI;
-	constexpr SDL_Keycode DefaultKey = SDLK_P;
-	#else
-	constexpr SDL_Keymod DefaultMod  = SDL_KMOD_ALT;
-	constexpr SDL_Keycode DefaultKey = SDLK_PAUSE;
-	#endif
-	return event.key.key == DefaultKey && (event.key.mod & DefaultMod);
-}
-
 // Thin wrapper around the FSM. The state machine + `paused_tick()` in
 // `dosbox.cpp` own the actual pause loop; here we just translate the
 // hotkey press into the right transition.
@@ -2133,68 +2104,44 @@ int GFX_GetUserSdlEventId(DosBoxSdlEvent event)
 	return sdl.start_event_id + enum_val(event);
 }
 
+// Focus-loss / focus-gain hook. Routes window-focus events into the FSM:
+// loss requests a `FocusLossPaused`; gain resumes IFF the current pause is
+// a focus-loss one (user-initiated pauses survive focus changes -- the FSM
+// encodes that).
+//
 static void handle_pause_when_inactive(const SDL_Event& event)
 {
-	if (event.type == SDL_EVENT_WINDOW_FOCUS_LOST ||
-	    event.type == SDL_EVENT_WINDOW_MINIMIZED) {
-		// Window has lost focus, pause the emulator. This is similar to
-		// what PauseDOSBox() does, but the exit criteria is different.
-		// Instead of waiting for the user to hit Alt+Break, we wait for
-		// the window to regain window or input focus.
-		//
-		apply_inactive_settings();
+	using enum PauseState;
 
+	switch (event.type) {
+	case SDL_EVENT_WINDOW_FOCUS_LOST:
+	case SDL_EVENT_WINDOW_MINIMIZED:
+		apply_inactive_settings();
 		KEYBOARD_ClrBuffer();
 
-		sdl.is_paused = true;
-		TITLEBAR_RefreshTitle();
-
-		// Prevent the mixer from running while in our pause loop.
-		// Muting is not ideal for some sound devices such as GUS that
-		// loop samples. This also saves CPU time by not rendering
-		// samples we're not going to play anyway.
-		MIXER_LockMixerThread();
-
-		SDL_Event ev;
-
-		while (sdl.is_paused && !DOSBOX_IsShutdownRequested()) {
-			// WaitEvent() waits for an event rather than
-			// polling, so CPU usage drops to zero.
-			SDL_WaitEvent(&ev);
-
-			switch (ev.type) {
-			case SDL_EVENT_QUIT: GFX_RequestExit(true); break;
-			case SDL_EVENT_WINDOW_FOCUS_LOST:
-			case SDL_EVENT_WINDOW_MINIMIZED:
-			case SDL_EVENT_WINDOW_FOCUS_GAINED:
-			case SDL_EVENT_WINDOW_RESTORED:
-			case SDL_EVENT_WINDOW_EXPOSED: {
-				const auto we = ev.type;
-
-				if (we == SDL_EVENT_WINDOW_FOCUS_GAINED ||
-				    we == SDL_EVENT_WINDOW_RESTORED ||
-				    we == SDL_EVENT_WINDOW_EXPOSED) {
-					sdl.is_paused = false;
-					TITLEBAR_RefreshTitle();
-
-					if (we == SDL_EVENT_WINDOW_FOCUS_GAINED) {
-						sdl.is_paused = false;
-						apply_active_settings();
-					}
-				}
-
-				// Release ALT keys, otherwise ALT can stick and cause problems.
-				KEYBOARD_AddKey(KBD_leftalt, false);
-				KEYBOARD_AddKey(KBD_rightalt, false);
-
-				if (we == SDL_EVENT_WINDOW_RESTORED) {
-					// We may need to re-create a texture and more.
-					GFX_ResetScreen();
-				}
-			} break;
-			}
+		if (DOSBOX_GetPauseState() == Running) {
+			DOSBOX_SetPauseState(FocusLossPaused);
+			TITLEBAR_RefreshTitle();
 		}
-		MIXER_UnlockMixerThread();
+		break;
+
+	case SDL_EVENT_WINDOW_FOCUS_GAINED:
+	case SDL_EVENT_WINDOW_RESTORED:
+	case SDL_EVENT_WINDOW_EXPOSED: {
+		if (DOSBOX_GetPauseState() == FocusLossPaused) {
+			DOSBOX_SetPauseState(Running);
+			TITLEBAR_RefreshTitle();
+		}
+		if (event.type == SDL_EVENT_WINDOW_FOCUS_GAINED) {
+			apply_active_settings();
+		}
+		// Release ALT keys; ALT can stick on focus loss.
+		KEYBOARD_AddKey(KBD_leftalt, false);
+		KEYBOARD_AddKey(KBD_rightalt, false);
+		break;
+	}
+
+	default: break;
 	}
 }
 
@@ -2539,13 +2486,20 @@ bool GFX_PollAndHandleEvents()
 		}
 
 		if (is_window_event(event)) {
-			auto handling_finished = handle_sdl_windowevent(event);
+			const auto handling_finished = handle_sdl_windowevent(event);
+
+			// Pause-when-inactive must run for BOTH focus loss
+			// (`FOCUS_LOST` / `MINIMIZED`, which return `false`)
+			// and focus gain (`FOCUS_GAINED` / `RESTORED` /
+			// `EXPOSED`, which return `true`). Bailing on
+			// `handling_finished` before this point would skip the
+			// focus-gain side and leave `FocusLossPaused` stuck.
+			if (sdl.pause_when_inactive) {
+				handle_pause_when_inactive(event);
+			}
 			if (handling_finished) {
 				continue;
 			}
-			if (sdl.pause_when_inactive) {
-				handle_pause_when_inactive(event);
-			}			
 		}
 
 		switch(event.type) {

--- a/src/hardware/input/mouse.cpp
+++ b/src/hardware/input/mouse.cpp
@@ -16,6 +16,7 @@
 
 #include "cpu/callback.h"
 #include "cpu/cpu.h"
+#include "dosbox.h"
 #include "gui/common.h"
 #include "hardware/pic.h"
 #include "misc/video.h"
@@ -393,10 +394,14 @@ static void update_state() // updates whole 'state' structure, except cursor vis
 	first_time = false;
 }
 
+// While paused, host mouse motion would otherwise accumulate into the DOS
+// driver's pending delta and deliver as a single large jump on resume.
+//
 static bool should_drop_move()
 {
 	return state.should_drop_events ||
-	       (state.cursor_is_outside && !state.is_seamless);
+	       (state.cursor_is_outside && !state.is_seamless) ||
+	       DOSBOX_IsPaused();
 }
 
 static bool should_drop_press_or_wheel()

--- a/src/hardware/video/vga_draw.cpp
+++ b/src/hardware/video/vga_draw.cpp
@@ -3305,6 +3305,14 @@ void VGA_SetupDrawing(uint32_t /*val*/)
 		        image_info.video_mode);
 
 		if (shader_changed) {
+			// `RENDER_NotifyVideoModeChanged()` may itself have picked a new
+			// shader in auto-shader modes. Re-sync
+			// `vga.draw.scan_doubling_allowed` before recomputing geometry;
+			// otherwise `setup_drawing()` reads the stale
+			// `scan_doubling_allowed` flag and we write a
+			// `vga.draw.image_info` that mismatches what the new shader
+			// expects (results as stride-mismatched garbage output).
+			RENDER_SetScanAndPixelDoubling();
 			image_info = setup_drawing();
 		}
 

--- a/src/midi/fluidsynth.cpp
+++ b/src/midi/fluidsynth.cpp
@@ -1078,27 +1078,7 @@ void MidiDeviceFluidSynth::ProcessWorkFromFifo()
 void MidiDeviceFluidSynth::Render()
 {
 	while (work_fifo.IsRunning()) {
-		if (is_paused.load(std::memory_order_acquire)) {
-			// Halt the synth so its internal clock doesn't advance
-			// past the pause edge. Stop `audio_frame_fifo` while
-			// parked so a concurrent mixer `BulkDequeue()` returns
-			// a short read instead of blocking on the
-			// empty-but-running queue -- that block (while holding
-			// `mixer.mutex`) was the pause/resume deadlock the
-			// `MIDI_Pause`/`MIDI_Resume` lock + ordering used to
-			// guard against. Buffered pre-pause frames survive the
-			// stop and drain on resume.
-			std::unique_lock lock(pause_mutex);
-
-			audio_frame_fifo.Stop();
-
-			pause_cv.wait(lock, [this] {
-				return !is_paused.load(std::memory_order_acquire) ||
-				       !work_fifo.IsRunning();
-			});
-
-			audio_frame_fifo.Start();
-
+		if (pauser.ParkIfPaused(audio_frame_fifo, work_fifo)) {
 			continue;
 		}
 
@@ -1109,16 +1089,12 @@ void MidiDeviceFluidSynth::Render()
 
 void MidiDeviceFluidSynth::Pause()
 {
-	is_paused.store(true, std::memory_order_release);
+	pauser.Pause();
 }
 
 void MidiDeviceFluidSynth::Resume()
 {
-	{
-		const std::lock_guard lock(pause_mutex);
-		is_paused.store(false, std::memory_order_release);
-	}
-	pause_cv.notify_all();
+	pauser.Resume();
 }
 
 std_fs::path MidiDeviceFluidSynth::GetSoundFontPath()

--- a/src/midi/fluidsynth.cpp
+++ b/src/midi/fluidsynth.cpp
@@ -795,8 +795,9 @@ MidiDeviceFluidSynth::~MidiDeviceFluidSynth()
 	work_fifo.Stop();
 	audio_frame_fifo.Stop();
 
-	// Wake the renderer if it's blocked in the pause condvar so it sees
-	// `work_fifo.IsRunning() == false` and exits cleanly.
+	// Wake the renderer via the pauser's condvar if it's parked (stopping
+	// `work_fifo` alone does not notify it); once unblocked it sees
+	// `work_fifo` has stopped and exits its loop cleanly.
 	Resume();
 
 	// Wait for the rendering thread to finish

--- a/src/midi/fluidsynth.cpp
+++ b/src/midi/fluidsynth.cpp
@@ -451,7 +451,6 @@ void MidiDeviceFluidSynth::SetChorus()
 			SetChorusParams(Trevor0402_Sc55ChorusParameters);
 			break;
 
-
 		default: assertm(false, "Invalid SoundFont value");
 		};
 	};
@@ -477,7 +476,7 @@ void MidiDeviceFluidSynth::SetChorus()
 
 		} else {
 			// TODO error
-	
+
 			set_section_property_value("fluidsynth",
 			                           ChorusSettingName,
 			                           DefaultChorusSetting);
@@ -615,7 +614,7 @@ void MidiDeviceFluidSynth::SetReverb()
 
 		} else {
 			// TODO error
-	
+
 			set_section_property_value("fluidsynth",
 			                           ReverbSettingName,
 			                           DefaultReverbSetting);
@@ -795,6 +794,10 @@ MidiDeviceFluidSynth::~MidiDeviceFluidSynth()
 	// Stop queueing new MIDI work and audio frames
 	work_fifo.Stop();
 	audio_frame_fifo.Stop();
+
+	// Wake the renderer if it's blocked in the pause condvar so it sees
+	// `work_fifo.IsRunning() == false` and exits cleanly.
+	Resume();
 
 	// Wait for the rendering thread to finish
 	if (renderer.joinable()) {
@@ -1001,17 +1004,19 @@ void MidiDeviceFluidSynth::MixerCallback(const int requested_audio_frames)
 
 	static std::vector<AudioFrame> audio_frames = {};
 
-	const auto has_dequeued = audio_frame_fifo.BulkDequeue(audio_frames,
+	// A short read means the fifo was stopped for a pause (or a genuine
+	// underrun): add whatever we got and pad the shortfall with silence.
+	// Never hand `AddSamples_sfloat` fewer frames than it will read.
+	const auto num_dequeued = audio_frame_fifo.BulkDequeue(audio_frames,
 	                                                       requested_audio_frames);
 
-	if (has_dequeued) {
-		assert(check_cast<int>(audio_frames.size()) == requested_audio_frames);
-		mixer_channel->AddSamples_sfloat(requested_audio_frames,
+	if (num_dequeued > 0) {
+		mixer_channel->AddSamples_sfloat(check_cast<int>(num_dequeued),
 		                                 &audio_frames[0][0]);
 
 		last_rendered_ms = PIC_AtomicIndex();
-	} else {
-		assert(!audio_frame_fifo.IsRunning());
+	}
+	if (check_cast<int>(num_dequeued) < requested_audio_frames) {
 		mixer_channel->AddSilence();
 	}
 }
@@ -1073,9 +1078,47 @@ void MidiDeviceFluidSynth::ProcessWorkFromFifo()
 void MidiDeviceFluidSynth::Render()
 {
 	while (work_fifo.IsRunning()) {
+		if (is_paused.load(std::memory_order_acquire)) {
+			// Halt the synth so its internal clock doesn't advance
+			// past the pause edge. Stop `audio_frame_fifo` while
+			// parked so a concurrent mixer `BulkDequeue()` returns
+			// a short read instead of blocking on the
+			// empty-but-running queue -- that block (while holding
+			// `mixer.mutex`) was the pause/resume deadlock the
+			// `MIDI_Pause`/`MIDI_Resume` lock + ordering used to
+			// guard against. Buffered pre-pause frames survive the
+			// stop and drain on resume.
+			std::unique_lock lock(pause_mutex);
+
+			audio_frame_fifo.Stop();
+
+			pause_cv.wait(lock, [this] {
+				return !is_paused.load(std::memory_order_acquire) ||
+				       !work_fifo.IsRunning();
+			});
+
+			audio_frame_fifo.Start();
+
+			continue;
+		}
+
 		work_fifo.IsEmpty() ? RenderAudioFramesToFifo()
 		                    : ProcessWorkFromFifo();
 	}
+}
+
+void MidiDeviceFluidSynth::Pause()
+{
+	is_paused.store(true, std::memory_order_release);
+}
+
+void MidiDeviceFluidSynth::Resume()
+{
+	{
+		const std::lock_guard lock(pause_mutex);
+		is_paused.store(false, std::memory_order_release);
+	}
+	pause_cv.notify_all();
 }
 
 std_fs::path MidiDeviceFluidSynth::GetSoundFontPath()
@@ -1297,7 +1340,6 @@ static void init_fluidsynth_config_settings(SectionProp& secprop)
 	        "  off:       Don't filter the output (default).\n"
 	        "  <custom>:  Custom filter definition; see 'sb_filter' for details.");
 }
-
 
 static void register_fluidsynth_text_messages()
 {

--- a/src/midi/fluidsynth.cpp
+++ b/src/midi/fluidsynth.cpp
@@ -1079,7 +1079,7 @@ void MidiDeviceFluidSynth::ProcessWorkFromFifo()
 void MidiDeviceFluidSynth::Render()
 {
 	while (work_fifo.IsRunning()) {
-		if (pauser.ParkIfPaused(audio_frame_fifo, work_fifo)) {
+		if (pauser.ParkIfPaused(audio_frame_fifo)) {
 			continue;
 		}
 

--- a/src/midi/midi.cpp
+++ b/src/midi/midi.cpp
@@ -584,6 +584,23 @@ void MIDI_Unmute()
 	midi.is_muted = false;
 }
 
+void MIDI_Pause()
+{
+	// If the user has already muted via the mixer, don't double-mute.
+	// `MIDI_Resume()` queries `MIXER_IsManuallyMuted()` to decide whether to
+	// undo on resume; that check is the single source of truth.
+	if (!MIXER_IsManuallyMuted()) {
+		MIDI_Mute();
+	}
+}
+
+void MIDI_Resume()
+{
+	if (!MIXER_IsManuallyMuted()) {
+		MIDI_Unmute();
+	}
+}
+
 bool MIDI_IsAvailable()
 {
 	return (midi.device != nullptr);

--- a/src/midi/midi.cpp
+++ b/src/midi/midi.cpp
@@ -602,15 +602,14 @@ void MIDI_Unmute()
 //
 void MIDI_Pause()
 {
-	// External devices need an explicit volume-zero broadcast during pause
-	// so they go silent (the mixer's silence path only affects SDL output,
-	// not the side channel out to external MIDI). Skip if the mixer is
-	// already in a non-Audible mute state -- the FSM transition that put us
-	// there already broadcast volume-0; the resume side will undo only if
-	// mute is back to Audible by then.
-	if (MIXER_GetMuteState() == MixerMuteState::Audible) {
-		MIDI_Mute();
-	}
+	// External MIDI devices need an explicit volume-zero broadcast on pause
+	// so they go silent (the mixer's fade only silences internal audio
+	// flowing through SDL; external MIDI is a side channel).
+	//
+	// Called unconditionally: `MIDI_Mute()` is idempotent (early-returns if
+	// already muted), so if the mute FSM already muted us there's no
+	// double-mute.
+	MIDI_Mute();
 
 	// For internal software synths (FluidSynth/MT-32/SoundCanvas) this
 	// halts their renderer thread so the synth's internal clock doesn't

--- a/src/midi/midi.cpp
+++ b/src/midi/midi.cpp
@@ -220,8 +220,8 @@ public:
 	MidiState& operator=(const MidiState&) = delete;
 
 private:
-	std::array<bool, NumMidiNotes* NumMidiChannels> note_on_tracker = {};
-	std::array<uint8_t, NumMidiChannels> channel_volume_tracker     = {};
+	std::array<bool, NumMidiNotes * NumMidiChannels> note_on_tracker = {};
+	std::array<uint8_t, NumMidiChannels> channel_volume_tracker      = {};
 
 	inline size_t NoteAddr(const uint8_t channel, const uint8_t note)
 	{
@@ -587,14 +587,18 @@ void MIDI_Unmute()
 
 // Pause MIDI output as part of a DOSBox pause.
 //
-// !!! ORDER MATTERS: this must be called BEFORE MIXER_Pause() !!!
+// Halting the software synth renderer keeps it from advancing the synth's
+// internal clock while the mixer is halted; without it the renderer rushes
+// to fill the `audio_frame_fifo` headroom that opens up the moment the mixer
+// halts, advancing the synth clock and leaking music into the next capture.
 //
-// Halting the software synth renderer before the mixer stops draining keeps
-// the renderer from rushing to fill the `audio_frame_fifo` headroom that
-// opens up the moment the mixer halts. With the reverse order, the synth's
-// internal clock advances by up to one mixer pull (~21 ms) per pause cycle,
-// and the rendered samples reach the capture queue on resume. As a result,
-// captured music gets "stretched" by N * ~21 ms across N pause/resume cycles.
+// The renderer stops its own `audio_frame_fifo` while parked (see the synth
+// `Render()` loops), so a mixer `BulkDequeue()` racing this gets a short read
+// instead of blocking on the empty-but-running queue. That former block --
+// `mix_samples()` stuck mid-`BulkDequeue()` waiting for a halted renderer
+// while holding `mixer.mutex` -- was the pause/resume deadlock. The fifo stop
+// removes it, so this no longer needs `MIXER_LockMixerThread()` coverage or a
+// strict order relative to `MIXER_Pause()`.
 //
 void MIDI_Pause()
 {
@@ -618,12 +622,15 @@ void MIDI_Pause()
 
 // Resume MIDI output as part of a DOSBox resume.
 //
-// !!! ORDER MATTERS: this must be called AFTER MIXER_Resume() !!!
-//
-// The mixer must drain the pre-pause buffered audio from `audio_frame_fifo`
-// before the renderer wakes; otherwise the renderer refills the fifo headroom
-// in the gap before the mixer starts pulling, the synth's internal clock
-// advances, and the extra samples reach the capture queue.
+// Waking the renderer no longer has to precede `MIXER_Resume()`. The synth's
+// `audio_frame_fifo` is stopped while the renderer is parked, so if the mixer
+// races into `mix_samples()` first (in the window between
+// `pause_state.store(Running)` and the renderer waking), its `BulkDequeue()`
+// returns a short read -- silence-padded by the synth's `MixerCallback` --
+// instead of blocking on a still-parked renderer while holding `mixer.mutex`.
+// That block was the pause/resume deadlock; the fifo stop removes it. The
+// renderer restarts its fifo on wake and the buffered pre-pause frames drain
+// normally.
 //
 void MIDI_Resume()
 {
@@ -951,16 +958,16 @@ static void init_midiconfig_settings(SectionProp& secprop)
 
 	str_prop->SetEnabledOptions({
 #if (defined(MACOSX) || defined(WIN32))
-		"windows_or_macos",
+	        "windows_or_macos",
 #endif
 #if defined(MACOSX)
-		        "coreaudio",
+	        "coreaudio",
 #endif
 #if C_ALSA
-		        "linux",
+	        "linux",
 #endif
-		        "internal_synth", "physical_mt32"
-	});
+	        "internal_synth",
+	        "physical_mt32"});
 }
 
 void init_midi_config_settings(SectionProp& secprop)

--- a/src/midi/midi.cpp
+++ b/src/midi/midi.cpp
@@ -608,7 +608,10 @@ void MIDI_Pause()
 	//
 	// Called unconditionally: `MIDI_Mute()` is idempotent (early-returns if
 	// already muted), so if the mute FSM already muted us there's no
-	// double-mute.
+	// double-mute. This also covers the case where the user toggled mute
+	// during `Pending` -- `set_mute_state()` skips MIDI while a pause is in
+	// flight (so it can't accidentally unmute hanging notes mid-pause), and
+	// we catch up here.
 	MIDI_Mute();
 
 	// For internal software synths (FluidSynth/MT-32/SoundCanvas) this

--- a/src/midi/midi.cpp
+++ b/src/midi/midi.cpp
@@ -33,6 +33,7 @@
 #include "config/config.h"
 #include "config/setup.h"
 #include "dos/programs.h"
+#include "dosbox.h"
 #include "dosbox_config.h"
 #include "gui/mapper.h"
 #include "hardware/audio/mpu401.h"
@@ -584,6 +585,17 @@ void MIDI_Unmute()
 	midi.is_muted = false;
 }
 
+// Pause MIDI output as part of a DOSBox pause.
+//
+// !!! ORDER MATTERS: this must be called BEFORE MIXER_Pause() !!!
+//
+// Halting the software synth renderer before the mixer stops draining keeps
+// the renderer from rushing to fill the `audio_frame_fifo` headroom that
+// opens up the moment the mixer halts. With the reverse order, the synth's
+// internal clock advances by up to one mixer pull (~21 ms) per pause cycle,
+// and the rendered samples reach the capture queue on resume. As a result,
+// captured music gets "stretched" by N * ~21 ms across N pause/resume cycles.
+//
 void MIDI_Pause()
 {
 	// If the user has already muted via the mixer, don't double-mute.
@@ -592,10 +604,30 @@ void MIDI_Pause()
 	if (!MIXER_IsManuallyMuted()) {
 		MIDI_Mute();
 	}
+
+	// External devices got the volume-zero broadcast above. For internal
+	// software synths (FluidSynth/MT-32/SoundCanvas) this halts their
+	// renderer thread so the synth's internal clock doesn't advance
+	// during the pause; default no-op override for External.
+	if (MIDI_IsAvailable()) {
+		midi.device->Pause();
+	}
 }
 
+// Resume MIDI output as part of a DOSBox resume.
+//
+// !!! ORDER MATTERS: this must be called AFTER MIXER_Resume() !!!
+//
+// The mixer must drain the pre-pause buffered audio from `audio_frame_fifo`
+// before the renderer wakes; otherwise the renderer refills the fifo headroom
+// in the gap before the mixer starts pulling, the synth's internal clock
+// advances, and the extra samples reach the capture queue.
+//
 void MIDI_Resume()
 {
+	if (MIDI_IsAvailable()) {
+		midi.device->Resume();
+	}
 	if (!MIXER_IsManuallyMuted()) {
 		MIDI_Unmute();
 	}
@@ -758,6 +790,17 @@ void MIDI_Init()
 		try {
 			midi_instance = std::make_unique<MIDI>();
 			midi_state.Reset();
+
+			// The device may have been re-created while paused (a
+			// config change via hot-reload or the HTTP API).
+			// Re-engage the pause hook so the fresh synth renderer
+			// starts out halted too; otherwise it would keep
+			// rendering into its `audio_frame_fifo` during the
+			// pause, advancing the synth clock past the pause edge
+			// (see `MIDI_Pause()`).
+			if (DOSBOX_IsPaused()) {
+				MIDI_Pause();
+			}
 
 			// A MIDI device has been successfully initialised
 			return;

--- a/src/midi/midi.cpp
+++ b/src/midi/midi.cpp
@@ -598,17 +598,19 @@ void MIDI_Unmute()
 //
 void MIDI_Pause()
 {
-	// If the user has already muted via the mixer, don't double-mute.
-	// `MIDI_Resume()` queries `MIXER_IsManuallyMuted()` to decide whether to
-	// undo on resume; that check is the single source of truth.
-	if (!MIXER_IsManuallyMuted()) {
+	// External devices need an explicit volume-zero broadcast during pause
+	// so they go silent (the mixer's silence path only affects SDL output,
+	// not the side channel out to external MIDI). Skip if the mixer is
+	// already in a non-Audible mute state -- the FSM transition that put us
+	// there already broadcast volume-0; the resume side will undo only if
+	// mute is back to Audible by then.
+	if (MIXER_GetMuteState() == MixerMuteState::Audible) {
 		MIDI_Mute();
 	}
 
-	// External devices got the volume-zero broadcast above. For internal
-	// software synths (FluidSynth/MT-32/SoundCanvas) this halts their
-	// renderer thread so the synth's internal clock doesn't advance
-	// during the pause; default no-op override for External.
+	// For internal software synths (FluidSynth/MT-32/SoundCanvas) this
+	// halts their renderer thread so the synth's internal clock doesn't
+	// advance during the pause; default no-op override for External.
 	if (MIDI_IsAvailable()) {
 		midi.device->Pause();
 	}
@@ -628,7 +630,11 @@ void MIDI_Resume()
 	if (MIDI_IsAvailable()) {
 		midi.device->Resume();
 	}
-	if (!MIXER_IsManuallyMuted()) {
+	// Only restore MIDI volume if the mixer is back to Audible. If the user
+	// toggled mute during the pause and we're still UserMuted (or
+	// AutoMuted), leave MIDI silent -- the FSM transition will undo the
+	// MIDI mute when the user un-mutes.
+	if (MIXER_GetMuteState() == MixerMuteState::Audible) {
 		MIDI_Unmute();
 	}
 }

--- a/src/midi/midi.cpp
+++ b/src/midi/midi.cpp
@@ -597,8 +597,7 @@ void MIDI_Unmute()
 // instead of blocking on the empty-but-running queue. That former block --
 // `mix_samples()` stuck mid-`BulkDequeue()` waiting for a halted renderer
 // while holding `mixer.mutex` -- was the pause/resume deadlock. The fifo stop
-// removes it, so this no longer needs `MIXER_LockMixerThread()` coverage or a
-// strict order relative to `MIXER_Pause()`.
+// removes it, so this no longer needs `MIXER_LockMixerThread()` coverage.
 //
 void MIDI_Pause()
 {
@@ -624,9 +623,8 @@ void MIDI_Pause()
 
 // Resume MIDI output as part of a DOSBox resume.
 //
-// Waking the renderer no longer has to precede `MIXER_Resume()`. The synth's
-// `audio_frame_fifo` is stopped while the renderer is parked, so if the mixer
-// races into `mix_samples()` first (in the window between
+// The synth's `audio_frame_fifo` is stopped while the renderer is parked, so
+// if the mixer races into `mix_samples()` first (in the window between
 // `pause_state.store(Running)` and the renderer waking), its `BulkDequeue()`
 // returns a short read -- silence-padded by the synth's `MixerCallback` --
 // instead of blocking on a still-parked renderer while holding `mixer.mutex`.

--- a/src/midi/midi.h
+++ b/src/midi/midi.h
@@ -223,9 +223,7 @@ void MIDI_Unmute();
 // Pause hook: silence external MIDI (CC 7 = 0 per channel) so sustained
 // notes on hardware synths don't ring through the pause, and halt the
 // internal software synths' renderer threads so the synth clock doesn't
-// advance while paused. Ordering relative to `MIXER_Pause()` /
-// `MIXER_Resume()` is critical -- see `set_subsystems_paused()` in
-// `dosbox.cpp`.
+// advance while paused.
 void MIDI_Pause();
 void MIDI_Resume();
 

--- a/src/midi/midi.h
+++ b/src/midi/midi.h
@@ -220,6 +220,13 @@ void MIDI_RawOutByte(const uint8_t data);
 void MIDI_Mute();
 void MIDI_Unmute();
 
+// Pause hook: silence external MIDI (CC 7 = 0 per channel) so sustained
+// notes on hardware synths don't ring through the pause. Skip if the user
+// has already muted via the mixer hotkey. Internal synths idle naturally
+// via `audio_frame_fifo` backpressure when the mixer pauses.
+void MIDI_Pause();
+void MIDI_Resume();
+
 struct MidiWork {
 	std::vector<uint8_t> message = {};
 	int num_pending_audio_frames = 0;

--- a/src/midi/midi.h
+++ b/src/midi/midi.h
@@ -221,9 +221,11 @@ void MIDI_Mute();
 void MIDI_Unmute();
 
 // Pause hook: silence external MIDI (CC 7 = 0 per channel) so sustained
-// notes on hardware synths don't ring through the pause. Skip if the user
-// has already muted via the mixer hotkey. Internal synths idle naturally
-// via `audio_frame_fifo` backpressure when the mixer pauses.
+// notes on hardware synths don't ring through the pause, and halt the
+// internal software synths' renderer threads so the synth clock doesn't
+// advance while paused. Ordering relative to `MIXER_Pause()` /
+// `MIXER_Resume()` is critical -- see `set_subsystems_paused()` in
+// `dosbox.cpp`.
 void MIDI_Pause();
 void MIDI_Resume();
 

--- a/src/midi/mt32.cpp
+++ b/src/midi/mt32.cpp
@@ -782,8 +782,9 @@ MidiDeviceMt32::~MidiDeviceMt32()
 	work_fifo.Stop();
 	audio_frame_fifo.Stop();
 
-	// Wake the renderer if it's blocked in the pause condvar so it sees
-	// `work_fifo.IsRunning() == false` and exits cleanly.
+	// Wake the renderer via the pauser's condvar if it's parked (stopping
+	// `work_fifo` alone does not notify it); once unblocked it sees
+	// `work_fifo` has stopped and exits its loop cleanly.
 	Resume();
 
 	// Wait for the rendering thread to finish

--- a/src/midi/mt32.cpp
+++ b/src/midi/mt32.cpp
@@ -782,6 +782,10 @@ MidiDeviceMt32::~MidiDeviceMt32()
 	work_fifo.Stop();
 	audio_frame_fifo.Stop();
 
+	// Wake the renderer if it's blocked in the pause condvar so it sees
+	// `work_fifo.IsRunning() == false` and exits cleanly.
+	Resume();
+
 	// Wait for the rendering thread to finish
 	if (renderer.joinable()) {
 		renderer.join();
@@ -872,17 +876,19 @@ void MidiDeviceMt32::MixerCallback(const int requested_audio_frames)
 
 	static std::vector<AudioFrame> audio_frames = {};
 
-	const auto has_dequeued = audio_frame_fifo.BulkDequeue(audio_frames,
+	// A short read means the fifo was stopped for a pause (or a genuine
+	// underrun): add whatever we got and pad the shortfall with silence.
+	// Never hand `AddSamples_sfloat` fewer frames than it will read.
+	const auto num_dequeued = audio_frame_fifo.BulkDequeue(audio_frames,
 	                                                       requested_audio_frames);
 
-	if (has_dequeued) {
-		assert(check_cast<int>(audio_frames.size()) == requested_audio_frames);
-		channel->AddSamples_sfloat(requested_audio_frames,
+	if (num_dequeued > 0) {
+		channel->AddSamples_sfloat(check_cast<int>(num_dequeued),
 		                           &audio_frames[0][0]);
 
 		last_rendered_ms = PIC_AtomicIndex();
-	} else {
-		assert(!audio_frame_fifo.IsRunning());
+	}
+	if (check_cast<int>(num_dequeued) < requested_audio_frames) {
 		channel->AddSilence();
 	}
 }
@@ -948,9 +954,47 @@ void MidiDeviceMt32::ProcessWorkFromFifo()
 void MidiDeviceMt32::Render()
 {
 	while (work_fifo.IsRunning()) {
+		if (is_paused.load(std::memory_order_acquire)) {
+			// Halt the synth so its internal clock doesn't advance
+			// past the pause edge. Stop `audio_frame_fifo` while
+			// parked so a concurrent mixer `BulkDequeue()` returns
+			// a short read instead of blocking on the
+			// empty-but-running queue -- that block (while holding
+			// `mixer.mutex`) was the pause/resume deadlock the
+			// `MIDI_Pause`/`MIDI_Resume` lock + ordering used to
+			// guard against. Buffered pre-pause frames survive the
+			// stop and drain on resume.
+			std::unique_lock lock(pause_mutex);
+
+			audio_frame_fifo.Stop();
+
+			pause_cv.wait(lock, [this] {
+				return !is_paused.load(std::memory_order_acquire) ||
+				       !work_fifo.IsRunning();
+			});
+
+			audio_frame_fifo.Start();
+
+			continue;
+		}
+
 		work_fifo.IsEmpty() ? RenderAudioFramesToFifo()
 		                    : ProcessWorkFromFifo();
 	}
+}
+
+void MidiDeviceMt32::Pause()
+{
+	is_paused.store(true, std::memory_order_release);
+}
+
+void MidiDeviceMt32::Resume()
+{
+	{
+		const std::lock_guard lock(pause_mutex);
+		is_paused.store(false, std::memory_order_release);
+	}
+	pause_cv.notify_all();
 }
 
 ModelAndDir MidiDeviceMt32::GetModelAndDir()

--- a/src/midi/mt32.cpp
+++ b/src/midi/mt32.cpp
@@ -954,27 +954,7 @@ void MidiDeviceMt32::ProcessWorkFromFifo()
 void MidiDeviceMt32::Render()
 {
 	while (work_fifo.IsRunning()) {
-		if (is_paused.load(std::memory_order_acquire)) {
-			// Halt the synth so its internal clock doesn't advance
-			// past the pause edge. Stop `audio_frame_fifo` while
-			// parked so a concurrent mixer `BulkDequeue()` returns
-			// a short read instead of blocking on the
-			// empty-but-running queue -- that block (while holding
-			// `mixer.mutex`) was the pause/resume deadlock the
-			// `MIDI_Pause`/`MIDI_Resume` lock + ordering used to
-			// guard against. Buffered pre-pause frames survive the
-			// stop and drain on resume.
-			std::unique_lock lock(pause_mutex);
-
-			audio_frame_fifo.Stop();
-
-			pause_cv.wait(lock, [this] {
-				return !is_paused.load(std::memory_order_acquire) ||
-				       !work_fifo.IsRunning();
-			});
-
-			audio_frame_fifo.Start();
-
+		if (pauser.ParkIfPaused(audio_frame_fifo, work_fifo)) {
 			continue;
 		}
 
@@ -985,16 +965,12 @@ void MidiDeviceMt32::Render()
 
 void MidiDeviceMt32::Pause()
 {
-	is_paused.store(true, std::memory_order_release);
+	pauser.Pause();
 }
 
 void MidiDeviceMt32::Resume()
 {
-	{
-		const std::lock_guard lock(pause_mutex);
-		is_paused.store(false, std::memory_order_release);
-	}
-	pause_cv.notify_all();
+	pauser.Resume();
 }
 
 ModelAndDir MidiDeviceMt32::GetModelAndDir()

--- a/src/midi/mt32.cpp
+++ b/src/midi/mt32.cpp
@@ -955,7 +955,7 @@ void MidiDeviceMt32::ProcessWorkFromFifo()
 void MidiDeviceMt32::Render()
 {
 	while (work_fifo.IsRunning()) {
-		if (pauser.ParkIfPaused(audio_frame_fifo, work_fifo)) {
+		if (pauser.ParkIfPaused(audio_frame_fifo)) {
 			continue;
 		}
 

--- a/src/midi/private/fluidsynth.h
+++ b/src/midi/private/fluidsynth.h
@@ -7,8 +7,10 @@
 #include "midi_device.h"
 
 #include <atomic>
+#include <condition_variable>
 #include <fluidsynth.h>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <thread>
 #include <vector>
@@ -101,6 +103,9 @@ public:
 	void SendMidiMessage(const MidiMessage& msg) override;
 	void SendSysExMessage(uint8_t* sysex, size_t len) override;
 
+	void Pause() override;
+	void Resume() override;
+
 	std_fs::path GetSoundFontPath();
 
 	void SetChorus();
@@ -136,6 +141,13 @@ private:
 	RWQueue<AudioFrame> audio_frame_fifo{1};
 	RWQueue<MidiWork> work_fifo{1};
 	std::thread renderer = {};
+
+	// Pause primitives for the renderer thread. The `Render()` loop blocks
+	// on `pause_cv` while `is_paused` is set so the synth's internal clock
+	// doesn't advance during a DOSBox pause.
+	std::atomic<bool> is_paused      = false;
+	std::mutex pause_mutex           = {};
+	std::condition_variable pause_cv = {};
 
 	std_fs::path soundfont_path = {};
 

--- a/src/midi/private/fluidsynth.h
+++ b/src/midi/private/fluidsynth.h
@@ -5,12 +5,10 @@
 #define DOSBOX_FLUIDSYNTH_H
 
 #include "midi_device.h"
+#include "synth_render_pauser.h"
 
-#include <atomic>
-#include <condition_variable>
 #include <fluidsynth.h>
 #include <memory>
-#include <mutex>
 #include <optional>
 #include <thread>
 #include <vector>
@@ -142,12 +140,8 @@ private:
 	RWQueue<MidiWork> work_fifo{1};
 	std::thread renderer = {};
 
-	// Pause primitives for the renderer thread. The `Render()` loop blocks
-	// on `pause_cv` while `is_paused` is set so the synth's internal clock
-	// doesn't advance during a DOSBox pause.
-	std::atomic<bool> is_paused      = false;
-	std::mutex pause_mutex           = {};
-	std::condition_variable pause_cv = {};
+	// Parks the renderer thread during a DOSBox pause.
+	SynthRenderPauser pauser = {};
 
 	std_fs::path soundfont_path = {};
 

--- a/src/midi/private/midi_device.h
+++ b/src/midi/private/midi_device.h
@@ -33,6 +33,15 @@ public:
 
 	virtual void SendMidiMessage(const MidiMessage& msg)      = 0;
 	virtual void SendSysExMessage(uint8_t* sysex, size_t len) = 0;
+
+	// Halt / resume the internal renderer thread (FluidSynth, MT-32,
+	// SoundCanvas).
+	//
+	// No-op default for External devices, which don't run
+	// a renderer; their pause path is the volume-zero broadcast in
+	// `MIDI_Mute()`.
+	virtual void Pause() {}
+	virtual void Resume() {}
 };
 
 void MIDI_Reset(MidiDevice* device);

--- a/src/midi/private/mt32.h
+++ b/src/midi/private/mt32.h
@@ -5,11 +5,10 @@
 #define DOSBOX_MT32_H
 
 #include "midi_device.h"
+#include "synth_render_pauser.h"
 
 #if C_MT32EMU
 
-#include <atomic>
-#include <condition_variable>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -81,12 +80,8 @@ private:
 	std::unique_ptr<MT32Emu::Service> service = {};
 	std::thread renderer                      = {};
 
-	// Pause primitives for the renderer thread. The `Render()` loop blocks
-	// on `pause_cv` while `is_paused` is set so the synth's internal clock
-	// doesn't advance during a DOSBox pause.
-	std::atomic<bool> is_paused      = false;
-	std::mutex pause_mutex           = {};
-	std::condition_variable pause_cv = {};
+	// Parks the renderer thread during a DOSBox pause.
+	SynthRenderPauser pauser = {};
 
 	ModelAndDir model_and_dir = {};
 

--- a/src/midi/private/mt32.h
+++ b/src/midi/private/mt32.h
@@ -9,6 +9,7 @@
 #if C_MT32EMU
 
 #include <atomic>
+#include <condition_variable>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -55,6 +56,9 @@ public:
 	void SendMidiMessage(const MidiMessage& msg) override;
 	void SendSysExMessage(uint8_t* sysex, size_t len) override;
 
+	void Pause() override;
+	void Resume() override;
+
 	void PrintStats();
 
 	ModelAndDir GetModelAndDir();
@@ -76,6 +80,13 @@ private:
 	std::mutex service_mutex                  = {};
 	std::unique_ptr<MT32Emu::Service> service = {};
 	std::thread renderer                      = {};
+
+	// Pause primitives for the renderer thread. The `Render()` loop blocks
+	// on `pause_cv` while `is_paused` is set so the synth's internal clock
+	// doesn't advance during a DOSBox pause.
+	std::atomic<bool> is_paused      = false;
+	std::mutex pause_mutex           = {};
+	std::condition_variable pause_cv = {};
 
 	ModelAndDir model_and_dir = {};
 

--- a/src/midi/private/soundcanvas.h
+++ b/src/midi/private/soundcanvas.h
@@ -6,8 +6,12 @@
 
 #include "midi_device.h"
 
+#include <atomic>
+#include <condition_variable>
 #include <memory>
+#include <mutex>
 #include <optional>
+#include <thread>
 
 #include "audio/clap/event_list.h"
 #include "audio/clap/plugin.h"
@@ -73,6 +77,9 @@ public:
 	void SendMidiMessage(const MidiMessage& msg) override;
 	void SendSysExMessage(uint8_t* sysex, size_t len) override;
 
+	void Pause() override;
+	void Resume() override;
+
 private:
 	void MixerCallback(const int requested_audio_frames);
 	void ProcessWorkFromFifo();
@@ -96,6 +103,13 @@ private:
 	} clap = {};
 
 	std::thread renderer = {};
+
+	// Pause primitives for the renderer thread. The `Render()` loop blocks
+	// on `pause_cv` while `is_paused` is set so the synth's internal clock
+	// doesn't advance during a DOSBox pause.
+	std::atomic<bool> is_paused      = false;
+	std::mutex pause_mutex           = {};
+	std::condition_variable pause_cv = {};
 
 	SoundCanvas::SynthModel model = {};
 

--- a/src/midi/private/soundcanvas.h
+++ b/src/midi/private/soundcanvas.h
@@ -5,11 +5,9 @@
 #define DOSBOX_SOUNDCANVAS_H
 
 #include "midi_device.h"
+#include "synth_render_pauser.h"
 
-#include <atomic>
-#include <condition_variable>
 #include <memory>
-#include <mutex>
 #include <optional>
 #include <thread>
 
@@ -104,12 +102,8 @@ private:
 
 	std::thread renderer = {};
 
-	// Pause primitives for the renderer thread. The `Render()` loop blocks
-	// on `pause_cv` while `is_paused` is set so the synth's internal clock
-	// doesn't advance during a DOSBox pause.
-	std::atomic<bool> is_paused      = false;
-	std::mutex pause_mutex           = {};
-	std::condition_variable pause_cv = {};
+	// Parks the renderer thread during a DOSBox pause.
+	SynthRenderPauser pauser = {};
 
 	SoundCanvas::SynthModel model = {};
 

--- a/src/midi/private/synth_render_pauser.h
+++ b/src/midi/private/synth_render_pauser.h
@@ -4,7 +4,6 @@
 #ifndef DOSBOX_MIDI_SYNTH_RENDER_PAUSER_H
 #define DOSBOX_MIDI_SYNTH_RENDER_PAUSER_H
 
-#include <atomic>
 #include <condition_variable>
 #include <mutex>
 
@@ -31,7 +30,8 @@ public:
 	// Request the renderer to park at its next loop iteration.
 	void Pause()
 	{
-		is_paused.store(true, std::memory_order_release);
+		const std::lock_guard lock(mutex);
+		is_paused = true;
 	}
 
 	// Wake a parked renderer. Also called during device teardown so a
@@ -40,29 +40,39 @@ public:
 	{
 		{
 			const std::lock_guard lock(mutex);
-			is_paused.store(false, std::memory_order_release);
+			is_paused = false;
 		}
 		cv.notify_all();
 	}
 
 	// Called at the top of the render loop. If a pause is in effect, block
-	// until resumed or until `work_fifo` stops (shutdown), stopping
-	// `audio_frame_fifo` for the duration. Returns true if it parked, in
-	// which case the caller should re-check its loop condition (`continue`).
+	// until resumed, stopping `audio_frame_fifo` for the duration. Returns
+	// true if it parked, in which case the caller should re-check its loop
+	// condition (`continue`).
+	//
+	// The `is_paused` check runs under the lock so it can't race a
+	// concurrent `Resume()`; a stale read would otherwise stop and
+	// immediately restart `audio_frame_fifo`, risking a glitch.
+	//
+	// The wake always comes from `Resume()`'s `notify_all()` -- including
+	// on shutdown, where teardown stops `work_fifo` and then calls
+	// `Resume()`. Stopping `work_fifo` does NOT notify this condvar; the
+	// `!work_fifo.IsRunning()` term is only a safety net so a wake for any
+	// reason falls through once teardown has begun. The outer render loop
+	// then exits because `work_fifo` has stopped.
 	bool ParkIfPaused(RWQueue<AudioFrame>& audio_frame_fifo,
 	                  RWQueue<MidiWork>& work_fifo)
 	{
-		if (!is_paused.load(std::memory_order_acquire)) {
+		std::unique_lock lock(mutex);
+
+		if (!is_paused) {
 			return false;
 		}
-
-		std::unique_lock lock(mutex);
 
 		audio_frame_fifo.Stop();
 
 		cv.wait(lock, [this, &work_fifo] {
-			return !is_paused.load(std::memory_order_acquire) ||
-			       !work_fifo.IsRunning();
+			return !is_paused || !work_fifo.IsRunning();
 		});
 
 		audio_frame_fifo.Start();
@@ -71,9 +81,9 @@ public:
 	}
 
 private:
-	std::atomic<bool> is_paused = false;
-	std::mutex mutex            = {};
-	std::condition_variable cv  = {};
+	bool is_paused             = false;
+	std::mutex mutex           = {};
+	std::condition_variable cv = {};
 };
 
 #endif // DOSBOX_MIDI_SYNTH_RENDER_PAUSER_H

--- a/src/midi/private/synth_render_pauser.h
+++ b/src/midi/private/synth_render_pauser.h
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText:  2020-2026 The DOSBox Staging Team
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#ifndef DOSBOX_MIDI_SYNTH_RENDER_PAUSER_H
+#define DOSBOX_MIDI_SYNTH_RENDER_PAUSER_H
+
+#include <atomic>
+#include <condition_variable>
+#include <mutex>
+
+#include "audio/audio_frame.h"
+#include "midi/midi.h"
+#include "utils/rwqueue.h"
+
+// Parks an internal MIDI synth's renderer thread (FluidSynth, MT-32,
+// SoundCanvas) at a DOSBox pause edge so the synth's internal clock stops
+// advancing while paused.
+//
+// While parked it stops the outbound `audio_frame_fifo` so a mixer
+// `BulkDequeue()` that races the halt gets a short read instead of blocking on
+// the empty-but-running queue -- that block (while the mixer held
+// `mixer.mutex`) was the pause/resume deadlock the old `MIDI_Pause`/
+// `MIDI_Resume` lock + ordering used to guard against. Buffered pre-pause
+// frames survive the stop and drain on resume.
+//
+// Shared by the three internal synths via composition; each holds one and
+// delegates its `MidiDevice::Pause()`/`Resume()` to it and calls
+// `ParkIfPaused()` at the top of its render loop.
+class SynthRenderPauser {
+public:
+	// Request the renderer to park at its next loop iteration.
+	void Pause()
+	{
+		is_paused.store(true, std::memory_order_release);
+	}
+
+	// Wake a parked renderer. Also called during device teardown so a
+	// paused synth doesn't deadlock on shutdown.
+	void Resume()
+	{
+		{
+			const std::lock_guard lock(mutex);
+			is_paused.store(false, std::memory_order_release);
+		}
+		cv.notify_all();
+	}
+
+	// Called at the top of the render loop. If a pause is in effect, block
+	// until resumed or until `work_fifo` stops (shutdown), stopping
+	// `audio_frame_fifo` for the duration. Returns true if it parked, in
+	// which case the caller should re-check its loop condition (`continue`).
+	bool ParkIfPaused(RWQueue<AudioFrame>& audio_frame_fifo,
+	                  RWQueue<MidiWork>& work_fifo)
+	{
+		if (!is_paused.load(std::memory_order_acquire)) {
+			return false;
+		}
+
+		std::unique_lock lock(mutex);
+
+		audio_frame_fifo.Stop();
+
+		cv.wait(lock, [this, &work_fifo] {
+			return !is_paused.load(std::memory_order_acquire) ||
+			       !work_fifo.IsRunning();
+		});
+
+		audio_frame_fifo.Start();
+
+		return true;
+	}
+
+private:
+	std::atomic<bool> is_paused = false;
+	std::mutex mutex            = {};
+	std::condition_variable cv  = {};
+};
+
+#endif // DOSBOX_MIDI_SYNTH_RENDER_PAUSER_H

--- a/src/midi/private/synth_render_pauser.h
+++ b/src/midi/private/synth_render_pauser.h
@@ -8,7 +8,6 @@
 #include <mutex>
 
 #include "audio/audio_frame.h"
-#include "midi/midi.h"
 #include "utils/rwqueue.h"
 
 // Parks an internal MIDI synth's renderer thread (FluidSynth, MT-32,
@@ -54,14 +53,11 @@ public:
 	// concurrent `Resume()`; a stale read would otherwise stop and
 	// immediately restart `audio_frame_fifo`, risking a glitch.
 	//
-	// The wake always comes from `Resume()`'s `notify_all()` -- including
-	// on shutdown, where teardown stops `work_fifo` and then calls
-	// `Resume()`. Stopping `work_fifo` does NOT notify this condvar; the
-	// `!work_fifo.IsRunning()` term is only a safety net so a wake for any
-	// reason falls through once teardown has begun. The outer render loop
-	// then exits because `work_fifo` has stopped.
-	bool ParkIfPaused(RWQueue<AudioFrame>& audio_frame_fifo,
-	                  RWQueue<MidiWork>& work_fifo)
+	// The only thing that unparks this wait is `Resume()`'s `notify_all()`.
+	// On shutdown the synth destructors call `Resume()` after stopping
+	// their work fifo (the stopped fifo is what makes the render loop
+	// itself exit), so a parked renderer never hangs teardown.
+	bool ParkIfPaused(RWQueue<AudioFrame>& audio_frame_fifo)
 	{
 		std::unique_lock lock(mutex);
 
@@ -71,9 +67,7 @@ public:
 
 		audio_frame_fifo.Stop();
 
-		cv.wait(lock, [this, &work_fifo] {
-			return !is_paused || !work_fifo.IsRunning();
-		});
+		cv.wait(lock, [this] { return !is_paused; });
 
 		audio_frame_fifo.Start();
 

--- a/src/midi/soundcanvas.cpp
+++ b/src/midi/soundcanvas.cpp
@@ -511,6 +511,10 @@ MidiDeviceSoundCanvas::~MidiDeviceSoundCanvas()
 	work_fifo.Stop();
 	audio_frame_fifo.Stop();
 
+	// Wake the renderer if it's blocked in the pause condvar so it sees
+	// `work_fifo.IsRunning() == false` and exits cleanly.
+	Resume();
+
 	// Wait for the rendering thread to finish
 	if (renderer.joinable()) {
 		renderer.join();
@@ -594,16 +598,19 @@ void MidiDeviceSoundCanvas::MixerCallback(const int requested_audio_frames)
 
 	static std::vector<AudioFrame> audio_frames = {};
 
-	const auto has_dequeued = audio_frame_fifo.BulkDequeue(audio_frames,
+	// A short read means the fifo was stopped for a pause (or a genuine
+	// underrun): add whatever we got and pad the shortfall with silence.
+	// Never hand `AddSamples_sfloat` fewer frames than it will read.
+	const auto num_dequeued = audio_frame_fifo.BulkDequeue(audio_frames,
 	                                                       requested_audio_frames);
 
-	if (has_dequeued) {
-		mixer_channel->AddSamples_sfloat(requested_audio_frames,
+	if (num_dequeued > 0) {
+		mixer_channel->AddSamples_sfloat(check_cast<int>(num_dequeued),
 		                                 &audio_frames[0][0]);
 
 		last_rendered_ms = PIC_AtomicIndex();
-	} else {
-		assert(!audio_frame_fifo.IsRunning());
+	}
+	if (check_cast<int>(num_dequeued) < requested_audio_frames) {
 		mixer_channel->AddSilence();
 	}
 }
@@ -756,14 +763,53 @@ void MidiDeviceSoundCanvas::ProcessWorkFromFifoBacklogged()
 void MidiDeviceSoundCanvas::Render()
 {
 	while (work_fifo.IsRunning()) {
+		if (is_paused.load(std::memory_order_acquire)) {
+			// Halt the synth so its internal clock doesn't advance
+			// past the pause edge. Stop `audio_frame_fifo` while
+			// parked so a concurrent mixer `BulkDequeue()` returns
+			// a short read instead of blocking on the
+			// empty-but-running queue -- that block (while holding
+			// `mixer.mutex`) was the pause/resume deadlock the
+			// `MIDI_Pause`/`MIDI_Resume` lock + ordering used to
+			// guard against. Buffered pre-pause frames survive the
+			// stop and drain on resume.
+			std::unique_lock lock(pause_mutex);
+
+			audio_frame_fifo.Stop();
+
+			pause_cv.wait(lock, [this] {
+				return !is_paused.load(std::memory_order_acquire) ||
+				       !work_fifo.IsRunning();
+			});
+
+			audio_frame_fifo.Start();
+
+			continue;
+		}
+
 		if (is_work_fifo_backlogged) {
 			RenderBacklogged();
+
 		} else {
 			constexpr auto OneFrame = 1;
 			work_fifo.IsEmpty() ? RenderAudioFramesToFifo(OneFrame)
 			                    : ProcessWorkFromFifo();
 		}
 	}
+}
+
+void MidiDeviceSoundCanvas::Pause()
+{
+	is_paused.store(true, std::memory_order_release);
+}
+
+void MidiDeviceSoundCanvas::Resume()
+{
+	{
+		const std::lock_guard lock(pause_mutex);
+		is_paused.store(false, std::memory_order_release);
+	}
+	pause_cv.notify_all();
 }
 
 static std::set<const SoundCanvas::SynthModel*> available_models = {};

--- a/src/midi/soundcanvas.cpp
+++ b/src/midi/soundcanvas.cpp
@@ -763,27 +763,7 @@ void MidiDeviceSoundCanvas::ProcessWorkFromFifoBacklogged()
 void MidiDeviceSoundCanvas::Render()
 {
 	while (work_fifo.IsRunning()) {
-		if (is_paused.load(std::memory_order_acquire)) {
-			// Halt the synth so its internal clock doesn't advance
-			// past the pause edge. Stop `audio_frame_fifo` while
-			// parked so a concurrent mixer `BulkDequeue()` returns
-			// a short read instead of blocking on the
-			// empty-but-running queue -- that block (while holding
-			// `mixer.mutex`) was the pause/resume deadlock the
-			// `MIDI_Pause`/`MIDI_Resume` lock + ordering used to
-			// guard against. Buffered pre-pause frames survive the
-			// stop and drain on resume.
-			std::unique_lock lock(pause_mutex);
-
-			audio_frame_fifo.Stop();
-
-			pause_cv.wait(lock, [this] {
-				return !is_paused.load(std::memory_order_acquire) ||
-				       !work_fifo.IsRunning();
-			});
-
-			audio_frame_fifo.Start();
-
+		if (pauser.ParkIfPaused(audio_frame_fifo, work_fifo)) {
 			continue;
 		}
 
@@ -800,16 +780,12 @@ void MidiDeviceSoundCanvas::Render()
 
 void MidiDeviceSoundCanvas::Pause()
 {
-	is_paused.store(true, std::memory_order_release);
+	pauser.Pause();
 }
 
 void MidiDeviceSoundCanvas::Resume()
 {
-	{
-		const std::lock_guard lock(pause_mutex);
-		is_paused.store(false, std::memory_order_release);
-	}
-	pause_cv.notify_all();
+	pauser.Resume();
 }
 
 static std::set<const SoundCanvas::SynthModel*> available_models = {};

--- a/src/midi/soundcanvas.cpp
+++ b/src/midi/soundcanvas.cpp
@@ -764,7 +764,7 @@ void MidiDeviceSoundCanvas::ProcessWorkFromFifoBacklogged()
 void MidiDeviceSoundCanvas::Render()
 {
 	while (work_fifo.IsRunning()) {
-		if (pauser.ParkIfPaused(audio_frame_fifo, work_fifo)) {
+		if (pauser.ParkIfPaused(audio_frame_fifo)) {
 			continue;
 		}
 

--- a/src/midi/soundcanvas.cpp
+++ b/src/midi/soundcanvas.cpp
@@ -511,8 +511,9 @@ MidiDeviceSoundCanvas::~MidiDeviceSoundCanvas()
 	work_fifo.Stop();
 	audio_frame_fifo.Stop();
 
-	// Wake the renderer if it's blocked in the pause condvar so it sees
-	// `work_fifo.IsRunning() == false` and exits cleanly.
+	// Wake the renderer via the pauser's condvar if it's parked (stopping
+	// `work_fifo` alone does not notify it); once unblocked it sees
+	// `work_fifo` has stopped and exits its loop cleanly.
 	Resume();
 
 	// Wait for the rendering thread to finish

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable(dosbox_tests
     cmd_move_tests.cpp
     dos_files_tests.cpp
     dos_memory_struct_tests.cpp
+    dosbox_pause_fsm_tests.cpp
     dosbox_test_fixture.h
     drives_tests.cpp
     fraction_tests.cpp

--- a/tests/dosbox_pause_fsm_tests.cpp
+++ b/tests/dosbox_pause_fsm_tests.cpp
@@ -1,0 +1,170 @@
+// SPDX-FileCopyrightText:  2026-2026 The DOSBox Staging Team
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "dosbox_pause_fsm.h"
+
+#include <gtest/gtest.h>
+
+#include <optional>
+
+namespace {
+
+using enum PauseState;
+
+const char* name(const PauseState state)
+{
+	switch (state) {
+	case Running: return "Running";
+	case UserPausePending: return "UserPausePending";
+	case AutoPausePending: return "AutoPausePending";
+	case UserPaused: return "UserPaused";
+	case AutoPaused: return "AutoPaused";
+	}
+	return "?";
+}
+
+const char* name(const PauseEvent event)
+{
+	switch (event) {
+	case PauseEvent::UserPause: return "UserPause";
+	case PauseEvent::UserResume: return "UserResume";
+	case PauseEvent::AutoPause: return "AutoPause";
+	case PauseEvent::AutoResume: return "AutoResume";
+	case PauseEvent::FadeComplete: return "FadeComplete";
+	}
+	return "?";
+}
+
+// --------------------------------------------------------------------------
+// Behaviourally-important rules, spelled out
+// --------------------------------------------------------------------------
+
+TEST(PauseFsm, UserPauseEngagesFromRunning)
+{
+	EXPECT_EQ(NextPauseState(Running, PauseEvent::UserPause), UserPausePending);
+}
+
+TEST(PauseFsm, UserPauseIsIdempotent)
+{
+	EXPECT_EQ(NextPauseState(UserPausePending, PauseEvent::UserPause),
+	          std::nullopt);
+	EXPECT_EQ(NextPauseState(UserPaused, PauseEvent::UserPause), std::nullopt);
+}
+
+TEST(PauseFsm, UserPauseUpgradesAutoPause)
+{
+	// A manual pause while auto-paused must stick around after focus gain,
+	// so it upgrades to the user-owned states.
+	EXPECT_EQ(NextPauseState(AutoPausePending, PauseEvent::UserPause),
+	          UserPausePending);
+	EXPECT_EQ(NextPauseState(AutoPaused, PauseEvent::UserPause), UserPaused);
+}
+
+TEST(PauseFsm, UserResumeClearsUserPauseOnly)
+{
+	EXPECT_EQ(NextPauseState(UserPausePending, PauseEvent::UserResume), Running);
+	EXPECT_EQ(NextPauseState(UserPaused, PauseEvent::UserResume), Running);
+
+	// Auto-pauses are left for the auto-resume path.
+	EXPECT_EQ(NextPauseState(AutoPausePending, PauseEvent::UserResume),
+	          std::nullopt);
+
+	EXPECT_EQ(NextPauseState(AutoPaused, PauseEvent::UserResume), std::nullopt);
+}
+
+TEST(PauseFsm, AutoPauseEngagesOnlyFromRunning)
+{
+	EXPECT_EQ(NextPauseState(Running, PauseEvent::AutoPause), AutoPausePending);
+
+	// A user pause survives an auto-pause signal; an auto-pause is idempotent.
+	EXPECT_EQ(NextPauseState(UserPausePending, PauseEvent::AutoPause),
+	          std::nullopt);
+
+	EXPECT_EQ(NextPauseState(UserPaused, PauseEvent::AutoPause), std::nullopt);
+	EXPECT_EQ(NextPauseState(AutoPausePending, PauseEvent::AutoPause),
+	          std::nullopt);
+
+	EXPECT_EQ(NextPauseState(AutoPaused, PauseEvent::AutoPause), std::nullopt);
+}
+
+TEST(PauseFsm, AutoResumeNeverResumesUserPause)
+{
+	EXPECT_EQ(NextPauseState(AutoPausePending, PauseEvent::AutoResume), Running);
+	EXPECT_EQ(NextPauseState(AutoPaused, PauseEvent::AutoResume), Running);
+
+	// The whole point of the user/auto split: focus gain must not undo a
+	// manual pause.
+	EXPECT_EQ(NextPauseState(UserPausePending, PauseEvent::AutoResume),
+	          std::nullopt);
+
+	EXPECT_EQ(NextPauseState(UserPaused, PauseEvent::AutoResume), std::nullopt);
+}
+
+TEST(PauseFsm, FadeCompleteEngagesPendingPause)
+{
+	EXPECT_EQ(NextPauseState(UserPausePending, PauseEvent::FadeComplete),
+	          UserPaused);
+
+	EXPECT_EQ(NextPauseState(AutoPausePending, PauseEvent::FadeComplete),
+	          AutoPaused);
+
+	// Only meaningful while a pause is pending.
+	EXPECT_EQ(NextPauseState(Running, PauseEvent::FadeComplete), std::nullopt);
+	EXPECT_EQ(NextPauseState(UserPaused, PauseEvent::FadeComplete), std::nullopt);
+	EXPECT_EQ(NextPauseState(AutoPaused, PauseEvent::FadeComplete), std::nullopt);
+}
+
+// --------------------------------------------------------------------------
+// Full transition matrix
+// --------------------------------------------------------------------------
+//
+// Guards the entire decision table so any accidental change to a single
+// cell is caught, not just the rules exercised above.
+
+TEST(PauseFsm, FullTransitionMatrix)
+{
+	struct Case {
+		PauseState from              = {};
+		PauseEvent event             = {};
+		std::optional<PauseState> to = {};
+	};
+
+	const Case cases[] = {
+	        {         Running,    PauseEvent::UserPause, UserPausePending},
+	        {         Running,   PauseEvent::UserResume,     std::nullopt},
+	        {         Running,    PauseEvent::AutoPause, AutoPausePending},
+	        {         Running,   PauseEvent::AutoResume,     std::nullopt},
+	        {         Running, PauseEvent::FadeComplete,     std::nullopt},
+
+	        {UserPausePending,    PauseEvent::UserPause,     std::nullopt},
+	        {UserPausePending,   PauseEvent::UserResume,          Running},
+	        {UserPausePending,    PauseEvent::AutoPause,     std::nullopt},
+	        {UserPausePending,   PauseEvent::AutoResume,     std::nullopt},
+	        {UserPausePending, PauseEvent::FadeComplete,       UserPaused},
+
+	        {AutoPausePending,    PauseEvent::UserPause, UserPausePending},
+	        {AutoPausePending,   PauseEvent::UserResume,     std::nullopt},
+	        {AutoPausePending,    PauseEvent::AutoPause,     std::nullopt},
+	        {AutoPausePending,   PauseEvent::AutoResume,          Running},
+	        {AutoPausePending, PauseEvent::FadeComplete,       AutoPaused},
+
+	        {      UserPaused,    PauseEvent::UserPause,     std::nullopt},
+	        {      UserPaused,   PauseEvent::UserResume,          Running},
+	        {      UserPaused,    PauseEvent::AutoPause,     std::nullopt},
+	        {      UserPaused,   PauseEvent::AutoResume,     std::nullopt},
+	        {      UserPaused, PauseEvent::FadeComplete,     std::nullopt},
+
+	        {      AutoPaused,    PauseEvent::UserPause,       UserPaused},
+	        {      AutoPaused,   PauseEvent::UserResume,     std::nullopt},
+	        {      AutoPaused,    PauseEvent::AutoPause,     std::nullopt},
+	        {      AutoPaused,   PauseEvent::AutoResume,          Running},
+	        {      AutoPaused, PauseEvent::FadeComplete,     std::nullopt},
+	};
+
+	for (const auto& c : cases) {
+		EXPECT_EQ(NextPauseState(c.from, c.event), c.to)
+		        << "from=" << name(c.from) << " event=" << name(c.event);
+	}
+}
+
+} // namespace

--- a/tests/mixer_tests.cpp
+++ b/tests/mixer_tests.cpp
@@ -3,6 +3,8 @@
 
 #include "audio/mixer.h"
 
+#include <optional>
+
 #include <gtest/gtest.h>
 
 static void callback(const uint16_t) {}
@@ -62,6 +64,100 @@ TEST(MixerConfigureFadeOut, OutOfBounds)
 	ASSERT_FALSE(channel.ConfigureFadeOut("99 9"));
 	ASSERT_FALSE(channel.ConfigureFadeOut("-1 -10000"));
 	ASSERT_FALSE(channel.ConfigureFadeOut("3001 10000"));
+}
+
+// --------------------------------------------------------------------------
+// Mute FSM policy
+// --------------------------------------------------------------------------
+
+using enum MixerMuteState;
+
+const char* name(const MixerMuteState state)
+{
+	switch (state) {
+	case Audible: return "Audible";
+	case UserMuted: return "UserMuted";
+	case AutoMuted: return "AutoMuted";
+	}
+	return "?";
+}
+
+const char* name(const MuteRequest request)
+{
+	switch (request) {
+	case MuteRequest::UserMute: return "UserMute";
+	case MuteRequest::UserUnmute: return "UserUnmute";
+	case MuteRequest::AutoMute: return "AutoMute";
+	case MuteRequest::AutoUnmute: return "AutoUnmute";
+	}
+	return "?";
+}
+
+TEST(MixerMuteFsm, UserMuteTrumpsAutoMute)
+{
+	// A user mute engages from Audible and overrides an auto-mute; it is
+	// idempotent once user-muted.
+	EXPECT_EQ(MIXER_NextMuteState(Audible, MuteRequest::UserMute), UserMuted);
+	EXPECT_EQ(MIXER_NextMuteState(AutoMuted, MuteRequest::UserMute), UserMuted);
+	EXPECT_EQ(MIXER_NextMuteState(UserMuted, MuteRequest::UserMute), std::nullopt);
+}
+
+TEST(MixerMuteFsm, UserUnmuteClearsEitherMute)
+{
+	EXPECT_EQ(MIXER_NextMuteState(UserMuted, MuteRequest::UserUnmute), Audible);
+	EXPECT_EQ(MIXER_NextMuteState(AutoMuted, MuteRequest::UserUnmute), Audible);
+	EXPECT_EQ(MIXER_NextMuteState(Audible, MuteRequest::UserUnmute), std::nullopt);
+}
+
+TEST(MixerMuteFsm, AutoMuteEngagesOnlyFromAudible)
+{
+	EXPECT_EQ(MIXER_NextMuteState(Audible, MuteRequest::AutoMute), AutoMuted);
+
+	// A user-mute survives focus loss; an existing auto-mute is idempotent.
+	EXPECT_EQ(MIXER_NextMuteState(UserMuted, MuteRequest::AutoMute), std::nullopt);
+	EXPECT_EQ(MIXER_NextMuteState(AutoMuted, MuteRequest::AutoMute), std::nullopt);
+}
+
+TEST(MixerMuteFsm, AutoUnmuteNeverClearsUserMute)
+{
+	EXPECT_EQ(MIXER_NextMuteState(AutoMuted, MuteRequest::AutoUnmute), Audible);
+
+	// Focus gain must not clear a user-mute.
+	EXPECT_EQ(MIXER_NextMuteState(UserMuted, MuteRequest::AutoUnmute),
+	          std::nullopt);
+	EXPECT_EQ(MIXER_NextMuteState(Audible, MuteRequest::AutoUnmute), std::nullopt);
+}
+
+TEST(MixerMuteFsm, FullTransitionMatrix)
+{
+	struct Case {
+		MixerMuteState from              = {};
+		MuteRequest request              = {};
+		std::optional<MixerMuteState> to = {};
+	};
+
+	const Case cases[] = {
+	        {  Audible,   MuteRequest::UserMute,    UserMuted},
+	        {  Audible, MuteRequest::UserUnmute, std::nullopt},
+	        {  Audible,   MuteRequest::AutoMute,    AutoMuted},
+	        {  Audible, MuteRequest::AutoUnmute, std::nullopt},
+
+	        {UserMuted,   MuteRequest::UserMute, std::nullopt},
+	        {UserMuted, MuteRequest::UserUnmute,      Audible},
+	        {UserMuted,   MuteRequest::AutoMute, std::nullopt},
+	        {UserMuted, MuteRequest::AutoUnmute, std::nullopt},
+
+	        {AutoMuted,   MuteRequest::UserMute,    UserMuted},
+	        {AutoMuted, MuteRequest::UserUnmute,      Audible},
+	        {AutoMuted,   MuteRequest::AutoMute, std::nullopt},
+	        {AutoMuted, MuteRequest::AutoUnmute,      Audible},
+	};
+
+	for (const auto& c : cases) {
+		EXPECT_EQ(MIXER_NextMuteState(c.from, c.request), c.to)
+		        << "from=" << name(c.from)
+		        << " request=" << name(c.request);
+	}
 }
 
 } // namespace


### PR DESCRIPTION
_(Based on `wd/mixer` because I wanted to test this together with @weirddan455 's mixer change. This must go in after that PR was merged.)_

# Description

The pause  feature we inherited from original DOSBox has been annoying me to no end. It blocks all input, so you can't even switch between windowed/fullscreen, can't use any hotkeys (like start video capturing), can't open the mapper, the viewport doesn't get properly updated when resizing the window, and so on. Even the pause hotkey remapping is buggy; when you change it to something else from the defaults, you get some quirky unpause behaviour when you still use Alt+Pause to unpause because it's still accepted. Ugh.

All this just crap and makes us look like amateurs. Every normal emulator has a properly implemented pause feature, not this hacky mess. A proper pause mode that responds to hotkeys, SDL events, and updates the viewport correctly is a prerequisite for the OSD — when you pause a movie on your TV you'd still expect the menu system to work, right? 😆 It would be supremely stupid _not_ to be able to change the subtitle language or adjust the video settings while the movie is paused 😂 Same deal with Staging; you should have full access to all available hotkeys and emulator functionality while paused, including interacting with the OSD via the mouse, keyboard, etc.

Now this has all been rectified. This branch fixes all pause related issues so now:

- All hotkeys work during pause, except fast-forward (you can take screenshots, switch between windowed/fullscreen, use the mapper, mute/unmute, start/stop audio & video capture, etc.)
- The viewport gets updated while paused when resizing the window or switching between fullscreen/windowed (so you get auto-shader switching, integer scaling snapping, and so on)
- You can remap the pause hotkey and it works without any quirks, just like any other hotkey.

Some existing bugs and issues have also been fixed:

- Fixed some bugs around audio captures rarely inserting micro-silences (a few ms) into the capture (it was much easier to trigger this when spamming pause/unpause during my stress tests)
- Fixed some latent bugs around image and video capturing that could rarely capture some garbage (pausing/unpausing made these more likely to happen)
- Muting/unmuting (either manually or via `mute_when_inactive`) and pausing/unpausing now fades the audio in and out over about 5 ms to avoid clicks and pops (you get that when you go from a non-zero sample to absolute zero abruptly without a fade / volume ramp — all good audio software do these microfades instead of just cutting the volume to zero)
- Mixer channel sleep and `opl_fadeout` were using wall-clock time instead of emulator time (so the time spent paused counted towards the sleep/fadeout timeout timers, which was incorrect)

## Implementation details

### Old design

Previously, the pause literally "lived" _inside_ the pause hotkey's handler! That remarkable and horrifying in equal measures! 😆  This is how the stack trace looked like when paused:

```
main thread
 └── normal_loop()
      └── cpudecoder / PIC_RunQueue
           └── some handler runs the mapper (via a deferred PIC event or direct dispatch)
                └── pause_emulation()
                     └── while (sdl.is_paused) SDL_WaitEvent(...)   ← BLOCKED HERE
```

So basically the pause handler called `pause_emulation()`, which had a nested (!) event loop _embedded_ in the main event loop 🥶 Then `SDL_WaitEvent()` effectively blocked the calling thread until we received an "unpause" event in this nested loop. Because `normal_loop()` was effectively blocked, which also blocked PIC handling, the emulator was stopped... 

...for the most part. The internal MIDI synth render threads were still running, at least for a bit longer until they filled their buffers/FIFOs (nothing was draining their work FIFOs as the mixer was blocked as well by calling `MIXER_LockMixerThread()` when entering pause mode). This resulted in a very subtle bug where the actually rendered MIDI output was "prolonged" by up to  10-20ms (depending on the buffer audio sizes) which actually showed up in the audio capture as well (if you spammed pause/resume industriously over a minute or so, you could make the recorded audio a few seconds longer).

So this is why we could not use any hotkeys in pause mode, why the video output was frozen (because frame presentation was also blocked), the webserver did not respond to requests, and so on.

### New design

The new design flips this on its head: pause is an FSM state, and `normal_loop()` explicitly returns `paused_tick()` when paused. `paused_tick()` runs its own tight loop that still calls `GFX_PollAndHandleEvents()`, `MAPPER_RunPending()`, `Bridge::ProcessRequests()`, `GFX_MaybePresentFrame()`, and `SDL_DelayPrecise(1ms)`, so hotkeys, frame presentation, webserver, mapper, and window events all keep working. The mixer keeps running, too (just producing silence with a fade-in/fade-out ramp), and the MIDI renderer threads are explicitly halted via the pause conditional variable so they don't advance their synth clocks (fixes the bug of inserting random up to ~10-20 ms delays into the MIDI data stream (conceptually) on every pause/resume cycle when capturing the audio output).

For video updates during pause, the "synchronous" scan doubling/halving based on the "last committed" scaler cache frame was the simplest solution. That circumvents having to re-run through the VGA code when the forced single-scanning / pixel-doubling VGA render params change due to auto-shader switching (e.g., going from a true-double scanning 4k shader to 1080p-fake-double-scan or sharp). Previous failed attempts included decoupling the VGA emulation layer entirely from the PIC (because the PIC is stopped during pause) and running through the entire flow manually when paused. Messy. Non-solutions included disabling auto-shader switching in pause mode — I won't have that 😎 

The ultimate solution will be moving the entire scanline/pixel doubling business into the shaders, and either making compensatory changes in the SDL texture renderer. Then some of functionality can be scaled back. That will come in a future PR.

I also recommend reading the last commit that adds a high-level overview doco on how the mixer and our audio pipeline work:

https://github.com/dosbox-staging/dosbox-staging/blob/08b99d9cb3a066ce4623faf57633fbd3cb679a94/src/audio/README.md

### LLM usage

This was an iterative, collaborative effort with Claude, both in the design and implementation phase. My first two attempts were discarded; the end result was too buggy and overcomplicated. This (IMO ideal) final solution was made possible by quickly experimenting with those two earlier proof of concepts. Centralising the pause states into an FSM was the winning formula. Previous iterations were very hard to follow because clients of the pause API made certain pause transition-related decisions, so the logic was not fully encapsulated, and a multitude of flags were sprinkled around the codebase to mark the paused/muted states (instead of a single FSM). The FSM has worked so well that I refactored the mixer too to use this pattern for mute handling — a lot of the existing complexity fell away.

I went through every single line, touched up things in a few places and clarified the comments, but technically I did not handwrite the code. I also asked it to exhaustively analyse the codebase for any other things pausing/resuming using might have affected that I could not think of — it could not find anything, but what it found instead were some really obscure bugs like the sleep and OPL fadeout being affected by the pause duration (as they used to use wall-clock time). We fixed all these.

I've done deadlock and correct mutex usage analysis several times with Claude (more than 10 times in total), ran the thread sanitiser build on macOS, and have done very extensive manual testing both on Windows and macOS of every single feature affected by the rework. As far as I can tell, everything works perfectly, often better than previously. I'll admit concurrency issues and multithreading just do my head in, so I'm happy to take all the help I can get. Yes, Claude is stochastic, and sometimes gets hopelessly lost, but many times it found valid threading issues I just did not see. Some of the bugs were insidious and could only be triggered when pausing/resuming vigorously for over a minute (but eventually they could be tiggered). Hunting and eliminating all these is a major win.

Claude Opus 4.7 on "max effort" mode came up with some particularly creative solutions to some problems, for example the fade in/out implementation is genuinely elegant. That was the result of 4-5 failed attempts; all I could think of was some questionable solutions that would add extra latency, but this final solution by Claude is a lot better.

The mixer README was also 100% written by Claude. I gave it a go, I asked it to describe how the mixer works based on its "understanding" (after I was really impressed by how it tracked down some evil concurrency issues). The result was so good that I did not feel the need to change much (I think I changed a few adjectives, but that's it).

## Related issues

- https://github.com/dosbox-staging/dosbox-staging/issues/3371


# Release notes

## Improved pause feature

The pause feature has been redesigned from the ground up: now you can use all hotkeys after you've activated pause mode with the `Alt+Pause` hotkey (`Cmd+P` on macOS). So you can switch to fullscreen, take screenshots, start audio capture, etc., while paused, and the viewport also gets correctly updated when you resize the window. Additionally, there are no more random clicks and pops in the audio when pausing/unpausing.

Several subtle pause related issues have been fixed as well (e.g., the pause duration "confusing" the `opl_fadeout` timeout, occasional glitches in audio captures, etc.)

## Video capture improvements

Video captures have been much improved if the host CPU cannot keep up with real-time emulation. Most notably, the audio stays in tighter sync with the video and it doesn't slow down or abruptly jump forward.


# Manual testing

### General

- `[PAUSED]` is shown in the titlebar in pause mode.
- Remapping the pause hotkey to any other key or key combo works.
- Cmd+P still works on macOS to pause/resume (it's the macOS default).
- Remapping the hotkey works while in pause mode; the new hotkey unpauses, or if I unmap, I can't unpause with the old hotkey (expected and correct).
- Fast-forward is not allowed in pause mode (a log message informs the user about this when the hotkey is activated).
- Quitting while paused works.
- `pause_when_inactive = on` works correctly with manual pause.
- The webserver responds to commands at while paused.

### Video

- The window can be resized in pause mode, fullscreen/windowed switching works
- Auto-shader switching is happening correctly when resizing the window while. paused, in particular switching between `interpolation/sharp`, `crt/vga-1080p-fake-double-scan` and `crt/crt-hyllian:vga-1440p` (or higher) doesn't result in artifacts, wrong single or double scanning being show, or flashes.
- Pause, shrink window so `sharp` shader is active, open mapper, then enlarge window and exit mapper. On mapper exist, we should switch to correct double-scanning shader and there are zero visual artifacts or flashes.
- Do the opposite (start from large window), and various other combinations -- there should always be zero visual artifacts. Pausing should never show torn/half-rendered frames (we pause always on frame boundaries). Exception to this is when the DOS game itself does frame tearing (doesn't do vsync on real hardware either).
- With `output texture` the image is correctly updated when resizing the window, switching fullscreen/windowed, etc. in pause mode.
- Tested **Return to Zork** (ReelMagic game), pause/resume works, resizing window whan paused works as expected.
- Tested 3dfx Voodoo version of **Tomb Raider**, pause/resume works, resizing window whan paused works as expected. 

### Image capture

- Image capture works while in pause mode (all image capture formats). Repeated image capture hotkey activations result in multiple images being written, exactly like in unpaused mode.
- Edge case test: make sure to create screenshots only in pause mode in the session (so no image captures prior to entering pause mode).

### Video capture

- Tested in a similar way like audio captures: pause/unpause spamming while recording, start/stop recording while in pause mode, etc. Zero issues in the recorded video, no hangs, no crashes. Tested the resulting video captures in VLC.

### Audio

- Audio is muted when in pause mode.
- If manual mute is engaged before pausing ([MUTE] is shown in the titlebar), pause/resume should preserve the manual mute state.
- Manual mute can be enabled/disabled when paused (i.e. muting during pause, then resuming will result in `[MUTE]` in the titlebar and no sound).
- There is no audible click when pausing/resuming and muting/unmuting; it's always smooth and click-free.
- Pausing/resuming while capturing audio doesn't result in artifacts in the resulting audio. Space Quest III is a good test case for this as there long-held clean notes in the intro music, so any glitch in the recording is very obvious. Recorded the music for about a minute while pausing/resuming at random intervals, with occasional burst-spamming of the pause hotkey. Zero glitches.
- Spamming pause/resumecontinuously using the debug build to uncover deadlocks or race conditions -- no hang, zero audible issues, perfect audio capture.
- Audio capture can be stopped and stared while in pause mode.
- `mute_when_inactive = on` works correctly with manual muting and pause. Also tried enabling `pause_when_inactive = on` as well and tried lots of different state transitions and combos of manual mute/unmute, manual pause/unpause, and Alt-Tabbing -- all works as expected, no bugs.
- Tested an IMFC game and spammed pause/resume, no issues (IMFC does it's own threading using SDL threads, so it was worth double-checking).
- Tested Discworld with SoundCanvas and SB16 configured, started audio capture, then fast-forwarded randomly, spammed pause/unpause, fast-forwarded again, repeat a few times. Audio capture came out perfectly, zero glitches, no missed content, 100% correct.
- Tested Discworld with an external MIDI synth (Roland SoundCanvas VA running in REAPER); pause/resume and fast-forward works with external MIDI devices as expected.
- `nosound = on` works with pause/resume and audio captures.
- `prebuffer = 0` and pause/resuming vigorously over a minute doesn't result in deadlocks (with and without an active audio capture).

### Input

- Mouse can be captured/uncaptured while in pause mode.
- In games with mouse support (e.g., Space Quest III), capturing the mouse, pausing, moving the mouse, then unpausing won't result in the in-game mouse pointer jumping around.
- The above test, but also uncapturing/moving the mouse/capturing/resuming -- no in-game mouse pointer jump.
- Typing something (like typing `asdf`) while paused and then resumingwon't pass the keypresses to the emulator (test at the DOS prompt).
- Holding the 'A' key down so key repeat is triggered, pause, then unpause with 'A' still held down.  No stuck key repeat (the key repeat stops when resuming).
- Variation: hold down `A`, pause, release `A`, resume. No stuck key repeat.
- Variation: pause, hold down `A`, resume, release `A`. Only a single `A` letter gets passed, no key repeat is triggered (seems reasonable to me).

The change has been manually tested on:

- [x] Windows
- [x] macOS
- [ ] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

- [x] I am a human, I have read and understood the [project's policy on the use of generative AI tools](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md#policy-on-the-use-of-generative-ai-tools), and I have acted in accordance to it.

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my work (especially important for AI-assisted contributions).
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [x] my change has been manually tested on Windows, macOS, and Linux.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [x] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [x] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

