### PR TITLE
Save window size & position on mapper exit

### DIFF
--- a/src/gui/mapper.cpp
+++ b/src/gui/mapper.cpp
@@ -23,6 +23,7 @@
 #include "config/setup.h"
 #include "gui/common.h"
 #include "gui/mapper.h"
+#include "gui/private/common.h"
 #include "hardware/input/joystick.h"
 #include "hardware/input/keyboard.h"
 #include "hardware/input/mouse.h"
@@ -3158,6 +3159,8 @@ void MAPPER_DisplayUI() {
 
 	// Exiting the mapper
 	MIXER_UnlockMixerThread();
+
+	GFX_SaveCurrentWindowSizeAndPosition();
 
 	SDL_DestroyTexture(mapper.font_atlas);
 	if (!SDL_SetRenderLogicalPresentation(

--- a/src/gui/private/common.h
+++ b/src/gui/private/common.h
@@ -4,6 +4,8 @@
 #ifndef DOSBOX_GUI_PRIVATE_COMMON_H
 #define DOSBOX_GUI_PRIVATE_COMMON_H
 
+#include <optional>
+
 #include "dosbox_config.h"
 #include "misc/video.h"
 #include "utils/fraction.h"
@@ -120,5 +122,7 @@ enum class DosBoxSdlEvent {
 int GFX_GetUserSdlEventId(DosBoxSdlEvent event);
 
 bool GFX_IsPaused();
+
+void GFX_SaveCurrentWindowSizeAndPosition();
 
 #endif // DOSBOX_GUI_COMMON_H

--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -1461,6 +1461,21 @@ static void save_window_size(const int w, const int h)
 	set_section_property_value("sdl", "window_size", format_str("%dx%d", w, h));
 }
 
+void GFX_SaveCurrentWindowSizeAndPosition()
+{
+	if (sdl.is_fullscreen) {
+		return;
+	}
+
+	SDL_Rect r = {};
+
+	SDL_GetWindowPosition(sdl.window, &r.x, &r.y);
+	SDL_GetWindowSize(sdl.window, &r.w, &r.h);
+
+	save_window_position(SDL_Point{r.x, r.y});
+	save_window_size(r.w, r.h);
+}
+
 static void handle_window_size_pref_after_config_load()
 {
 	assert(control);

--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -1414,30 +1414,29 @@ static std::optional<SDL_Point> parse_window_position_conf(const std::string& wi
 	return SDL_Point{x, y};
 }
 
-static void save_window_position(const std::optional<SDL_Point> pos)
+static void save_window_position(const int x, const int y)
 {
-	if (pos) {
-		if (sdl.fullscreen.mode == FullscreenMode::ForcedBorderless) {
-			sdl.fullscreen.prev_window.x_pos = pos->x;
-			sdl.fullscreen.prev_window.y_pos = pos->y;
-		} else {
-			sdl.windowed.x_pos = pos->x;
-			sdl.windowed.y_pos = pos->y;
-		}
+	if (sdl.fullscreen.mode == FullscreenMode::ForcedBorderless) {
+		sdl.fullscreen.prev_window.x_pos = x;
+		sdl.fullscreen.prev_window.y_pos = y;
 	} else {
-		if (sdl.fullscreen.mode == FullscreenMode::ForcedBorderless) {
-			sdl.fullscreen.prev_window.x_pos = SDL_WINDOWPOS_UNDEFINED_DISPLAY(
-			        sdl.display_number);
+		sdl.windowed.x_pos = x;
+		sdl.windowed.y_pos = y;
+	}
+}
 
-			sdl.fullscreen.prev_window.y_pos = SDL_WINDOWPOS_UNDEFINED_DISPLAY(
-			        sdl.display_number);
-		} else {
-			sdl.windowed.x_pos = SDL_WINDOWPOS_UNDEFINED_DISPLAY(
-			        sdl.display_number);
+static void save_default_window_position()
+{
+	if (sdl.fullscreen.mode == FullscreenMode::ForcedBorderless) {
+		sdl.fullscreen.prev_window.x_pos = SDL_WINDOWPOS_UNDEFINED_DISPLAY(
+		        sdl.display_number);
 
-			sdl.windowed.y_pos = SDL_WINDOWPOS_UNDEFINED_DISPLAY(
-			        sdl.display_number);
-		}
+		sdl.fullscreen.prev_window.y_pos = SDL_WINDOWPOS_UNDEFINED_DISPLAY(
+		        sdl.display_number);
+	} else {
+		sdl.windowed.x_pos = SDL_WINDOWPOS_UNDEFINED_DISPLAY(sdl.display_number);
+
+		sdl.windowed.y_pos = SDL_WINDOWPOS_UNDEFINED_DISPLAY(sdl.display_number);
 	}
 }
 
@@ -1472,7 +1471,7 @@ void GFX_SaveCurrentWindowSizeAndPosition()
 	SDL_GetWindowPosition(sdl.window, &r.x, &r.y);
 	SDL_GetWindowSize(sdl.window, &r.w, &r.h);
 
-	save_window_position(SDL_Point{r.x, r.y});
+	save_window_position(r.x, r.y);
 	save_window_size(r.w, r.h);
 }
 
@@ -1565,8 +1564,14 @@ static void set_window_size()
 
 static void save_window_position_from_conf()
 {
-	save_window_position(parse_window_position_conf(
-	        get_sdl_section()->GetString("window_position")));
+	if (const auto pos = parse_window_position_conf(
+	            get_sdl_section()->GetString("window_position"));
+	    pos) {
+
+		save_window_position(pos->x, pos->y);
+	} else {
+		save_default_window_position();
+	}
 }
 
 TextureFilterMode GFX_GetTextureFilterMode()
@@ -2355,7 +2360,7 @@ static bool handle_sdl_windowevent(const SDL_Event& event)
 		const auto new_y = std::max(y, 0);
 
 		if (!sdl.is_fullscreen) {
-			save_window_position(SDL_Point{new_x, new_y});
+			save_window_position(new_x, new_y);
 
 			set_section_property_value("sdl",
 			                           "window_position",


### PR DESCRIPTION
# Description

Small fix for a small issue 😎 

Repro steps:

### Case 1 (OK)

1. Start Staging, resize the window & move it
2. Enter fullscreen
3. Exit fullscreen — note that the window size & position prior to the fullscreen switch has been restored

### Case 1 (bug)

1. Start Staging, **open mapper**, then resize the window & move it
2. Exit mapper, then enter fullscreen
3. Exit fullscreen — note that the window size & position prior to the fullscreen has **not** been restored

Now this is fixed.

# Release notes

Not worth mentioning.

# Manual testing

As above.

The change has been manually tested on:

- [ ] Windows
- [x] macOS
- [ ] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

- [x] I am a human, I have read and understood the [project's policy on the use of generative AI tools](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md#policy-on-the-use-of-generative-ai-tools), and I have acted in accordance to it.

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my work (especially important for AI-assisted contributions).
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

