### PR TITLE
Fix MT-32 MIDI rushing forward after fast-forwarding on slow hosts

### DIFF
--- a/src/midi/CMakeLists.txt
+++ b/src/midi/CMakeLists.txt
@@ -4,6 +4,7 @@ target_sources(libdosboxcommon PRIVATE
   coremidi.cpp
   fluidsynth.cpp
   midi.cpp
+  midi_synth.cpp
   mt32.cpp
   mt32_lasynth_model.cpp
   soundcanvas.cpp

--- a/src/midi/fluidsynth.cpp
+++ b/src/midi/fluidsynth.cpp
@@ -730,7 +730,7 @@ MidiDeviceFluidSynth::MidiDeviceFluidSynth()
 	MIXER_LockMixerThread();
 
 	// Set up the mixer callback
-	const auto mixer_callback = std::bind(&MidiDeviceFluidSynth::MixerCallback,
+	const auto mixer_callback = std::bind(&MidiSynth::MixerCallback,
 	                                      this,
 	                                      std::placeholders::_1);
 
@@ -900,56 +900,6 @@ void MidiDeviceFluidSynth::SetFilter()
 	}
 }
 
-int MidiDeviceFluidSynth::GetNumPendingAudioFrames()
-{
-	const auto now_ms = PIC_FullIndex();
-
-	// Wake up the channel and update the last rendered time datum.
-	assert(mixer_channel);
-	if (mixer_channel->WakeUp()) {
-		last_rendered_ms = now_ms;
-		return 0;
-	}
-	if (last_rendered_ms >= now_ms) {
-		return 0;
-	}
-
-	// Return the number of audio frames needed to get current again
-	assert(ms_per_audio_frame > 0.0);
-
-	const auto elapsed_ms = now_ms - last_rendered_ms;
-	const auto num_audio_frames = iround(ceil(elapsed_ms / ms_per_audio_frame));
-	last_rendered_ms += (num_audio_frames * ms_per_audio_frame);
-
-	return num_audio_frames;
-}
-
-// The request to play the channel message is placed in the MIDI work FIFO
-void MidiDeviceFluidSynth::SendMidiMessage(const MidiMessage& msg)
-{
-	std::vector<uint8_t> message(msg.data.begin(), msg.data.end());
-
-	MidiWork work{std::move(message),
-	              GetNumPendingAudioFrames(),
-	              MessageType::Channel,
-	              PIC_AtomicIndex()};
-
-	work_fifo.Enqueue(std::move(work));
-}
-
-// The request to play the sysex message is placed in the MIDI work FIFO
-void MidiDeviceFluidSynth::SendSysExMessage(uint8_t* sysex, size_t len)
-{
-	std::vector<uint8_t> message(sysex, sysex + len);
-
-	MidiWork work{std::move(message),
-	              GetNumPendingAudioFrames(),
-	              MessageType::SysEx,
-	              PIC_AtomicIndex()};
-
-	work_fifo.Enqueue(std::move(work));
-}
-
 void MidiDeviceFluidSynth::ApplyChannelMessage(const std::vector<uint8_t>& msg)
 {
 	const auto status_byte = msg[0];
@@ -980,42 +930,6 @@ void MidiDeviceFluidSynth::ApplySysExMessage(const std::vector<uint8_t>& msg)
 	fluid_synth_sysex(synth.get(), data, n, nullptr, nullptr, nullptr, false);
 }
 
-// The callback operates at the audio frame-level, steadily adding
-// samples to the mixer until the requested numbers of audio frames is
-// met.
-void MidiDeviceFluidSynth::MixerCallback(const int requested_audio_frames)
-{
-	assert(mixer_channel);
-
-	// Report buffer underruns
-	constexpr auto WarningPercent = 5.0f;
-
-	if (const auto percent_full = audio_frame_fifo.GetPercentFull();
-	    percent_full < WarningPercent) {
-		static auto iteration = 0;
-		if (iteration++ % 100 == 0) {
-			LOG_WARNING("FSYNTH: Audio buffer underrun");
-		}
-		had_underruns = true;
-	}
-
-	static std::vector<AudioFrame> audio_frames = {};
-
-	const auto has_dequeued = audio_frame_fifo.BulkDequeue(audio_frames,
-	                                                       requested_audio_frames);
-
-	if (has_dequeued) {
-		assert(check_cast<int>(audio_frames.size()) == requested_audio_frames);
-		mixer_channel->AddSamples_sfloat(requested_audio_frames,
-		                                 &audio_frames[0][0]);
-
-		last_rendered_ms = PIC_AtomicIndex();
-	} else {
-		assert(!audio_frame_fifo.IsRunning());
-		mixer_channel->AddSilence();
-	}
-}
-
 void MidiDeviceFluidSynth::RenderAudioFramesToFifo(const int num_audio_frames)
 {
 	static std::vector<AudioFrame> audio_frames = {};
@@ -1037,44 +951,15 @@ void MidiDeviceFluidSynth::RenderAudioFramesToFifo(const int num_audio_frames)
 	audio_frame_fifo.BulkEnqueue(audio_frames, num_audio_frames);
 }
 
-void MidiDeviceFluidSynth::ProcessWorkFromFifo()
+void MidiDeviceFluidSynth::ProcessWorkItem(const MidiWork& work)
 {
-	const auto work = work_fifo.Dequeue();
-	if (!work) {
-		return;
-	}
+	if (work.message_type == MessageType::Channel) {
+		assert(work.message.size() <= MaxMidiMessageLen);
+		ApplyChannelMessage(work.message);
 
-#if 0
-	// To log inter-cycle rendering
-	if (work->num_pending_audio_frames > 0) {
-		LOG_DEBUG("FSYNTH: %2u audio frames prior to %s message, followed by "
-		          "%2lu more messages. Have %4lu audio frames queued",
-		          work->num_pending_audio_frames,
-		          work->message_type == MessageType::Channel ? "channel" : "sysex",
-		          work_fifo.Size(),
-		          audio_frame_fifo.Size());
-	}
-#endif
-
-	if (work->num_pending_audio_frames > 0) {
-		RenderAudioFramesToFifo(work->num_pending_audio_frames);
-	}
-
-	if (work->message_type == MessageType::Channel) {
-		assert(work->message.size() <= MaxMidiMessageLen);
-		ApplyChannelMessage(work->message);
 	} else {
-		assert(work->message_type == MessageType::SysEx);
-		ApplySysExMessage(work->message);
-	}
-}
-
-// Keep the fifo populated with freshly rendered buffers
-void MidiDeviceFluidSynth::Render()
-{
-	while (work_fifo.IsRunning()) {
-		work_fifo.IsEmpty() ? RenderAudioFramesToFifo()
-		                    : ProcessWorkFromFifo();
+		assert(work.message_type == MessageType::SysEx);
+		ApplySysExMessage(work.message);
 	}
 }
 

--- a/src/midi/fluidsynth.cpp
+++ b/src/midi/fluidsynth.cpp
@@ -632,6 +632,7 @@ void MidiDeviceFluidSynth::SetVolume(const int volume_percent)
 
 MidiDeviceFluidSynth::MidiDeviceFluidSynth()
 {
+
 	fluid_set_log_function(FLUID_DBG, NULL, NULL);
 
 #ifdef NDEBUG
@@ -772,40 +773,6 @@ MidiDeviceFluidSynth::MidiDeviceFluidSynth()
 	set_thread_name(renderer, "dosbox:fsynth");
 
 	// Start playback
-	MIXER_UnlockMixerThread();
-}
-
-MidiDeviceFluidSynth::~MidiDeviceFluidSynth()
-{
-	LOG_MSG("FSYNTH: Shutting down");
-
-	if (had_underruns) {
-		LOG_WARNING(
-		        "FSYNTH: Fix underruns by lowering the CPU load, increasing "
-		        "the 'prebuffer' or 'blocksize' settings, or using a simpler SoundFont");
-	}
-
-	MIXER_LockMixerThread();
-
-	// Stop playback
-	if (mixer_channel) {
-		mixer_channel->Enable(false);
-	}
-
-	// Stop queueing new MIDI work and audio frames
-	work_fifo.Stop();
-	audio_frame_fifo.Stop();
-
-	// Wait for the rendering thread to finish
-	if (renderer.joinable()) {
-		renderer.join();
-	}
-
-	// Deregister the mixer channel and remove it
-	assert(mixer_channel);
-	MIXER_DeregisterChannel(mixer_channel);
-	mixer_channel.reset();
-
 	MIXER_UnlockMixerThread();
 }
 

--- a/src/midi/midi_synth.cpp
+++ b/src/midi/midi_synth.cpp
@@ -1,0 +1,221 @@
+// SPDX-FileCopyrightText:  2026-2026 The DOSBox Staging Team
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "private/midi_synth.h"
+
+#include "hardware/pic.h"
+#include "utils/math_utils.h"
+#include "utils/string_utils.h"
+
+// #define MIDI_SYNTH_DEBUG
+
+// Keep the FIFO populated with freshly rendered buffers
+void MidiSynth::Render()
+{
+	while (work_fifo.IsRunning()) {
+		if (is_work_fifo_backlogged) {
+			RenderBacklogged();
+		} else {
+			constexpr auto OneFrame = 1;
+			work_fifo.IsEmpty() ? RenderAudioFramesToFifo(OneFrame)
+			                    : ProcessWorkFromFifo();
+		}
+	}
+}
+
+// The next MIDI work task is processed, which includes rendering audio frames
+// prior to applying channel and sysex messages to the service
+void MidiSynth::ProcessWorkFromFifo()
+{
+	const auto work = work_fifo.Dequeue();
+	if (!work) {
+		return;
+	}
+
+	// Detect if the work FIFO is heavily backlogged and enter the special
+	// backlogged rendering mode. This happens in fast-forward mode if the
+	// MIDI synth can't keep up with the sped-up CPU emulation.
+	const auto delta_from_now    = PIC_AtomicIndex() - work->timestamp;
+	constexpr auto OneSecondInMs = 1000.0;
+
+	if (delta_from_now > OneSecondInMs) {
+		is_work_fifo_backlogged = true;
+	}
+
+#ifdef MIDI_SYNTH_DEBUG
+	LOG_TRACE(
+	        "%s: %2u audio frames prior to %s message, followed by "
+	        "%2lu more messages. Have %4lu audio frames queued",
+	        upcase(GetName()).c_str(),
+	        work->num_pending_audio_frames,
+	        work->message_type == MessageType::Channel ? "channel" : "SysEx",
+	        work_fifo.Size(),
+	        audio_frame_fifo.Size());
+#endif
+
+	if (work->num_pending_audio_frames > 0) {
+		RenderAudioFramesToFifo(work->num_pending_audio_frames);
+	}
+
+	ProcessWorkItem(*work);
+}
+
+void MidiSynth::RenderBacklogged()
+{
+	// This will only keep the MIDI events we must process (e.g. program
+	// change and SysEx messages).
+	ProcessWorkFromFifoBacklogged();
+
+	// We must drip-feed these essential MIDI events to the MIDI synth
+	// while in fast-forward mode and render a nominal sample now and then
+	// to keep the emulation ticking along. Batching them up in groups of 10
+	// does the job fine.
+	//
+	// If we'd let them pile up and send in one big batch after exiting
+	// fast-forward mode, we'd overload the MIDI synth's input buffers so
+	// not all messages would be processed. This has been proven to not be a
+	// viable approach as it resulted in wrong-sounding instruments in many
+	// cases.
+	//
+	if (work_fifo.Size() > 10) {
+		constexpr auto OneFrame = 1;
+		RenderAudioFramesToFifo(OneFrame);
+	}
+
+	if (!MIXER_FastForwardModeEnabled()) {
+		is_work_fifo_backlogged = false;
+
+		// Send "All Notes Off" message to all MIDI channels when
+		// exiting from fast-forward mode. This is the best we can do as
+		// we've skipped processing any "Note On" or "Note Off" messages
+		// while in fast-forward mode. There would be a lot of hanging
+		// notes if we don't do this.
+		//
+		for (uint8_t ch = 0; ch < NumMidiChannels; ++ch) {
+			const uint8_t status = MidiStatus::ControlChange | ch;
+
+			MidiMessage msg = {};
+			msg[0]          = status;
+			msg[1]          = MidiChannelMode::AllNotesOff;
+
+			SendMidiMessage(msg);
+		}
+	}
+}
+
+void MidiSynth::ProcessWorkFromFifoBacklogged()
+{
+	const auto work = work_fifo.Dequeue();
+	if (!work) {
+		return;
+	}
+
+	// If we're in backlogged mode when fast-forward is activated, it means
+	// the MIDI synth can't keep up with the sped-up CPU emulation.
+	// Therefore, we need to minimise the work to catch up.
+	//
+	// We can't just *not* process any MIDI events at all; we need to keep
+	// processing program change, control change, etc. events, otherwise
+	// there's a chance the instrument sounds will be wrong when we resume
+	// normal playback. But we can drop all MIDI notes and bypass the actual
+	// audio rendering; we'll just render a few samples from time to time to
+	// keep the MIDI synth ticking along. This way, we can catch up and stay
+	// in sync with the CPU emulation.
+	//
+	if (const auto status = get_midi_status(work->message[0]);
+	    get_midi_message_type(status) == MessageType::Channel) {
+
+		if (status == MidiStatus::NoteOn || status == MidiStatus::NoteOff) {
+			// Drop all MIDI note messages as we won't render any audio
+			return;
+		}
+	}
+
+	ProcessWorkItem(*work);
+}
+
+// The request to play the channel message is placed in the MIDI work FIFO
+void MidiSynth::SendMidiMessage(const MidiMessage& msg)
+{
+	std::vector<uint8_t> message(msg.data.begin(), msg.data.end());
+
+	MidiWork work{std::move(message),
+	              GetNumPendingAudioFrames(),
+	              MessageType::Channel,
+	              PIC_AtomicIndex()};
+
+	work_fifo.Enqueue(std::move(work));
+}
+
+// The request to play the sysex message is placed in the MIDI work FIFO
+void MidiSynth::SendSysExMessage(uint8_t* sysex, size_t len)
+{
+	std::vector<uint8_t> message(sysex, sysex + len);
+
+	MidiWork work{std::move(message),
+	              GetNumPendingAudioFrames(),
+	              MessageType::SysEx,
+	              PIC_AtomicIndex()};
+
+	work_fifo.Enqueue(std::move(work));
+}
+
+int MidiSynth::GetNumPendingAudioFrames()
+{
+	const auto now_ms = PIC_FullIndex();
+
+	// Wake up the channel and update the last rendered time datum.
+	assert(mixer_channel);
+	if (mixer_channel->WakeUp()) {
+		last_rendered_ms = now_ms;
+		return 0;
+	}
+	if (last_rendered_ms >= now_ms) {
+		return 0;
+	}
+
+	// Return the number of audio frames needed to get current again
+	assert(ms_per_audio_frame > 0.0);
+
+	const auto elapsed_ms = now_ms - last_rendered_ms;
+	const auto num_audio_frames = iround(ceil(elapsed_ms / ms_per_audio_frame));
+	last_rendered_ms += (num_audio_frames * ms_per_audio_frame);
+
+	return num_audio_frames;
+}
+
+// The callback operates at the audio frame-level, steadily adding
+// samples to the mixer until the requested numbers of audio frames is
+// met.
+void MidiSynth::MixerCallback(const int requested_audio_frames)
+{
+	assert(mixer_channel);
+
+	// Report buffer underruns
+	constexpr auto WarningPercent = 5.0f;
+
+	if (const auto percent_full = audio_frame_fifo.GetPercentFull();
+	    percent_full < WarningPercent) {
+		static auto iteration = 0;
+		if (iteration++ % 100 == 0) {
+			LOG_WARNING("FSYNTH: Audio buffer underrun");
+		}
+		had_underruns = true;
+	}
+
+	static std::vector<AudioFrame> audio_frames = {};
+
+	const auto has_dequeued = audio_frame_fifo.BulkDequeue(audio_frames,
+	                                                       requested_audio_frames);
+
+	if (has_dequeued) {
+		assert(check_cast<int>(audio_frames.size()) == requested_audio_frames);
+		mixer_channel->AddSamples_sfloat(requested_audio_frames,
+		                                 &audio_frames[0][0]);
+
+		last_rendered_ms = PIC_AtomicIndex();
+	} else {
+		assert(!audio_frame_fifo.IsRunning());
+		mixer_channel->AddSilence();
+	}
+}

--- a/src/midi/midi_synth.cpp
+++ b/src/midi/midi_synth.cpp
@@ -23,6 +23,43 @@ void MidiSynth::Render()
 	}
 }
 
+void MidiSynth::Shutdown()
+{
+	LOG_MSG("%s: Shutting down", upcase(GetName()).c_str());
+
+	if (had_underruns) {
+		LOG_WARNING(
+		        "%s: Fix underruns by lowering the CPU load or increasing "
+		        "the 'prebuffer' or 'blocksize' settings",
+		        upcase(GetName()).c_str());
+	}
+
+	MIXER_LockMixerThread();
+
+	// Stop playback
+	if (mixer_channel) {
+		mixer_channel->Enable(false);
+	}
+
+	// Stop queueing new MIDI work and audio frames
+	work_fifo.Stop();
+	audio_frame_fifo.Stop();
+
+	// Wait for the rendering thread to finish
+	if (renderer.joinable()) {
+		renderer.join();
+	}
+
+	CloseSynth();
+
+	// Deregister the mixer channel and remove it
+	assert(mixer_channel);
+	MIXER_DeregisterChannel(mixer_channel);
+	mixer_channel.reset();
+
+	MIXER_UnlockMixerThread();
+}
+
 // The next MIDI work task is processed, which includes rendering audio frames
 // prior to applying channel and sysex messages to the service
 void MidiSynth::ProcessWorkFromFifo()

--- a/src/midi/midi_synth.cpp
+++ b/src/midi/midi_synth.cpp
@@ -162,7 +162,7 @@ void MidiSynth::SendSysExMessage(uint8_t* sysex, size_t len)
 
 int MidiSynth::GetNumPendingAudioFrames()
 {
-	const auto now_ms = PIC_FullIndex();
+	const auto now_ms = PIC_AtomicIndex();
 
 	// Wake up the channel and update the last rendered time datum.
 	assert(mixer_channel);

--- a/src/midi/mt32.cpp
+++ b/src/midi/mt32.cpp
@@ -621,6 +621,7 @@ static mt32emu_report_handler_i get_report_handler_interface()
 static std::unique_ptr<MT32Emu::Service> create_mt32_service()
 {
 	auto service = std::make_unique<MT32Emu::Service>();
+
 	// Has libmt32emu already created a context?
 	if (!service->getContext()) {
 		service->createContext(get_report_handler_interface(), nullptr);
@@ -650,7 +651,8 @@ static std::set<const LASynthModel*> find_available_models(MT32Emu::Service& ser
 
 MidiDeviceMt32::MidiDeviceMt32()
 {
-	auto mt32_service     = create_mt32_service();
+	auto mt32_service = create_mt32_service();
+
 	const auto model_name = get_model_setting();
 	const auto rom_dirs   = get_rom_dirs();
 
@@ -667,6 +669,8 @@ MidiDeviceMt32::MidiDeviceMt32()
 		}
 		throw std::runtime_error(msg);
 	}
+
+	const std::lock_guard<std::mutex> lock(service_mutex);
 
 	mt32emu_rom_info rom_info;
 	mt32_service->getROMInfo(&rom_info);
@@ -761,45 +765,14 @@ MidiDeviceMt32::MidiDeviceMt32()
 	MIXER_UnlockMixerThread();
 }
 
-MidiDeviceMt32::~MidiDeviceMt32()
+void MidiDeviceMt32::CloseSynth()
 {
-	LOG_MSG("MT32: Shutting down");
+	const std::lock_guard<std::mutex> lock(service_mutex);
 
-	if (had_underruns) {
-		LOG_WARNING(
-		        "MT32: Fix underruns by lowering the CPU load or increasing "
-		        "the 'prebuffer' or 'blocksize' settings");
-	}
-
-	MIXER_LockMixerThread();
-
-	// Stop playback
-	if (mixer_channel) {
-		mixer_channel->Enable(false);
-	}
-
-	// Stop queueing new MIDI work and audio frames
-	work_fifo.Stop();
-	audio_frame_fifo.Stop();
-
-	// Wait for the rendering thread to finish
-	if (renderer.joinable()) {
-		renderer.join();
-	}
-
-	// Stop the synthesizer
 	if (service) {
-		const std::lock_guard<std::mutex> lock(service_mutex);
 		service->closeSynth();
 		service->freeContext();
 	}
-
-	// Deregister the mixer channel and remove it
-	assert(mixer_channel);
-	MIXER_DeregisterChannel(mixer_channel);
-	mixer_channel.reset();
-
-	MIXER_UnlockMixerThread();
 }
 
 void MidiDeviceMt32::RenderAudioFramesToFifo(const int num_frames)
@@ -813,14 +786,12 @@ void MidiDeviceMt32::RenderAudioFramesToFifo(const int num_frames)
 
 	std::unique_lock<std::mutex> lock(service_mutex);
 	service->renderFloat(&audio_frames[0][0], num_frames);
-	lock.unlock();
 
 	audio_frame_fifo.BulkEnqueue(audio_frames, num_frames);
 }
 
 void MidiDeviceMt32::ProcessWorkItem(const MidiWork& work)
 {
-	// Request exclusive access prior to applying messages
 	const std::lock_guard<std::mutex> lock(service_mutex);
 
 	if (work.message_type == MessageType::Channel) {

--- a/src/midi/mt32.cpp
+++ b/src/midi/mt32.cpp
@@ -700,33 +700,33 @@ MidiDeviceMt32::MidiDeviceMt32()
 	MIXER_LockMixerThread();
 
 	// Set up the mixer callback
-	const auto mixer_callback = std::bind(&MidiDeviceMt32::MixerCallback,
+	const auto mixer_callback = std::bind(&MidiSynth::MixerCallback,
 	                                      this,
 	                                      std::placeholders::_1);
 
-	auto mixer_channel = MIXER_AddChannel(mixer_callback,
-	                                      sample_rate_hz,
-	                                      ChannelName::RolandMt32,
-	                                      {ChannelFeature::Sleep,
-	                                       ChannelFeature::Stereo,
-	                                       ChannelFeature::Synthesizer});
+	auto channel = MIXER_AddChannel(mixer_callback,
+	                                sample_rate_hz,
+	                                ChannelName::RolandMt32,
+	                                {ChannelFeature::Sleep,
+	                                 ChannelFeature::Stereo,
+	                                 ChannelFeature::Synthesizer});
 
-	mixer_channel->SetResampleMethod(ResampleMethod::Resample);
+	channel->SetResampleMethod(ResampleMethod::Resample);
 
 	// libmt32emu renders float audio frames between -1.0f and +1.0f, so we
 	// ask the channel to scale all the samples up to its 0db level.
-	mixer_channel->Set0dbScalar(Max16BitSampleValue);
+	channel->Set0dbScalar(Max16BitSampleValue);
 
 	const std::string filter_prefs = get_mt32_section()->GetString("mt32_filter");
 
-	if (!mixer_channel->TryParseAndSetCustomFilter(filter_prefs)) {
+	if (!channel->TryParseAndSetCustomFilter(filter_prefs)) {
 		if (!has_false(filter_prefs)) {
 			LOG_WARNING("MT32: Invalid 'mt32_filter' value: '%s', using 'off'",
 			            filter_prefs.c_str());
 		}
 
-		mixer_channel->SetHighPassFilter(FilterState::Off);
-		mixer_channel->SetLowPassFilter(FilterState::Off);
+		channel->SetHighPassFilter(FilterState::Off);
+		channel->SetLowPassFilter(FilterState::Off);
 
 		set_section_property_value("mt32", "mt32_filter", "off");
 	}
@@ -749,7 +749,7 @@ MidiDeviceMt32::MidiDeviceMt32()
 
 	// Move the local objects into the member variables
 	service       = std::move(mt32_service);
-	channel       = std::move(mixer_channel);
+	mixer_channel = std::move(channel);
 	model_and_dir = std::move(*loaded_model_and_dir);
 
 	// Start rendering audio
@@ -774,8 +774,8 @@ MidiDeviceMt32::~MidiDeviceMt32()
 	MIXER_LockMixerThread();
 
 	// Stop playback
-	if (channel) {
-		channel->Enable(false);
+	if (mixer_channel) {
+		mixer_channel->Enable(false);
 	}
 
 	// Stop queueing new MIDI work and audio frames
@@ -795,96 +795,11 @@ MidiDeviceMt32::~MidiDeviceMt32()
 	}
 
 	// Deregister the mixer channel and remove it
-	assert(channel);
-	MIXER_DeregisterChannel(channel);
-	channel.reset();
+	assert(mixer_channel);
+	MIXER_DeregisterChannel(mixer_channel);
+	mixer_channel.reset();
 
 	MIXER_UnlockMixerThread();
-}
-
-int MidiDeviceMt32::GetNumPendingAudioFrames()
-{
-	const auto now_ms = PIC_FullIndex();
-
-	// Wake up the channel and update the last rendered time datum.
-	assert(channel);
-	if (channel->WakeUp()) {
-		last_rendered_ms = now_ms;
-		return 0;
-	}
-	if (last_rendered_ms >= now_ms) {
-		return 0;
-	}
-
-	// Return the number of audio frames needed to get current again
-	assert(ms_per_audio_frame > 0.0);
-
-	const auto elapsed_ms = now_ms - last_rendered_ms;
-	const auto num_audio_frames = iround(ceil(elapsed_ms / ms_per_audio_frame));
-	last_rendered_ms += (num_audio_frames * ms_per_audio_frame);
-
-	return num_audio_frames;
-}
-
-// The request to play the channel message is placed in the MIDI work FIFO
-void MidiDeviceMt32::SendMidiMessage(const MidiMessage& msg)
-{
-	std::vector<uint8_t> message(msg.data.begin(), msg.data.end());
-
-	MidiWork work{std::move(message),
-	              GetNumPendingAudioFrames(),
-	              MessageType::Channel,
-	              PIC_AtomicIndex()};
-
-	work_fifo.Enqueue(std::move(work));
-}
-
-// The request to play the sysex message is placed in the MIDI work FIFO
-void MidiDeviceMt32::SendSysExMessage(uint8_t* sysex, size_t len)
-{
-	std::vector<uint8_t> message(sysex, sysex + len);
-
-	MidiWork work{std::move(message),
-	              GetNumPendingAudioFrames(),
-	              MessageType::SysEx,
-	              PIC_AtomicIndex()};
-
-	work_fifo.Enqueue(std::move(work));
-}
-
-// The callback operates at the audio frame-level, steadily adding samples to
-// the mixer until the requested numbers of audio frames is met.
-void MidiDeviceMt32::MixerCallback(const int requested_audio_frames)
-{
-	assert(channel);
-
-	// Report buffer underruns
-	constexpr auto warning_percent = 5.0f;
-
-	if (const auto percent_full = audio_frame_fifo.GetPercentFull();
-	    percent_full < warning_percent) {
-		static auto iteration = 0;
-		if (iteration++ % 100 == 0) {
-			LOG_WARNING("MT32: Audio buffer underrun");
-		}
-		had_underruns = true;
-	}
-
-	static std::vector<AudioFrame> audio_frames = {};
-
-	const auto has_dequeued = audio_frame_fifo.BulkDequeue(audio_frames,
-	                                                       requested_audio_frames);
-
-	if (has_dequeued) {
-		assert(check_cast<int>(audio_frames.size()) == requested_audio_frames);
-		channel->AddSamples_sfloat(requested_audio_frames,
-		                           &audio_frames[0][0]);
-
-		last_rendered_ms = PIC_AtomicIndex();
-	} else {
-		assert(!audio_frame_fifo.IsRunning());
-		channel->AddSilence();
-	}
 }
 
 void MidiDeviceMt32::RenderAudioFramesToFifo(const int num_frames)
@@ -903,53 +818,23 @@ void MidiDeviceMt32::RenderAudioFramesToFifo(const int num_frames)
 	audio_frame_fifo.BulkEnqueue(audio_frames, num_frames);
 }
 
-// The next MIDI work task is processed, which includes rendering audio frames
-// prior to applying channel and sysex messages to the service
-void MidiDeviceMt32::ProcessWorkFromFifo()
+void MidiDeviceMt32::ProcessWorkItem(const MidiWork& work)
 {
-	const auto work = work_fifo.Dequeue();
-	if (!work) {
-		return;
-	}
-
-#ifdef DEBUG_MT32
-	LOG_TRACE(
-	        "MT32: %2u audio frames prior to %s message, followed by "
-	        "%2lu more messages. Have %4lu audio frames queued",
-	        work->num_pending_audio_frames,
-	        work->message_type == MessageType::Channel ? "channel" : "sysex",
-	        work_fifo.Size(),
-	        audio_frame_fifo.Size());
-#endif
-
-	if (work->num_pending_audio_frames > 0) {
-		RenderAudioFramesToFifo(work->num_pending_audio_frames);
-	}
-
 	// Request exclusive access prior to applying messages
 	const std::lock_guard<std::mutex> lock(service_mutex);
 
-	if (work->message_type == MessageType::Channel) {
-		assert(work->message.size() <= MaxMidiMessageLen);
+	if (work.message_type == MessageType::Channel) {
+		assert(work.message.size() <= MaxMidiMessageLen);
 
-		const auto& data   = work->message.data();
+		const auto& data   = work.message.data();
 		const uint32_t msg = data[0] + (data[1] << 8) + (data[2] << 16);
 
 		service->playMsg(msg);
 	} else {
-		assert(work->message_type == MessageType::SysEx);
+		assert(work.message_type == MessageType::SysEx);
 
-		service->playSysex(work->message.data(),
-		                   static_cast<uint32_t>(work->message.size()));
-	}
-}
-
-// Keep the FIFO populated with freshly rendered buffers
-void MidiDeviceMt32::Render()
-{
-	while (work_fifo.IsRunning()) {
-		work_fifo.IsEmpty() ? RenderAudioFramesToFifo()
-		                    : ProcessWorkFromFifo();
+		service->playSysex(work.message.data(),
+		                   static_cast<uint32_t>(work.message.size()));
 	}
 }
 

--- a/src/midi/private/fluidsynth.h
+++ b/src/midi/private/fluidsynth.h
@@ -4,19 +4,17 @@
 #ifndef DOSBOX_FLUIDSYNTH_H
 #define DOSBOX_FLUIDSYNTH_H
 
-#include "midi_device.h"
+#include "midi_synth.h"
 
-#include <atomic>
-#include <fluidsynth.h>
 #include <memory>
-#include <optional>
-#include <thread>
+#include <string>
 #include <vector>
+
+#include <fluidsynth.h>
 
 #include "audio/mixer.h"
 #include "dos/programs/more_output.h"
 #include "misc/std_filesystem.h"
-#include "utils/rwqueue.h"
 
 struct ChorusParameters {
 	int voice_count = {};
@@ -78,13 +76,18 @@ enum class SoundFont {
 	Trevor0402_Sc55
 };
 
-class MidiDeviceFluidSynth final : public MidiDevice {
+class MidiDeviceFluidSynth final : public MidiSynth {
 public:
 	// Throws `std::runtime_error` if the MIDI device cannot be initialiased
 	// (e.g., the requested SoundFont cannot be loaded).
 	MidiDeviceFluidSynth();
 
 	~MidiDeviceFluidSynth() override;
+
+	// prevent copying
+	MidiDeviceFluidSynth(const MidiDeviceFluidSynth&) = delete;
+	// prevent assignment
+	MidiDeviceFluidSynth& operator=(const MidiDeviceFluidSynth&) = delete;
 
 	void PrintStats();
 
@@ -97,9 +100,6 @@ public:
 	{
 		return MidiDevice::Type::Internal;
 	}
-
-	void SendMidiMessage(const MidiMessage& msg) override;
-	void SendSysExMessage(uint8_t* sysex, size_t len) override;
 
 	std_fs::path GetSoundFontPath();
 
@@ -117,36 +117,20 @@ private:
 
 	void ApplyChannelMessage(const std::vector<uint8_t>& msg);
 	void ApplySysExMessage(const std::vector<uint8_t>& msg);
-	void MixerCallback(const int requested_audio_frames);
-	void ProcessWorkFromFifo();
 
-	int GetNumPendingAudioFrames();
-	void RenderAudioFramesToFifo(const int num_audio_frames = 1);
-	void Render();
+	void ProcessWorkItem(const MidiWork& work) override;
+	void RenderAudioFramesToFifo(const int num_audio_frames) override;
 
 	using FluidSynthSettingsPtr =
 	        std::unique_ptr<fluid_settings_t, decltype(&delete_fluid_settings)>;
 
 	using FluidSynthPtr = std::unique_ptr<fluid_synth_t, decltype(&delete_fluid_synth)>;
 
-	FluidSynthSettingsPtr settings{nullptr, &delete_fluid_settings};
-	FluidSynthPtr synth{nullptr, &delete_fluid_synth};
-
-	MixerChannelPtr mixer_channel = nullptr;
-	RWQueue<AudioFrame> audio_frame_fifo{1};
-	RWQueue<MidiWork> work_fifo{1};
-	std::thread renderer = {};
+	FluidSynthSettingsPtr settings = {nullptr, &delete_fluid_settings};
+	FluidSynthPtr synth            = {nullptr, &delete_fluid_synth};
 
 	std_fs::path soundfont_path = {};
-
-	SoundFont soundfont = {};
-
-	// Used to track the balance of time between the last mixer callback
-	// versus the current MIDI SysEx or Msg event.
-	double last_rendered_ms   = 0.0;
-	double ms_per_audio_frame = 0.0;
-
-	bool had_underruns = false;
+	SoundFont soundfont         = {};
 };
 
 void FSYNTH_ListDevices(MidiDeviceFluidSynth* device, MoreOutputStrings& output);

--- a/src/midi/private/fluidsynth.h
+++ b/src/midi/private/fluidsynth.h
@@ -82,14 +82,15 @@ public:
 	// (e.g., the requested SoundFont cannot be loaded).
 	MidiDeviceFluidSynth();
 
-	~MidiDeviceFluidSynth() override;
+	~MidiDeviceFluidSynth()
+	{
+		Shutdown();
+	}
 
 	// prevent copying
 	MidiDeviceFluidSynth(const MidiDeviceFluidSynth&) = delete;
 	// prevent assignment
 	MidiDeviceFluidSynth& operator=(const MidiDeviceFluidSynth&) = delete;
-
-	void PrintStats();
 
 	std::string GetName() const override
 	{
@@ -100,6 +101,8 @@ public:
 	{
 		return MidiDevice::Type::Internal;
 	}
+
+	void PrintStats();
 
 	std_fs::path GetSoundFontPath();
 
@@ -120,6 +123,8 @@ private:
 
 	void ProcessWorkItem(const MidiWork& work) override;
 	void RenderAudioFramesToFifo(const int num_audio_frames) override;
+
+	void CloseSynth() override {}
 
 	using FluidSynthSettingsPtr =
 	        std::unique_ptr<fluid_settings_t, decltype(&delete_fluid_settings)>;

--- a/src/midi/private/midi_device.h
+++ b/src/midi/private/midi_device.h
@@ -5,11 +5,12 @@
 #ifndef DOSBOX_MIDI_DEVICE_H
 #define DOSBOX_MIDI_DEVICE_H
 
-#include "midi/midi.h"
-
 #include <cstdint>
 
+#include "midi/midi.h"
+
 namespace MidiDeviceName {
+
 // Internal synths
 constexpr auto FluidSynth  = "fluidsynth";
 constexpr auto SoundCanvas = "soundcanvas";
@@ -22,6 +23,10 @@ constexpr auto CoreMidi  = "coremidi";
 constexpr auto Win32     = "win32";
 } // namespace MidiDeviceName
 
+// Generic interface for all MIDI devices. MIDI devices can be either internal
+// (our three MIDI synths: SoundCanvas, MT-32, and FluidSynth; see
+// `midi_synth.cpp`), or external (various OS-specific ways to output raw MIDI
+// data from DOSBox Staging).
 class MidiDevice {
 public:
 	enum class Type { Internal, External };
@@ -35,7 +40,10 @@ public:
 	virtual void SendSysExMessage(uint8_t* sysex, size_t len) = 0;
 };
 
+// Send All Notes Off and Reset All Controllers to all MIDI channels for this
+// device.
 void MIDI_Reset(MidiDevice* device);
+
 MidiDevice* MIDI_GetCurrentDevice();
 
 #endif // DOSBOX_MIDI_DEVICE_H

--- a/src/midi/private/midi_synth.h
+++ b/src/midi/private/midi_synth.h
@@ -22,6 +22,7 @@ public:
 
 protected:
 	void Render();
+	void Shutdown();
 
 	MixerChannelPtr mixer_channel        = nullptr;
 	RWQueue<AudioFrame> audio_frame_fifo = {1};
@@ -44,6 +45,8 @@ private:
 
 	virtual void ProcessWorkItem(const MidiWork& work)         = 0;
 	virtual void RenderAudioFramesToFifo(const int num_frames) = 0;
+
+	virtual void CloseSynth() = 0;
 
 	// Used to track the balance of time between the last mixer
 	// callback versus the current MIDI SysEx or Msg event.

--- a/src/midi/private/midi_synth.h
+++ b/src/midi/private/midi_synth.h
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText:  2026-2026 The DOSBox Staging Team
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#ifndef DOSBOX_MIDI_SYNTH_H
+#define DOSBOX_MIDI_SYNTH_H
+
+#include "midi_device.h"
+
+#include <cstdint>
+
+#include "audio/mixer.h"
+#include "midi/midi.h"
+#include "utils/rwqueue.h"
+
+// Base class encapsulating the commonalities of all MIDI synthesizers
+// (SoundCanvas, MT-32, and FluidSynth). Implements the Template Method design
+// patterns. Actual MIDI implementations only need to implement the
+// `ProcessWorkItem()` and `RenderAudioFramesToFifo()` hooks.
+class MidiSynth : public MidiDevice {
+public:
+	void MixerCallback(const int requested_audio_frames);
+
+protected:
+	void Render();
+
+	MixerChannelPtr mixer_channel        = nullptr;
+	RWQueue<AudioFrame> audio_frame_fifo = {1};
+	RWQueue<MidiWork> work_fifo          = {1};
+
+	double ms_per_audio_frame = 0.0;
+	bool had_underruns        = false;
+
+	// MIDI synths run in a separate render thread
+	std::thread renderer = {};
+
+private:
+	void SendMidiMessage(const MidiMessage& msg) override;
+	void SendSysExMessage(uint8_t* sysex, size_t len) override;
+
+	void RenderBacklogged();
+	void ProcessWorkFromFifo();
+	void ProcessWorkFromFifoBacklogged();
+	int GetNumPendingAudioFrames();
+
+	virtual void ProcessWorkItem(const MidiWork& work)         = 0;
+	virtual void RenderAudioFramesToFifo(const int num_frames) = 0;
+
+	// Used to track the balance of time between the last mixer
+	// callback versus the current MIDI SysEx or Msg event.
+	double last_rendered_ms = 0.0;
+
+	bool is_work_fifo_backlogged = false;
+};
+
+#endif // DOSBOX_MIDI_SYNTH_H

--- a/src/midi/private/mt32.h
+++ b/src/midi/private/mt32.h
@@ -9,7 +9,6 @@
 #if C_MT32EMU
 
 #include <memory>
-#include <mutex>
 #include <string>
 
 #define MT32EMU_API_TYPE 3
@@ -34,7 +33,10 @@ public:
 	// (e.g., the requested MT-32 ROM cannot be loaded).
 	MidiDeviceMt32();
 
-	~MidiDeviceMt32() override;
+	~MidiDeviceMt32()
+	{
+		Shutdown();
+	}
 
 	// prevent copying
 	MidiDeviceMt32(const MidiDeviceMt32&) = delete;
@@ -51,6 +53,10 @@ public:
 		return MidiDevice::Type::Internal;
 	}
 
+	std::mutex service_mutex = {};
+
+	using Mt32SynthPtr = std::unique_ptr<MT32Emu::Service>;
+
 	void PrintStats();
 
 	ModelAndDir GetModelAndDir();
@@ -62,8 +68,9 @@ private:
 	void ProcessWorkItem(const MidiWork& work) override;
 	void RenderAudioFramesToFifo(const int num_frames) override;
 
-	std::mutex service_mutex                  = {};
-	std::unique_ptr<MT32Emu::Service> service = {};
+	void CloseSynth() override;
+
+	Mt32SynthPtr service = {};
 
 	ModelAndDir model_and_dir = {};
 };

--- a/src/midi/private/mt32.h
+++ b/src/midi/private/mt32.h
@@ -4,26 +4,20 @@
 #ifndef DOSBOX_MT32_H
 #define DOSBOX_MT32_H
 
-#include "midi_device.h"
+#include "midi_synth.h"
 
 #if C_MT32EMU
 
-#include <atomic>
 #include <memory>
 #include <mutex>
-#include <optional>
 #include <string>
-#include <thread>
-#include <vector>
 
 #define MT32EMU_API_TYPE 3
 #include <mt32emu/mt32emu.h>
 
-#include "audio/mixer.h"
 #include "dos/programs/more_output.h"
 #include "midi/midi.h"
 #include "misc/std_filesystem.h"
-#include "utils/rwqueue.h"
 
 // forward declaration
 class LASynthModel;
@@ -34,13 +28,18 @@ static_assert(MT32EMU_VERSION_MAJOR > 2 ||
                       (MT32EMU_VERSION_MAJOR == 2 && MT32EMU_VERSION_MINOR >= 5),
               "libmt32emu >= 2.5.0 required (using " MT32EMU_VERSION ")");
 
-class MidiDeviceMt32 final : public MidiDevice {
+class MidiDeviceMt32 final : public MidiSynth {
 public:
 	// Throws `std::runtime_error` if the MIDI device cannot be initialiased
 	// (e.g., the requested MT-32 ROM cannot be loaded).
 	MidiDeviceMt32();
 
 	~MidiDeviceMt32() override;
+
+	// prevent copying
+	MidiDeviceMt32(const MidiDeviceMt32&) = delete;
+	// prevent assignment
+	MidiDeviceMt32& operator=(const MidiDeviceMt32&) = delete;
 
 	std::string GetName() const override
 	{
@@ -52,9 +51,6 @@ public:
 		return MidiDevice::Type::Internal;
 	}
 
-	void SendMidiMessage(const MidiMessage& msg) override;
-	void SendSysExMessage(uint8_t* sysex, size_t len) override;
-
 	void PrintStats();
 
 	ModelAndDir GetModelAndDir();
@@ -62,29 +58,14 @@ public:
 
 private:
 	void MixerCallback(const int requested_audio_frames);
-	void ProcessWorkFromFifo();
 
-	int GetNumPendingAudioFrames();
-	void RenderAudioFramesToFifo(const int num_frames = 1);
-	void Render();
-
-	// Managed objects
-	MixerChannelPtr channel = nullptr;
-	RWQueue<AudioFrame> audio_frame_fifo{1};
-	RWQueue<MidiWork> work_fifo{1};
+	void ProcessWorkItem(const MidiWork& work) override;
+	void RenderAudioFramesToFifo(const int num_frames) override;
 
 	std::mutex service_mutex                  = {};
 	std::unique_ptr<MT32Emu::Service> service = {};
-	std::thread renderer                      = {};
 
 	ModelAndDir model_and_dir = {};
-
-	// Used to track the balance of time between the last mixer callback
-	// versus the current MIDI SysEx or Msg event.
-	double last_rendered_ms   = 0.0;
-	double ms_per_audio_frame = 0.0;
-
-	bool had_underruns = false;
 };
 
 void MT32_ListDevices(MidiDeviceMt32* device, MoreOutputStrings& output);

--- a/src/midi/private/soundcanvas.h
+++ b/src/midi/private/soundcanvas.h
@@ -4,7 +4,7 @@
 #ifndef DOSBOX_SOUNDCANVAS_H
 #define DOSBOX_SOUNDCANVAS_H
 
-#include "midi_device.h"
+#include "midi_synth.h"
 
 #include <memory>
 #include <optional>
@@ -13,7 +13,6 @@
 #include "audio/clap/plugin.h"
 #include "audio/mixer.h"
 #include "dos/programs/more_output.h"
-#include "utils/rwqueue.h"
 
 namespace SoundCanvas {
 
@@ -45,7 +44,7 @@ struct SynthModel {
 
 } // namespace SoundCanvas
 
-class MidiDeviceSoundCanvas final : public MidiDevice {
+class MidiDeviceSoundCanvas final : public MidiSynth {
 public:
 	// Throws `std::runtime_error` if the MIDI device cannot be
 	// initialiased (e.g., the requested SoundFont cannot be loaded).
@@ -70,42 +69,18 @@ public:
 
 	SoundCanvas::SynthModel GetModel() const;
 
-	void SendMidiMessage(const MidiMessage& msg) override;
-	void SendSysExMessage(uint8_t* sysex, size_t len) override;
-
 private:
 	void MixerCallback(const int requested_audio_frames);
-	void ProcessWorkFromFifo();
-	void ProcessWorkFromFifoBacklogged();
 
-	int GetNumPendingAudioFrames();
-	void RenderAudioFramesToFifo(const int num_frames);
-	void Render();
-	void RenderBacklogged();
-
-	void AddClapEvent(const MidiWork& work);
-
-	// Managed objects
-	MixerChannelPtr mixer_channel        = nullptr;
-	RWQueue<AudioFrame> audio_frame_fifo = {1};
-	RWQueue<MidiWork> work_fifo          = {1};
+	void ProcessWorkItem(const MidiWork& work) override;
+	void RenderAudioFramesToFifo(const int num_frames) override;
 
 	struct {
 		std::unique_ptr<Clap::Plugin> plugin = nullptr;
 		Clap::EventList event_list           = {};
 	} clap = {};
 
-	std::thread renderer = {};
-
 	SoundCanvas::SynthModel model = {};
-
-	// Used to track the balance of time between the last mixer
-	// callback versus the current MIDI SysEx or Msg event.
-	double last_rendered_ms   = 0.0;
-	double ms_per_audio_frame = 0.0;
-
-	bool had_underruns           = false;
-	bool is_work_fifo_backlogged = false;
 };
 
 void SOUNDCANVAS_ListDevices(MidiDeviceSoundCanvas* device, MoreOutputStrings& output);

--- a/src/midi/private/soundcanvas.h
+++ b/src/midi/private/soundcanvas.h
@@ -50,7 +50,10 @@ public:
 	// initialiased (e.g., the requested SoundFont cannot be loaded).
 	MidiDeviceSoundCanvas();
 
-	~MidiDeviceSoundCanvas() override;
+	~MidiDeviceSoundCanvas()
+	{
+		Shutdown();
+	}
 
 	// prevent copying
 	MidiDeviceSoundCanvas(const MidiDeviceSoundCanvas&) = delete;
@@ -74,6 +77,8 @@ private:
 
 	void ProcessWorkItem(const MidiWork& work) override;
 	void RenderAudioFramesToFifo(const int num_frames) override;
+
+	void CloseSynth() override {}
 
 	struct {
 		std::unique_ptr<Clap::Plugin> plugin = nullptr;

--- a/src/midi/soundcanvas.cpp
+++ b/src/midi/soundcanvas.cpp
@@ -489,41 +489,6 @@ MidiDeviceSoundCanvas::MidiDeviceSoundCanvas()
 	MIXER_UnlockMixerThread();
 }
 
-MidiDeviceSoundCanvas::~MidiDeviceSoundCanvas()
-{
-	LOG_MSG("SOUNDCANVAS: Shutting down");
-
-	if (had_underruns) {
-		LOG_WARNING(
-		        "SOUNDCANVAS: Fix underruns by lowering the CPU load "
-		        "or increasing the 'prebuffer' or 'blocksize' setting");
-		had_underruns = false;
-	}
-
-	MIXER_LockMixerThread();
-
-	// Stop playback
-	if (mixer_channel) {
-		mixer_channel->Enable(false);
-	}
-
-	// Stop queueing new MIDI work and audio frames
-	work_fifo.Stop();
-	audio_frame_fifo.Stop();
-
-	// Wait for the rendering thread to finish
-	if (renderer.joinable()) {
-		renderer.join();
-	}
-
-	// Deregister the mixer channel and remove it
-	assert(mixer_channel);
-	MIXER_DeregisterChannel(mixer_channel);
-	mixer_channel.reset();
-
-	MIXER_UnlockMixerThread();
-}
-
 void MidiDeviceSoundCanvas::RenderAudioFramesToFifo(const int num_audio_frames)
 {
 	assert(num_audio_frames > 0);

--- a/src/midi/soundcanvas.cpp
+++ b/src/midi/soundcanvas.cpp
@@ -406,7 +406,7 @@ MidiDeviceSoundCanvas::MidiDeviceSoundCanvas()
 	MIXER_LockMixerThread();
 
 	// Set up the mixer callback
-	const auto mixer_callback = std::bind(&MidiDeviceSoundCanvas::MixerCallback,
+	const auto mixer_callback = std::bind(&MidiSynth::MixerCallback,
 	                                      this,
 	                                      std::placeholders::_1);
 
@@ -524,90 +524,6 @@ MidiDeviceSoundCanvas::~MidiDeviceSoundCanvas()
 	MIXER_UnlockMixerThread();
 }
 
-int MidiDeviceSoundCanvas::GetNumPendingAudioFrames()
-{
-	const auto now_ms = PIC_AtomicIndex();
-
-	// Wake up the channel and update the last rendered time datum.
-	assert(mixer_channel);
-	if (mixer_channel->WakeUp()) {
-		last_rendered_ms = now_ms;
-		return 0;
-	}
-	if (last_rendered_ms >= now_ms) {
-		return 0;
-	}
-
-	// Return the number of audio frames needed to get current again
-	assert(ms_per_audio_frame > 0.0);
-
-	const auto elapsed_ms = now_ms - last_rendered_ms;
-	const auto num_audio_frames = iround(ceil(elapsed_ms / ms_per_audio_frame));
-	last_rendered_ms += (num_audio_frames * ms_per_audio_frame);
-
-	return num_audio_frames;
-}
-
-// The request to play the channel message is placed in the MIDI work FIFO
-void MidiDeviceSoundCanvas::SendMidiMessage(const MidiMessage& msg)
-{
-	std::vector<uint8_t> message(msg.data.begin(), msg.data.end());
-
-	MidiWork work{std::move(message),
-	              GetNumPendingAudioFrames(),
-	              MessageType::Channel,
-	              PIC_AtomicIndex()};
-
-	work_fifo.Enqueue(std::move(work));
-}
-
-// The request to play the sysex message is placed in the MIDI work FIFO
-void MidiDeviceSoundCanvas::SendSysExMessage(uint8_t* sysex, size_t len)
-{
-	std::vector<uint8_t> message(sysex, sysex + len);
-
-	MidiWork work{std::move(message),
-	              GetNumPendingAudioFrames(),
-	              MessageType::SysEx,
-	              PIC_AtomicIndex()};
-
-	work_fifo.Enqueue(std::move(work));
-}
-
-// The callback operates at the audio frame-level, steadily adding samples to
-// the mixer until the requested numbers of audio frames is met.
-void MidiDeviceSoundCanvas::MixerCallback(const int requested_audio_frames)
-{
-	assert(mixer_channel);
-
-	// Report buffer underruns
-	constexpr auto warning_percent = 5.0f;
-
-	if (const auto percent_full = audio_frame_fifo.GetPercentFull();
-	    percent_full < warning_percent) {
-		static auto iteration = 0;
-		if (iteration++ % 100 == 0) {
-			LOG_WARNING("SOUNDCANVAS: Audio buffer underrun");
-		}
-		had_underruns = true;
-	}
-
-	static std::vector<AudioFrame> audio_frames = {};
-
-	const auto has_dequeued = audio_frame_fifo.BulkDequeue(audio_frames,
-	                                                       requested_audio_frames);
-
-	if (has_dequeued) {
-		mixer_channel->AddSamples_sfloat(requested_audio_frames,
-		                                 &audio_frames[0][0]);
-
-		last_rendered_ms = PIC_AtomicIndex();
-	} else {
-		assert(!audio_frame_fifo.IsRunning());
-		mixer_channel->AddSilence();
-	}
-}
-
 void MidiDeviceSoundCanvas::RenderAudioFramesToFifo(const int num_audio_frames)
 {
 	assert(num_audio_frames > 0);
@@ -631,45 +547,7 @@ void MidiDeviceSoundCanvas::RenderAudioFramesToFifo(const int num_audio_frames)
 	}
 }
 
-// The next MIDI work task is processed, which includes rendering audio frames
-// prior to sending channel and sysex messages to the plugin
-void MidiDeviceSoundCanvas::ProcessWorkFromFifo()
-{
-	const auto work = work_fifo.Dequeue();
-	if (!work) {
-		return;
-	}
-
-	// Detect if the work FIFO is heavily backlogged and enter the special
-	// backlogged rendering mode. This happens in fast-forward mode if the
-	// Sound Canvas emulation can't keep up with the sped-up CPU emulation.
-	const auto delta_from_now    = PIC_AtomicIndex() - work->timestamp;
-	constexpr auto OneSecondInMs = 1000.0;
-
-	if (delta_from_now > OneSecondInMs) {
-		is_work_fifo_backlogged = true;
-	}
-
-#if 0
-	// To log inter-cycle rendering
-	if (work->num_pending_audio_frames > 0) {
-		LOG_MSG("SOUNDCANVAS: %2u audio frames prior to %s message, followed by "
-		        "%2lu more messages. Have %4lu audio frames queued",
-		        work->num_pending_audio_frames,
-		        work->message_type == MessageType::Channel ? "channel" : "sysex",
-		        work_fifo.Size(),
-		        audio_frame_fifo.Size());
-	}
-#endif
-
-	if (work->num_pending_audio_frames > 0) {
-		RenderAudioFramesToFifo(work->num_pending_audio_frames);
-	}
-
-	AddClapEvent(*work);
-}
-
-void MidiDeviceSoundCanvas::AddClapEvent(const MidiWork& work)
+void MidiDeviceSoundCanvas::ProcessWorkItem(const MidiWork& work)
 {
 	if (work.message_type == MessageType::Channel) {
 		assert(work.message.size() >= MaxMidiMessageLen);
@@ -678,91 +556,6 @@ void MidiDeviceSoundCanvas::AddClapEvent(const MidiWork& work)
 	} else {
 		assert(work.message_type == MessageType::SysEx);
 		clap.event_list.AddMidiSysExEvent(work.message, 0);
-	}
-}
-
-void MidiDeviceSoundCanvas::RenderBacklogged()
-{
-	// This will only keep the MIDI events we must process (e.g. program
-	// change and SysEx messages).
-	ProcessWorkFromFifoBacklogged();
-
-	// We must drip-feed these essential MIDI events to the Sound Canvas
-	// emulation while in fast-forward mode and render a nominal sample now
-	// and then to keep the emulation ticking along. Batching them up in
-	// groups of 10 does the job fine.
-	//
-	// If we'd let them pile up and send them to the Sound Canvas in one big
-	// batch after exiting fast-forward mode, we'd overload the Sound
-	// Canvas' input buffers so not all messages would be processed. This
-	// has been proven to not be a viable approach as it resulted in
-	// wrong-sounding instruments in many cases.
-	//
-	if (clap.event_list.Size() > 10) {
-		constexpr auto OneFrame = 1;
-		RenderAudioFramesToFifo(OneFrame);
-	}
-
-	if (!MIXER_FastForwardModeEnabled()) {
-		is_work_fifo_backlogged = false;
-
-		// Send "All Notes Off" message to all MIDI channels when
-		// exiting from fast-forward mode. This is the best we can do as
-		// we've skipped processing any "Note On" or "Note Off" messages
-		// while in fast-forward mode. There would be a lot of hanging
-		// notes if we don't do this.
-		for (uint8_t ch = 0; ch < NumMidiChannels; ++ch) {
-			const uint8_t status = MidiStatus::ControlChange | ch;
-			const std::vector<uint8_t> all_notes_off_msg = {
-			        status, MidiChannelMode::AllNotesOff};
-
-			clap.event_list.AddMidiEvent(all_notes_off_msg, 0);
-		}
-	}
-}
-
-void MidiDeviceSoundCanvas::ProcessWorkFromFifoBacklogged()
-{
-	const auto work = work_fifo.Dequeue();
-	if (!work) {
-		return;
-	}
-
-	// If we're in backlogged mode when fast-forward is activated, it means
-	// the Sound Canvas can't keep up with the sped-up CPU emulation.
-	// Therefore, we need to minimise the work to catch up.
-	//
-	// We can't just *not* process any MIDI events at all; we need to keep
-	// processing program change, control change, etc. events, otherwise
-	// there's a real chance the instrument sounds will be wrong when we
-	// resume normal playback. But we can drop all MIDI notes and bypass the
-	// actual audio rendering; we'll just render a few samples from time to
-	// time to keep the Sound Canvas emulation ticking along. This way, we
-	// can catch up and stay in sync with the CPU emulation.
-	//
-	if (const auto status = get_midi_status(work->message[0]);
-	    get_midi_message_type(status) == MessageType::Channel) {
-
-		if (status == MidiStatus::NoteOn || status == MidiStatus::NoteOff) {
-			// Drop all MIDI note messages as we won't render any audio
-			return;
-		}
-	}
-
-	AddClapEvent(*work);
-}
-
-// Keep the FIFO populated with freshly rendered buffers
-void MidiDeviceSoundCanvas::Render()
-{
-	while (work_fifo.IsRunning()) {
-		if (is_work_fifo_backlogged) {
-			RenderBacklogged();
-		} else {
-			constexpr auto OneFrame = 1;
-			work_fifo.IsEmpty() ? RenderAudioFramesToFifo(OneFrame)
-			                    : ProcessWorkFromFifo();
-		}
 	}
 }
 


### PR DESCRIPTION
# Description

## The problem

During fast-forward, if the MIDI synth cannot "keep the pace" with the sped-up emulated machine, it will accumulate a backlog of MIDI events that will result in the music "rushing forward" after resuming normal operation. Interestingly, the rush-forward effect is delayed, not immediate (usually happens within about 30 seconds of resuming).

I added a fast-forward protection to the SoundCanvas MIDI device more than a year ago — it was easy to trigger the glitch in release builds as NukedSC55 is a CPU hog. But now I realised the MT-32 can be affected too on slow hosts (ran into it during debugging the pause rework). I was able to trigger the issue with **Space Quest III** using the debug build on my Ryzen 7900 on Windows 10. Interestingly, I couldn't trigger it on macOS.

Here's a recording how it sounds. The "chipmunk" effect happens about 20-30 seconds in before the transition to the quiet part (change the ZIP extension to MP3):

[mt32-fastforward-bug.zip](https://github.com/user-attachments/files/30499318/mt32-fastforward-bug.zip)


## The fix

There's no point copy-pasting the special fast-forward path from `soundcanvas.cpp` into `mt32.cpp`; it's some non-trivial piece of code. So I introduced a new `MidiSynth` abstract base class (template pattern) and the MT-32, FluidSynth, and SoundCanvas devices just implement the hooks that are different per device.

This way FluidSynth also gets the fast-forward mitigation for free. Not strictly needed as FS is rather fast, but I like to keep things uniform.

While I was at it, I also moved the common parts of the MIDI synth implementations into `MidiSynth` that were essentially copy-pasted between the three devices.

I will forward-port this to `main` later.

## Related issues

- Original SoundCanvas-only fix: https://github.com/dosbox-staging/dosbox-staging/pull/4210
- IMFC is similarly affected by fast-forwarding (as it's a CPU hog, too), but the solution will be different (it's not a MIDI synth): https://github.com/dosbox-staging/dosbox-staging/issues/3218

# Release notes

I don't think it's worth mentioning, and I'm not even sure 0.82.2 was affected (too lazy to test with a 0.82.2 debug build).

# Manual testing

Tested the following games & MIDI devices with fast-forwarding, confirming the music never rushes forward and no weird artifacts are introduced after resuming normal operation.

- **Space Quest III** (MT-32)
- **Azrael's Tear** (SoundCanvas)
- **Azrael's Tear** (FluidSynth)


The change has been manually tested on:

- [x] Windows
- [x] macOS
- [ ] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

- [x] I am a human, I have read and understood the [project's policy on the use of generative AI tools](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md#policy-on-the-use-of-generative-ai-tools), and I have acted in accordance to it.

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my work (especially important for AI-assisted contributions).
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [x] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

