### PR TITLE
Deinterlacer & image capture fixes

### DIFF
--- a/src/gui/render/deinterlacer.cpp
+++ b/src/gui/render/deinterlacer.cpp
@@ -55,9 +55,17 @@ uint32_t Deinterlacer::DetectBackgroundColor(const uint32_t* pixel_data) const
 		return true;
 	}();
 
-	// Return the detected colour if we succeeded, or revert to black
+	// Return the detected colour if we succeeded, or revert to black.
+	//
+	// Mask out the unused X byte: `ThresholdInput()` compares masked
+	// pixels against this colour, and on the display path the pixels of
+	// Indexed8 modes carry X=255 from the palette LUT. Without the mask,
+	// every pixel would appear as non-background and these modes would
+	// silently never get deinterlaced.
+	constexpr uint32_t RgbMask = 0x00ffffff;
+
 	constexpr uint32_t Black = 0;
-	return bg_color_detected ? top_left_pixel_color : Black;
+	return (bg_color_detected ? top_left_pixel_color : Black) & RgbMask;
 }
 
 void Deinterlacer::ThresholdInput(const uint32_t* src, bit_buffer& dest,

--- a/src/misc/image_decoder.cpp
+++ b/src/misc/image_decoder.cpp
@@ -41,7 +41,7 @@ void ImageDecoder::GetNextRowAsIndexed8Pixels(std::vector<uint8_t>::iterator out
 
 		*out = palette_index;
 
-		++in_pos;
+		in_pos += (pixel_skip_count + 1);
 		++out;
 	}
 

--- a/src/misc/image_decoder.cpp
+++ b/src/misc/image_decoder.cpp
@@ -72,7 +72,7 @@ void ImageDecoder::GetBgrx32RowFromIndexed8(std::vector<uint32_t>::iterator out)
 		const auto palette_index = *in_pos;
 		const auto color         = image.palette[palette_index];
 
-		*out = color;
+		*out = Bgrx8888{color.red, color.green, color.blue};
 
 		in_pos += (pixel_skip_count + 1);
 		++out;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,6 +13,7 @@ add_executable(dosbox_tests
     drives_tests.cpp
     fraction_tests.cpp
     fs_utils_tests.cpp
+    image_decoder_tests.cpp
     int10_modes_tests.cpp
     language_territory_tests.cpp
     math_utils_tests.cpp

--- a/tests/image_decoder_tests.cpp
+++ b/tests/image_decoder_tests.cpp
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText:  2026-2026 The DOSBox Staging Team
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "misc/image_decoder.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <vector>
+
+#include "misc/rendered_image.h"
+#include "misc/video.h"
+#include "utils/rgb888.h"
+
+namespace {
+
+// Distinct channel values so red/blue swaps are detectable
+constexpr uint8_t Red   = 0xcc;
+constexpr uint8_t Green = 0x88;
+constexpr uint8_t Blue  = 0x44;
+
+// The BGRX32 in-memory byte order is B,G,R,X, which reads as 0x00RRGGBB
+// on little-endian (see `Bgrx8888`)
+constexpr uint32_t ExpectedBgrx32 = (Red << 16) | (Green << 8) | Blue;
+
+} // namespace
+
+TEST(ImageDecoderTest, DecodesIndexed8ToBgrx32InBgrxByteOrder)
+{
+	std::vector<uint8_t> pixels = {1, 0};
+
+	RenderedImage image = {};
+
+	image.params.width        = 2;
+	image.params.height       = 1;
+	image.params.pixel_format = PixelFormat::Indexed8;
+
+	image.pitch      = 2;
+	image.image_data = pixels.data();
+	image.palette[1] = Rgb888(Red, Green, Blue);
+
+	ImageDecoder decoder(image, 0, 0);
+
+	std::vector<uint32_t> row(2);
+	decoder.GetNextRowAsBgrx32Pixels(row.begin());
+
+	EXPECT_EQ(row[0], ExpectedBgrx32);
+	EXPECT_EQ(row[1], 0x00000000u);
+}
+
+TEST(ImageDecoderTest, DecodesBgrx32ToBgrx32Unchanged)
+{
+	std::vector<uint32_t> pixels = {ExpectedBgrx32, 0x00000000};
+
+	RenderedImage image = {};
+
+	image.params.width        = 2;
+	image.params.height       = 1;
+	image.params.pixel_format = PixelFormat::BGRX32_ByteArray;
+
+	image.pitch      = 2 * static_cast<int>(sizeof(uint32_t));
+	image.image_data = reinterpret_cast<uint8_t*>(pixels.data());
+
+	ImageDecoder decoder(image, 0, 0);
+
+	std::vector<uint32_t> row(2);
+	decoder.GetNextRowAsBgrx32Pixels(row.begin());
+
+	EXPECT_EQ(row[0], ExpectedBgrx32);
+	EXPECT_EQ(row[1], 0x00000000u);
+}

--- a/tests/image_decoder_tests.cpp
+++ b/tests/image_decoder_tests.cpp
@@ -14,14 +14,34 @@
 
 namespace {
 
-// Distinct channel values so red/blue swaps are detectable
-constexpr uint8_t Red   = 0xcc;
-constexpr uint8_t Green = 0x88;
-constexpr uint8_t Blue  = 0x44;
+// Distinct channel values so RGB channel swaps and skipped pixels are
+// detectable
+constexpr uint8_t RedA   = 0xcc;
+constexpr uint8_t GreenA = 0x88;
+constexpr uint8_t BlueA  = 0x44;
+
+constexpr uint8_t RedB   = 0x11;
+constexpr uint8_t GreenB = 0x22;
+constexpr uint8_t BlueB  = 0x33;
 
 // The BGRX32 in-memory byte order is B,G,R,X, which reads as 0x00RRGGBB
 // on little-endian (see `Bgrx8888`)
-constexpr uint32_t ExpectedBgrx32 = (Red << 16) | (Green << 8) | Blue;
+constexpr uint32_t ExpectedBgrxA = (RedA << 16) | (GreenA << 8) | BlueA;
+constexpr uint32_t ExpectedBgrxB = (RedB << 16) | (GreenB << 8) | BlueB;
+
+// 5-bit R,G,B channel values 25,12,6 packed as -RRRRRGGGGGBBBBB
+constexpr uint16_t PackedRgb555 = (25 << 10) | (12 << 5) | 6;
+
+// The 8-bit channel values follow the `(c * 255 + 15) / 31` expansion
+// (see `rgb5_to_8()`)
+constexpr uint32_t ExpectedBgrxFromRgb555 = (206 << 16) | (99 << 8) | 49;
+
+// 5/6/5-bit R,G,B channel values 25,33,6 packed as RRRRRGGGGGGBBBBB
+constexpr uint16_t PackedRgb565 = (25 << 11) | (33 << 5) | 6;
+
+// The 8-bit green value follows the `(c * 255 + 31) / 63` expansion
+// (see `rgb6_to_8()`)
+constexpr uint32_t ExpectedBgrxFromRgb565 = (206 << 16) | (134 << 8) | 49;
 
 } // namespace
 
@@ -37,20 +57,87 @@ TEST(ImageDecoderTest, DecodesIndexed8ToBgrx32InBgrxByteOrder)
 
 	image.pitch      = 2;
 	image.image_data = pixels.data();
-	image.palette[1] = Rgb888(Red, Green, Blue);
+	image.palette[1] = Rgb888(RedA, GreenA, BlueA);
 
 	ImageDecoder decoder(image, 0, 0);
 
 	std::vector<uint32_t> row(2);
 	decoder.GetNextRowAsBgrx32Pixels(row.begin());
 
-	EXPECT_EQ(row[0], ExpectedBgrx32);
+	EXPECT_EQ(row[0], ExpectedBgrxA);
+	EXPECT_EQ(row[1], 0x00000000u);
+}
+
+TEST(ImageDecoderTest, DecodesRgb555ToBgrx32)
+{
+	std::vector<uint16_t> pixels = {PackedRgb555, 0x0000};
+
+	RenderedImage image = {};
+
+	image.params.width        = 2;
+	image.params.height       = 1;
+	image.params.pixel_format = PixelFormat::RGB555_Packed16;
+
+	image.pitch      = 2 * static_cast<int>(sizeof(uint16_t));
+	image.image_data = reinterpret_cast<uint8_t*>(pixels.data());
+
+	ImageDecoder decoder(image, 0, 0);
+
+	std::vector<uint32_t> row(2);
+	decoder.GetNextRowAsBgrx32Pixels(row.begin());
+
+	EXPECT_EQ(row[0], ExpectedBgrxFromRgb555);
+	EXPECT_EQ(row[1], 0x00000000u);
+}
+
+TEST(ImageDecoderTest, DecodesRgb565ToBgrx32)
+{
+	std::vector<uint16_t> pixels = {PackedRgb565, 0x0000};
+
+	RenderedImage image = {};
+
+	image.params.width        = 2;
+	image.params.height       = 1;
+	image.params.pixel_format = PixelFormat::RGB565_Packed16;
+
+	image.pitch      = 2 * static_cast<int>(sizeof(uint16_t));
+	image.image_data = reinterpret_cast<uint8_t*>(pixels.data());
+
+	ImageDecoder decoder(image, 0, 0);
+
+	std::vector<uint32_t> row(2);
+	decoder.GetNextRowAsBgrx32Pixels(row.begin());
+
+	EXPECT_EQ(row[0], ExpectedBgrxFromRgb565);
+	EXPECT_EQ(row[1], 0x00000000u);
+}
+
+TEST(ImageDecoderTest, DecodesBgr24ToBgrx32)
+{
+	// Pixels are stored in B,G,R byte order
+	std::vector<uint8_t> pixels = {BlueA, GreenA, RedA, 0, 0, 0};
+
+	RenderedImage image = {};
+
+	image.params.width        = 2;
+	image.params.height       = 1;
+	image.params.pixel_format = PixelFormat::BGR24_ByteArray;
+
+	image.pitch      = 2 * 3;
+	image.image_data = pixels.data();
+
+	ImageDecoder decoder(image, 0, 0);
+
+	std::vector<uint32_t> row(2);
+	decoder.GetNextRowAsBgrx32Pixels(row.begin());
+
+	EXPECT_EQ(row[0], ExpectedBgrxA);
 	EXPECT_EQ(row[1], 0x00000000u);
 }
 
 TEST(ImageDecoderTest, DecodesBgrx32ToBgrx32Unchanged)
 {
-	std::vector<uint32_t> pixels = {ExpectedBgrx32, 0x00000000};
+	std::vector<uint32_t> pixels = {ExpectedBgrxA, 0x00000000};
 
 	RenderedImage image = {};
 
@@ -66,6 +153,279 @@ TEST(ImageDecoderTest, DecodesBgrx32ToBgrx32Unchanged)
 	std::vector<uint32_t> row(2);
 	decoder.GetNextRowAsBgrx32Pixels(row.begin());
 
-	EXPECT_EQ(row[0], ExpectedBgrx32);
+	EXPECT_EQ(row[0], ExpectedBgrxA);
 	EXPECT_EQ(row[1], 0x00000000u);
+}
+
+TEST(ImageDecoderTest, DecodesIndexed8ToIndexed8Unchanged)
+{
+	std::vector<uint8_t> pixels = {7, 42};
+
+	RenderedImage image = {};
+
+	image.params.width        = 2;
+	image.params.height       = 1;
+	image.params.pixel_format = PixelFormat::Indexed8;
+
+	image.pitch      = 2;
+	image.image_data = pixels.data();
+
+	ImageDecoder decoder(image, 0, 0);
+
+	std::vector<uint8_t> row(2);
+	decoder.GetNextRowAsIndexed8Pixels(row.begin());
+
+	EXPECT_EQ(row[0], 7);
+	EXPECT_EQ(row[1], 42);
+}
+
+TEST(ImageDecoderTest, AdvancesRowsUsingPitch)
+{
+	// Two 2-pixel rows with two padding bytes at the end of each row
+	std::vector<uint8_t> pixels = {1, 2, 0xee, 0xee, 3, 4, 0xee, 0xee};
+
+	RenderedImage image = {};
+
+	image.params.width        = 2;
+	image.params.height       = 2;
+	image.params.pixel_format = PixelFormat::Indexed8;
+
+	image.pitch      = 4;
+	image.image_data = pixels.data();
+
+	ImageDecoder decoder(image, 0, 0);
+
+	std::vector<uint8_t> row(2);
+
+	decoder.GetNextRowAsIndexed8Pixels(row.begin());
+	EXPECT_EQ(row[0], 1);
+	EXPECT_EQ(row[1], 2);
+
+	decoder.GetNextRowAsIndexed8Pixels(row.begin());
+	EXPECT_EQ(row[0], 3);
+	EXPECT_EQ(row[1], 4);
+}
+
+TEST(ImageDecoderTest, SkipsRowsWithRowSkipCount)
+{
+	std::vector<uint8_t> pixels = {1, 2, 3, 4, 5, 6, 7, 8};
+
+	RenderedImage image = {};
+
+	image.params.width        = 2;
+	image.params.height       = 4;
+	image.params.pixel_format = PixelFormat::Indexed8;
+
+	image.pitch      = 2;
+	image.image_data = pixels.data();
+
+	ImageDecoder decoder(image, 1, 0);
+
+	std::vector<uint8_t> row(2);
+
+	decoder.GetNextRowAsIndexed8Pixels(row.begin());
+	EXPECT_EQ(row[0], 1);
+	EXPECT_EQ(row[1], 2);
+
+	decoder.GetNextRowAsIndexed8Pixels(row.begin());
+	EXPECT_EQ(row[0], 5);
+	EXPECT_EQ(row[1], 6);
+}
+
+TEST(ImageDecoderTest, DecodesFlippedImageBottomUp)
+{
+	std::vector<uint8_t> pixels = {1, 2, 3, 4};
+
+	RenderedImage image = {};
+
+	image.params.width        = 2;
+	image.params.height       = 2;
+	image.params.pixel_format = PixelFormat::Indexed8;
+
+	image.is_flipped_vertically = true;
+
+	image.pitch      = 2;
+	image.image_data = pixels.data();
+
+	ImageDecoder decoder(image, 0, 0);
+
+	std::vector<uint8_t> row(2);
+
+	decoder.GetNextRowAsIndexed8Pixels(row.begin());
+	EXPECT_EQ(row[0], 3);
+	EXPECT_EQ(row[1], 4);
+
+	decoder.GetNextRowAsIndexed8Pixels(row.begin());
+	EXPECT_EQ(row[0], 1);
+	EXPECT_EQ(row[1], 2);
+}
+
+TEST(ImageDecoderTest, SkipsRowsInFlippedImage)
+{
+	std::vector<uint8_t> pixels = {1, 2, 3, 4, 5, 6, 7, 8};
+
+	RenderedImage image = {};
+
+	image.params.width        = 2;
+	image.params.height       = 4;
+	image.params.pixel_format = PixelFormat::Indexed8;
+
+	image.is_flipped_vertically = true;
+
+	image.pitch      = 2;
+	image.image_data = pixels.data();
+
+	ImageDecoder decoder(image, 1, 0);
+
+	std::vector<uint8_t> row(2);
+
+	decoder.GetNextRowAsIndexed8Pixels(row.begin());
+	EXPECT_EQ(row[0], 7);
+	EXPECT_EQ(row[1], 8);
+
+	decoder.GetNextRowAsIndexed8Pixels(row.begin());
+	EXPECT_EQ(row[0], 3);
+	EXPECT_EQ(row[1], 4);
+}
+
+TEST(ImageDecoderTest, SkipsPixelsIndexed8ToBgrx32)
+{
+	// Every second pixel is a "poison pixel" that must be skipped
+	std::vector<uint8_t> pixels = {1, 3, 2, 3};
+
+	RenderedImage image = {};
+
+	image.params.width        = 4;
+	image.params.height       = 1;
+	image.params.pixel_format = PixelFormat::Indexed8;
+
+	image.pitch      = 4;
+	image.image_data = pixels.data();
+	image.palette[1] = Rgb888(RedA, GreenA, BlueA);
+	image.palette[2] = Rgb888(RedB, GreenB, BlueB);
+	image.palette[3] = Rgb888(0xff, 0xff, 0xff);
+
+	ImageDecoder decoder(image, 0, 1);
+
+	std::vector<uint32_t> row(2);
+	decoder.GetNextRowAsBgrx32Pixels(row.begin());
+
+	EXPECT_EQ(row[0], ExpectedBgrxA);
+	EXPECT_EQ(row[1], ExpectedBgrxB);
+}
+
+TEST(ImageDecoderTest, SkipsPixelsRgb555ToBgrx32)
+{
+	// Every second pixel is a "poison pixel" that must be skipped
+	std::vector<uint16_t> pixels = {PackedRgb555, 0x7fff, 0x0000, 0x7fff};
+
+	RenderedImage image = {};
+
+	image.params.width        = 4;
+	image.params.height       = 1;
+	image.params.pixel_format = PixelFormat::RGB555_Packed16;
+
+	image.pitch      = 4 * static_cast<int>(sizeof(uint16_t));
+	image.image_data = reinterpret_cast<uint8_t*>(pixels.data());
+
+	ImageDecoder decoder(image, 0, 1);
+
+	std::vector<uint32_t> row(2);
+	decoder.GetNextRowAsBgrx32Pixels(row.begin());
+
+	EXPECT_EQ(row[0], ExpectedBgrxFromRgb555);
+	EXPECT_EQ(row[1], 0x00000000u);
+}
+
+TEST(ImageDecoderTest, SkipsPixelsRgb565ToBgrx32)
+{
+	// Every second pixel is a "poison pixel" that must be skipped
+	std::vector<uint16_t> pixels = {PackedRgb565, 0xffff, 0x0000, 0xffff};
+
+	RenderedImage image = {};
+
+	image.params.width        = 4;
+	image.params.height       = 1;
+	image.params.pixel_format = PixelFormat::RGB565_Packed16;
+
+	image.pitch      = 4 * static_cast<int>(sizeof(uint16_t));
+	image.image_data = reinterpret_cast<uint8_t*>(pixels.data());
+
+	ImageDecoder decoder(image, 0, 1);
+
+	std::vector<uint32_t> row(2);
+	decoder.GetNextRowAsBgrx32Pixels(row.begin());
+
+	EXPECT_EQ(row[0], ExpectedBgrxFromRgb565);
+	EXPECT_EQ(row[1], 0x00000000u);
+}
+
+TEST(ImageDecoderTest, SkipsPixelsBgr24ToBgrx32)
+{
+	// Every second pixel is a "poison pixel" that must be skipped
+	std::vector<uint8_t> pixels = {
+	        BlueA, GreenA, RedA, 0xff, 0xff, 0xff, BlueB, GreenB, RedB, 0xff, 0xff, 0xff};
+
+	RenderedImage image = {};
+
+	image.params.width        = 4;
+	image.params.height       = 1;
+	image.params.pixel_format = PixelFormat::BGR24_ByteArray;
+
+	image.pitch      = 4 * 3;
+	image.image_data = pixels.data();
+
+	ImageDecoder decoder(image, 0, 1);
+
+	std::vector<uint32_t> row(2);
+	decoder.GetNextRowAsBgrx32Pixels(row.begin());
+
+	EXPECT_EQ(row[0], ExpectedBgrxA);
+	EXPECT_EQ(row[1], ExpectedBgrxB);
+}
+
+TEST(ImageDecoderTest, SkipsPixelsBgrx32ToBgrx32)
+{
+	// Every second pixel is a "poison pixel" that must be skipped
+	std::vector<uint32_t> pixels = {ExpectedBgrxA, 0x00ffffff, ExpectedBgrxB, 0x00ffffff};
+
+	RenderedImage image = {};
+
+	image.params.width        = 4;
+	image.params.height       = 1;
+	image.params.pixel_format = PixelFormat::BGRX32_ByteArray;
+
+	image.pitch      = 4 * static_cast<int>(sizeof(uint32_t));
+	image.image_data = reinterpret_cast<uint8_t*>(pixels.data());
+
+	ImageDecoder decoder(image, 0, 1);
+
+	std::vector<uint32_t> row(2);
+	decoder.GetNextRowAsBgrx32Pixels(row.begin());
+
+	EXPECT_EQ(row[0], ExpectedBgrxA);
+	EXPECT_EQ(row[1], ExpectedBgrxB);
+}
+
+TEST(ImageDecoderTest, SkipsPixelsIndexed8ToIndexed8)
+{
+	// Every second pixel is a "poison pixel" that must be skipped
+	std::vector<uint8_t> pixels = {1, 9, 2, 9};
+
+	RenderedImage image = {};
+
+	image.params.width        = 4;
+	image.params.height       = 1;
+	image.params.pixel_format = PixelFormat::Indexed8;
+
+	image.pitch      = 4;
+	image.image_data = pixels.data();
+
+	ImageDecoder decoder(image, 0, 1);
+
+	std::vector<uint8_t> row(2);
+	decoder.GetNextRowAsIndexed8Pixels(row.begin());
+
+	EXPECT_EQ(row[0], 1);
+	EXPECT_EQ(row[1], 2);
 }


### PR DESCRIPTION
# Description

I've been planning out some large VGA/render code refactor with Claude, and in the correctness analysis / review phase it flagged three pre-existing bugs I introduced when I did the FMV deinterlacer feature:

- The first bug manifests when `deinterlacing` is enabled _and_ we're capturing upscaled screenshots that are paletted. Than can only happen on pre-VGA adapters (we always use BGRX32 for VGA), e.g. 640x350 modes on `machine = ega`, all Hercules modes, etc. The bug is that the red and blue channels are swapped in the upscaled screenshot only.
- The second bug is not deinterlacing related; it affects the _raw_ screenshots (and only that) of any Tandy & PCjr game that uses the 160x200 resolution.
- The third is a theoretical case as nobody would really do any actual deinterlacing on pre-VGA adapters, but it's fixed now for correctness ("[Ignore the unused X byte in deinterlacer background detection](https://github.com/dosbox-staging/dosbox-staging/pull/4969/changes/aeb2bc2d5bdb739b29cbf6e4d4f52d4ad80a7157)")

I've also added unit tests for the image decoder as re-testing the image capture paths over and over for all possible video modes is extremely tedious. This should protect against regressions to some degree.

Here are some examples and `main` (bad) and post-fix results (good):

### Spellcasting 101 —  bad 

`machine = ega` & `deinterlacing = on`, 640x350 16-colours (Indexed8), upscaled screenshot

<img width="1400" height="1050" alt="sc101-bad" src="https://github.com/user-attachments/assets/79dc318c-a85b-471d-a997-cbbd03db2de9" />

### Spellcasting 101 —  good

`machine = ega` & `deinterlacing = on`, 640x350 16-colours (Indexed8), upscaled screenshot

<img width="1400" height="1050" alt="sc101-good" src="https://github.com/user-attachments/assets/7f00fb9f-1386-4a55-bf08-3926c920897a" />

### Prince of Persia — bad

`machine = hercules` & `deinterlacing = on`, 720x348 (Indexed8), upscaled screenshot

<img width="1857" height="1392" alt="prince-bad" src="https://github.com/user-attachments/assets/cae51bde-857f-416b-b91c-50129f1b217d" />

### Prince of Persia — good

`machine = hercules` & `deinterlacing = on`, 720x348 (Indexed8), upscaled screenshot

<img width="1857" height="1392" alt="prince-good" src="https://github.com/user-attachments/assets/a0fcd4f0-8917-4c1f-98a2-dcdc16db0648" />

### Maniac Mansion v1 — bad

`machine = tandy`, 160x200 (Indexed8), raw screenshot

<img width="160" height="200" alt="mm-bad" src="https://github.com/user-attachments/assets/6bf974a7-ae16-44b7-88cf-e557cef23a04" />

### Maniac Mansion v1 — good

`machine = tandy`, 160x200 (Indexed8), raw screenshot

<img width="160" height="200" alt="mm-good" src="https://github.com/user-attachments/assets/b4cf08bd-7b8d-414c-bc03-29fc7378ce37" />

# Release notes

We'll just silently backport to 0.83.0 final, that's the only release affected so far.

# Manual testing

In addition to the above, I've also tested a few more modes. Just pasting the bad results here with `main` (all are fixed).

### `machine = cga` & `deinterlacing = on`, 640x350, text mode

<img width="1600" height="1200" alt="cga-dos-bad" src="https://github.com/user-attachments/assets/adf568f1-4d99-44fa-83e0-033d9b0d9818" />

### `machine = ega` & `deinterlacing = on`, 640x350, text mode

<img width="1400" height="1050" alt="ega-dos-bad" src="https://github.com/user-attachments/assets/f5c464f9-8157-480c-a4e2-a58bf669215d" />

### `machine = hercules` & `deinterlacing = on`, 640x350, text mode

<img width="1400" height="1050" alt="hercules-dos-bad" src="https://github.com/user-attachments/assets/9c8fbd00-21f8-4ffe-902a-d115f6525388" />




The change has been manually tested on:

- [ ] Windows
- [x] macOS
- [ ] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

- [x] I am a human, I have read and understood the [project's policy on the use of generative AI tools](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md#policy-on-the-use-of-generative-ai-tools), and I have acted in accordance to it.

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my work (especially important for AI-assisted contributions).
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [x] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

