### PR TITLE
Add 'vesa_custom_resolution' setting

### DIFF
--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -1486,11 +1486,13 @@ static void add_dosbox_config_section(const ConfigPtr& conf)
 	pstring->SetHelp(
 	        "Replace the 1152x864 VESA modes with a custom resolution ('none' by default).\n"
 	        "Specify the resolution in WIDTHxHEIGHT format (e.g., 1920x1080); the valid range\n"
-	        "is from 320x200 to 1920x1440, and WIDTH must be a multiple of 8. Modes that\n"
-	        "don't fit into the configured video memory ('vmemsize') are not available. This\n"
-	        "is useful for games that support custom VESA resolutions (e.g., Duke Nukem 3D),\n"
-	        "and for running Windows 3.1 at modern resolutions with the VBESVGA driver.\n"
-	        "Custom resolutions are always displayed with square pixels.");
+	        "is from 320x200 to 1920x1440, and WIDTH must be a multiple of 8. Colour depth\n"
+	        "variants of the custom resolution that don't fit into the video memory are\n"
+	        "unavailable and log a warning at startup; increase 'vmemsize' to make them\n"
+	        "available (e.g., 1920x1080 32-bit needs 8 MB). This is useful for games that\n"
+	        "support custom VESA resolutions (e.g., Duke Nukem 3D), and for running\n"
+	        "Windows 3.1 at modern resolutions with the VBESVGA driver. Custom resolutions\n"
+	        "are always displayed with square pixels.");
 
 	auto pbool = section->AddBool("vga_8dot_font", OnlyAtStart, false);
 	pbool->SetHelp("Use 8-pixel-wide fonts on VGA adapters ('off' by default).");

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -75,6 +75,7 @@
 #include "shell/autoexec.h"
 #include "shell/shell.h"
 #include "utils/math_utils.h"
+#include "utils/string_utils.h"
 #include "webserver/bridge.h"
 #include "webserver/webserver.h"
 
@@ -1137,6 +1138,44 @@ void DOSBOX_Restart(std::vector<std::string>& parameters)
 #endif // WIN32
 }
 
+static std::optional<VesaCustomResolution> parse_vesa_custom_resolution(
+        const std::string& pref)
+{
+	if (pref.empty() || has_false(pref)) {
+		return {};
+	}
+
+	constexpr auto MinWidth  = 320;
+	constexpr auto MinHeight = 200;
+	constexpr auto MaxWidth  = 1920;
+	constexpr auto MaxHeight = 1440;
+
+	if (const auto dimensions = parse_int_dimensions(pref)) {
+		const auto [width, height] = *dimensions;
+
+		const auto is_out_of_bounds = (width < MinWidth || width > MaxWidth ||
+		                               height < MinHeight ||
+		                               height > MaxHeight);
+
+		const auto is_valid_width = ((width % 8) == 0);
+
+		if (!is_out_of_bounds && is_valid_width) {
+			return VesaCustomResolution{width, height};
+		}
+	}
+
+	LOG_WARNING(
+	        "VIDEO: Invalid 'vesa_custom_resolution' setting: '%s'; "
+	        "must be from %dx%d to %dx%d with the width a multiple of 8, "
+	        "using 'none'",
+	        pref.c_str(),
+	        MinWidth,
+	        MinHeight,
+	        MaxWidth,
+	        MaxHeight);
+	return {};
+}
+
 static void dosbox_realinit(SectionProp& section)
 {
 	// Initialize some dosbox internals
@@ -1172,6 +1211,9 @@ static void dosbox_realinit(SectionProp& section)
 	} else {
 		int10.vesa_modes = VesaModes::All;
 	}
+
+	int10.vesa_custom_resolution = parse_vesa_custom_resolution(
+	        section.GetString("vesa_custom_resolution"));
 
 	VGA_SetRefreshRateMode(section.GetString("dos_rate"));
 
@@ -1439,6 +1481,16 @@ static void add_dosbox_config_section(const ConfigPtr& conf)
 	        "               'compatible' mode if this happens. The 320x200 high colour\n"
 	        "               modes available in this mode are often required by late '90s\n"
 	        "               demoscene productions.");
+
+	pstring = section->AddString("vesa_custom_resolution", OnlyAtStart, "none");
+	pstring->SetHelp(
+	        "Replace the 1152x864 VESA modes with a custom resolution ('none' by default).\n"
+	        "Specify the resolution in WIDTHxHEIGHT format (e.g., 1920x1080); the valid range\n"
+	        "is from 320x200 to 1920x1440, and WIDTH must be a multiple of 8. Modes that\n"
+	        "don't fit into the configured video memory ('vmemsize') are not available. This\n"
+	        "is useful for games that support custom VESA resolutions (e.g., Duke Nukem 3D),\n"
+	        "and for running Windows 3.1 at modern resolutions with the VBESVGA driver.\n"
+	        "Custom resolutions are always displayed with square pixels.");
 
 	auto pbool = section->AddBool("vga_8dot_font", OnlyAtStart, false);
 	pbool->SetHelp("Use 8-pixel-wide fonts on VGA adapters ('off' by default).");

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -1484,15 +1484,22 @@ static void add_dosbox_config_section(const ConfigPtr& conf)
 
 	pstring = section->AddString("vesa_custom_resolution", OnlyAtStart, "none");
 	pstring->SetHelp(
-	        "Replace the 1152x864 VESA modes with a custom resolution ('none' by default).\n"
-	        "Specify the resolution in WIDTHxHEIGHT format (e.g., 1920x1080); the valid range\n"
-	        "is from 320x200 to 1920x1440, and WIDTH must be a multiple of 8. Colour depth\n"
-	        "variants of the custom resolution that don't fit into the video memory are\n"
-	        "unavailable and log a warning at startup; increase 'vmemsize' to make them\n"
-	        "available (e.g., 1920x1080 32-bit needs 8 MB). This is useful for games that\n"
-	        "support custom VESA resolutions (e.g., Duke Nukem 3D), and for running\n"
-	        "Windows 3.1 at modern resolutions with the VBESVGA driver. Custom resolutions\n"
-	        "are always displayed with square pixels.");
+	        "Replace the 1152x864 VESA resolution with a custom one ('none' by default).\n"
+	        "Useful for playing games in widescreen that support custom VESA resolutions\n"
+	        "(e.g., Quake and Build Engine games such as Duke Nukem 3D and Blood), or for\n"
+	        "running Windows 3.1 in widescreen with the VBESVGA driver. Custom resolutions\n"
+	        "always use square pixels. Possible values:\n"
+	        "\n"
+	        "  none:  Don't replace the 1152x864 VESA resolution.\n"
+	        "\n"
+	        "  WxH:   Replacement resolution in WxH format (e.g., 1920x1080, 960x540,\n"
+	        "         480x270). Valid range is 320x200 to 1920x1440; width must be a multiple\n"
+	        "         of 8. Colour depth variants that don't fit into the video memory are\n"
+	        "         skipped with a warning in the logs; increase 'vmemsize' to fit them\n"
+	        "         (e.g., 1920x1080 32-bit needs 8 MB).\n"
+	        "\n"
+	        "Note: The feature only works with the `svga_s3` machine type; any other `svga_*`\n"
+	        "      and `vesa_*` machine types are not supported.");
 
 	auto pbool = section->AddBool("vga_8dot_font", OnlyAtStart, false);
 	pbool->SetHelp("Use 8-pixel-wide fonts on VGA adapters ('off' by default).");

--- a/src/gui/render/render.cpp
+++ b/src/gui/render/render.cpp
@@ -1094,21 +1094,6 @@ static void log_invalid_viewport_setting_warning(
 	}
 }
 
-std::optional<std::pair<int, int>> parse_int_dimensions(const std::string_view s)
-{
-	const auto parts = split(s, "x");
-	if (parts.size() == 2) {
-		const auto w = parse_int(parts[0]);
-		const auto h = parse_int(parts[1]);
-		if (w && h) {
-			return {
-			        {*w, *h}
-                        };
-		}
-	}
-	return {};
-}
-
 static std::optional<ViewportSettings> parse_fit_viewport_modes(const std::string& pref)
 {
 	if (pref == "fit") {

--- a/src/gui/render/scaler/scalers.h
+++ b/src/gui/render/scaler/scalers.h
@@ -19,8 +19,10 @@
 // Make sure ScalerMaxWidth remains a multiple of 8
 constexpr int ScalerWidthExtraPadding = 8 * 5;
 
-constexpr int ScalerMaxWidth  = 1600 + ScalerWidthExtraPadding;
-constexpr int ScalerMaxHeight = 1200;
+// Sized to accommodate custom VESA resolutions of up to 1920x1440 (see the
+// 'vesa_custom_resolution' config setting)
+constexpr int ScalerMaxWidth  = 1920 + ScalerWidthExtraPadding;
+constexpr int ScalerMaxHeight = 1440;
 
 extern std::array<int, ScalerMaxHeight> scaler_changed_lines;
 extern int scaler_changed_line_index;

--- a/src/hardware/video/vga.h
+++ b/src/hardware/video/vga.h
@@ -122,6 +122,10 @@ constexpr uint16_t EGA_HALF_CLOCK = 1 << 0;
 constexpr uint16_t EGA_LINE_DOUBLE = 1 << 1;
 constexpr uint16_t VGA_PIXEL_DOUBLE = 1 << 2;
 
+// Tags modes replaced via the 'vesa_custom_resolution' setting, only so we
+// can force square pixels for them
+constexpr uint16_t VESA_CUSTOM_RESOLUTION = 1 << 3;
+
 // Refresh rate constants
 constexpr auto RefreshRateMin        = 24;
 constexpr auto RefreshRateDosDefault = 70;

--- a/src/hardware/video/vga.h
+++ b/src/hardware/video/vga.h
@@ -116,7 +116,7 @@ constexpr auto NumVgaSequencerRegisters = 0x05;
 constexpr auto NumVgaGraphicsRegisters  = 0x09;
 constexpr auto NumVgaAttributeRegisters = 0x15;
 
-constexpr auto vesa_2_0_modes_start = 0x120;
+constexpr auto Vesa20ModesStart = 0x150;
 
 constexpr uint16_t EGA_HALF_CLOCK = 1 << 0;
 constexpr uint16_t EGA_LINE_DOUBLE = 1 << 1;

--- a/src/hardware/video/vga_draw.cpp
+++ b/src/hardware/video/vga_draw.cpp
@@ -2484,8 +2484,15 @@ ImageInfo setup_drawing()
 		const auto is_1280x1024_mode = (CurMode->swidth == 1280 &&
 		                                CurMode->sheight == 1024);
 
+		const auto is_custom_resolution_mode = (CurMode->special &
+		                                        VESA_CUSTOM_RESOLUTION);
+
 		if (is_1280x1024_mode) {
 			render_pixel_aspect_ratio = pixel_aspect_1280x1024;
+		} else if (is_custom_resolution_mode) {
+			// Custom VESA resolutions target modern square-pixel
+			// flat-screen displays, not 4:3 CRT monitors
+			render_pixel_aspect_ratio = {1};
 		} else {
 			render_pixel_aspect_ratio = calc_pixel_aspect_from_dimensions(
 			        render_width, render_height, double_width, double_height);

--- a/src/hardware/video/vga_s3.cpp
+++ b/src/hardware/video/vga_s3.cpp
@@ -7,7 +7,6 @@
 #include <algorithm>
 #include <cassert>
 #include <string>
-#include <map>
 
 #include "vga.h"
 
@@ -666,6 +665,14 @@ void replace_mode_120h_with_halfline()
 	}
 }
 
+// Planar 4-bit modes store four planes, so they take up four times the
+// page size.
+static int to_required_vmem_bytes(const VideoModeBlock& mode_block)
+{
+	const auto num_planes = (mode_block.type == M_LIN4) ? 4 : 1;
+	return VESA_GetModePageSize(mode_block) * num_planes;
+}
+
 void replace_1152x864_modes_with_custom_resolution(const VesaCustomResolution& custom)
 {
 	// The custom resolution is enumerated by the VESA BIOS under the
@@ -723,144 +730,126 @@ void replace_1152x864_modes_with_custom_resolution(const VesaCustomResolution& c
 	}
 }
 
-void filter_compatible_s3_vesa_modes()
+void filter_compatible_vesa_modes()
 {
-	enum dram_size_t {
-		kb_512 = 1 << 0,
-		mb_1   = 1 << 1,
-		mb_2   = 1 << 2,
-		mb_4   = 1 << 3,
-		mb_8   = 1 << 4,
+	// VESA modes allowed in compatible mode, provided there is enough video
+	// memory for them (that is checked dynamically in mode_allowed() below).
+	//
+	static const std::vector<uint16_t> compatible_modes = {
+	        0x151, //  320x240  8-bit
+	        0x155, //  320x240  15-bit
+	        0x160, //  320x240  15-bit
+	        0x156, //  320x240  16-bit
+	        0x170, //  320x240  16-bit
+	        0x157, //  320x240  24-bit
+	        0x158, //  320x240  32-bit
+	        0x190, //  320x240  32-bit
+
+	        0x166, //  400x300  8-bit
+	        0x167, //  400x300  15-bit
+	        0x168, //  400x300  16-bit
+	        0x169, //  400x300  24-bit
+	        0x16a, //  400x300  32-bit
+
+	        0x215, //  512x384  8-bit
+	        0x216, //  512x384  15-bit
+	        0x16c, //  512x384  24-bit
+
+	        0x213, //  640x400  32-bit
+
+	        0x177, //  640x480  4-bit
+	        0x212, //  640x480  24-bit
+
+	        0x178, //  800x600  24-bit
+
+	        0x207, // 1152x864  8-bit
+	        0x209, // 1152x864  15-bit
+	        0x20a, // 1152x864  16-bit
+	        0x17b, // 1152x864  24-bit
+	        0x20b, // 1152x864  32-bit
+
+	        0x17c, // 1280x960  4-bit
+	        0x17d, // 1280x960  8-bit
+	        0x17e, // 1280x960  15-bit
+	        0x17f, // 1280x960  16-bit
+	        0x180, // 1280x960  24-bit
+	        0x181, // 1280x960  32-bit
+
+	        0x182, // 1280x1024 24-bit
+
+	        0x183, // 1600x1200 4-bit
+	        0x184, // 1600x1200 24-bit
+	        0x185, // 1600x1200 32-bit
 	};
-
-	auto hash = [](const uint16_t w, const uint16_t h, const int d) {
-		return check_cast<uint32_t>((w + h) * d);
-	};
-
-	const std::map<uint32_t, uint8_t> oem_modes = {
-	        { hash(640,  400, M_LIN32),          mb_1 | mb_2 | mb_4 | mb_8},
-
-	        { hash(640,  480,  M_LIN4), kb_512 | mb_1 | mb_2 | mb_4 | mb_8},
-	        { hash(640,  480,  M_LIN8), kb_512 | mb_1 | mb_2 | mb_4 | mb_8},
-	        { hash(640,  480, M_LIN15),          mb_1 | mb_2 | mb_4 | mb_8},
-	        { hash(640,  480, M_LIN16),          mb_1 | mb_2 | mb_4 | mb_8},
-	        { hash(640,  480, M_LIN24),          mb_1 | mb_2 | mb_4 | mb_8},
-	        { hash(640,  480, M_LIN32),                 mb_2 | mb_4 | mb_8},
-
-	        { hash(800,  600,  M_LIN4), kb_512 | mb_1 | mb_2 | mb_4 | mb_8},
-	        { hash(800,  600,  M_LIN8), kb_512 | mb_1 | mb_2 | mb_4 | mb_8},
-	        { hash(800,  600, M_LIN16),          mb_1 | mb_2 | mb_4 | mb_8},
-	        { hash(800,  600, M_LIN32),                 mb_2 | mb_4 | mb_8},
-
-	        {hash(1024,  768,  M_LIN4), kb_512 | mb_1 | mb_2 | mb_4 | mb_8},
-	        {hash(1024,  768,  M_LIN8),          mb_1 | mb_2 | mb_4 | mb_8},
-	        {hash(1024,  768, M_LIN16),                 mb_2 | mb_4 | mb_8},
-	        {hash(1024,  768, M_LIN32),                        mb_4 | mb_8},
-
-	        {hash(1152,  864,  M_LIN8),          mb_1 | mb_2 | mb_4 | mb_8},
-	        {hash(1152,  864, M_LIN15),                 mb_2 | mb_4 | mb_8},
-	        {hash(1152,  864, M_LIN16),                 mb_2 | mb_4 | mb_8},
-	        {hash(1152,  864, M_LIN24),                        mb_4 | mb_8},
-	        {hash(1152,  864, M_LIN32),                        mb_4 | mb_8},
-
-	        {hash(1280,  960,  M_LIN4),          mb_1 | mb_2 | mb_4 | mb_8},
-	        {hash(1280,  960,  M_LIN8),                 mb_2 | mb_4 | mb_8},
-	        {hash(1280,  960, M_LIN16),                        mb_4 | mb_8},
-	        {hash(1280,  960, M_LIN24),                        mb_4 | mb_8},
-	        {hash(1280,  960, M_LIN32),                               mb_8},
-
-	        {hash(1280, 1024,  M_LIN4),          mb_1 | mb_2 | mb_4 | mb_8},
-	        {hash(1280, 1024,  M_LIN8),                 mb_2 | mb_4 | mb_8},
-	        {hash(1280, 1024, M_LIN16),                        mb_4 | mb_8},
-	        {hash(1280, 1024, M_LIN24),                        mb_4 | mb_8},
-	        {hash(1280, 1024, M_LIN32),                               mb_8},
-
-	        {hash(1600, 1200,  M_LIN4),          mb_1 | mb_2 | mb_4 | mb_8},
-	        {hash(1600, 1200,  M_LIN8),                 mb_2 | mb_4 | mb_8},
-	        {hash(1600, 1200, M_LIN16),                        mb_4 | mb_8},
-	        {hash(1600, 1200, M_LIN24),                               mb_8},
-	        {hash(1600, 1200, M_LIN32),                               mb_8},
-	};
-
-	const auto dram_size = [&]() -> dram_size_t {
-		switch (vga.vmemsize) {
-		case 512 * 1024: return kb_512;
-		case 1024 * 1024: return mb_1;
-		case 2048 * 1024: return mb_2;
-		case 4096 * 1024: return mb_4;
-		case 8192 * 1024: return mb_8;
-		default:
-			assertm(false,
-			        format_str("Unexpected vga.memsize size: %d",
-			                   vga.vmemsize));
-			return {};
-		};
-	}();
 
 	auto mode_allowed = [&](const VideoModeBlock& m) {
-		// Only allow standard text modes
-		if (m.type == M_TEXT) {
-			constexpr auto _132x28 = 0x230;
-			constexpr auto _132x30 = 0x231;
-			constexpr auto _132x34 = 0x232;
+		const auto is_allowed = [&] {
+			// Only allow standard text modes
+			if (m.type == M_TEXT) {
+				constexpr auto _132x28 = 0x230;
+				constexpr auto _132x30 = 0x231;
+				constexpr auto _132x34 = 0x232;
 
-			return !contains(std::vector({_132x28, _132x30, _132x34}),
-			                 m.mode);
-		}
+				return !contains(std::vector({_132x28, _132x30, _132x34}),
+				                 m.mode);
+			}
 
-		// Allow all non-VESA modes (standard VGA modes, and CGA and EGA
-		// as emulated by VGA adapters)
-		if (!VESA_IsVesaMode(m.mode)) {
-			return true;
-		}
+			// Allow all non-VESA modes (standard VGA modes, and CGA
+			// and EGA as emulated by VGA adapters)
+			if (!VESA_IsVesaMode(m.mode)) {
+				return true;
+			}
 
-		// Allow common standard VESA modes, except 320x200 hi-color
-		// modes that were rarely properly supported until the late 90s,
-		// and the DOSBox-specific widescreen modes.
-		constexpr auto s3_vesa_modes_start = 0x150;
+			// Allow all common VBA 1.2 modes, regardless of whether
+			// they fit into video memory, except 320x200 hi-color
+			// modes that were rarely properly supported until the
+			// late 90s.
+			//
+			// VESA_GetSVGAModeInformation() in int_vesa.cpp will
+			// set the "Mode supported by hardware configuration"
+			// (bit 0 of ModeAttributes) to 0 in the returned mode
+			// info block.
+			//
+			if (m.mode < Vesa20ModesStart) {
+				constexpr auto _320x200_15bit = 0x10d;
+				constexpr auto _320x200_16bit = 0x10e;
+				constexpr auto _320x200_32bit = 0x10f;
 
-		if (m.mode < s3_vesa_modes_start) {
-			constexpr auto _320x200_15bit = 0x10d;
-			constexpr auto _320x200_16bit = 0x10e;
-			constexpr auto _320x200_32bit = 0x10f;
+				return !contains(std::vector({_320x200_15bit,
+				                              _320x200_16bit,
+				                              _320x200_32bit}),
+				                 m.mode);
+			}
 
-			// Additional DOSBox-specific widescreen modes
-			constexpr auto _848x480_8bit  = 0x222;
-			constexpr auto _848x480_15bit = 0x223;
-			constexpr auto _848x480_16bit = 0x224;
-			constexpr auto _848x480_32bit = 0x225;
+			// Selectively allow specific VBE 2.0 modes. This means
+			// VESA_GetSVGAModeInformation() won't even return them
+			// when a program queries the list of available VESA
+			// modes. We do this culling of VBE 2.0 modes to protect
+			// programs that crash or misbehave (due to buffer
+			// overflow errors) if then encounter "too many" VESA
+			// modes.
+			if (!contains(compatible_modes, m.mode)) {
+				return false;
+			}
 
-			return !contains(std::vector({_320x200_15bit,
-			                              _320x200_16bit,
-			                              _320x200_32bit,
-			                              _848x480_8bit,
-			                              _848x480_15bit,
-			                              _848x480_16bit,
-			                              _848x480_32bit}),
-			                 m.mode);
-		}
-
-		// Selectively allow S3-specific VESA modes.
-
-		// Does the S3 OEM list have this mode for the given DRAM size?
-		const auto it = oem_modes.find(
-		        hash(m.swidth, m.sheight, enum_val(m.type)));
-
-		const bool is_oem_mode = (it != oem_modes.end()) &&
-		                         (it->second & dram_size);
+			// Allow only VBE 2.0 that fit into the video memory.
+			const bool fits_vmem = (to_required_vmem_bytes(m) <=
+			                        static_cast<int>(vga.vmemsize));
+			return fits_vmem;
+		}();
 #if 0
-		auto mode_info = format_str("S3: mode %Xh: %4u x %4u - m.type: %3d",
+		auto mode_info = format_str("VGA:S3: mode %04Xh: %4u x %4u - %s",
 		                            m.mode,
 		                            m.swidth,
 		                            m.sheight,
-		                            m.type);
-		if (is_oem_mode) {
-			LOG_DEBUG(mode_info.c_str());
+		                            to_string(m.type));
+		if (is_allowed) {
+			LOG_DEBUG("%s", mode_info.c_str());
 		} else {
-			LOG_ERR(mode_info.c_str());
+			LOG_ERR("%s", mode_info.c_str());
 		}
 #endif
-		return is_oem_mode;
+		return is_allowed;
 	};
 
 	auto mode_not_allowed = [&](const VideoModeBlock& m) {
@@ -938,7 +927,7 @@ void SVGA_Setup_S3()
 
 	switch (int10.vesa_modes) {
 	case VesaModes::Compatible:
-		filter_compatible_s3_vesa_modes();
+		filter_compatible_vesa_modes();
 		description += " compatible";
 		break;
 

--- a/src/hardware/video/vga_s3.cpp
+++ b/src/hardware/video/vga_s3.cpp
@@ -719,6 +719,7 @@ void replace_1152x864_modes_with_custom_resolution(const VesaCustomResolution& c
 		block.hdispend = check_cast<uint16_t>(is_doubled ? width_chars * 2
 		                                                 : width_chars);
 		block.vdispend = check_cast<uint16_t>(custom.height);
+		block.special |= VESA_CUSTOM_RESOLUTION;
 	}
 }
 

--- a/src/hardware/video/vga_s3.cpp
+++ b/src/hardware/video/vga_s3.cpp
@@ -666,6 +666,62 @@ void replace_mode_120h_with_halfline()
 	}
 }
 
+void replace_1152x864_modes_with_custom_resolution(const VesaCustomResolution& custom)
+{
+	// The custom resolution is enumerated by the VESA BIOS under the
+	// well-established 1152x864 mode numbers, so programs that build
+	// their mode list via VESA BIOS calls pick it up automatically
+	// (e.g., the VBESVGA Windows 3.x driver).
+	constexpr auto _1152x864_4bit  = 0x17a;
+	constexpr auto _1152x864_8bit  = 0x207;
+	constexpr auto _1152x864_15bit = 0x209;
+	constexpr auto _1152x864_16bit = 0x20a;
+	constexpr auto _1152x864_24bit = 0x17b;
+	constexpr auto _1152x864_32bit = 0x20b;
+
+	// The exact blanking margins only affect the pixel clock, which is
+	// derived from the totals to hit the fixed 70 Hz VESA refresh rate.
+	constexpr auto BlankingOverheadPercent = 10;
+
+	constexpr auto CharCellHeightPixels = 16;
+
+	const auto width_chars = custom.width / 8;
+
+	const auto htotal = width_chars * (100 + BlankingOverheadPercent) / 100;
+	const auto vtotal = custom.height * (100 + BlankingOverheadPercent) / 100;
+
+	for (auto& block : ModeList_VGA) {
+		if (!contains(std::vector({_1152x864_4bit,
+		                           _1152x864_8bit,
+		                           _1152x864_15bit,
+		                           _1152x864_16bit,
+		                           _1152x864_24bit,
+		                           _1152x864_32bit}),
+		              block.mode)) {
+			continue;
+		}
+
+		// The horizontal display end of the 15 and 16-bit modes is
+		// doubled (two memory fetches per pixel), but the horizontal
+		// total is not, following the original 1152x864 entries. The
+		// CRTC setup only handles 9-bit horizontal values, which a
+		// doubled total would exceed.
+		const auto is_doubled = (block.type == M_LIN15 ||
+		                         block.type == M_LIN16);
+
+		block.swidth  = check_cast<uint16_t>(custom.width);
+		block.sheight = check_cast<uint16_t>(custom.height);
+		block.twidth  = check_cast<uint8_t>(width_chars);
+		block.theight = check_cast<uint8_t>(custom.height /
+		                                    CharCellHeightPixels);
+		block.htotal  = check_cast<uint16_t>(htotal);
+		block.vtotal  = check_cast<uint16_t>(vtotal);
+		block.hdispend = check_cast<uint16_t>(is_doubled ? width_chars * 2
+		                                                 : width_chars);
+		block.vdispend = check_cast<uint16_t>(custom.height);
+	}
+}
+
 void filter_compatible_s3_vesa_modes()
 {
 	enum dram_size_t {
@@ -891,6 +947,13 @@ void SVGA_Setup_S3()
 		break;
 
 	case VesaModes::All: break;
+	}
+
+	// Must come after the 'vesa_modes' filtering, which matches on the
+	// original 1152x864 dimensions
+	if (int10.vesa_custom_resolution) {
+		replace_1152x864_modes_with_custom_resolution(
+		        *int10.vesa_custom_resolution);
 	}
 
 	if (int10.vesa_nolfb) {

--- a/src/hardware/video/vga_s3.cpp
+++ b/src/hardware/video/vga_s3.cpp
@@ -727,6 +727,35 @@ void replace_1152x864_modes_with_custom_resolution(const VesaCustomResolution& c
 		                                                 : width_chars);
 		block.vdispend = check_cast<uint16_t>(custom.height);
 		block.special |= VESA_CUSTOM_RESOLUTION;
+
+		const auto required_vmem_bytes = to_required_vmem_bytes(block);
+
+		if (required_vmem_bytes > static_cast<int>(vga.vmemsize)) {
+			auto bits_per_pixel = [&] {
+				switch (block.type) {
+				case M_LIN4: return 4;
+				case M_LIN8: return 8;
+				case M_LIN15: return 15;
+				case M_LIN16: return 16;
+				case M_LIN24: return 24;
+				case M_LIN32: return 32;
+				default:
+					assertm(false, "Invalid VGAModes value");
+					return 0;
+				}
+			};
+
+			LOG_WARNING(
+			        "VIDEO: The %dx%d %d-bit custom VESA mode needs "
+			        "%d KB of video memory but only %u KB is "
+			        "available; increase 'vmemsize' to make the "
+			        "mode available",
+			        custom.width,
+			        custom.height,
+			        bits_per_pixel(),
+			        required_vmem_bytes / 1024,
+			        vga.vmemsize / 1024);
+		}
 	}
 }
 
@@ -925,6 +954,13 @@ void SVGA_Setup_S3()
 
 	description += int10.vesa_oldvbe ? "VESA 1.2" : "VESA 2.0";
 
+	// Must come before the 'vesa_modes' filtering so the custom modes are
+	// filtered by their real dimensions
+	if (int10.vesa_custom_resolution) {
+		replace_1152x864_modes_with_custom_resolution(
+		        *int10.vesa_custom_resolution);
+	}
+
 	switch (int10.vesa_modes) {
 	case VesaModes::Compatible:
 		filter_compatible_vesa_modes();
@@ -937,13 +973,6 @@ void SVGA_Setup_S3()
 		break;
 
 	case VesaModes::All: break;
-	}
-
-	// Must come after the 'vesa_modes' filtering, which matches on the
-	// original 1152x864 dimensions
-	if (int10.vesa_custom_resolution) {
-		replace_1152x864_modes_with_custom_resolution(
-		        *int10.vesa_custom_resolution);
 	}
 
 	if (int10.vesa_nolfb) {

--- a/src/ints/int10.h
+++ b/src/ints/int10.h
@@ -397,7 +397,13 @@ void INT10_PerformGrayScaleSumming(uint16_t start_reg,uint16_t count);
 // VESA functions
 uint8_t VESA_GetSVGAInformation(const uint16_t segment, const uint16_t offset);
 bool VESA_IsVesaMode(const uint16_t bios_mode_number);
-uint8_t VESA_GetSVGAModeInformation(uint16_t mode,uint16_t seg,uint16_t off);
+
+// Size of a single display page in bytes, rounded up to the 64 KB
+// granularity many applications assume. For planar modes this is the size
+// of a single plane.
+int VESA_GetModePageSize(const VideoModeBlock& mode_block);
+
+uint8_t VESA_GetSVGAModeInformation(uint16_t mode, uint16_t seg, uint16_t off);
 uint8_t VESA_SetSVGAMode(uint16_t mode);
 uint8_t VESA_GetSVGAMode(uint16_t & mode);
 uint8_t VESA_SetCPUWindow(uint8_t window,uint8_t address);

--- a/src/ints/int10.h
+++ b/src/ints/int10.h
@@ -272,6 +272,13 @@ enum class VesaModes {
 	All
 };
 
+// Custom resolution that replaces the 1152x864 VESA modes (see the
+// 'vesa_custom_resolution' config setting)
+struct VesaCustomResolution {
+	int width  = 0;
+	int height = 0;
+};
+
 struct Int10Data {
 	struct Int10DataRom {
 		RealPt font_8_first;
@@ -300,6 +307,8 @@ struct Int10Data {
 	uint16_t vesa_setmode = 0;
 
 	VesaModes vesa_modes = VesaModes::Compatible;
+
+	std::optional<VesaCustomResolution> vesa_custom_resolution = {};
 
 	bool vesa_nolfb  = false;
 	bool vesa_oldvbe = false;

--- a/src/ints/int10_modes.cpp
+++ b/src/ints/int10_modes.cpp
@@ -228,12 +228,6 @@ std::vector<VideoModeBlock> ModeList_VGA = {
 
 	// Additional DOSBox specific VESA 2.0 modes
 	// -----------------------------------------
-	// A nice 16:9 mode
-	{ 0x222,  M_LIN8,  848,  480,  80, 30, 8, 16, 1, 0xA0000, 0x10000, 132,  525, 106,  480,                                  0},
-	{ 0x223, M_LIN15,  848,  480,  80, 30, 8, 16, 1, 0xA0000, 0x10000, 264,  525, 212,  480,                                  0},
-	{ 0x224, M_LIN16,  848,  480,  80, 30, 8, 16, 1, 0xA0000, 0x10000, 264,  525, 212,  480,                                  0},
-	{ 0x225, M_LIN32,  848,  480,  80, 30, 8, 16, 1, 0xA0000, 0x10000, 132,  525, 106,  480,                                  0},
-
 	// The MODE command uses these extra 132-column text modes
 	//
 	// The timings of these modes have been tweaked for exact 3:2 aspect ratio.

--- a/src/ints/int10_modes.cpp
+++ b/src/ints/int10_modes.cpp
@@ -124,19 +124,34 @@ std::vector<VideoModeBlock> ModeList_VGA = {
 	{ 0x11A, M_LIN16, 1280, 1024, 160, 64, 8, 16, 1, 0xA0000, 0x10000, 212, 1066, 320, 1024,                                  0},
 	{ 0x11B, M_LIN32, 1280, 1024, 160, 64, 8, 16, 1, 0xA0000, 0x10000, 212, 1066, 160, 1024,                                  0},
 
-	// S3 specific 1600x1200 VESA modes
-	// TODO Are these VESA 2.0 modes or non-standard VESA 1.2 additions?
+	// The highest mode specified by VBE 1.2 is 1280x1024 at 24 bits per pixel
+	// (mode 0x11B). Modes 0x120 to 0x122 are non-standard S3-specific
+	// 1600x1200 VESA modes.
+	//
+	// The old Trio64 (86C764X) only had 0x120 and its BIOS identified itself
+	// as VBE 1.2. Later models such as the ViRGE/GX2 (86C357) added the
+	// remaining 0x122 and 0x122 modes and identified themselves as VBE 2.0.
+	//
+	// We treat all three modes as VBE 1.2 for simplicity. The 1600x1200 modes
+	// are duplicated in the VESA 2.0 range below, so these modes numbers
+	// effectively act as aliases for VBE 1.2 programs that hardcode them.
+	//
 	{ 0x120,  M_LIN8, 1600, 1200, 200, 75, 8, 16, 1, 0xA0000, 0x10000, 264, 1250, 200, 1200,                                  0},
 	{ 0x121, M_LIN15, 1600, 1200, 200, 75, 8, 16, 1, 0xA0000, 0x10000, 264, 1250, 400, 1200,                                  0},
 	{ 0x122, M_LIN16, 1600, 1200, 200, 75, 8, 16, 1, 0xA0000, 0x10000, 264, 1250, 400, 1200,                                  0},
 
-	// S3 specific VESA 2.0 modes
-	// --------------------------
-	// The VESA 2.0 defines no more mode numbers, and treats old VBE 1.2 modes
-	// number as deprecated.
+	// VESA 2.0 modes
+	// --------------
+	// Starting with VBE 2.0, VESA stopped defining new fixed mode ID numbers,
+	// and treats old VBE 1.2 modes number as deprecated.
 	//
 	// Software should not rely on any hardcoded mode numbers but discover
-	// available video modes via standard VESA 2.0 BIOS calls.
+	// available video modes via standard VBE 2.0 BIOS calls.
+	//
+	// These modes numbers are not S3 specific; we could technically use any
+	// mode number we want.
+	//
+	// Ref: https://pcdosretro.gitlab.io/VBE20.pdf
 	//
 	{ 0x150,  M_LIN8,  320,  200,  40, 25, 8,  8, 1, 0xA0000, 0x10000, 100,  449,  80,  400, VGA_PIXEL_DOUBLE | EGA_LINE_DOUBLE},
 	{ 0x151,  M_LIN8,  320,  240,  40, 30, 8,  8, 1, 0xA0000, 0x10000, 100,  525,  80,  480, VGA_PIXEL_DOUBLE | EGA_LINE_DOUBLE},
@@ -666,7 +681,7 @@ static bool set_cur_mode(const std::vector<VideoModeBlock>& modeblock, uint16_t 
 			++i;
 		} else {
 			if (!int10.vesa_oldvbe ||
-			    ModeList_VGA[i].mode < vesa_2_0_modes_start) {
+			    ModeList_VGA[i].mode < Vesa20ModesStart) {
 				CurMode = modeblock.begin() + i;
 #if 0
 				if (!video_mode_change_in_progress) {

--- a/src/ints/int10_vesa.cpp
+++ b/src/ints/int10_vesa.cpp
@@ -189,6 +189,50 @@ static bool can_triple_buffer_8bit(const VideoModeBlock& m)
 	return vga.vmemsize >= needed_bytes;
 }
 
+int VESA_GetModePageSize(const VideoModeBlock& mode_block)
+{
+	int page_size = 0;
+
+	switch (mode_block.type) {
+	case M_LIN4:
+		// Size of a single plane; planar modes store four planes
+		page_size = mode_block.sheight * mode_block.swidth / 8;
+		break;
+
+	case M_LIN8: page_size = mode_block.sheight * mode_block.swidth; break;
+
+	case M_LIN15:
+	case M_LIN16:
+		page_size = mode_block.sheight * mode_block.swidth * 2;
+		break;
+
+	case M_LIN24:
+		// Mode 0x212 has 128 extra bytes per scan line for
+		// compatibility with Windows 640x480 24-bit S3 Trio drivers
+		if (mode_block.mode == 0x212) {
+			page_size = mode_block.sheight *
+			            (mode_block.swidth * 3 + 128);
+		} else {
+			page_size = mode_block.sheight * (mode_block.swidth * 3);
+		}
+		break;
+
+	case M_LIN32:
+		page_size = mode_block.sheight * mode_block.swidth * 4;
+		break;
+
+	default: break;
+	}
+
+	if (page_size & 0xFFFF) {
+		// It is documented that many applications assume 64k-aligned
+		// page sizes VBETEST is one of them
+		page_size += 0x10000;
+		page_size &= ~0xFFFF;
+	}
+
+	return page_size;
+}
 
 uint8_t VESA_GetSVGAModeInformation(uint16_t mode, uint16_t seg, uint16_t off)
 {
@@ -197,7 +241,6 @@ uint8_t VESA_GetSVGAModeInformation(uint16_t mode, uint16_t seg, uint16_t off)
 
 	PhysPt buf = PhysicalMake(seg, off);
 
-	int modePageSize = 0;
 	uint8_t modeAttributes;
 
 	mode &= 0x3fff; // vbe2 compatible, ignore lfb and keep screen content bits
@@ -222,9 +265,10 @@ uint8_t VESA_GetSVGAModeInformation(uint16_t mode, uint16_t seg, uint16_t off)
 		return VESA_FAIL;
 	}
 
+	const int modePageSize = VESA_GetModePageSize(mblock);
+
 	switch (mblock.type) {
 	case M_LIN4:
-		modePageSize           = mblock.sheight * mblock.swidth / 8;
 		minfo.BytesPerScanLine = host_to_le16(mblock.swidth / 8);
 		minfo.NumberOfPlanes   = 0x4;
 		minfo.BitsPerPixel     = 4u;
@@ -235,7 +279,6 @@ uint8_t VESA_GetSVGAModeInformation(uint16_t mode, uint16_t seg, uint16_t off)
 		break;
 
 	case M_LIN8: {
-		modePageSize           = mblock.sheight * mblock.swidth;
 		minfo.BytesPerScanLine = host_to_le16(mblock.swidth);
 		minfo.NumberOfPlanes   = 0x1;
 		minfo.BitsPerPixel     = 8u;
@@ -262,7 +305,6 @@ uint8_t VESA_GetSVGAModeInformation(uint16_t mode, uint16_t seg, uint16_t off)
 	} break;
 
 	case M_LIN15:
-		modePageSize           = mblock.sheight * mblock.swidth * 2;
 		minfo.BytesPerScanLine = host_to_le16(mblock.swidth * 2);
 		minfo.NumberOfPlanes   = 0x1;
 		minfo.BitsPerPixel     = 15u;
@@ -285,7 +327,6 @@ uint8_t VESA_GetSVGAModeInformation(uint16_t mode, uint16_t seg, uint16_t off)
 		break;
 
 	case M_LIN16:
-		modePageSize           = mblock.sheight * mblock.swidth * 2;
 		minfo.BytesPerScanLine = host_to_le16(mblock.swidth * 2);
 		minfo.NumberOfPlanes   = 0x1;
 		minfo.BitsPerPixel     = 16u;
@@ -309,10 +350,8 @@ uint8_t VESA_GetSVGAModeInformation(uint16_t mode, uint16_t seg, uint16_t off)
 		// Mode 0x212 has 128 extra bytes per scan line for
 		// compatibility with Windows 640x480 24-bit S3 Trio drivers
 		if (mode == 0x212) {
-			modePageSize = mblock.sheight * (mblock.swidth * 3 + 128);
 			minfo.BytesPerScanLine = host_to_le16(mblock.swidth * 3 + 128);
 		} else {
-			modePageSize = mblock.sheight * (mblock.swidth * 3);
 			minfo.BytesPerScanLine = host_to_le16(mblock.swidth * 3);
 		}
 		minfo.NumberOfPlanes = 0x1u;
@@ -334,7 +373,6 @@ uint8_t VESA_GetSVGAModeInformation(uint16_t mode, uint16_t seg, uint16_t off)
 		break;
 
 	case M_LIN32:
-		modePageSize           = mblock.sheight * mblock.swidth * 4;
 		minfo.BytesPerScanLine = host_to_le16(mblock.swidth * 4);
 		minfo.NumberOfPlanes   = 0x1u;
 		minfo.BitsPerPixel     = 32u;
@@ -357,7 +395,6 @@ uint8_t VESA_GetSVGAModeInformation(uint16_t mode, uint16_t seg, uint16_t off)
 		break;
 
 	case M_TEXT:
-		modePageSize           = 0;
 		minfo.BytesPerScanLine = host_to_le16(mblock.twidth * 2);
 		minfo.NumberOfPlanes   = 0x4;
 		minfo.BitsPerPixel     = 4u;
@@ -368,13 +405,6 @@ uint8_t VESA_GetSVGAModeInformation(uint16_t mode, uint16_t seg, uint16_t off)
 		break;
 
 	default: return VESA_FAIL;
-	}
-
-	if (modePageSize & 0xFFFF) {
-		// It is documented that many applications assume 64k-aligned
-		// page sizes VBETEST is one of them
-		modePageSize += 0x10000;
-		modePageSize &= ~0xFFFF;
 	}
 
 	int modePages = 0;

--- a/src/ints/int10_vesa.cpp
+++ b/src/ints/int10_vesa.cpp
@@ -261,7 +261,7 @@ uint8_t VESA_GetSVGAModeInformation(uint16_t mode, uint16_t seg, uint16_t off)
 	const auto mblock = *maybe_mode_block;
 
 	// Was the found mode VESA 2.0 but the user requested VESA 1.2?
-	if (mblock.mode >= vesa_2_0_modes_start && int10.vesa_oldvbe) {
+	if (mblock.mode >= Vesa20ModesStart && int10.vesa_oldvbe) {
 		return VESA_FAIL;
 	}
 

--- a/src/utils/string_utils.cpp
+++ b/src/utils/string_utils.cpp
@@ -423,6 +423,21 @@ std::optional<int> parse_int(const std::string& s, const int base)
 	return {};
 }
 
+std::optional<std::pair<int, int>> parse_int_dimensions(const std::string_view s)
+{
+	const auto parts = split(s, "x");
+	if (parts.size() == 2) {
+		const auto w = parse_int(parts[0]);
+		const auto h = parse_int(parts[1]);
+		if (w && h) {
+			return {
+			        {*w, *h}
+                        };
+		}
+	}
+	return {};
+}
+
 std::optional<float> parse_percentage(const std::string_view s,
                                       const bool is_percent_sign_optional)
 {

--- a/src/utils/string_utils.h
+++ b/src/utils/string_utils.h
@@ -12,6 +12,7 @@
 #include <cstring>
 #include <optional>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "misc/support.h"
@@ -347,6 +348,16 @@ std::optional<float> parse_float(const std::string& s);
 //  - parse_value("txt")  returns empty
 //
 std::optional<int> parse_int(const std::string& s, const int base = 10);
+
+// Parse a 'WIDTHxHEIGHT' string (e.g. "1024x768") into a (width, height)
+// integer pair.
+//
+// For example:
+//  - parse_int_dimensions("1024x768") returns {1024, 768}
+//  - parse_int_dimensions("1024x")    returns empty
+//  - parse_int_dimensions("txt")      returns empty
+//
+std::optional<std::pair<int, int>> parse_int_dimensions(const std::string_view s);
 
 // Returned percentage values are unscaled.
 std::optional<float> parse_percentage_with_percent_sign(const std::string_view s);

--- a/website/docs/0.83/manual/system/general.md
+++ b/website/docs/0.83/manual/system/general.md
@@ -51,6 +51,35 @@ Use `halfline` only for
 requires a special halfline VESA mode. See
 [`vesa_modes`](#vesa_modes) for the full resolution table.
 
+### Custom VESA resolutions
+
+The [`vesa_custom_resolution`](#vesa_custom_resolution) setting replaces the
+1152x864 VESA resolution with a custom one of your choosing, from 320x200 up
+to 1920x1440. Custom resolutions always use square pixels.
+
+This is useful for games that build their video mode list by asking the VESA
+BIOS what resolutions are available, rather than using a fixed internal list.
+For example, you can play [Quake](https://www.mobygames.com/game/374/quake/)
+and Build Engine games such as
+[Duke Nukem 3D](https://www.mobygames.com/game/365/duke-nukem-3d/),
+[Shadow Warrior](https://www.mobygames.com/game/1779/shadow-warrior/), and
+[Blood](https://www.mobygames.com/game/793/blood/) in widescreen by setting
+`vesa_custom_resolution = 1920x1080` --- the custom resolution simply shows up
+in the game's own video mode selector. Low resolutions work too: 960x540 or
+480x270 give you chunky-pixel 16:9 widescreen.
+
+You can also run Windows 3.1 in widescreen or at modern high resolutions with
+the [VBESVGA driver](https://github.com/PluMGMK/vbesvga.drv), which picks up
+any resolution the VESA BIOS reports.
+
+Colour depth variants of the custom resolution that don't fit into the video
+memory are skipped with a warning in the logs; increase
+[`vmemsize`](#vmemsize) to make them available (e.g., 1920x1080 in 32-bit
+colour needs 8 MB of video memory).
+
+The feature only works with the default `svga_s3` [`machine`](#machine) type;
+the other `svga_*` and `vesa_*` machine types are not supported.
+
 VGA text mode normally uses 9-pixel-wide character cells.
 [`vga_8dot_font`](#vga_8dot_font) forces 8-pixel-wide characters instead. Very
 few programs need this.
@@ -201,9 +230,12 @@ The settings below are configured in the `[sdl]` section.
 
     | Resolution      | 4-bit | 8-bit | 16-bit | 24-bit | 32-bit |
     |-----------------|-------|-------|--------|--------|--------|
+    | 320&times;240   | ---   | any   | any    | any    | any    |
+    | 400&times;300   | ---   | any   | any    | any    | any    |
+    | 512&times;384   | ---   | any   | any    | 1 MB   | ---    |
     | 640&times;400   | ---   | any   | ---    | ---    | 1 MB   |
     | 640&times;480   | any   | any   | 1 MB   | 1 MB   | 2 MB   |
-    | 800&times;600   | any   | any   | 1 MB   | ---    | 2 MB   |
+    | 800&times;600   | any   | any   | 1 MB   | 2 MB   | 2 MB   |
     | 1024&times;768  | any   | 1 MB  | 2 MB   | ---    | 4 MB   |
     | 1152&times;864  | ---   | 1 MB  | 2 MB   | 4 MB   | 4 MB   |
     | 1280&times;960  | 1 MB  | 2 MB  | 4 MB   | 4 MB   | 8 MB   |
@@ -212,17 +244,52 @@ The settings below are configured in the `[sdl]` section.
 
     </div>
 
+    The 16-bit column includes the 15-bit high colour modes; 512&times;384
+    high colour is 15-bit only.
+
+    In `compatible` mode, the 256-colour 320&times;240, 400&times;300, and
+    512&times;384 modes are not visible to games that require a linear
+    framebuffer (e.g., Quake); use `vesa_modes = all` for those.
+
     The `all` mode adds the following on top of `compatible`:
 
     <div class="compact" markdown>
 
-    - 320&times;200 and 320&times;240 high colour modes (15/16/24/32-bit)
-    - 320&times;400 and 320&times;480 modes in various depths
-    - 400&times;300 modes (8/15/16/24-bit)
-    - 512&times;384 modes (8/15/16/32-bit)
-    - 848&times;480 widescreen modes (8/15/16/32-bit)
+    - 320&times;200 modes (8/15/16/32-bit)
+    - 320&times;400 and 320&times;480 modes in all colour depths
+    - 512&times;384 modes (4/16/32-bit)
+    - 640&times;350 modes (4/8/15-bit)
+    - 640&times;400 modes (4/15/16/24-bit)
+    - 1024&times;768 24-bit and 1152&times;864 4-bit modes
 
     </div>
+
+
+##### vesa_custom_resolution
+
+:   Replace the 1152x864 VESA resolution with a custom one. Useful for playing
+    games in widescreen that support custom VESA resolutions (e.g., Quake and
+    Build Engine games such as Duke Nukem 3D and Blood), or for running
+    Windows 3.1 in widescreen with the VBESVGA driver. Custom resolutions
+    always use square pixels.
+
+    Possible values:
+
+    - `none` *default*{ .default } -- Don't replace the 1152x864 VESA
+      resolution.
+
+    - `WxH` -- Replacement resolution in WxH format (e.g., `1920x1080`,
+      `960x540`, `480x270`). Valid range is 320x200 to 1920x1440; width must
+      be a multiple of 8. Colour depth variants that don't fit into the video
+      memory are skipped with a warning in the logs; increase
+      [`vmemsize`](#vmemsize) to fit them (e.g., 1920x1080 32-bit needs 8 MB).
+
+    See [Custom VESA resolutions](#custom-vesa-resolutions) for more details.
+
+    !!! note
+
+        The feature only works with the `svga_s3` machine type; any other
+        `svga_*` and `vesa_*` machine types are not supported.
 
 
 ##### vga_8dot_font


### PR DESCRIPTION
# Description

Implements the `vesa_custom_resolution` setting proposed in #3357. It replaces the 1152x864 VESA modes in place with a custom resolution (320x200 to 1920x1440, width a multiple of 8), so programs that build their mode list from the VESA BIOS pick it up under the existing mode numbers — for example the VBESVGA Windows 3.x driver, or DOS games that let you select a VESA mode. Custom resolutions are displayed with square pixels.

Following review, the compatible-mode filter now calculates each mode's page size dynamically and checks it against video memory (replacing a static OEM table), and colour-depth variants of the custom resolution that don't fit into `vmemsize` are skipped with a startup warning.


## Related issues

Closes #3357


# Release notes

**Custom VESA resolutions**

New `vesa_custom_resolution` setting that replaces the 1152x864 VESA resolution with a custom one, from 320x200 up to 1920x1440. Games that discover video modes through the VESA BIOS --- such as Quake and Build Engine games like Duke Nukem 3D and Blood --- can then run in true widescreen: set `vesa_custom_resolution = 1920x1080` and the new resolution simply appears in the game's own video mode selector. Low resolutions work too (e.g., 480x270 or 960x540 for chunky-pixel 16:9), and Windows 3.1 can run in widescreen with the [VBESVGA driver](https://github.com/PluMGMK/vbesvga.drv). Custom resolutions are always displayed with square pixels. See [Custom VESA resolutions](https://www.dosbox-staging.org/0.83/manual/system/general/#custom-vesa-resolutions) in the manual for the details.

**VESA mode changes**

The DOSBox-specific 848x480 widescreen VESA modes have been removed --- set `vesa_custom_resolution = 848x480` if you still need them. The `vesa_modes = compatible` mode list is now filtered by actually measuring
each mode against the configured video memory size: a number of low-resolution modes that always fitted but were previously unavailable with `vmemsize` below 4 MB are now offered, and a couple of large modes that could
never really fit in 512 KB are no longer falsely advertised. See the updated [resolution table](https://www.dosbox-staging.org/0.83/manual/system/general/#vesa_modes) in the manual.

# Manual testing

Tested on macOS (Apple Silicon), `machine = svga_s3`, `vmemsize = 8`,`memsize = 32`.

- Direct mode-set tests: the 8/16/32-bit variants of a range of   resolutions from 320x200 to 1920x1440 set correctly with 1:1 pixel   aspect, except 1920x1440 32-bit which correctly doesn't fit in 8 MB and   is skipped with a warning.
- Duke Nukem 3D shareware 1.3d (`vesa_modes = compatible`): the custom   modes work at the resolutions I tested up to 1600x1200; at 1920x1080   the image is corrupted and 1920x1440 crashes with a DOS/4GW error —
  that's Duke itself hitting a limit, not the modes: the 1920x1080 mode   sets correctly in the mode-set tests and displays correctly in Windows   3.1. The deliberately-restricted small modes I tested in Duke (320x240
  and 400x300) play correctly.
- Quake shareware 1.06: the custom mode appears in Quake's own Video  Modes list and plays with correct aspect and sound. 512x384 doesn't  appear under `compatible` (it's on the old-game denylist, which  disables its linear framebuffer, and Quake only uses linear-framebuffer  modes) but does appear under `vesa_modes = all`, as expected.
- Windows 3.1 with the VBESVGA driver at 1920x1080: correct, letterboxed  16:9 desktop (screenshot below).
- 24-bit output checked in QPV (640x480, mode 0212): no shearing.
- With `vesa_custom_resolution = none` the mode list matches the previous  behaviour at the default 4 MB and at 8 MB (at smaller video-memory  sizes a few small modes that always fit but were previously excluded  now appear).

<img width="1496" height="938" alt="Screenshot 2026-07-19 at 10 24 50 pm" src="https://github.com/user-attachments/assets/26c914fa-fdec-492c-9c5e-5df325f2438a" />
<img width="1067" height="860" alt="Screenshot 2026-07-19 at 10 23 59 pm" src="https://github.com/user-attachments/assets/ce3e151c-24bf-4b8b-9fac-c52972bffa61" />
<img width="1067" height="860" alt="Screenshot 2026-07-19 at 10 23 19 pm" src="https://github.com/user-attachments/assets/8a9fc989-ebdf-42ce-a2a8-40b567996ab6" />


Only tested on macOS so far — I'd appreciate help verifying on Windows
and Linux.

The change has been manually tested on:

- [ ] Windows
- [x] macOS
- [ ] Linux


# Checklist

- [x] I am a human, I have read and understood the project's policy on the use of generative AI tools, and I have acted in accordance to it.

I have:

- [x] followed the project's contributing guidelines and code of conduct.
- [x] performed a self-review of my work (especially important for AI-assisted contributions).
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I named my commits well.
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] checked that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [x] provided the release notes draft (for significant user-facing changes).
- [x] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [x] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

