### PR TITLE
Add CHCP to allow changing only the codepage.

### DIFF
--- a/src/dos/programs/keyb.cpp
+++ b/src/dos/programs/keyb.cpp
@@ -368,6 +368,8 @@ void KEYB::AddMessages()
 	        "    CGA, or Hercules always use the ROM screen font.\n"
 	        "  - You can use the 'us' keyboard layout with any code page; all the other\n"
 	        "    layouts work with selected code pages only.\n"
+	        "  - Use the [color=light-green]chcp[reset] command to change the code page while keeping the\n"
+	        "    current keyboard layout.\n"
 	        "\n"
 	        "Examples:\n"
 	        "  [color=light-green]KEYB[reset]\n"

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -1216,6 +1216,48 @@ void SHELL_InitAndRun()
 	        " Volume Serial Number is %04X-%04X\n"
 	        "\n");
 
+	MSG_Add("SHELL_CMD_CHCP_HELP",
+	        "Display or change the active character set (code page).\n");
+
+	MSG_Add("SHELL_CMD_CHCP_HELP_LONG",
+	        "Usage:\n"
+	        "  [color=light-green]chcp[reset]\n"
+	        "  [color=light-green]chcp[reset] [color=white]CODEPAGE[reset]\n"
+	        "\n"
+	        "Parameters:\n"
+	        "  [color=white]CODEPAGE[reset]  code page number, e.g. [color=white]437[reset] or [color=white]850[reset]\n"
+	        "\n"
+	        "Notes:\n"
+	        "  - Running [color=light-green]chcp[reset] without an argument shows the currently active code page.\n"
+	        "  - Changing the code page keeps the currently loaded keyboard layout; use the\n"
+	        "    [color=light-green]keyb[reset] command to also change the keyboard layout.\n"
+	        "  - The code page cannot be changed if no keyboard layout is loaded yet.\n"
+	        "\n"
+	        "Examples:\n"
+	        "  [color=light-green]chcp[reset]\n"
+	        "  [color=light-green]chcp[reset] [color=white]437[reset]\n");
+
+	MSG_Add("SHELL_CMD_CHCP_ACTIVE", "Active code page: %d\n");
+	MSG_Add("SHELL_CMD_CHCP_INVALID_CODE_PAGE", "Invalid code page.\n");
+
+	MSG_Add("SHELL_CMD_CHCP_NO_LAYOUT_LOADED",
+	        "No keyboard layout loaded, can't change the code page.\n");
+
+	MSG_Add("SHELL_CMD_CHCP_SCREEN_FONT_UNUSABLE",
+	        "Code page %d found, but the screen font could not be used.\n");
+
+	MSG_Add("SHELL_CMD_CHCP_NO_BUNDLED_CPI_FILE",
+	        "No bundled code page information file for code page %d.\n");
+
+	MSG_Add("SHELL_CMD_CHCP_NO_CODE_PAGE_IN_FILE",
+	        "No code page %d in the code page information file.\n");
+
+	MSG_Add("SHELL_CMD_CHCP_INCOMPATIBLE_MACHINE",
+	        "Can't change the screen font; EGA machine or better is required.\n");
+
+	MSG_Add("SHELL_CMD_CHCP_NO_LAYOUT_FOR_CODE_PAGE",
+	        "No keyboard layout '%s' for code page %d.\n");
+
 	MSG_Add("SHELL_CMD_MOVE_HELP",
 	        "Move files and rename files and directories.\n");
 	MSG_Add("SHELL_CMD_MOVE_HELP_LONG",

--- a/src/shell/shell.h
+++ b/src/shell/shell.h
@@ -141,6 +141,7 @@ public:
 
 	/* Commands */
 	void CMD_HELP(char* args);
+	void CMD_CHCP(char* args);
 	void CMD_CLS(char* args);
 	void CMD_COPY(char* args);
 	void CMD_DATE(char* args);

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -23,6 +23,7 @@
 #include "cpu/paging.h"
 #include "cpu/registers.h"
 #include "dos/dos.h"
+#include "dos/dos_keyboard_layout.h"
 #include "dos/drives.h"
 #include "dos/programs/more_output.h"
 #include "hardware/pic.h"
@@ -39,6 +40,7 @@
 static const std::map<std::string, SHELL_Cmd> shell_cmds = {
 	{ "CALL",     {&DOS_Shell::CMD_CALL,     "CALL",     HELP_Filter::All,    HELP_Category::Batch } },
 	{ "CD",       {&DOS_Shell::CMD_CHDIR,    "CHDIR",    HELP_Filter::Common, HELP_Category::File } },
+	{ "CHCP",     {&DOS_Shell::CMD_CHCP,     "CHCP",     HELP_Filter::All,    HELP_Category::Misc } },
 	{ "CHDIR",    {&DOS_Shell::CMD_CHDIR,    "CHDIR",    HELP_Filter::All,    HELP_Category::File } },
 	{ "CLS",      {&DOS_Shell::CMD_CLS,      "CLS",      HELP_Filter::Common, HELP_Category::Misc} },
 	{ "COPY",     {&DOS_Shell::CMD_COPY,     "COPY",     HELP_Filter::Common, HELP_Category::File} },
@@ -2122,7 +2124,75 @@ void DOS_Shell::CMD_PATH(char *args){
 	}
 }
 
-void DOS_Shell::CMD_VER(char *args)
+void DOS_Shell::CMD_CHCP(char* args)
+{
+	HELP("CHCP");
+
+	if (args) {
+		StripSpaces(args);
+	}
+
+	if (!args || !*args) {
+		WriteOut(MSG_Get("SHELL_CMD_CHCP_ACTIVE"), dos.loaded_codepage);
+		return;
+	}
+
+	const auto keyboard_layout = DOS_GetLoadedLayout();
+	if (keyboard_layout.empty()) {
+		WriteOut(MSG_Get("SHELL_CMD_CHCP_NO_LAYOUT_LOADED"));
+		return;
+	}
+
+	const auto value = parse_int(args);
+	if (!value || (*value < 1) || (*value > UINT16_MAX)) {
+		WriteOut(MSG_Get("SHELL_CMD_CHCP_INVALID_CODE_PAGE"));
+		return;
+	}
+
+	auto tried_code_page = static_cast<uint16_t>(*value);
+
+	const auto result = DOS_LoadKeyboardLayout(keyboard_layout, tried_code_page);
+	if (result != KeyboardLayoutResult::OK) {
+		using enum KeyboardLayoutResult;
+		switch (result) {
+		case ScreenFontUnusable:
+			WriteOut(MSG_Get("SHELL_CMD_CHCP_SCREEN_FONT_UNUSABLE"),
+			         tried_code_page);
+			break;
+
+		case NoBundledCpiFileForCodePage:
+			WriteOut(MSG_Get("SHELL_CMD_CHCP_NO_BUNDLED_CPI_FILE"),
+			         tried_code_page);
+			break;
+
+		case NoCodePageInCpiFile:
+			WriteOut(MSG_Get("SHELL_CMD_CHCP_NO_CODE_PAGE_IN_FILE"),
+			         tried_code_page);
+			break;
+
+		case IncompatibleMachine:
+			WriteOut(MSG_Get("SHELL_CMD_CHCP_INCOMPATIBLE_MACHINE"));
+			break;
+
+		case NoLayoutForCodePage:
+			WriteOut(MSG_Get("SHELL_CMD_CHCP_NO_LAYOUT_FOR_CODE_PAGE"),
+			         keyboard_layout.c_str(),
+			         tried_code_page);
+			break;
+
+		default:
+			LOG_WARNING("SHELL:CHCP: Invalid return code %x",
+			            enum_val(result));
+			assert(false);
+			break;
+		}
+		return;
+	}
+
+	WriteOut(MSG_Get("SHELL_CMD_CHCP_ACTIVE"), dos.loaded_codepage);
+}
+
+void DOS_Shell::CMD_VER(char* args)
 {
 	HELP("VER");
 	if (args && strlen(args)) {

--- a/website/docs/0.83/manual/input/keyboard.md
+++ b/website/docs/0.83/manual/input/keyboard.md
@@ -15,6 +15,21 @@ All key bindings can be customised through the [key mapper](keymapper.md)
 default bindings.
 
 
+## DOS keyboard layout and code pages
+
+The settings above control how your physical keyboard is captured and mapped
+by DOSBox Staging. The DOS-level keyboard layout --- which characters your
+keys actually produce inside DOS programs --- is a separate matter; see
+[Keyboard layout and code pages](../system/localisation.md#keyboard_layout).
+
+At the DOS prompt, use the `KEYB` command to change the keyboard layout and
+code page together (run `KEYB /?` for details), or the `CHCP` command to
+switch just the code page while keeping the current keyboard layout (run
+`CHCP /?` for details). This is useful when a game assumes a certain code
+page --- usually 437 --- but you want the keyboard layout unchanged (for example,
+the game [Tommy's Manor](https://www.mobygames.com/game/49191/tommys-manor/)).
+
+
 ## Configuration settings
 
 The keyboard capture setting is configured in the `[sdl]` configuration

--- a/website/docs/0.83/manual/system/localisation.md
+++ b/website/docs/0.83/manual/system/localisation.md
@@ -47,7 +47,8 @@ Code pages control which character set is available on screen. DOSBox Staging
 bundles the FreeDOS ISO, KOI, MAC, and WIN code page packages, providing
 broad coverage of Latin, Cyrillic, and Greek scripts. After startup, use the
 `KEYB` command to manage keyboard layouts and code pages at runtime (run
-`HELP KEYB` for details).
+`KEYB /?` for details), or the `CHCP` command to switch just the code page
+while keeping the current keyboard layout (run `CHCP /?` for details).
 
 To see what's available, start DOSBox Staging with the following command line
 arguments:
@@ -108,7 +109,7 @@ in `[dos]`.
     values from the host OS settings. The layout can be followed by the code
     page number, e.g., `uk 850` selects a Western European screen font. After
     startup, use the `KEYB` command to manage keyboard layouts and code pages
-    (run `HELP KEYB` for details).
+    (run `KEYB /?` for details).
 
     !!! note
 

--- a/website/docs/0.83/manual/using-dosbox-staging/commands.md
+++ b/website/docs/0.83/manual/using-dosbox-staging/commands.md
@@ -94,6 +94,7 @@ These commands are specific to DOSBox Staging and have no MS-DOS equivalent.
 
 | Command    | Aliases    | Description |
 |------------|------------|-------------|
+| `CHCP`     |            | Display or change the active character set (code page) |
 | `CLS`      |            | Clear the DOS screen |
 | `DATE`     |            | Display or change the internal date |
 | `EXIT`     |            | Exit from the DOS shell |


### PR DESCRIPTION
# Description

Dosbox Staging has support for KEYB, but not CHCP, unlike Dosbox-X. At the moment, to change the codepage, the user must type KEYB [layout] [codepage]. It is not possible to elide the layout or keep it at "automatic". This means that codepage 850 is automatically selected because I'm on a German machine, which in turn means US-centric software, expecting codepage 437, renders certain graphical characters wrong. Changing to KEYB US 437, in turn, also changes the keyboard layout (Z/Y are switched, etc.)

This PR adds a CHCP command to allow changing the codepage without changing any of the other localisation settings.

# Release notes

International users have long been plagued by localisation issues — for example, on a German Windows system, DOSBox will default to a German keyboard layout and international code page 850. This means that in games that use fancy box graphics, like _Tommy's Manor_, they will see characters like Ï instead of the ASCII art. Using KEYB, it was possible to change both keyboard layout and code page, but, with a pre-existing dosbox.conf, that meant forcing your layout on the player; in German, for example, that swaps Y and Z, among other things.

No more! This release adds the beloved CHCP command, which switches code pages at will without touching the remainder of the localisation settings.

# Manual testing

I tested several games that I am aware have this issue:

* Kithe-14
* Quarterstaff for DOS
* Star Trek: The Promethean Prophecy
* Tommy's Manor
* Demon's Tomb: The Awakening.

1) `CHCP 850` unless you're already on that code page.
2) Start the game normally - there will be ASCII issues.
3) Quit the game or restart DOSBox.
4) `CHCP 437`
5) Start the game - there will not be ASCII issues anymore.

Example:

<img width="1066" height="800" alt="20260730195636045" src="https://github.com/user-attachments/assets/2fefc1cd-ff4d-4d06-8d09-2226088e85cb" /> <img width="1066" height="800" alt="20260730195737220" src="https://github.com/user-attachments/assets/737cae6c-fa9a-4232-8f52-1733428f70c6" />

The change has been manually tested on:

- [X] Windows
- [ ] macOS
- [ ] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

- [X] I am a human, I have read and understood the [project's policy on the use of generative AI tools](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md#policy-on-the-use-of-generative-ai-tools), and I have acted in accordance to it.

I have:

- [X] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [X] performed a self-review of my work (especially important for AI-assisted contributions).
- [ ] commented on the particularly hard-to-understand areas of my code.
- [X] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [X] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [X] provided the release notes draft (for significant user-facing changes).
- [X] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [X] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

