### PR TITLE
Only lock/unlock SDL surface when it is not already in that state

### DIFF
--- a/src/gui/render/sdl_renderer.cpp
+++ b/src/gui/render/sdl_renderer.cpp
@@ -151,12 +151,12 @@ SdlRenderer::~SdlRenderer()
 		renderer = {};
 		texture  = {};
 	}
-	if (curr_framebuf) {
-		SDL_DestroySurface(curr_framebuf);
+	if (curr_framebuf.surface) {
+		SDL_DestroySurface(curr_framebuf.surface);
 		curr_framebuf = {};
 	}
-	if (last_framebuf) {
-		SDL_DestroySurface(last_framebuf);
+	if (last_framebuf.surface) {
+		SDL_DestroySurface(last_framebuf.surface);
 		last_framebuf = {};
 	}
 	if (window) {
@@ -227,24 +227,26 @@ void SdlRenderer::NotifyRenderSizeChanged(const int render_width_px,
 	default: assertm(false, "Invalid TextureFilterMode"); return;
 	}
 
-	if (curr_framebuf) {
-		SDL_DestroySurface(curr_framebuf);
+	if (curr_framebuf.surface) {
+		SDL_DestroySurface(curr_framebuf.surface);
+		curr_framebuf = {};
 	}
-	if (last_framebuf) {
-		SDL_DestroySurface(last_framebuf);
+	if (last_framebuf.surface) {
+		SDL_DestroySurface(last_framebuf.surface);
+		last_framebuf = {};
 	}
 
-	curr_framebuf = SDL_CreateSurface(
+	curr_framebuf.surface = SDL_CreateSurface(
 	                                               render_width_px,
 	                                               render_height_px,
 	                                               SdlPixelFormat);
 
-	last_framebuf = SDL_CreateSurface(
+	last_framebuf.surface = SDL_CreateSurface(
 	                                               render_width_px,
 	                                               render_height_px,
 	                                               SdlPixelFormat);
 
-	if (!curr_framebuf || !last_framebuf) {
+	if (!curr_framebuf.surface || !last_framebuf.surface) {
 		SDL_DestroyTexture(texture);
 		LOG_ERR("SDL: Error creating input surface: %s", SDL_GetError());
 		return;
@@ -299,25 +301,21 @@ ShaderDescriptor SdlRenderer::GetCurrentShaderDescriptor()
 
 void SdlRenderer::StartFrame(uint32_t*& pixels_out, int& pitch_out)
 {
-	assert(curr_framebuf);
+	assert(curr_framebuf.surface);
 
 	// Some surfaces must be locked for direct access
-	if (SDL_MUSTLOCK(curr_framebuf)) {
-		SDL_LockSurface(curr_framebuf);
-	}
+	curr_framebuf.LockSurface();
 
-	pixels_out = static_cast<uint32_t*>(curr_framebuf->pixels);
-	pitch_out  = curr_framebuf->pitch;
+	pixels_out = static_cast<uint32_t*>(curr_framebuf.surface->pixels);
+	pitch_out  = curr_framebuf.surface->pitch;
 }
 
 void SdlRenderer::EndFrame()
 {
-	assert(curr_framebuf);
-	assert(last_framebuf);
+	assert(curr_framebuf.surface);
+	assert(last_framebuf.surface);
 
-	if (SDL_MUSTLOCK(last_framebuf)) {
-		SDL_LockSurface(last_framebuf);
-	}
+	last_framebuf.LockSurface();
 
 	// We need to copy the buffers. We can't just swap them because the VGA
 	// emulation only writes the changed pixels to the framebuffer in each
@@ -326,9 +324,9 @@ void SdlRenderer::EndFrame()
 	// TODO Couldn't get SDL_BlitSurface to work... If you
 	// can, feel free to use that here, but this works
 	// perfectly fine.
-	std::memcpy(last_framebuf->pixels,
-	            curr_framebuf->pixels,
-	            (curr_framebuf->h * curr_framebuf->pitch));
+	std::memcpy(last_framebuf.surface->pixels,
+	            curr_framebuf.surface->pixels,
+	            (curr_framebuf.surface->h * curr_framebuf.surface->pitch));
 
 	last_framebuf_dirty = true;
 }
@@ -336,17 +334,15 @@ void SdlRenderer::EndFrame()
 void SdlRenderer::PrepareFrame()
 {
 	assert(texture);
-	assert(last_framebuf);
+	assert(last_framebuf.surface);
 
-	if (SDL_MUSTLOCK(last_framebuf)) {
-		SDL_UnlockSurface(last_framebuf);
-	}
+	last_framebuf.UnlockSurface();
 
 	if (last_framebuf_dirty) {
 		SDL_UpdateTexture(texture,
 		                  nullptr, // entire texture
-		                  last_framebuf->pixels,
-		                  last_framebuf->pitch);
+		                  last_framebuf.surface->pixels,
+		                  last_framebuf.surface->pitch);
 
 		last_framebuf_dirty = false;
 	}
@@ -470,4 +466,22 @@ uint32_t SdlRenderer::MakePixel(const uint8_t red, const uint8_t green,
 {
 	static_assert(SdlPixelFormat == SDL_PIXELFORMAT_XRGB8888);
 	return ((blue << 0) | (green << 8) | (red << 16)) | (255 << 24);
+}
+
+void SdlSurface::LockSurface()
+{
+	assert(surface);
+	if (SDL_MUSTLOCK(surface) && !is_locked) {
+		SDL_LockSurface(surface);
+		is_locked = true;
+	}
+}
+
+void SdlSurface::UnlockSurface()
+{
+	assert(surface);
+	if (SDL_MUSTLOCK(surface) && is_locked) {
+		SDL_UnlockSurface(surface);
+		is_locked = false;
+	}
 }

--- a/src/gui/render/sdl_renderer.h
+++ b/src/gui/render/sdl_renderer.h
@@ -17,6 +17,17 @@
 // must be included after dosbox_config.h
 #include <SDL3/SDL.h>
 
+class SdlSurface {
+
+public:
+	void LockSurface();
+	void UnlockSurface();
+	SDL_Surface* surface = nullptr;
+
+private:
+	bool is_locked = false;
+};
+
 class SdlRenderer : public RenderBackend {
 
 public:
@@ -85,10 +96,10 @@ private:
 	// four packed 8-bit values in BGRX byte order (that's in memory order,
 	// so byte N is B, byte N+1 is G, byte N+2 is R).
 	//
-	SDL_Surface* curr_framebuf = {};
+	SdlSurface curr_framebuf = {};
 
 	// Contains the last fully rendered frame, waiting to be presented.
-	SDL_Surface* last_framebuf = {};
+	SdlSurface last_framebuf = {};
 
 	// True if the last framebuffer has been updated since the last present
 	bool last_framebuf_dirty = false;


### PR DESCRIPTION
# Description

SDL's surface lock functions like a recursive mutex. You can lock it multiple times but you must then unlock it the same number of times.

We were locking and unlocking at different rates.
This went un-noticed due to most surfaces not required locking at all.

Fix by creating a small wrapper class that keeps track of lock state.

## Related issues

Fixes #4942

# Manual testing

DOOM still runs on texture backend.

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [x] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

- [x] I am a human, I have read and understood the [project's policy on the use of generative AI tools](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md#policy-on-the-use-of-generative-ai-tools), and I have acted in accordance to it.

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my work (especially important for AI-assisted contributions).
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

