### PR TITLE
Add zed directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,6 @@ cmake_test_discovery_*.json
 
 # Python
 __pycache__
+
+# Zed text editor
+.zed


### PR DESCRIPTION
# Description

This is trivial enough I'm removing the usual boilerplate.

https://zed.dev/ - This has replaced VSCode for me now. Just wanted to add the .zed directory it creates for local settings to the .gitignore.