### PR TITLE
Clear BIOS cursor type in EGA/VGA graphics modes

### DIFF
--- a/src/ints/int10_modes.cpp
+++ b/src/ints/int10_modes.cpp
@@ -894,6 +894,12 @@ static void finish_set_mode(bool clearmem) {
 	// Set cursor shape
 	if (CurMode->type==M_TEXT) {
 		INT10_SetCursorShape(0x06,0x07);
+	} else if (is_machine_ega_or_better()) {
+		// The word at offset 0x60 (BIOSMEM_CURSOR_TYPE) gets set
+		// to zero in the BDA after switching to a graphics mode.
+		// Some programs (typically TSRs) might check if this word is
+		// zero to determine whether they're in a graphics mode.
+		real_writew(BIOSMEM_SEG, BIOSMEM_CURSOR_TYPE, 0);
 	}
 	// Set cursor pos for page 0..7
 	for (uint8_t ct=0;ct<8;ct++) INT10_SetCursorPos(0,0,ct);


### PR DESCRIPTION
# Description

Clear stale text cursor state from the BIOS Data Area when switching to EGA/VGA graphics modes.

Some DOS TSRs use the BIOS cursor-type word in the BDA to distinguish graphics modes from text-mode font state. DOSBox was leaving the previous text-mode cursor shape there after switching to EGA/VGA graphics modes, which could make those TSRs take the wrong character or font handling path.

This change clears that BDA word on EGA/VGA graphics-mode switches so programs see graphics state instead of stale text cursor state.

Before:
<img width="2133" height="1599" alt="grafik" src="https://github.com/user-attachments/assets/696a1dda-3390-434f-821c-b99fbaa43dd3" />

After:
<img width="1069" height="832" alt="grafik" src="https://github.com/user-attachments/assets/5f7506d6-8749-46aa-8e08-a1a24bc6d788" />


## Related issues

- Fixes #4958


# Release notes

Fixed a graphics compatibility issue where some DOS TSRs could misdetect EGA/VGA graphics modes because DOSBox preserved stale text cursor state in the BIOS Data Area.


# Manual testing

Use the game attached at #4958 and run it with start.bat

_Non-trivial changes **must be** tested on all three OSes we support. If you can't test on a particular OS, ask the team or contributors for help._

The change has been manually tested on:

- [x] Windows
- [ ] macOS
- [ ] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

- [x] I am a human, I have read and understood the [project's policy on the use of generative AI tools](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md#policy-on-the-use-of-generative-ai-tools), and I have acted in accordance to it.

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my work (especially important for AI-assisted contributions).
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [ ] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [x] my change has been manually tested on Windows, macOS, and Linux.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [x] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

