### PR TITLE
Post SDL3 mixer cleanup and bugfixes

### DIFF
--- a/src/audio/mixer.cpp
+++ b/src/audio/mixer.cpp
@@ -186,7 +186,8 @@ struct MixerSettings {
 	int blocksize    = 0;
 	int prebuffer_ms = 25;
 
-	SDL_AudioStream* sdl_device = nullptr;
+	SDL_AudioDeviceID sdl_device = 0;
+	SDL_AudioStream* sdl_stream  = nullptr;
 
 	std::atomic<MixerState> state = {};
 
@@ -2741,9 +2742,14 @@ void MIXER_CloseAudioDevice()
 		channel->Enable(false);
 	}
 
-	if (mixer.sdl_device != nullptr) {
-		SDL_DestroyAudioStream(mixer.sdl_device);
-		mixer.sdl_device = nullptr;
+	if (mixer.sdl_stream != nullptr) {
+		SDL_DestroyAudioStream(mixer.sdl_stream);
+		mixer.sdl_stream = nullptr;
+	}
+
+	if (mixer.sdl_device != 0) {
+		SDL_CloseAudioDevice(mixer.sdl_device);
+		mixer.sdl_device = 0;
 	}
 }
 
@@ -2782,36 +2788,61 @@ static bool init_sdl_sound(const int requested_sample_rate_hz,
 		return false;
 	}
 
-	if ((mixer.sdl_device = SDL_OpenAudioDeviceStream(
-	             SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, &desired, mixer_callback, nullptr)) ==
-	    nullptr) {
+	mixer.sdl_device = SDL_OpenAudioDevice(SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, &desired);
+	if (mixer.sdl_device == 0) {
 		LOG_ERR("MIXER: Can't open audio device: '%s'; sound output is disabled",
 		        SDL_GetError());
-
 		return false;
 	}
 
-	const auto driver_name = SDL_GetCurrentAudioDriver();
-	const auto playback_name = SDL_GetAudioDeviceName(SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK);
-	LOG_MSG("MIXER: Initialised '%s' audio driver using '%s' output device", driver_name, playback_name);
-
-	// Opening SDL audio device succeeded
-	//
-	// An opened audio device starts out paused, and should be enabled for
-	// playing by calling `SDL_PauseAudioDevice()` when you are ready for
-	// your audio callback function to be called. We do that in
-	// `set_mixer_state()`.
-	//
+	// We open the audio device with our desired audio specs but these are only a hint.
+	// The hardware and/or platform may not support what we requested.
+	// Check here to see what the device actually got opened with.
 	int obtained_blocksize = 0;
+	SDL_GetAudioDeviceFormat(mixer.sdl_device, &obtained, &obtained_blocksize);
 
-	SDL_GetAudioDeviceFormat(SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, &obtained, &obtained_blocksize);
+	// An audio stream can accept any arbitary format.
+	// SDL will do any necessary conversion to match the device specs.
+	// We always output 2 channel F32 audio but let's change the sample rate
+	// to match the device's rate to avoid SDL having to resample our
+	// already resampled audio.
 	const auto obtained_sample_rate_hz = obtained.freq;
+	desired.freq = obtained_sample_rate_hz;
 
+	// This is a playback stream so the source must match our mixer's output.
+	// The destination spec will be set by SDL in SDL_BindAudioStream()
+	// to match the audio device we bind to. We can leave it nullptr here.
+	SDL_AudioSpec* stream_src = &desired;
+	SDL_AudioSpec* stream_dst = nullptr;
+	mixer.sdl_stream = SDL_CreateAudioStream(stream_src, stream_dst);
+	if (mixer.sdl_stream == nullptr) {
+		LOG_ERR("MIXER: Failed to create audio stream: '%s'; sound output is disabled",
+		        SDL_GetError());
+
+		SDL_CloseAudioDevice(mixer.sdl_device);
+		mixer.sdl_device = 0;
+		return false;
+	}
+
+	if (!SDL_BindAudioStream(mixer.sdl_device, mixer.sdl_stream)) {
+		LOG_ERR("MIXER: Failed to bind audio stream: '%s'; sound output is disabled",
+		        SDL_GetError());
+
+		SDL_DestroyAudioStream(mixer.sdl_stream);
+		mixer.sdl_stream = nullptr;
+
+		SDL_CloseAudioDevice(mixer.sdl_device);
+		mixer.sdl_device = 0;
+		return false;
+	}
+
+	// Set these mixer values after we've passed all error points.
 	mixer.sample_rate_hz = obtained_sample_rate_hz;
 	mixer.blocksize = obtained_blocksize;
 
-	assert(obtained.channels == NumStereoChannels);
-	assert(obtained.format == desired.format);
+	const auto driver_name = SDL_GetCurrentAudioDriver();
+	const auto playback_name = SDL_GetAudioDeviceName(mixer.sdl_device);
+	LOG_MSG("MIXER: Initialised '%s' audio driver using '%s' output device", driver_name, playback_name);
 
 	// Did SDL negotiate a different playback rate?
 	if (obtained_sample_rate_hz != requested_sample_rate_hz) {
@@ -2901,7 +2932,8 @@ void MIXER_Init()
 	                                                     : MixerState::On;
 
 	auto set_no_sound = [&] {
-		assert(mixer.sdl_device == nullptr);
+		assert(mixer.sdl_device == 0);
+		assert(mixer.sdl_stream == nullptr);
 
 		LOG_MSG("MIXER: Sound output disabled ('nosound' mode)");
 
@@ -2922,11 +2954,10 @@ void MIXER_Init()
 
 			mixer.final_output.Start();
 
-			// SDL starts out paused so unpause it when we first set
-			// the mixer state. We always keep SDL running in the
-			// future. When the mixer becomes muted, we just write
-			// silence.
-			SDL_ResumeAudioStreamDevice(mixer.sdl_device);
+			// The stream becomes live (unpaused) during the SDL_BindAudioStream() call.
+			// It will play silence until we start the callback here and start feeding it audio.
+			// We never use SDL's pause feature. Instead we write silence when we mute the audio.
+			SDL_SetAudioStreamGetCallback(mixer.sdl_stream, mixer_callback, nullptr);
 
 			set_mixer_state(MixerState::On);
 		} else {

--- a/src/audio/mixer.cpp
+++ b/src/audio/mixer.cpp
@@ -61,6 +61,7 @@ constexpr auto EnvelopeMaxExpansionOverMs = 15;
 // should the envelope monitor the initial signal? (recommended > 5s)
 constexpr auto EnvelopeExpiresAfterSeconds = 10;
 
+constexpr auto DefaultPrebufferMs = 20;
 constexpr auto MaxPrebufferMs = 100;
 
 template <class T, size_t ROWS, size_t COLS>
@@ -184,7 +185,7 @@ struct MixerSettings {
 
 	// Matches SDL AudioSpec.samples type
 	int blocksize    = 0;
-	int prebuffer_ms = 25;
+	int prebuffer_ms = DefaultPrebufferMs;
 
 	SDL_AudioDeviceID sdl_device = 0;
 	SDL_AudioStream* sdl_stream  = nullptr;
@@ -3114,13 +3115,11 @@ static void init_mixer_config_settings(SectionProp& sec_prop)
 #if defined(WIN32)
 	// Longstanding known-good defaults for Windows
 	constexpr auto DefaultBlocksize      = 1024;
-	constexpr auto DefaultPrebufferMs    = 25;
 	constexpr bool DefaultAllowNegotiate = false;
 
 #else
 	// Non-Windows platforms tolerate slightly lower latency
 	constexpr auto DefaultBlocksize      = 512;
-	constexpr auto DefaultPrebufferMs    = 20;
 	constexpr bool DefaultAllowNegotiate = true;
 #endif
 

--- a/src/audio/mixer.cpp
+++ b/src/audio/mixer.cpp
@@ -64,6 +64,8 @@ constexpr auto EnvelopeExpiresAfterSeconds = 10;
 constexpr auto DefaultPrebufferMs = 20;
 constexpr auto MaxPrebufferMs = 100;
 
+constexpr auto DefaultBlocksize = 1024;
+
 template <class T, size_t ROWS, size_t COLS>
 using matrix = std::array<std::array<T, COLS>, ROWS>;
 
@@ -184,7 +186,7 @@ struct MixerSettings {
 	std::atomic<int> sample_rate_hz = 0;
 
 	// Matches SDL AudioSpec.samples type
-	int blocksize    = 0;
+	int blocksize    = DefaultBlocksize;
 	int prebuffer_ms = DefaultPrebufferMs;
 
 	SDL_AudioDeviceID sdl_device = 0;
@@ -3114,12 +3116,10 @@ static void init_mixer_config_settings(SectionProp& sec_prop)
 {
 #if defined(WIN32)
 	// Longstanding known-good defaults for Windows
-	constexpr auto DefaultBlocksize      = 1024;
 	constexpr bool DefaultAllowNegotiate = false;
 
 #else
 	// Non-Windows platforms tolerate slightly lower latency
-	constexpr auto DefaultBlocksize      = 512;
 	constexpr bool DefaultAllowNegotiate = true;
 #endif
 

--- a/src/audio/mixer.cpp
+++ b/src/audio/mixer.cpp
@@ -2788,7 +2788,6 @@ static bool init_sdl_sound(const int requested_sample_rate_hz,
 		LOG_ERR("MIXER: Can't open audio device: '%s'; sound output is disabled",
 		        SDL_GetError());
 
-		set_section_property_value("mixer", "nosound", "off");
 		return false;
 	}
 
@@ -2907,6 +2906,7 @@ void MIXER_Init()
 		LOG_MSG("MIXER: Sound output disabled ('nosound' mode)");
 
 		mixer.state = MixerState::NoSound;
+		set_section_property_value("mixer", "nosound", "on");
 	};
 
 	mixer.sample_rate_hz = section->GetInt("rate");

--- a/src/audio/mixer.cpp
+++ b/src/audio/mixer.cpp
@@ -2591,19 +2591,13 @@ static void SDLCALL mixer_callback([[maybe_unused]] void* userdata,
 
 	// Mac OSX has been observed to be problematic if we ever block inside
 	// SDL's callback. This ensures that we do not block waiting for more
-	// audio. If the queue has run dry, we write what we have available and
-	// the rest of the request is silence.
+	// audio. If the queue has run dry, we write what we have available.
 	const auto frames_to_dequeue = std::min(mixer.final_output.Size(),
 	                                        frames_requested);
 
-	output.resize(frames_requested);
+	const auto frames_received = mixer.final_output.BulkDequeue(output, frames_to_dequeue);
 
-	const auto frames_received = mixer.final_output.BulkDequeue(output.data(),
-	                                                             frames_to_dequeue);
-	// Satisfy any shortfall with silence
-	std::fill(output.begin() + frames_received, output.end(), AudioFrame{});
-
-	SDL_PutAudioStreamData(stream, output.data(), bytes_requested);
+	SDL_PutAudioStreamData(stream, output.data(), check_cast<int>(frames_received) * BytesPerAudioFrame);
 }
 
 static void mixer_thread_loop()

--- a/src/audio/mixer.cpp
+++ b/src/audio/mixer.cpp
@@ -65,6 +65,8 @@ constexpr auto DefaultPrebufferMs = 20;
 constexpr auto MaxPrebufferMs = 100;
 
 constexpr auto DefaultBlocksize = 1024;
+constexpr auto MinBlocksize     = 16;
+constexpr auto MaxBlocksize     = 8192;
 
 template <class T, size_t ROWS, size_t COLS>
 using matrix = std::array<std::array<T, COLS>, ROWS>;
@@ -2758,8 +2760,7 @@ void MIXER_CloseAudioDevice()
 
 // Sets `mixer.sample_rate_hz` and `mixer.blocksize` on success
 static bool init_sdl_sound(const int requested_sample_rate_hz,
-                           const int requested_blocksize_in_frames,
-                           const bool allow_negotiate)
+                           const std::optional<int> requested_blocksize_in_frames)
 {
 	SDL_AudioSpec desired  = {};
 	SDL_AudioSpec obtained = {};
@@ -2770,18 +2771,8 @@ static bool init_sdl_sound(const int requested_sample_rate_hz,
 	desired.format   = SDL_AUDIO_F32;
 	desired.freq     = requested_sample_rate_hz;
 
-	// The relationship between negotiate and blocksize changed in SDL3. In SDL2,
-	// you requested a blocksize via the `samples` field, and then if negotiate
-	// was true, SDL could try for a 'better' blocksize. In SDL3, you now use a 
-	// hint to request a specific blocksize; negotiate doesn't affect SDL's 
-	// behavior in that regard anymore. To maintain the old behavior for the
-	// user, we set the hint only when negotiate is false. If negotiate is true,
-	// we just let SDL decide everything. However, the hint is still just a
-	// request, and SDL may still return a different blocksize, according to the
-	// docs. https://wiki.libsdl.org/SDL3/SDL_HINT_AUDIO_DEVICE_SAMPLE_FRAMES
-	// TODO: clean these options up and just let SDL3 do its thing
-	if (!allow_negotiate) {
-		const std::string samples = std::to_string(requested_blocksize_in_frames);
+	if (requested_blocksize_in_frames) {
+		const auto samples = std::to_string(*requested_blocksize_in_frames);
 		SDL_SetHint(SDL_HINT_AUDIO_DEVICE_SAMPLE_FRAMES, samples.c_str());
 	}
 
@@ -2860,10 +2851,10 @@ static bool init_sdl_sound(const int requested_sample_rate_hz,
 	}
 
 	// Did SDL adjust the hint request?
-	if (!allow_negotiate && obtained_blocksize != requested_blocksize_in_frames) {
+	if (requested_blocksize_in_frames && obtained_blocksize != *requested_blocksize_in_frames) {
 		LOG_MSG("MIXER: SDL changed the requested blocksize of "
 		        "%d to %d frames",
-		        requested_blocksize_in_frames,
+		        *requested_blocksize_in_frames,
 		        obtained_blocksize);
 
 		set_section_property_value("mixer",
@@ -2921,6 +2912,25 @@ static void init_denoiser(bool enabled)
 	}
 }
 
+static std::optional<int> parse_blocksize(SectionProp *section)
+{
+	const auto str = section->GetString("blocksize");
+	if (str == "auto") {
+		return {};
+	}
+	const auto blocksize = parse_int(str);
+	if (!blocksize || *blocksize < MinBlocksize || *blocksize > MaxBlocksize) {
+		NOTIFY_DisplayWarning(Notification::Source::Console,
+		                      "MIXER",
+		                      "PROGRAM_CONFIG_INVALID_SETTING",
+		                      "blocksize",
+		                      str.c_str(),
+		                      "auto");
+		return {};
+	}
+	return blocksize;
+}
+
 void MIXER_Init()
 {
 	auto section = get_section("mixer");
@@ -2944,16 +2954,18 @@ void MIXER_Init()
 		set_section_property_value("mixer", "nosound", "on");
 	};
 
-	mixer.sample_rate_hz = section->GetInt("rate");
-	mixer.blocksize      = section->GetInt("blocksize");
+	// Default values set for "nosound" case.
+	// These get over-written inside init_sdl_sound if there are no errors.
+	const auto sample_rate = section->GetInt("rate");
+	mixer.sample_rate_hz   = sample_rate;
+	const auto blocksize   = parse_blocksize(section);
+	mixer.blocksize        = blocksize.value_or(DefaultBlocksize);
 
 	if (mixer_state == MixerState::NoSound) {
 		set_no_sound();
 
 	} else {
-		if (init_sdl_sound(section->GetInt("rate"),
-		                   section->GetInt("blocksize"),
-		                   section->GetBool("negotiate"))) {
+		if (init_sdl_sound(sample_rate, blocksize)) {
 
 			mixer.final_output.Start();
 
@@ -3114,15 +3126,6 @@ static void handle_toggle_mute(const bool was_pressed)
 
 static void init_mixer_config_settings(SectionProp& sec_prop)
 {
-#if defined(WIN32)
-	// Longstanding known-good defaults for Windows
-	constexpr bool DefaultAllowNegotiate = false;
-
-#else
-	// Non-Windows platforms tolerate slightly lower latency
-	constexpr bool DefaultAllowNegotiate = true;
-#endif
-
 	using enum Property::Changeable::Value;
 
 	auto bool_prop = sec_prop.AddBool("nosound", OnlyAtStart, false);
@@ -3142,13 +3145,16 @@ static void init_mixer_config_settings(SectionProp& sec_prop)
 	        "good reason to change it. The OS will most likely resample non-standard sample\n"
 	        "rates to 48000 Hz anyway.");
 
-	int_prop = sec_prop.AddInt("blocksize", OnlyAtStart, DefaultBlocksize);
-	int_prop->SetMinMax(64, 8192);
-	int_prop->SetHelp(
-	        "Block size of the host audio device in sample frames (%s by default). Valid\n"
-	        "range is 64 to 8192. Should be set to power-of-two values (e.g., 256, 512, 1024,\n"
+	constexpr auto DefaultBlocksizeString = "auto";
+	auto string_prop = sec_prop.AddString("blocksize", OnlyAtStart, DefaultBlocksizeString);
+	string_prop->SetHelp(format_str(
+	        "Block size of the host audio device in sample frames ('%s' by default). Valid\n"
+	        "range is %d to %d. Should be set to power-of-two values (e.g., 256, 512, 1024,\n"
 	        "etc.) Larger values might help with sound stuttering but will introduce more\n"
-	        "latency. Also see 'negotiate'.");
+	        "latency.",
+	        DefaultBlocksizeString,
+	        MinBlocksize,
+	        MaxBlocksize));
 
 	int_prop = sec_prop.AddInt("prebuffer", OnlyAtStart, DefaultPrebufferMs);
 	int_prop->SetMinMax(0, MaxPrebufferMs);
@@ -3157,11 +3163,11 @@ static void init_mixer_config_settings(SectionProp& sec_prop)
 	        "(%s by default). Larger values might help with sound stuttering but will\n"
 	        "introduce more latency.");
 
-	bool_prop = sec_prop.AddBool("negotiate", OnlyAtStart, DefaultAllowNegotiate);
+	bool_prop = sec_prop.AddBool("negotiate", Deprecated, false);
 	bool_prop->SetHelp(
-	        "Negotiate a possibly better 'blocksize' setting (%s by default). Enable it if\n"
-	        "you're not getting audio or the sound is stuttering with your 'blocksize'\n"
-	        "setting. Disable it to force the manually set 'blocksize' value.");
+	        "Removed as of SDL3. This used to tell SDL2 whether to negotiate blocksize\n"
+	        "with the audio driver or to force/emulate any arbitary value.\n"
+	        "As of SDL3, blocksize is a hint which may or may not be honored.");
 
 	constexpr auto DefaultOn = true;
 	bool_prop = sec_prop.AddBool("compressor", WhenIdle, DefaultOn);
@@ -3172,7 +3178,7 @@ static void init_mixer_config_settings(SectionProp& sec_prop)
 	        "  off:  Disable compressor.\n"
 	        "  on:   Enable compressor (default).");
 
-	auto string_prop = sec_prop.AddString("crossfeed", WhenIdle, "off");
+	string_prop = sec_prop.AddString("crossfeed", WhenIdle, "off");
 	string_prop->SetHelp(
 	        "Set crossfeed on the OPL and CMS (Gameblaster) mixer channels ('off' by\n"
 	        "default). Many games pan the instruments 100%% left and 100%% right in the\n"

--- a/src/audio/mixer.cpp
+++ b/src/audio/mixer.cpp
@@ -183,7 +183,7 @@ struct MixerSettings {
 
 	// Sample rate negotiated with SDL (technically, this is the rate of
 	// sample *frames* per second).
-	std::atomic<int> sample_rate_hz = 0;
+	std::atomic<int> sample_rate_hz = DefaultSampleRateHz;
 
 	// Matches SDL AudioSpec.samples type
 	int blocksize    = DefaultBlocksize;

--- a/website/docs/0.83/manual/sound/mixer.md
+++ b/website/docs/0.83/manual/sound/mixer.md
@@ -34,8 +34,8 @@ emulated, but no audio reaches the host. This can be useful for capturing
 the emulated audio output to a WAV file without hearing it, or for running
 DOSBox on headless systems without audio hardware.
 
-For buffer tuning ([`blocksize`](#blocksize), [`prebuffer`](#prebuffer),
-[`negotiate`](#negotiate)) and troubleshooting audio glitches, see
+For buffer tuning ([`blocksize`](#blocksize), [`prebuffer`](#prebuffer))
+and troubleshooting audio glitches, see
 [Minimising audio glitches](#minimising-audio-glitches) below.
 
 
@@ -220,9 +220,8 @@ particular hardware, audio driver, and operating system combination.
 
 Increasing the audio buffer sizes usually helps. The trade-off is higher
 audio latency (a longer delay between an action and its sound). The
-default `blocksize` is 1024 on Windows and 512 on macOS and Linux
-(in sample frames). The default `prebuffer` is 25 ms on Windows and 20 ms
-on the other platforms.
+default [`blocksize`](#blocksize) is `auto` which selects a platform dependant default.
+(usually around 512-1024 sample frames). The default [`prebuffer`](#prebuffer) is 20ms.
 
 Try doubling both values as a starting point:
 
@@ -232,15 +231,10 @@ blocksize = 2048
 prebuffer = 50
 ```
 
-The `blocksize` should be a power of two: 256, 512, 1024, 2048, 4096, or
-8192. The `prebuffer` can be any value in milliseconds. Increase
+The [`blocksize`](#blocksize) should be a power of two: 256, 512, 1024, 2048, 4096, or
+8192. The [`prebuffer`](#prebuffer) can be any value in milliseconds. Increase
 further if glitches persist, but keep in mind that larger buffers mean more
 noticeable input-to-sound delay.
-
-The [`negotiate`](#negotiate) setting lets the audio driver override your
-[`blocksize`](#blocksize) with a value it considers optimal. It's enabled by
-default on macOS and Linux; disable it only if you need to force a specific
-buffer size.
 
 Also make sure your [`cpu_cycles`](../system/cpu.md#cpu_cycles) isn't set
 higher than the game actually needs --- overdoing it wastes host CPU
@@ -276,29 +270,17 @@ settings (crossfeed, reverb, chorus), see [Mixer effects](mixer-effects.md#confi
 
 ##### blocksize
 
-:   Block size of the host audio device in sample frames (`1024` on Windows,
-    `512` on other platforms by default). Valid range is 64 to 8192. Should
-    be set to power-of-two values (e.g., 256, 512, 1024). Larger values
-    might help with sound stuttering but will introduce more latency. Also
-    see [`negotiate`](#negotiate).
+:   Block size of the host audio device in sample frames ('auto' by default). Valid
+    range is 16 to 8192. Should be set to power-of-two values (e.g., 256, 512, 1024,
+    etc.) Larger values might help with sound stuttering but will introduce more
+    latency.
 
 
 ##### prebuffer
 
 :   How many milliseconds of sound to render in advance on top of
-    [`blocksize`](#blocksize) (`25` on Windows, `20` on other platforms by
-    default). Larger values might help with sound stuttering but will
-    introduce more latency.
-
-
-##### negotiate
-
-:   Negotiate a possibly better [`blocksize`](#blocksize) setting (`off` on
-    Windows, `on` on other platforms by default). Enable if you're not
-    getting audio or the sound is stuttering with your `blocksize` setting.
-    Disable to force the manually set `blocksize` value.
-
-    Possible values: `on`, `off`
+    [`blocksize`](#blocksize) (`20` by default). Larger values might
+    help with sound stuttering but will introduce more latency.
 
 
 ##### compressor


### PR DESCRIPTION
# Description

Found several issues post migration.

- Mixer callback doesn't need to fill with silence anymore.
- `rate = 30000` sounds slowed down on my system because the stream gets set to take 30,000 hz but we were looking at the device to get the sample rate. Result is we resample to 44,100 and then SDL resamples again to 30,000. This is fixed now. In this case, we set the stream to 44,100 (SDL negotiated rate) so we avoid SDL's resampler.
- Removed platform specific values for prebuffer, blocksize, etc.
- Removed the now mostly useless `negotiate` config option.
- `blocksize` now defaults to `auto`. Users can change it if they want but as of SDL3, this is only a hint. SDL3 doesn't do janky blocksize emulation which has [caused us problems in the past with SDL2](https://github.com/dosbox-staging/dosbox-staging/pull/4181#issuecomment-2654814744)
- `nosound` parameter was not being set correctly on SDL init failure.

20cbae6823d3e2380942d1511769ca176460c66b (nosound fix) can be backported. The rest depend on SDL 3.

I also spent a couple hours studying SDL3 source code and determined the audio callback is still the way to go. SDL3 audio is built on streams. To add audio to a stream, you call `SDL_PutAudioStreamData()`. This can be done at any time from any thread with any length of audio. We currently do this in the callback.

I considered moving `SDL_PutAudioStreamData()` to the mixer thread in order to remove the `mixer.final_output` queue entirely. However, this would require pre-filling SDL's queue with a blocksize or more to prevent under-runs so it's a wash.

The callback runs immediately before audio gets sent to the OS (in Pipewire it runs inside the Pipewire callback on the Pipewire thread for example). This lets us add audio "just in time" to have minimal latency. It's mostly the same as SDL2. There's a bit of overhead with extra copying but probably doesn't make much difference in practice.

# Release notes

The negotiate config option has been deprecated. It is meaningless since the transition to SDL3 and is now ignored.

The blocksize config option is now only a hint that may or may not be honored depending on OS and audio hardware/drivers. A warning will be shown in the logs if the requested blocksize could not be honored.

# Manual testing

Tested various sample rate and blocksize settings on Linux.

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [x] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

- [x] I am a human, I have read and understood the [project's policy on the use of generative AI tools](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md#policy-on-the-use-of-generative-ai-tools), and I have acted in accordance to it.

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my work (especially important for AI-assisted contributions).
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [x] provided the release notes draft (for significant user-facing changes).
- [x] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [x] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

