### PR TITLE
Convert filenames to UTF-8 on host and Codepage 437 in DOS

### DIFF
--- a/src/dos/dos_system.h
+++ b/src/dos/dos_system.h
@@ -212,8 +212,7 @@ public:
 		          id(MAX_OPENDIRS),
 		          nextEntry(0),
 		          shortNr(0),
-		          fileList(0),
-		          longNameList(0)
+		          fileList(0)
 		{}
 
 		~CFileInfo()
@@ -222,7 +221,6 @@ public:
 				delete p;
 			}
 			fileList.clear();
-			longNameList.clear();
 		}
 
 		char        orgname[CROSS_LEN];
@@ -234,7 +232,6 @@ public:
 		unsigned    shortNr;
 		// contents
 		std::vector<CFileInfo*> fileList;
-		std::vector<CFileInfo*> longNameList;
 	};
 
 private:

--- a/src/dos/drive_cache.cpp
+++ b/src/dos/drive_cache.cpp
@@ -351,7 +351,6 @@ void DOS_Drive_Cache::CacheOut(const char* path, bool ignoreLastDir) {
 	}
 	// clear lists
 	dir->fileList.clear();
-	dir->longNameList.clear();
 	save_dir = nullptr;
 }
 
@@ -372,7 +371,7 @@ bool DOS_Drive_Cache::GetShortName(const char* fullname, char* shortname) {
 	else
 		return false;
 
-	std::vector<CFileInfo*>::size_type filelist_size = curDir->longNameList.size();
+	std::vector<CFileInfo*>::size_type filelist_size = curDir->fileList.size();
 	if (filelist_size <= 0) {
 		return false;
 	}
@@ -380,11 +379,11 @@ bool DOS_Drive_Cache::GetShortName(const char* fullname, char* shortname) {
 	// The orgname part of the list is not sorted (shortname is)! So we can only walk through it.
 	for(Bitu i = 0; i < filelist_size; i++) {
 #if defined (WIN32)
-		if (strcasecmp(pos,curDir->longNameList[i]->orgname) == 0) {
+		if (strcasecmp(pos,curDir->fileList[i]->orgname) == 0) {
 #else
-		if (strcmp(pos,curDir->longNameList[i]->orgname) == 0) {
+		if (strcmp(pos,curDir->fileList[i]->orgname) == 0) {
 #endif
-			safe_strncpy(shortname, curDir->longNameList[i]->shortname, DOS_NAMELENGTH_ASCII);
+			safe_strncpy(shortname, curDir->fileList[i]->shortname, DOS_NAMELENGTH_ASCII);
 			return true;
 		}
 	}
@@ -425,7 +424,7 @@ int DOS_Drive_Cache::CompareShortname(const char* compareName, const char* short
 unsigned DOS_Drive_Cache::CreateShortNameID(CFileInfo *curDir, const char *name)
 {
 	assert(curDir);
-	const auto filelist_size = curDir->longNameList.size();
+	const auto filelist_size = curDir->fileList.size();
 	if (filelist_size == 0)
 		return 1; // short name IDs start with 1
 
@@ -435,7 +434,7 @@ unsigned DOS_Drive_Cache::CreateShortNameID(CFileInfo *curDir, const char *name)
 
 	while (low <= high) {
 		auto mid = std::midpoint(low, high);
-		const char *other_shortname = curDir->longNameList[mid]->shortname;
+		const char *other_shortname = curDir->fileList[mid]->shortname;
 		const int res = CompareShortname(name, other_shortname);
 		
 		if (res>0)	low  = mid+1; else
@@ -443,9 +442,9 @@ unsigned DOS_Drive_Cache::CreateShortNameID(CFileInfo *curDir, const char *name)
 		else {
 			// any more same x chars in next entries ?	
 			do {
-				found_nr = curDir->longNameList[mid]->shortNr;
+				found_nr = curDir->fileList[mid]->shortNr;
 				mid++;
-			} while((Bitu)mid < filelist_size && (CompareShortname(name, curDir->longNameList[mid]->shortname) == 0));
+			} while((Bitu)mid < filelist_size && (CompareShortname(name, curDir->fileList[mid]->shortname) == 0));
 			break;
 		};
 	}
@@ -577,30 +576,6 @@ void DOS_Drive_Cache::CreateShortName(CFileInfo* curDir, CFileInfo* info) {
 			unsigned int remaining_space = DOS_NAMELENGTH_ASCII - safe_strlen(info->shortname) - 1;
 			strncat(info->shortname, pos, 4 < remaining_space ? 4 : remaining_space);
 			info->shortname[DOS_NAMELENGTH] = 0;
-		}
-
-		// keep list sorted for CreateShortNameID to work correctly
-		if (!curDir->longNameList.empty()) {
-			if (!(strcmp(info->shortname,curDir->longNameList.back()->shortname)<0)) {
-				// append at end of list
-				curDir->longNameList.push_back(info);
-			} else {
-				// look for position where to insert this element
-				bool found=false;
-				std::vector<CFileInfo*>::iterator it;
-				for (it=curDir->longNameList.begin(); it!=curDir->longNameList.end(); ++it) {
-					if (strcmp(info->shortname,(*it)->shortname)<0) {
-						found = true;
-						break;
-					}
-				}
-				// Put it in longname list...
-				if (found) curDir->longNameList.insert(it,info);
-				else curDir->longNameList.push_back(info);
-			}
-		} else {
-			// empty file list, append
-			curDir->longNameList.push_back(info);
 		}
 	} else {
 		safe_strcpy(info->shortname, tmpName);

--- a/src/dos/drive_cache.cpp
+++ b/src/dos/drive_cache.cpp
@@ -13,6 +13,7 @@
 #include "dos/drives.h"
 #include "misc/cross.h"
 #include "misc/support.h"
+#include "misc/unicode.h"
 #include "utils/string_utils.h"
 
 int fileInfoCounter = 0;
@@ -486,6 +487,8 @@ Bits DOS_Drive_Cache::GetLongName(CFileInfo* curDir, char* shortName, const size
 		};
 	}
 	// not available
+	const std::string host_name = dos_437_to_fs_utf8(shortName);
+	safe_strncpy(shortName, host_name.c_str(), shortName_len);
 	return -1;
 }
 
@@ -504,10 +507,8 @@ void DOS_Drive_Cache::CreateShortName(CFileInfo* curDir, CFileInfo* info) {
 	Bits	len			= 0;
 	bool	createShort = false;
 
-	// Remove Spaces
-	char tmpNameBuffer[CROSS_LEN];
-	safe_strcpy(tmpNameBuffer, info->orgname);
-	char* tmpName = tmpNameBuffer;
+	std::string dos_name = fs_utf8_to_dos_437(info->orgname);
+	char* tmpName = dos_name.data();
 	upcase(tmpName);
 	createShort = RemoveSpaces(tmpName);
 

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -341,7 +341,6 @@ bool localDrive::FindFirst(const char* _dir, DOS_DTA& dta, bool fcb_findfirst)
 bool localDrive::FindNext(DOS_DTA& dta)
 {
 	char* dir_ent;
-	struct stat stat_block;
 	char full_name[CROSS_LEN];
 	char dir_entcopy[CROSS_LEN];
 
@@ -369,9 +368,6 @@ bool localDrive::FindNext(DOS_DTA& dta)
 		safe_strcpy(dir_entcopy, dir_ent);
 		const char* temp_name = dirCache.GetExpandNameAndNormaliseCase(
 		        full_name);
-		if (stat(temp_name, &stat_block) != 0) {
-			continue; // No symlinks and such
-		}
 
 		if (is_hidden_by_host(temp_name)) {
 			continue; // No host-only hidden files
@@ -390,23 +386,22 @@ bool localDrive::FindNext(DOS_DTA& dta)
 
 		/*file is okay, setup everything to be copied in DTA Block */
 		char find_name[DOS_NAMELENGTH_ASCII] = "";
-		uint16_t find_date;
-		uint16_t find_time;
-		uint32_t find_size;
+		uint16_t find_date = 6;
+		uint16_t find_time = 4;
+		uint32_t find_size = 0;
 
 		if (safe_strlen(dir_entcopy) < DOS_NAMELENGTH_ASCII) {
 			safe_strcpy(find_name, dir_entcopy);
 			upcase(find_name);
 		}
 
-		find_size = (uint32_t)stat_block.st_size;
-		struct tm datetime;
-		if (cross::localtime_r(&stat_block.st_mtime, &datetime)) {
-			find_date = DOS_PackDate(datetime);
-			find_time = DOS_PackTime(datetime);
-		} else {
-			find_time = 6;
-			find_date = 4;
+		const auto handle = open_native_file(temp_name, false);
+		if (handle != InvalidNativeFileHandle) {
+			const auto time = get_dos_file_time(handle);
+			find_date = time.date;
+			find_time = time.time;
+			find_size = local_drive_get_file_size(handle);
+			close_native_file(handle);
 		}
 		dta.SetResult(find_name,
 		              find_size,

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -477,18 +477,16 @@ bool localDrive::RemoveDir(const char* dir)
 bool localDrive::TestDir(const char* dir)
 {
 	const std::string host_dir = MapDosToHostFilename(dir);
+	FatAttributeFlags attributes = {};
+	if (local_drive_get_attributes(host_dir.c_str(), attributes) != DOSERR_NONE) {
+		return false;
+	}
 	// Skip directory test, if "\"
 	if (!host_dir.empty() && host_dir.back() != '\\') {
 		// It has to be a directory !
-		struct stat test;
-		if (stat(host_dir.c_str(), &test)) {
-			return false;
-		}
-		if ((test.st_mode & S_IFDIR) == 0) {
-			return false;
-		}
+		return attributes.directory;
 	}
-	return local_drive_path_exists(host_dir.c_str());
+	return true;
 }
 
 bool localDrive::Rename(const char* oldname, const char* newname)

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -519,14 +519,11 @@ bool localDrive::AllocationInfo(uint16_t* _bytes_sector, uint8_t* _sectors_clust
 bool localDrive::FileExists(const char* name)
 {
 	const std::string host_filename = MapDosToHostFilename(name);
-	struct stat temp_stat;
-	if (stat(host_filename.c_str(), &temp_stat) != 0) {
+	FatAttributeFlags attributes = {};
+	if (local_drive_get_attributes(host_filename.c_str(), attributes) != DOSERR_NONE) {
 		return false;
 	}
-	if (temp_stat.st_mode & S_IFDIR) {
-		return false;
-	}
-	return true;
+	return !attributes.directory;
 }
 
 uint8_t localDrive::GetMediaByte(void)

--- a/src/dos/drive_overlay.cpp
+++ b/src/dos/drive_overlay.cpp
@@ -387,13 +387,13 @@ Overlay_Drive::Overlay_Drive(const char *startdir,
 	// by explicitly converting to UTF-16 first.
 	#if defined(WIN32)
 	wchar_t utf16_path[MAX_PATH] = {};
-	if (!codepage437_to_utf16(startdir, utf16_path)) {
+	if (!windows_utf8_to_utf16(startdir, utf16_path)) {
 		error = -1;
 		return;
 	}
 	const bool is_absolute = std_fs::path(utf16_path).is_absolute();
 	memset(utf16_path, 0, sizeof(utf16_path));
-	if (!codepage437_to_utf16(overlay, utf16_path)) {
+	if (!windows_utf8_to_utf16(overlay, utf16_path)) {
 		error = -1;
 		return;
 	}

--- a/src/misc/cross.cpp
+++ b/src/misc/cross.cpp
@@ -238,12 +238,26 @@ DirInformation* open_directory(const char* dirname) {
 
 bool read_directory_first(DirInformation* dirp, char* entry_name, bool& is_directory) {
 	if (!dirp) return false;
-	dirp->handle = FindFirstFile(dirp->base_path, &dirp->search_data);
+
+	wchar_t wide_path[sizeof(dirp->base_path)] = {};
+	if (!windows_utf8_to_utf16(dirp->base_path, wide_path)) {
+		return false;
+	}
+
+	dirp->handle = FindFirstFileW(wide_path, &dirp->search_data);
 	if (INVALID_HANDLE_VALUE == dirp->handle) {
 		return false;
 	}
 
-	safe_strncpy(entry_name,dirp->search_data.cFileName,(MAX_PATH<CROSS_LEN)?MAX_PATH:CROSS_LEN);
+	// Edge case: This does not correctly handle filenames on the host that are invaid UTF-16.
+	// Windows does not enforce UTF-16 and can have filenames containing unpaired surrogates.
+	// The below function uses WideCharToMultiByte which replaces invalid code-points with the replacement character U+FFFD
+	// In order to properly handle this, we would need to write our own convertion to WTF-8 which can encode this.
+	// https://wtf-8.codeberg.page/
+	// Probably this is good enough for our use-case though. Such filenames would not display correctly in DOS anyway.
+	if (!windows_utf16_to_utf8(dirp->search_data.cFileName, entry_name, (MAX_PATH<CROSS_LEN)?MAX_PATH:CROSS_LEN)) {
+		return false;
+	}
 
 	if (dirp->search_data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) is_directory = true;
 	else is_directory = false;
@@ -253,10 +267,12 @@ bool read_directory_first(DirInformation* dirp, char* entry_name, bool& is_direc
 
 bool read_directory_next(DirInformation* dirp, char* entry_name, bool& is_directory) {
 	if (!dirp) return false;
-	int result = FindNextFile(dirp->handle, &dirp->search_data);
+	int result = FindNextFileW(dirp->handle, &dirp->search_data);
 	if (result==0) return false;
 
-	safe_strncpy(entry_name,dirp->search_data.cFileName,(MAX_PATH<CROSS_LEN)?MAX_PATH:CROSS_LEN);
+	if (!windows_utf16_to_utf8(dirp->search_data.cFileName, entry_name, (MAX_PATH<CROSS_LEN)?MAX_PATH:CROSS_LEN)) {
+		return false;
+	}
 
 	if (dirp->search_data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) is_directory = true;
 	else is_directory = false;

--- a/src/misc/cross.h
+++ b/src/misc/cross.h
@@ -106,9 +106,9 @@ std_fs::path resolve_home(const std::string &str) noexcept;
 #include <windows.h>
 
 typedef struct dir_struct {
-	HANDLE          handle;
-	char            base_path[MAX_PATH+4];
-	WIN32_FIND_DATA search_data;
+	HANDLE           handle;
+	char             base_path[MAX_PATH+4];
+	WIN32_FIND_DATAW search_data;
 } DirInformation;
 
 #else

--- a/src/misc/fs_utils_posix.cpp
+++ b/src/misc/fs_utils_posix.cpp
@@ -497,3 +497,12 @@ bool local_drive_rename_file_or_directory(const char* old_path, const char* new_
 {
 	return rename(old_path, new_path) == 0;
 }
+
+uint32_t local_drive_get_file_size(const NativeFileHandle handle)
+{
+	struct stat file_info = {};
+	if (fstat(handle, &file_info) == 0) {
+		return file_info.st_size;
+	}
+	return 0;
+}

--- a/src/misc/fs_utils_win32.cpp
+++ b/src/misc/fs_utils_win32.cpp
@@ -19,7 +19,7 @@ std::string to_native_path(const std::string &path) noexcept
 uint16_t local_drive_create_dir(const char* path)
 {
 	wchar_t utf16_path[MAX_PATH] = {};
-	if (!codepage437_to_utf16(path, utf16_path)) {
+	if (!windows_utf8_to_utf16(path, utf16_path)) {
 		return DOSERR_ACCESS_DENIED;
 	}
 	if (CreateDirectoryW(utf16_path, nullptr)) {
@@ -38,7 +38,7 @@ uint16_t local_drive_get_attributes(const char* path,
                                     FatAttributeFlags& attributes)
 {
 	wchar_t utf16_path[MAX_PATH] = {};
-	if (!codepage437_to_utf16(path, utf16_path)) {
+	if (!windows_utf8_to_utf16(path, utf16_path)) {
 		return DOSERR_ACCESS_DENIED;
 	}
 	const auto win32_attributes = GetFileAttributesW(utf16_path);
@@ -55,7 +55,7 @@ uint16_t local_drive_set_attributes(const char* path,
                                     const FatAttributeFlags attributes)
 {
 	wchar_t utf16_path[MAX_PATH] = {};
-	if (!codepage437_to_utf16(path, utf16_path)) {
+	if (!windows_utf8_to_utf16(path, utf16_path)) {
 		return DOSERR_ACCESS_DENIED;
 	}
 	if (!SetFileAttributesW(utf16_path, attributes._data)) {
@@ -68,7 +68,7 @@ uint16_t local_drive_set_attributes(const char* path,
 NativeFileHandle open_native_file(const char* path, const bool write_access)
 {
 	wchar_t utf16_path[MAX_PATH] = {};
-	if (!codepage437_to_utf16(path, utf16_path)) {
+	if (!windows_utf8_to_utf16(path, utf16_path)) {
 		return InvalidNativeFileHandle;
 	}
 	DWORD access = GENERIC_READ;
@@ -89,7 +89,7 @@ NativeFileHandle create_native_file(const char* path,
                                     const std::optional<FatAttributeFlags> attributes)
 {
 	wchar_t utf16_path[MAX_PATH] = {};
-	if (!codepage437_to_utf16(path, utf16_path)) {
+	if (!windows_utf8_to_utf16(path, utf16_path)) {
 		return InvalidNativeFileHandle;
 	}
 	const auto win32_attributes = (attributes && attributes->_data != 0)
@@ -281,7 +281,7 @@ void set_dos_file_time(const NativeFileHandle handle, const uint16_t date,
 bool delete_native_file(const char* path)
 {
 	wchar_t utf16_path[MAX_PATH] = {};
-	if (!codepage437_to_utf16(path, utf16_path)) {
+	if (!windows_utf8_to_utf16(path, utf16_path)) {
 		return false;
 	}
 
@@ -342,7 +342,7 @@ bool delete_native_file(const char* path)
 bool local_drive_remove_dir(const char* path)
 {
 	wchar_t utf16_path[MAX_PATH] = {};
-	if (!codepage437_to_utf16(path, utf16_path)) {
+	if (!windows_utf8_to_utf16(path, utf16_path)) {
 		return false;
 	}
 	if (RemoveDirectoryW(utf16_path)) {
@@ -373,7 +373,7 @@ bool local_drive_remove_dir(const char* path)
 bool local_drive_path_exists(const char* path)
 {
 	wchar_t utf16_path[MAX_PATH] = {};
-	if (!codepage437_to_utf16(path, utf16_path)) {
+	if (!windows_utf8_to_utf16(path, utf16_path)) {
 		return false;
 	}
 	return PathFileExistsW(utf16_path);
@@ -382,11 +382,11 @@ bool local_drive_path_exists(const char* path)
 bool local_drive_rename_file_or_directory(const char* old_path, const char* new_path)
 {
 	wchar_t utf16_old_path[MAX_PATH] = {};
-	if (!codepage437_to_utf16(old_path, utf16_old_path)) {
+	if (!windows_utf8_to_utf16(old_path, utf16_old_path)) {
 		return false;
 	}
 	wchar_t utf16_new_path[MAX_PATH] = {};
-	if (!codepage437_to_utf16(new_path, utf16_new_path)) {
+	if (!windows_utf8_to_utf16(new_path, utf16_new_path)) {
 		return false;
 	}
 	return MoveFileW(utf16_old_path, utf16_new_path);
@@ -399,44 +399,6 @@ uint32_t local_drive_get_file_size(const NativeFileHandle handle)
 		return 0;
 	}
 	return size;
-}
-
-bool codepage437_to_utf16(const char *in_string, wchar_t *out_string, const int out_length)
-{
-	constexpr UINT Codepage = 437;
-	constexpr DWORD Flags = 0;
-	// -1 means read the entire null terminated string
-	constexpr int InLength = -1;
-	const auto num_chars = MultiByteToWideChar(Codepage, Flags, in_string, InLength, out_string, out_length);
-	if (num_chars >= out_length) {
-		LOG_ERR("FS: codepage437_to_utf16: Insufficient output buffer length");
-		return false;
-	}
-	if (num_chars > 0) {
-		// Ensure output string is null terminated (should be, but just in case)
-		out_string[num_chars] = 0;
-		return true;
-	}
-	const auto error = GetLastError();
-	// Message table source or something, is ignored for our usage
-	constexpr LPCVOID lpSource = nullptr;
-	// Also ignored, only used for FORMAT_MESSAGE_FROM_STRING
-	constexpr va_list* Arguments = nullptr;
-	char error_message[512] = {};
-	if (FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
-						lpSource,
-						error,
-						LANG_USER_DEFAULT,
-						error_message,
-						sizeof(error_message),
-						Arguments)) {
-		// Just in case Windows does something dumb I'm sticking a null terminator on the end :)
-		error_message[sizeof(error_message) - 1] = 0;
-		LOG_ERR("FS: MultiByteToWideChar failed with error code %lu: %s", error, error_message);
-	} else {
-		LOG_ERR("FS: MultiByteToWideChar failed with error code %lu: FormatMessageA also failed", error);
-	}
-	return false;
 }
 
 bool windows_utf8_to_utf16(const char *in_string, wchar_t *out_string, const int out_length)

--- a/src/misc/fs_utils_win32.cpp
+++ b/src/misc/fs_utils_win32.cpp
@@ -391,3 +391,41 @@ bool local_drive_rename_file_or_directory(const char* old_path, const char* new_
 	}
 	return MoveFileW(utf16_old_path, utf16_new_path);
 }
+
+bool codepage437_to_utf16(const char *in_string, wchar_t *out_string, const int out_length)
+{
+	constexpr UINT Codepage = 437;
+	constexpr DWORD Flags = 0;
+	// -1 means read the entire null terminated string
+	constexpr int InLength = -1;
+	const auto num_chars = MultiByteToWideChar(Codepage, Flags, in_string, InLength, out_string, out_length);
+	if (num_chars >= out_length) {
+		LOG_ERR("FS: codepage437_to_utf16: Insufficient output buffer length");
+		return false;
+	}
+	if (num_chars > 0) {
+		// Ensure output string is null terminated (should be, but just in case)
+		out_string[num_chars] = 0;
+		return true;
+	}
+	const auto error = GetLastError();
+	// Message table source or something, is ignored for our usage
+	constexpr LPCVOID lpSource = nullptr;
+	// Also ignored, only used for FORMAT_MESSAGE_FROM_STRING
+	constexpr va_list* Arguments = nullptr;
+	char error_message[512] = {};
+	if (FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+						lpSource,
+						error,
+						LANG_USER_DEFAULT,
+						error_message,
+						sizeof(error_message),
+						Arguments)) {
+		// Just in case Windows does something dumb I'm sticking a null terminator on the end :)
+		error_message[sizeof(error_message) - 1] = 0;
+		LOG_ERR("FS: MultiByteToWideChar failed with error code %lu: %s", error, error_message);
+	} else {
+		LOG_ERR("FS: MultiByteToWideChar failed with error code %lu: FormatMessageA also failed", error);
+	}
+	return false;
+}

--- a/src/misc/fs_utils_win32.cpp
+++ b/src/misc/fs_utils_win32.cpp
@@ -429,3 +429,83 @@ bool codepage437_to_utf16(const char *in_string, wchar_t *out_string, const int 
 	}
 	return false;
 }
+
+bool windows_utf8_to_utf16(const char *in_string, wchar_t *out_string, const int out_length)
+{
+	constexpr UINT Codepage = CP_UTF8;
+	constexpr DWORD Flags = 0;
+	// -1 means read the entire null terminated string
+	constexpr int InLength = -1;
+	const auto num_chars = MultiByteToWideChar(Codepage, Flags, in_string, InLength, out_string, out_length);
+	if (num_chars >= out_length) {
+		LOG_ERR("FS: MultiByteToWideChar failed: Insufficient output buffer length");
+		return false;
+	}
+	if (num_chars > 0) {
+		// Ensure output string is null terminated (should be, but just in case)
+		out_string[num_chars] = 0;
+		return true;
+	}
+	const auto error = GetLastError();
+	// Message table source or something, is ignored for our usage
+	constexpr LPCVOID lpSource = nullptr;
+	// Also ignored, only used for FORMAT_MESSAGE_FROM_STRING
+	constexpr va_list* Arguments = nullptr;
+	char error_message[512] = {};
+	if (FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+						lpSource,
+						error,
+						LANG_USER_DEFAULT,
+						error_message,
+						sizeof(error_message),
+						Arguments)) {
+		// Just in case Windows does something dumb I'm sticking a null terminator on the end :)
+		error_message[sizeof(error_message) - 1] = 0;
+		LOG_ERR("FS: MultiByteToWideChar failed with error code %lu: %s", error, error_message);
+	} else {
+		LOG_ERR("FS: MultiByteToWideChar failed with error code %lu: FormatMessageA also failed", error);
+	}
+	return false;
+}
+
+bool windows_utf16_to_utf8(const wchar_t *in_string, char *out_string, int out_length)
+{
+	constexpr UINT Codepage = CP_UTF8;
+	constexpr DWORD Flags = 0;
+	// -1 means read the entire null terminated string
+	constexpr int InLength = -1;
+
+	// Must both be nullptr for UTF-8
+	constexpr LPCCH DefaultChar = nullptr;
+	constexpr LPBOOL WasDefaultCharUsed = nullptr;
+	const auto num_chars = WideCharToMultiByte(Codepage, Flags, in_string, InLength, out_string, out_length, DefaultChar, WasDefaultCharUsed);
+	if (num_chars >= out_length) {
+		LOG_ERR("FS: WideCharToMultiByte failed: Insufficient output buffer length");
+		return false;
+	}
+	if (num_chars > 0) {
+		// Ensure output string is null terminated (should be, but just in case)
+		out_string[num_chars] = 0;
+		return true;
+	}
+	const auto error = GetLastError();
+	// Message table source or something, is ignored for our usage
+	constexpr LPCVOID lpSource = nullptr;
+	// Also ignored, only used for FORMAT_MESSAGE_FROM_STRING
+	constexpr va_list* Arguments = nullptr;
+	char error_message[512] = {};
+	if (FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+						lpSource,
+						error,
+						LANG_USER_DEFAULT,
+						error_message,
+						sizeof(error_message),
+						Arguments)) {
+		// Just in case Windows does something dumb I'm sticking a null terminator on the end :)
+		error_message[sizeof(error_message) - 1] = 0;
+		LOG_ERR("FS: WideCharToMultiByte failed with error code %lu: %s", error, error_message);
+	} else {
+		LOG_ERR("FS: WideCharToMultiByte failed with error code %lu: FormatMessageA also failed", error);
+	}
+	return false;
+}

--- a/src/misc/fs_utils_win32.cpp
+++ b/src/misc/fs_utils_win32.cpp
@@ -392,6 +392,15 @@ bool local_drive_rename_file_or_directory(const char* old_path, const char* new_
 	return MoveFileW(utf16_old_path, utf16_new_path);
 }
 
+uint32_t local_drive_get_file_size(const NativeFileHandle handle)
+{
+	const auto size = GetFileSize(handle, nullptr);
+	if (size == INVALID_FILE_SIZE) {
+		return 0;
+	}
+	return size;
+}
+
 bool codepage437_to_utf16(const char *in_string, wchar_t *out_string, const int out_length)
 {
 	constexpr UINT Codepage = 437;

--- a/src/utils/fs_utils.h
+++ b/src/utils/fs_utils.h
@@ -23,43 +23,12 @@
 	// Cannot be constexpr due to Win32 macro
 	#define InvalidNativeFileHandle INVALID_HANDLE_VALUE
 
+	bool codepage437_to_utf16(const char *in_string, wchar_t *out_string, const int out_length);
+
 	template <int out_length>
 	bool codepage437_to_utf16(const char *in_string, wchar_t (&out_string)[out_length])
 	{
-		constexpr UINT Codepage = 437;
-		constexpr DWORD Flags = 0;
-		// -1 means read the entire null terminated string
-		constexpr int InLength = -1;
-		const auto num_chars = MultiByteToWideChar(Codepage, Flags, in_string, InLength, out_string, out_length);
-		if (num_chars >= out_length) {
-			LOG_ERR("FS: codepage437_to_utf16: Insufficient output buffer length");
-			return false;
-		}
-		if (num_chars > 0) {
-			// Ensure output string is null terminated (should be, but just in case)
-			out_string[num_chars] = 0;
-			return true;
-		}
-		const auto error = GetLastError();
-		// Message table source or something, is ignored for our usage
-		constexpr LPCVOID lpSource = nullptr;
-		// Also ignored, only used for FORMAT_MESSAGE_FROM_STRING
-		constexpr va_list* Arguments = nullptr;
-		char error_message[512] = {};
-		if (FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
-							lpSource,
-							error,
-							LANG_USER_DEFAULT,
-							error_message,
-							sizeof(error_message),
-							Arguments)) {
-			// Just in case Windows does something dumb I'm sticking a null terminator on the end :)
-			error_message[sizeof(error_message) - 1] = 0;
-			LOG_ERR("FS: MultiByteToWideChar failed with error code %lu: %s", error, error_message);
-		} else {
-			LOG_ERR("FS: MultiByteToWideChar failed with error code %lu: FormatMessageA also failed", error);
-		}
-		return false;
+		return codepage437_to_utf16(in_string, out_string, out_length);
 	}
 
 #else // Linux, macOS

--- a/src/utils/fs_utils.h
+++ b/src/utils/fs_utils.h
@@ -31,6 +31,22 @@
 		return codepage437_to_utf16(in_string, out_string, out_length);
 	}
 
+	bool windows_utf8_to_utf16(const char *in_string, wchar_t *out_string, const int out_length);
+
+	template <int out_length>
+	bool windows_utf8_to_utf16(const char *in_string, wchar_t (&out_string)[out_length])
+	{
+		return windows_utf8_to_utf16(in_string, out_string, out_length);
+	}
+
+	bool windows_utf16_to_utf8(const wchar_t *in_string, char *out_string, int out_length);
+
+	template <int out_length>
+	bool windows_utf16_to_utf8(const char *in_string, wchar_t (&out_string)[out_length])
+	{
+		return windows_utf16_to_utf8(in_string, out_string, out_length);
+	}
+
 #else // Linux, macOS
 	using NativeFileHandle = int;
 	constexpr NativeFileHandle InvalidNativeFileHandle = -1;

--- a/src/utils/fs_utils.h
+++ b/src/utils/fs_utils.h
@@ -195,4 +195,6 @@ bool delete_native_file(const char* path);
 // Simple file/directory removal routines, without MS-DOS compatibility hacks
 bool create_dir_if_not_exist(const std_fs::path& path);
 
+uint32_t local_drive_get_file_size(const NativeFileHandle handle);
+
 #endif

--- a/src/utils/fs_utils.h
+++ b/src/utils/fs_utils.h
@@ -23,14 +23,6 @@
 	// Cannot be constexpr due to Win32 macro
 	#define InvalidNativeFileHandle INVALID_HANDLE_VALUE
 
-	bool codepage437_to_utf16(const char *in_string, wchar_t *out_string, const int out_length);
-
-	template <int out_length>
-	bool codepage437_to_utf16(const char *in_string, wchar_t (&out_string)[out_length])
-	{
-		return codepage437_to_utf16(in_string, out_string, out_length);
-	}
-
 	bool windows_utf8_to_utf16(const char *in_string, wchar_t *out_string, const int out_length);
 
 	template <int out_length>


### PR DESCRIPTION
# Description

Final commit is where the Unicode fix is. Rest is just cleanup. See the commit message for details. It turned out to be an easier fix than I thought it would be.

In the drive cache, long name is stored as UTF-8 (even on Windows, this lets us avoid UTF-16 handling in the drive cache and continue to use the existing string manipulation). Short name is stored as Codepage 437.

Existing functions that map DOS to Host names now always return a UTF-8 path. On Windows, the final conversion is done from UTF-8 to UTF-16 in `fs_utils_win32.cpp` immediately before calling the Win32 functions.

## Related issues

Fixes #2619

# Release notes

Fixed handling of filenames with high ASCII bytes. They now show up formatted correctly on the host. On Windows, it was more broken and they would not show up in directory listings in DOSBox.

# Manual testing

Tested the zip files in #2619

The change has been manually tested on:

- [x] Windows
- [ ] macOS
- [x] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

- [x] I am a human, I have read and understood the [project's policy on the use of generative AI tools](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md#policy-on-the-use-of-generative-ai-tools), and I have acted in accordance to it.

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my work (especially important for AI-assisted contributions).
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [x] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

