### PR TITLE
Mount type auto-detection regression fix

### DIFF
--- a/docs/dosbox.1
+++ b/docs/dosbox.1
@@ -197,8 +197,7 @@ Pause/Unpause emulator.
 .IP Ctrl+F1
 Start the keymapper.
 .IP Ctrl+F4
-Swap mounted disk\(hyimage (only used with imgmount). Update directory cache
-for all drives.
+Swap mounted disk. Update directory cache for all drives.
 .IP Ctrl+F5
 Save a screenshot of the DOS pre-rendered image.
 .IP Alt+F5

--- a/src/dos/programs.cpp
+++ b/src/dos/programs.cpp
@@ -145,14 +145,14 @@ extern std::string full_arguments;
 
 void Program::ChangeToLongCmd()
 {
-	// Get arguments directly from the shell instead of the psp.
-	// this is done in securemode: (as then the arguments to mount and
-	// friends can only be given on the shell ( so no int 21 4b) Securemode
-	// part is disabled as each of the internal command has already
-	// protection for it. (and it breaks games like cdman) it is also done
-	// for long arguments to as it is convient (as the total commandline can
-	// be longer then 127 characters. imgmount with lot's of parameters
-	// Length of arguments can be ~120. but switch when above 100 to be sure
+	// Get arguments directly from the shell instead of the psp. This is done
+	// in securemode, as then the arguments to mount and friends can only be
+	// given on the shell (so no int 21 4b). Securemode part is disabled as
+	// each of the internal command has already protection for it (and it
+	// breaks games like cdman). it is also done for long arguments to as it
+	// is convenient (as the total commandline can be longer then 127
+	// characters (e.g. MOUNT with lot's of parameters). Length of arguments
+	// can be ~120, but switch when above 100 to be sure.
 
 	if (/*control->SecureMode() ||*/ cmd->GetNumArguments() > 100) {
 		auto temp = new CommandLine(cmd->GetFileName(), full_arguments);

--- a/src/dos/programs/boot.cpp
+++ b/src/dos/programs/boot.cpp
@@ -543,7 +543,7 @@ void BOOT::AddMessages()
 	        "  [color=light-cyan]IMAGEFILE[reset]  one or more floppy images, separated by spaces\n"
 	        "\n"
 	        "Notes:\n"
-	        "  A DOS drive letter must have been mounted previously with [color=light-green]imgmount[reset] command.\n"
+	        "  A DOS drive letter must have been mounted previously with [color=light-green]mount[reset] command.\n"
 	        "  The DOS drive or disk image must be bootable, containing DOS system files.\n"
 	        "  If more than one disk images are specified, you can swap them with a hotkey.\n"
 	        "\n"

--- a/src/dos/programs/mount.cpp
+++ b/src/dos/programs/mount.cpp
@@ -810,9 +810,10 @@ std::string MOUNT::GetDosMappedHostPath(const std::string& dos_path) const
 	return "";
 }
 
-// Returns true if processed successfully (even if it means it found an image
-// and decided to mount it) Returns false on failure.
-bool MOUNT::ProcessPaths(const std::string first_path, MountParameters& params,
+// Process paths and prepare (mutate) the passed `MountParameters` for
+// mounting. This includes resolving host paths, auto-detecting mount types,
+// etc.
+void MOUNT::ProcessPaths(const std::string first_path, MountParameters& params,
                          bool path_relative_to_last_config)
 {
 	// Expand ~ to home directory and apply relative path logic
@@ -846,21 +847,21 @@ bool MOUNT::ProcessPaths(const std::string first_path, MountParameters& params,
 	const auto has_wildcards       = path_arg_1.find_first_of("*?") !=
 	                           std::string::npos;
 
-	auto is_image_mode = explicit_image_type || params.is_drive_number ||
-	                     has_wildcards;
+	params.is_image_mode = explicit_image_type || params.is_drive_number ||
+	                       has_wildcards;
 
 	// If the target is a directory, it is a directory mount,
 	// even if -t floppy was specified (legacy MOUNT behavior).
 	if (target_is_dir) {
-		is_image_mode = false;
+		params.is_image_mode = false;
 	}
 
 	// Implicit trigger: First argument exists and is a regular file
-	if (!is_image_mode && stat_ok && S_ISREG(test.st_mode)) {
-		is_image_mode = true;
+	if (!params.is_image_mode && stat_ok && S_ISREG(test.st_mode)) {
+		params.is_image_mode = true;
 	}
 
-	if (is_image_mode) {
+	if (params.is_image_mode) {
 		// Loop through all remaining arguments
 		auto arg_idx = 2;
 		std::string cur_arg = "";
@@ -942,38 +943,41 @@ bool MOUNT::ProcessPaths(const std::string first_path, MountParameters& params,
 			params.paths.push_back(loop_final_path);
 		}
 
-		if (params.paths.empty()) {
-			NOTIFY_DisplayWarning(Notification::Source::Console,
-			                      "MOUNT",
-			                      "PROGRAM_IMGMOUNT_FILE_NOT_FOUND");
-			return false;
-		}
-
 		// Ensure consistency between type and fstype if user didn't
 		// override -fs
 		if (params.type == "floppy" && params.fstype == "fat") {
 			params.mediaid = MediaId::Floppy1_44MB;
 		}
 
+	} else {
+		// Standard directory or overlay mount
+		if (S_ISDIR(test.st_mode)) {
+			params.paths.push_back(path_arg_1);
+		}
+	}
+}
+
+bool MOUNT::MountPaths(MountParameters& params)
+{
+	if (params.paths.empty()) {
+		NOTIFY_DisplayWarning(Notification::Source::Console,
+							  "MOUNT",
+							  "PROGRAM_IMGMOUNT_FILE_NOT_FOUND");
+		return false;
+	}
+
+	if (params.is_image_mode) {
 		const auto success = MountImage(params);
 		if (success && params.type == "floppy") {
 			incrementFDD();
 		}
-		return true;
 
 	} else {
 		// Standard directory or overlay mount
-		if (!S_ISDIR(test.st_mode)) {
-			NOTIFY_DisplayWarning(Notification::Source::Console,
-			                      "MOUNT",
-			                      "PROGRAM_MOUNT_ERROR_2",
-			                      path_arg_1.c_str());
-			return false;
-		}
-
-		MountLocal(params, path_arg_1);
-		return true;
+		MountLocal(params, params.paths[0]);
 	}
+
+	return true;
 }
 
 void MOUNT::MountLocal(MountParameters& params, const std::string& local_path)
@@ -1206,7 +1210,9 @@ std::optional<MountParameters> MOUNT::ProcessArguments(CommandLine* cmd)
 		return {};
 	}
 
-	if (!ProcessPaths(first_path, params, path_relative_to_last_config)) {
+	ProcessPaths(first_path, params, path_relative_to_last_config);
+
+	if (!MountPaths(params)) {
 		return {};
 	}
 

--- a/src/dos/programs/mount.cpp
+++ b/src/dos/programs/mount.cpp
@@ -209,6 +209,9 @@ void MOUNT::WriteMountStatus(const std::string& image_type,
 	}
 }
 
+// Sets:
+//   params.sizes
+//
 bool MOUNT::MountImageFat(MountParameters& params)
 {
 	// Autosize detection
@@ -446,6 +449,9 @@ bool MOUNT::MountImageIso(const MountParameters& params)
 	return true;
 }
 
+// Sets:
+//   params.roflag
+//
 bool MOUNT::MountImageRaw(MountParameters& params)
 {
 	auto new_disk = fopen_wrap_ro_fallback(params.paths[0], params.roflag);
@@ -546,6 +552,17 @@ bool MOUNT::HandleUnmount()
 	return false;
 }
 
+// Sets:
+//   params.type   (from the -t option)
+//   params.roflag (from the -ro option)
+//   params.fstype (from the -fs option or if -t iso is specified)
+//
+//   params.is_ide (from the -ide option))
+//   params.ide_index (based on DOS internal state)
+//   params.is_second_cable_slot (based on DOS internal state)
+//
+//   params.label  (from the -label option)
+//
 bool MOUNT::ParseArguments(MountParameters& params, bool& explicit_fs,
                            bool& path_relative_to_last_config)
 {
@@ -598,6 +615,10 @@ bool MOUNT::ParseArguments(MountParameters& params, bool& explicit_fs,
 	return true;
 }
 
+// Sets:
+//   params.mediaid
+//   params.sizes
+//
 bool MOUNT::ParseGeometry(MountParameters& params)
 {
 	std::string str_size = "";
@@ -728,6 +749,11 @@ bool MOUNT::ParseGeometry(MountParameters& params)
 	return true;
 }
 
+// Sets:
+//   params.drive
+//   params.fstype
+//   params.is_drive_number
+//
 bool MOUNT::ParseDrive(MountParameters& params, bool explicit_fs)
 {
 	// get the drive letter or number
@@ -868,6 +894,13 @@ std::string MOUNT::GetDosMappedHostPath(const std::string& dos_path) const
 // mounting. This includes resolving host paths, wildcard path arguments,
 // auto-detecting mount types, and determining whether we're dealing with
 // image or directory/overlay mounts.
+//
+// Sets:
+//   params.fstype
+//   params.is_image_mode
+//   params.mediaid
+//   params.paths
+//   params.type
 //
 void MOUNT::ProcessPaths(const std::string first_path, MountParameters& params,
                          bool path_relative_to_last_config)

--- a/src/dos/programs/mount.cpp
+++ b/src/dos/programs/mount.cpp
@@ -180,7 +180,7 @@ void MOUNT::WriteMountStatus(const std::string& image_type,
 {
 	const size_t term_width = INT10_GetTextColumns();
 	constexpr auto Indent   = "  ";
-	const auto indent_size = strlen(Indent);
+	const auto indent_size  = strlen(Indent);
 	std::string images_str  = {};
 
 	if (images.size() == 1) {
@@ -212,11 +212,11 @@ void MOUNT::WriteMountStatus(const std::string& image_type,
 bool MOUNT::MountImageFat(MountParameters& params)
 {
 	// Autosize detection
-	bool imgsizedetect = (params.type == "hdd") &&
-	                     (params.sizes[0] == 0 && params.sizes[1] == 0 &&
-	                      params.sizes[2] == 0 && params.sizes[3] == 0);
+	bool detect_image_size = (params.type == "hdd") &&
+	                         (params.sizes[0] == 0 && params.sizes[1] == 0 &&
+	                          params.sizes[2] == 0 && params.sizes[3] == 0);
 
-	if (imgsizedetect) {
+	if (detect_image_size) {
 		FILE* diskfile = fopen_wrap_ro_fallback(params.paths[0],
 		                                        params.roflag);
 		if (!diskfile) {
@@ -233,36 +233,44 @@ bool MOUNT::MountImageFat(MountParameters& params)
 			                      "PROGRAM_IMGMOUNT_INVALID_IMAGE");
 			return false;
 		}
+
 		uint32_t fcsize = check_cast<uint32_t>(sz);
 		uint8_t buf[512];
+
 		if (cross_fseeko(diskfile, 0L, SEEK_SET) != 0 ||
 		    fread(buf, sizeof(uint8_t), 512, diskfile) < 512) {
 			fclose(diskfile);
+
 			NOTIFY_DisplayWarning(Notification::Source::Console,
 			                      "MOUNT",
 			                      "PROGRAM_IMGMOUNT_INVALID_IMAGE");
 			return false;
 		}
+
 		fclose(diskfile);
+
 		if ((buf[510] != 0x55) || (buf[511] != 0xaa)) {
 			NOTIFY_DisplayWarning(Notification::Source::Console,
 			                      "MOUNT",
 			                      "PROGRAM_IMGMOUNT_INVALID_GEOMETRY");
 			return false;
 		}
+
 		Bitu sectors = (Bitu)(fcsize / (16 * 63));
+
 		if (sectors * 16 * 63 != fcsize) {
 			NOTIFY_DisplayWarning(Notification::Source::Console,
 			                      "MOUNT",
 			                      "PROGRAM_IMGMOUNT_INVALID_GEOMETRY");
 			return false;
 		}
+
 		params.sizes[0] = 512;
 		params.sizes[1] = 63;
 		params.sizes[2] = 16;
 		params.sizes[3] = static_cast<uint16_t>(sectors);
 
-		LOG_MSG("autosized image file: %d:%d:%d:%d",
+		LOG_MSG("DRIVE: Autosized image file: %d:%d:%d:%d",
 		        params.sizes[0],
 		        params.sizes[1],
 		        params.sizes[2],
@@ -309,6 +317,7 @@ bool MOUNT::MountImageFat(MountParameters& params)
 	// Set the correct media byte in the table
 	// Each entry is 9 bytes, with the media byte at offset 0x00
 	constexpr auto DptEntrySize = 9;
+
 	mem_writeb(RealToPhysical(dos.tables.mediaid) +
 	                   drive_index(params.drive) * DptEntrySize,
 	           params.mediaid);
@@ -318,35 +327,43 @@ bool MOUNT::MountImageFat(MountParameters& params)
 	dos.dta(dos.tables.tempdta);
 
 	for (auto it = fat_images.begin(); it != fat_images.end(); ++it) {
-		const bool should_notify = std::next(it) == fat_images.end();
+		const bool should_notify = (std::next(it) == fat_images.end());
+
 		DriveManager::CycleDisks(drive_index(params.drive), should_notify);
-		char root[7] = {params.drive, ':', '\\', '*', '.', '*', 0};
 
 		// Obtain the drive label, saving it in the dirCache
+		char root[7] = {params.drive, ':', '\\', '*', '.', '*', 0};
+
 		if (!DOS_FindFirst(root, FatAttributeFlags::Volume)) {
 			LOG_WARNING("DRIVE: Unable to find %c drive's volume label",
 			            params.drive);
 		}
 	}
+
 	dos.dta(save_dta);
 
 	std::string mount_message = (params.paths.size() > 1)
 	                                  ? MSG_Get("MOUNT_TYPE_FAT_PLURAL")
 	                                  : MSG_Get("MOUNT_TYPE_FAT");
+
 	WriteMountStatus(mount_message, params.paths, params.drive, params.roflag);
 
 	const auto fat_image = std::dynamic_pointer_cast<fatDrive>(
 	        fat_images.front());
+
 	assert(fat_image);
 	const auto has_hdd = fat_image->loadedDisk && fat_image->loadedDisk->hardDrive;
 
 	const auto is_floppy = (params.drive == 'A' || params.drive == 'B') &&
 	                       !has_hdd;
+
 	const auto is_hdd = (params.drive == 'C' || params.drive == 'D') && has_hdd;
+
 	if (is_floppy || is_hdd) {
 		imageDiskList.at(drive_index(params.drive)) = fat_image->loadedDisk;
 		updateDPT();
 	}
+
 	return true;
 }
 
@@ -366,7 +383,7 @@ static const char* mscdex_error_to_message_id(const int error, const bool is_ima
 	}
 }
 
-bool MOUNT::MountImageIso(MountParameters& params)
+bool MOUNT::MountImageIso(const MountParameters& params)
 {
 	if (Drives.at(drive_index(params.drive))) {
 		NOTIFY_DisplayWarning(Notification::Source::Console,
@@ -423,6 +440,7 @@ bool MOUNT::MountImageIso(MountParameters& params)
 	std::string mount_message = (params.paths.size() > 1)
 	                                  ? MSG_Get("MOUNT_TYPE_CDIMAGE_PLURAL")
 	                                  : MSG_Get("MOUNT_TYPE_CDIMAGE");
+
 	WriteMountStatus(mount_message, params.paths, params.drive, params.roflag);
 
 	return true;
@@ -437,6 +455,7 @@ bool MOUNT::MountImageRaw(MountParameters& params)
 		                      "PROGRAM_IMGMOUNT_INVALID_IMAGE");
 		return false;
 	}
+
 	const auto sz = stdio_size_kb(new_disk);
 	if (sz < 0) {
 		fclose(new_disk);
@@ -445,13 +464,18 @@ bool MOUNT::MountImageRaw(MountParameters& params)
 		                      "PROGRAM_IMGMOUNT_INVALID_IMAGE");
 		return false;
 	}
+
 	auto imagesize = check_cast<uint32_t>(sz);
+
 	// 0=A:, 1=B:, 2=C:, 3=D:
 	const auto is_hdd = (params.drive >= '2');
+
 	// Seems to make sense to require a valid geometry..
 	if (is_hdd && params.sizes[0] == 0 && params.sizes[1] == 0 &&
 	    params.sizes[2] == 0 && params.sizes[3] == 0) {
+
 		fclose(new_disk);
+
 		NOTIFY_DisplayWarning(Notification::Source::Console,
 		                      "MOUNT",
 		                      "PROGRAM_IMGMOUNT_SPECIFY_GEOMETRY");
@@ -477,6 +501,7 @@ bool MOUNT::MountImageRaw(MountParameters& params)
 	WriteOut(MSG_Get("PROGRAM_IMGMOUNT_MOUNT_NUMBER"),
 	         drv_idx,
 	         params.paths[0].c_str());
+
 	return true;
 }
 
@@ -488,8 +513,10 @@ bool MOUNT::MountImage(MountParameters& params)
 
 	if (params.fstype == "fat") {
 		return MountImageFat(params);
+
 	} else if (params.fstype == "iso") {
 		return MountImageIso(params);
+
 	} else if (params.fstype == "none") {
 		return MountImageRaw(params);
 	}
@@ -527,6 +554,7 @@ bool MOUNT::ParseArguments(MountParameters& params, bool& explicit_fs,
 	}
 
 	cmd->FindString("-t", params.type, true);
+
 	// Allow aliases or standard image types to pass through
 	if (params.type == "cdrom") {
 		params.type = "iso";
@@ -577,7 +605,8 @@ bool MOUNT::ParseGeometry(MountParameters& params)
 
 	// Default sizing logic based on type
 	if (params.type == "floppy") {
-		str_size       = "512,1,2880,2880";
+		str_size = "512,1,2880,2880";
+
 		params.mediaid = MediaId::Floppy1_44MB;
 
 	} else if (params.type == "dir" || params.type == "overlay") {
@@ -590,18 +619,22 @@ bool MOUNT::ParseGeometry(MountParameters& params)
 		// be auto-mounted as type "dir"
 		std::string command_arg;
 		cmd->FindCommand(1, command_arg);
+
 		if (!command_arg.empty()) {
 			const int i_drive = std::toupper(command_arg[0]);
 			if (i_drive == 'A' || i_drive == 'B') {
 				params.mediaid = MediaId::Floppy1_44MB;
 			}
 		}
+
 	} else if (params.type == "iso") {
 		str_size = "2048,1,65535,0";
+
 		// mediaid is used in staging to differentiate between floppy
 		// and non-floppy for cache rescan, disk noise and I/O timing.
 		// The same value was used in the original dosbox code
 		params.mediaid = MediaId::HardDisk;
+
 	} else {
 		// Type parameter validation should prevent this from happening
 		assert(params.type == "hdd");
@@ -609,9 +642,12 @@ bool MOUNT::ParseGeometry(MountParameters& params)
 
 	// Parse the free space in mb (kb for floppies)
 	std::string mb_size;
+
 	if (cmd->FindString("-freesize", mb_size, true)) {
+
 		char teststr[1024];
 		uint16_t freesize = static_cast<uint16_t>(atoi(mb_size.c_str()));
+
 		if (params.type == "floppy") {
 			// freesize in kb
 			safe_sprintf(teststr,
@@ -619,8 +655,10 @@ bool MOUNT::ParseGeometry(MountParameters& params)
 			             freesize * 1024 / (512 * 1));
 		} else {
 			uint32_t total_size_cyl = 32765;
-			uint32_t free_size_cyl  = (uint32_t)freesize * 1024 *
+
+			uint32_t free_size_cyl = (uint32_t)freesize * 1024 *
 			                         1024 / (512 * 32);
+
 			if (free_size_cyl > 65534) {
 				free_size_cyl = 65534;
 			}
@@ -642,8 +680,10 @@ bool MOUNT::ParseGeometry(MountParameters& params)
 	if (!str_size.empty()) {
 		char number[21]  = {0};
 		const char* scan = str_size.c_str();
-		int index        = 0;
-		int count        = 0;
+
+		int index = 0;
+		int count = 0;
+
 		// Parse the str_size string
 		while (*scan && index < 20 && count < 4) {
 			if (*scan == ',') {
@@ -657,20 +697,26 @@ bool MOUNT::ParseGeometry(MountParameters& params)
 		}
 		if (count < 4) {
 			// always goes correct as index is max 20 at this point.
-			number[index]       = 0;
+			number[index] = 0;
+
 			params.sizes[count] = atoi(number);
 		}
 	}
 
 	// Parse -chs C,H,S
 	if (cmd->FindString("-chs", str_chs, true)) {
-		int cmd_cylinders = 0, cmd_heads = 0, cmd_sectors = 0;
+		int cmd_cylinders = 0;
+		int cmd_heads     = 0;
+		int cmd_sectors   = 0;
+
 		if (sscanf(str_chs.c_str(), "%d,%d,%d", &cmd_cylinders, &cmd_heads, &cmd_sectors) ==
 		    3) {
+
 			params.sizes[0] = 512;
 			params.sizes[1] = static_cast<uint16_t>(cmd_sectors);
 			params.sizes[2] = static_cast<uint16_t>(cmd_heads);
 			params.sizes[3] = static_cast<uint16_t>(cmd_cylinders);
+
 		} else {
 			NOTIFY_DisplayWarning(Notification::Source::Console,
 			                      "MOUNT",
@@ -687,8 +733,10 @@ bool MOUNT::ParseDrive(MountParameters& params, bool explicit_fs)
 	// get the drive letter or number
 	std::string temp_line;
 	cmd->FindCommand(1, temp_line);
+
 	if ((temp_line.size() > 2) ||
 	    ((temp_line.size() > 1) && (temp_line[1] != ':'))) {
+
 		ShowUsage();
 		return false;
 	}
@@ -715,6 +763,7 @@ bool MOUNT::ParseDrive(MountParameters& params, bool explicit_fs)
 		}
 	} else if (first_char >= 'A' && first_char <= 'Z') {
 		params.drive = first_char;
+
 		// Allow A:, B:, C: and D: to be mounted as raw bootable images
 		if (explicit_fs && params.fstype == "none") {
 			switch (params.drive) {
@@ -768,6 +817,7 @@ bool MOUNT::ParseDrive(MountParameters& params, bool explicit_fs)
 			return false;
 		}
 	}
+
 	return true;
 }
 
@@ -776,8 +826,10 @@ std::string MOUNT::ApplyRelativePath(const std::string& path,
 {
 	if (is_relative_to_last_config && !control->config_files.empty() &&
 	    !std_fs::path(path).is_absolute()) {
+
 		auto last_config_dir = control->config_files.back();
-		const auto pos       = last_config_dir.rfind(CROSS_FILESPLIT);
+
+		const auto pos = last_config_dir.rfind(CROSS_FILESPLIT);
 
 		last_config_dir.erase(pos == std::string::npos ? 0 : pos);
 		if (!last_config_dir.empty()) {
@@ -802,11 +854,13 @@ std::string MOUNT::GetDosMappedHostPath(const std::string& dos_path) const
 
 			if (const auto local_drive = std::dynamic_pointer_cast<localDrive>(
 			            Drives.at(drive_idx))) {
+
 				return local_drive->MapDosToHostFilename(
 				        fullname_buf.data());
 			}
 		}
 	}
+
 	return "";
 }
 
@@ -829,7 +883,7 @@ void MOUNT::ProcessPaths(const std::string first_path, MountParameters& params,
 
 	// Check first path on the host OS
 	struct stat test = {};
-	auto stat_ok = (stat(path_arg_1.c_str(), &test) == 0);
+	auto stat_ok     = (stat(path_arg_1.c_str(), &test) == 0);
 
 	// If not found on the host, check if it is a mounted DOS path
 	if (!stat_ok) {
@@ -840,15 +894,17 @@ void MOUNT::ProcessPaths(const std::string first_path, MountParameters& params,
 		}
 	}
 
-	const auto target_is_dir       = stat_ok && S_ISDIR(test.st_mode);
+	const auto target_is_dir = stat_ok && S_ISDIR(test.st_mode);
+
 	const auto explicit_image_type = (params.type == "hdd" ||
 	                                  params.type == "iso" ||
 	                                  params.type == "floppy");
-	const auto has_wildcards       = path_arg_1.find_first_of("*?") !=
+
+	const auto has_wildcards = path_arg_1.find_first_of("*?") !=
 	                           std::string::npos;
 
-	params.is_image_mode = explicit_image_type || params.is_drive_number ||
-	                       has_wildcards;
+	params.is_image_mode = (explicit_image_type || params.is_drive_number ||
+	                        has_wildcards);
 
 	// If the target is a directory, it is a directory mount,
 	// even if -t floppy was specified (legacy MOUNT behavior).
@@ -863,7 +919,7 @@ void MOUNT::ProcessPaths(const std::string first_path, MountParameters& params,
 
 	if (params.is_image_mode) {
 		// Loop through all remaining arguments
-		auto arg_idx = 2;
+		auto arg_idx        = 2;
 		std::string cur_arg = "";
 
 		while (cmd->FindCommand(arg_idx++, cur_arg)) {
@@ -917,10 +973,13 @@ void MOUNT::ProcessPaths(const std::string first_path, MountParameters& params,
 			// Auto-detect type from FIRST valid file if generic "dir"
 			if (params.paths.empty() && params.type == "dir") {
 				struct stat t2 = {};
+
 				if (stat(loop_final_path.c_str(), &t2) == 0 &&
 				    S_ISREG(t2.st_mode)) {
+
 					auto ext = loop_final_path.substr(
 					        loop_final_path.find_last_of('.') + 1);
+
 					std::transform(ext.begin(),
 					               ext.end(),
 					               ext.begin(),
@@ -929,10 +988,13 @@ void MOUNT::ProcessPaths(const std::string first_path, MountParameters& params,
 					if (ext == "iso" || ext == "cue" ||
 					    ext == "bin" || ext == "mds" ||
 					    ext == "ccd") {
+
 						params.type   = "iso";
 						params.fstype = "iso";
+
 					} else if (ext == "img" ||
 					           ext == "ima" || ext == "vhd") {
+
 						params.type = "hdd";
 					}
 				}
@@ -1053,13 +1115,13 @@ void MOUNT::MountLocal(MountParameters& params, const std::string& local_path)
 		// Mount a host directory as a CD-ROM drive.
 		int error = 0;
 		newdrive  = std::make_shared<cdromDrive>(params.drive,
-		                                         final_path.c_str(),
-		                                         params.sizes[0],
-		                                         int8_tize,
-		                                         params.sizes[2],
-		                                         0,
-		                                         params.mediaid,
-		                                         error);
+                                                        final_path.c_str(),
+                                                        params.sizes[0],
+                                                        int8_tize,
+                                                        params.sizes[2],
+                                                        0,
+                                                        params.mediaid,
+                                                        error);
 
 		const char* msg_id = mscdex_error_to_message_id(error, false);
 		if (error == 0) { //-V457

--- a/src/dos/programs/mount.cpp
+++ b/src/dos/programs/mount.cpp
@@ -215,7 +215,7 @@ void MOUNT::WriteMountStatus(const std::string& image_type,
 bool MOUNT::MountImageFat(MountParameters& params)
 {
 	// Autosize detection
-	bool detect_image_size = (params.type == "hdd") &&
+	bool detect_image_size = (params.type == MountType::HardDiskImage) &&
 	                         (params.sizes[0] == 0 && params.sizes[1] == 0 &&
 	                          params.sizes[2] == 0 && params.sizes[3] == 0);
 
@@ -514,16 +514,17 @@ bool MOUNT::MountImageRaw(MountParameters& params)
 bool MOUNT::MountImage(MountParameters& params)
 {
 	// Determine Media ID if not already set strictly
-	params.mediaid = (params.type == "floppy") ? MediaId::Floppy1_44MB
-	                                           : MediaId::HardDisk;
+	params.mediaid = (params.type == MountType::FloppyImage)
+	                       ? MediaId::Floppy1_44MB
+	                       : MediaId::HardDisk;
 
-	if (params.fstype == "fat") {
+	if (params.fstype == MountFileSystemType::Fat16) {
 		return MountImageFat(params);
 
-	} else if (params.fstype == "iso") {
+	} else if (params.fstype == MountFileSystemType::Iso) {
 		return MountImageIso(params);
 
-	} else if (params.fstype == "none") {
+	} else if (params.fstype == MountFileSystemType::None) {
 		return MountImageRaw(params);
 	}
 	return true;
@@ -552,6 +553,44 @@ bool MOUNT::HandleUnmount()
 	return false;
 }
 
+static std::optional<MountType> parse_mount_type(const std::string s)
+{
+	if (s == "floppy" || s == "fdd") {
+		return MountType::FloppyImage;
+
+	} else if (s == "hdd") {
+		return MountType::HardDiskImage;
+
+	} else if (s == "iso" || s == "cdrom") {
+		return MountType::CdRomImage;
+
+	} else if (s == "dir") {
+		return MountType::Directory;
+
+	} else if (s == "overlay") {
+		return MountType::Overlay;
+
+	} else {
+		return {};
+	}
+}
+
+static std::optional<MountFileSystemType> parse_file_system_type(const std::string s)
+{
+	if (s == "fat") {
+		return MountFileSystemType::Fat16;
+
+	} else if (s == "iso") {
+		return MountFileSystemType::Iso;
+
+	} else if (s == "none") {
+		return MountFileSystemType::None;
+
+	} else {
+		return {};
+	}
+}
+
 // Sets:
 //   params.type   (from the -t option)
 //   params.roflag (from the -ro option)
@@ -570,42 +609,51 @@ bool MOUNT::ParseArguments(MountParameters& params, bool& explicit_fs,
 		path_relative_to_last_config = true;
 	}
 
-	cmd->FindString("-t", params.type, true);
+	// Default is "dir" if the -t option is not provided
+	std::string type_str = "dir";
+	cmd->FindString("-t", type_str, true);
 
-	// Allow aliases or standard image types to pass through
-	if (params.type == "cdrom") {
-		params.type = "iso";
-	}
-	if (params.type == "fdd") {
-		params.type = "floppy";
-	}
-
-	// Validate the requested mount type
-	if (params.type != "floppy" && params.type != "dir" &&
-	    params.type != "overlay" && params.type != "iso" &&
-	    params.type != "hdd") {
-
+	const auto maybe_mount_type = parse_mount_type(type_str);
+	if (!maybe_mount_type) {
 		NOTIFY_DisplayWarning(Notification::Source::Console,
 		                      "MOUNT",
 		                      "PROGRAM_MOUNT_ILL_TYPE",
-		                      params.type.c_str());
+		                      type_str.c_str());
 		return false;
 	}
+	params.type = *maybe_mount_type;
 
 	params.roflag = cmd->FindExist("-ro", true);
 
 	// Parse -fs (filesystem type)
-	if (params.type == "iso") {
-		params.fstype = "iso";
+	// Default is "fat" if the -fs option is not provided
+	std::string fstype_str = "fat";
+
+	explicit_fs = cmd->FindString("-fs", fstype_str, true);
+
+	const auto maybe_fs_type = parse_file_system_type(fstype_str);
+	if (!maybe_fs_type) {
+		NOTIFY_DisplayWarning(Notification::Source::Console,
+		                      "MOUNT",
+		                      "PROGRAM_MOUNT_ILL_TYPE",
+		                      fstype_str.c_str());
+		return false;
 	}
-	explicit_fs = cmd->FindString("-fs", params.fstype, true);
+	if (explicit_fs) {
+		params.fstype = *maybe_fs_type;
+	} else {
+		if (params.type == MountType::CdRomImage) {
+			params.fstype = MountFileSystemType::Iso;
+		}
+	}
 
 	// Parse -ide
 	std::string ide_value = {};
 
 	params.is_ide = cmd->FindString("-ide", ide_value, true) ||
 	                cmd->FindExist("-ide", true);
-	if (params.is_ide && (params.type == "iso")) {
+
+	if (params.is_ide && (params.type == MountType::CdRomImage)) {
 		IDE_Get_Next_Cable_Slot(params.ide_index, params.is_second_cable_slot);
 	}
 
@@ -625,12 +673,15 @@ bool MOUNT::ParseGeometry(MountParameters& params)
 	std::string str_chs  = "";
 
 	// Default sizing logic based on type
-	if (params.type == "floppy") {
+	switch (params.type) {
+	case MountType::FloppyImage:
 		str_size = "512,1,2880,2880";
 
 		params.mediaid = MediaId::Floppy1_44MB;
+		break;
 
-	} else if (params.type == "dir" || params.type == "overlay") {
+	case MountType::Directory:
+	case MountType::Overlay: {
 		// 512*32*32765==~500MB total size
 		// 512*32*16000==~250MB total free size
 		str_size = "512,32,32765,16000";
@@ -647,18 +698,20 @@ bool MOUNT::ParseGeometry(MountParameters& params)
 				params.mediaid = MediaId::Floppy1_44MB;
 			}
 		}
+	} break;
 
-	} else if (params.type == "iso") {
+	case MountType::CdRomImage:
 		str_size = "2048,1,65535,0";
 
 		// mediaid is used in staging to differentiate between floppy
 		// and non-floppy for cache rescan, disk noise and I/O timing.
 		// The same value was used in the original dosbox code
 		params.mediaid = MediaId::HardDisk;
+		break;
 
-	} else {
-		// Type parameter validation should prevent this from happening
-		assert(params.type == "hdd");
+	case MountType::HardDiskImage: break;
+
+	default: assertm(false, "Invalid MountType");
 	}
 
 	// Parse the free space in mb (kb for floppies)
@@ -669,7 +722,7 @@ bool MOUNT::ParseGeometry(MountParameters& params)
 		char teststr[1024];
 		uint16_t freesize = static_cast<uint16_t>(atoi(mb_size.c_str()));
 
-		if (params.type == "floppy") {
+		if (params.type == MountType::FloppyImage) {
 			// freesize in kb
 			safe_sprintf(teststr,
 			             "512,1,2880,%d",
@@ -779,7 +832,7 @@ bool MOUNT::ParseDrive(MountParameters& params, bool explicit_fs)
 			// If user did not explicit specify filesystem, assume
 			// 'none' for raw bootable access
 			if (!explicit_fs) {
-				params.fstype = "none";
+				params.fstype = MountFileSystemType::None;
 			}
 		} else {
 			NOTIFY_DisplayWarning(Notification::Source::Console,
@@ -791,7 +844,7 @@ bool MOUNT::ParseDrive(MountParameters& params, bool explicit_fs)
 		params.drive = first_char;
 
 		// Allow A:, B:, C: and D: to be mounted as raw bootable images
-		if (explicit_fs && params.fstype == "none") {
+		if (explicit_fs && params.fstype == MountFileSystemType::None) {
 			switch (params.drive) {
 			case 'A':
 				params.drive           = '0';
@@ -824,7 +877,7 @@ bool MOUNT::ParseDrive(MountParameters& params, bool explicit_fs)
 
 	// Check overlaps
 	if (!params.is_drive_number) {
-		if (params.type == "overlay") {
+		if (params.type == MountType::Overlay) {
 			// Ensure that the base drive exists:
 			if (!Drives.at(drive_index(params.drive))) {
 				NOTIFY_DisplayWarning(Notification::Source::Console,
@@ -931,9 +984,9 @@ void MOUNT::ProcessPaths(const std::string first_path, MountParameters& params,
 
 	const auto target_is_dir = stat_ok && S_ISDIR(test.st_mode);
 
-	const auto explicit_image_type = (params.type == "hdd" ||
-	                                  params.type == "iso" ||
-	                                  params.type == "floppy");
+	const auto explicit_image_type = (params.type == MountType::HardDiskImage ||
+	                                  params.type == MountType::CdRomImage ||
+	                                  params.type == MountType::FloppyImage);
 
 	const auto has_wildcards = path_arg_1.find_first_of("*?") !=
 	                           std::string::npos;
@@ -1006,7 +1059,8 @@ void MOUNT::ProcessPaths(const std::string first_path, MountParameters& params,
 			}
 
 			// Auto-detect type from FIRST valid file if generic "dir"
-			if (params.paths.empty() && params.type == "dir") {
+			if (params.paths.empty() &&
+			    params.type == MountType::Directory) {
 				struct stat t2 = {};
 
 				if (stat(loop_final_path.c_str(), &t2) == 0 &&
@@ -1024,13 +1078,13 @@ void MOUNT::ProcessPaths(const std::string first_path, MountParameters& params,
 					    ext == "bin" || ext == "mds" ||
 					    ext == "ccd") {
 
-						params.type   = "iso";
-						params.fstype = "iso";
+						params.type = MountType::CdRomImage;
+						params.fstype = MountFileSystemType::Iso;
 
 					} else if (ext == "img" ||
 					           ext == "ima" || ext == "vhd") {
 
-						params.type = "hdd";
+						params.type = MountType::HardDiskImage;
 					}
 				}
 			}
@@ -1042,7 +1096,9 @@ void MOUNT::ProcessPaths(const std::string first_path, MountParameters& params,
 
 		// Ensure consistency between type and fstype if user didn't
 		// override -fs
-		if (params.type == "floppy" && params.fstype == "fat") {
+		if (params.type == MountType::FloppyImage &&
+		    params.fstype == MountFileSystemType::Fat16) {
+
 			params.mediaid = MediaId::Floppy1_44MB;
 		}
 
@@ -1058,14 +1114,14 @@ bool MOUNT::MountPaths(MountParameters& params)
 {
 	if (params.paths.empty()) {
 		NOTIFY_DisplayWarning(Notification::Source::Console,
-							  "MOUNT",
-							  "PROGRAM_IMGMOUNT_FILE_NOT_FOUND");
+		                      "MOUNT",
+		                      "PROGRAM_IMGMOUNT_FILE_NOT_FOUND");
 		return false;
 	}
 
 	if (params.is_image_mode) {
 		const auto success = MountImage(params);
-		if (success && params.type == "floppy") {
+		if (success && params.type == MountType::FloppyImage) {
 			incrementFDD();
 		}
 
@@ -1103,11 +1159,13 @@ void MOUNT::MountLocal(MountParameters& params, const std::string& local_path)
 	std::shared_ptr<DOS_Drive> newdrive = {};
 	const uint8_t int8_tize             = (uint8_t)params.sizes[1];
 
-	if (params.type == "overlay") {
+	if (params.type == MountType::Overlay) {
 		const auto ldp = std::dynamic_pointer_cast<localDrive>(
 		        Drives[drive_index(params.drive)]);
+
 		const auto cdp = std::dynamic_pointer_cast<cdromDrive>(
 		        Drives[drive_index(params.drive)]);
+
 		if (!ldp || cdp) {
 			NOTIFY_DisplayWarning(Notification::Source::Console,
 			                      "MOUNT",
@@ -1146,7 +1204,8 @@ void MOUNT::MountLocal(MountParameters& params, const std::string& local_path)
 			safe_strcpy(newdrive->curdir, ldp->curdir);
 		}
 		Drives.at(drive_index(params.drive)) = nullptr;
-	} else if (params.type == "iso") {
+
+	} else if (params.type == MountType::CdRomImage) {
 		// Mount a host directory as a CD-ROM drive.
 		int error = 0;
 		newdrive  = std::make_shared<cdromDrive>(params.drive,
@@ -1196,10 +1255,11 @@ void MOUNT::MountLocal(MountParameters& params, const std::string& local_path)
 	                   (drive_index(params.drive)) * 9,
 	           newdrive->GetMediaByte());
 
-	if (params.type != "overlay") {
+	if (params.type != MountType::Overlay) {
 		WriteOut(MSG_Get("PROGRAM_MOUNT_STATUS_2"),
 		         newdrive->GetInfoString().c_str(),
 		         params.drive);
+
 		if (params.roflag) {
 			WriteOut(MSG_Get("PROGRAM_MOUNT_READONLY"));
 		}
@@ -1212,28 +1272,31 @@ void MOUNT::MountLocal(MountParameters& params, const std::string& local_path)
 	// check if volume label is given and don't allow it to updated in the
 	// future
 	if (!params.label.empty()) {
-		const auto is_cdrom = (params.type == "iso");
+		const auto is_cdrom = (params.type == MountType::CdRomImage);
 		newdrive->dirCache.SetLabel(params.label.c_str(), is_cdrom, false);
 
-	} else if (params.type == "dir" || params.type == "overlay") {
+	} else if (params.type == MountType::Directory ||
+	           params.type == MountType::Overlay) {
 		// For hard drives set the label to DRIVELETTER_Drive.
 		// For floppy drives set the label to DRIVELETTER_Floppy.
 		// This way every drive except cdroms should get a label.
 		params.label = params.drive;
 		params.label += "_DRIVE";
+
 		newdrive->dirCache.SetLabel(params.label.c_str(), false, false);
 
-	} else if (params.type == "floppy") {
+	} else if (params.type == MountType::FloppyImage) {
 		// Floppy labels handled in IMGMOUNT logic usually, but if
 		// mounted as dir:
 		params.label = params.drive;
 		params.label += "_FLOPPY";
+
 		newdrive->dirCache.SetLabel(params.label.c_str(), false, true);
 	}
 
 	// We incrementFDD here only if it was a directory mount pretending to
 	// be floppy Image mounts return early.
-	if (params.type == "floppy") {
+	if (params.type == MountType::FloppyImage) {
 		incrementFDD();
 	}
 }

--- a/src/dos/programs/mount.cpp
+++ b/src/dos/programs/mount.cpp
@@ -1145,8 +1145,6 @@ void MOUNT::MountLocal(MountParameters& params, const std::string& local_path)
 
 void MOUNT::Run(void)
 {
-	MountParameters params;
-
 	if (std::string{cmd->GetFileName()} == "Z:\\IMGMOUNT.COM") {
 		// Print deprecation notice
 		NOTIFY_DisplayWarning(Notification::Source::Console,
@@ -1177,26 +1175,40 @@ void MOUNT::Run(void)
 		return;
 	}
 
+	ProcessArguments(cmd);
+}
+
+std::optional<MountParameters> MOUNT::ProcessArguments(CommandLine* cmd)
+{
+	// To make it easier injecting arbitrary command lines in the unit tests
+	this->cmd = cmd;
+
+	MountParameters params;
+
 	bool explicit_fs                  = false;
 	bool path_relative_to_last_config = false;
 
 	// Parse command line arguments
 	if (!ParseArguments(params, explicit_fs, path_relative_to_last_config)) {
-		return;
+		return {};
 	}
 
 	// Check drive geometry and types, abort if not valid
 	if (!ParseGeometry(params)) {
-		return;
+		return {};
 	}
 
 	// Check drive letter/number and overlaps, abort if not valid
 	if (!ParseDrive(params, explicit_fs)) {
-		return;
+		return {};
 	}
 
 	// Parse paths and execute (MountImage or MountLocal)
-	ProcessPaths(params, path_relative_to_last_config);
+	if (!ProcessPaths(params, path_relative_to_last_config)) {
+		return {};
+	}
+
+	return params;
 }
 
 void MOUNT::AddMessages()

--- a/src/dos/programs/mount.cpp
+++ b/src/dos/programs/mount.cpp
@@ -865,8 +865,10 @@ std::string MOUNT::GetDosMappedHostPath(const std::string& dos_path) const
 }
 
 // Process paths and prepare (mutate) the passed `MountParameters` for
-// mounting. This includes resolving host paths, auto-detecting mount types,
-// etc.
+// mounting. This includes resolving host paths, wildcard path arguments,
+// auto-detecting mount types, and determining whether we're dealing with
+// image or directory/overlay mounts.
+//
 void MOUNT::ProcessPaths(const std::string first_path, MountParameters& params,
                          bool path_relative_to_last_config)
 {
@@ -1253,6 +1255,18 @@ std::optional<MountParameters> MOUNT::ProcessArguments(CommandLine* cmd)
 		return {};
 	}
 
+	// Get the first path argument
+	std::string first_path = {};
+	if (!cmd->FindCommand(2, first_path) || first_path.empty()) {
+		ShowUsage();
+		return {};
+	}
+
+	// Resolve host paths, wildcard path arguments, auto-detect mount types,
+	// and determine whether we're dealing with image or directory/overlay
+	// mounts.
+	ProcessPaths(first_path, params, path_relative_to_last_config);
+
 	// Check drive geometry and types, abort if not valid
 	if (!ParseGeometry(params)) {
 		return {};
@@ -1262,17 +1276,6 @@ std::optional<MountParameters> MOUNT::ProcessArguments(CommandLine* cmd)
 	if (!ParseDrive(params, explicit_fs)) {
 		return {};
 	}
-
-	// Parse paths and execute (MountImage or MountLocal)
-	std::string first_path = {};
-
-	// Get the first path argument
-	if (!cmd->FindCommand(2, first_path) || first_path.empty()) {
-		ShowUsage();
-		return {};
-	}
-
-	ProcessPaths(first_path, params, path_relative_to_last_config);
 
 	if (!MountPaths(params)) {
 		return {};

--- a/src/dos/programs/mount.cpp
+++ b/src/dos/programs/mount.cpp
@@ -812,18 +812,11 @@ std::string MOUNT::GetDosMappedHostPath(const std::string& dos_path) const
 
 // Returns true if processed successfully (even if it means it found an image
 // and decided to mount it) Returns false on failure.
-bool MOUNT::ProcessPaths(MountParameters& params, bool path_relative_to_last_config)
+bool MOUNT::ProcessPaths(const std::string first_path, MountParameters& params,
+                         bool path_relative_to_last_config)
 {
-	std::string final_path = {};
-
-	// Get the first path argument
-	if (!cmd->FindCommand(2, final_path) || final_path.empty()) {
-		ShowUsage();
-		return false;
-	}
-
 	// Expand ~ to home directory and apply relative path logic
-	auto path_arg_1 = ApplyRelativePath(resolve_home(final_path).string(),
+	auto path_arg_1 = ApplyRelativePath(resolve_home(first_path).string(),
 	                                    path_relative_to_last_config);
 
 #if defined(WIN32)
@@ -967,19 +960,20 @@ bool MOUNT::ProcessPaths(MountParameters& params, bool path_relative_to_last_con
 			incrementFDD();
 		}
 		return true;
-	}
 
-	// Standard directory or overlay mount
-	if (!S_ISDIR(test.st_mode)) {
-		NOTIFY_DisplayWarning(Notification::Source::Console,
-		                      "MOUNT",
-		                      "PROGRAM_MOUNT_ERROR_2",
-		                      path_arg_1.c_str());
-		return false;
-	}
+	} else {
+		// Standard directory or overlay mount
+		if (!S_ISDIR(test.st_mode)) {
+			NOTIFY_DisplayWarning(Notification::Source::Console,
+			                      "MOUNT",
+			                      "PROGRAM_MOUNT_ERROR_2",
+			                      path_arg_1.c_str());
+			return false;
+		}
 
-	MountLocal(params, path_arg_1);
-	return true;
+		MountLocal(params, path_arg_1);
+		return true;
+	}
 }
 
 void MOUNT::MountLocal(MountParameters& params, const std::string& local_path)
@@ -1204,7 +1198,15 @@ std::optional<MountParameters> MOUNT::ProcessArguments(CommandLine* cmd)
 	}
 
 	// Parse paths and execute (MountImage or MountLocal)
-	if (!ProcessPaths(params, path_relative_to_last_config)) {
+	std::string first_path = {};
+
+	// Get the first path argument
+	if (!cmd->FindCommand(2, first_path) || first_path.empty()) {
+		ShowUsage();
+		return {};
+	}
+
+	if (!ProcessPaths(first_path, params, path_relative_to_last_config)) {
 		return {};
 	}
 

--- a/src/dos/programs/mount.h
+++ b/src/dos/programs/mount.h
@@ -7,7 +7,10 @@
 
 #include "dos/dos.h"
 #include "dos/programs.h"
+#include "shell/command_line.h"
+
 #include <array>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -48,6 +51,8 @@ public:
 	                      std::vector<std::string>& paths);
 
 	bool MountImage(MountParameters& params);
+
+	std::optional<MountParameters> ProcessArguments(CommandLine* cmd);
 
 private:
 	static void AddMessages();

--- a/src/dos/programs/mount.h
+++ b/src/dos/programs/mount.h
@@ -68,7 +68,9 @@ private:
 	                              bool is_relative_to_last_config) const;
 	std::string GetDosMappedHostPath(const std::string& dos_path) const;
 
-	bool ProcessPaths(MountParameters& params, bool path_relative_to_last_config);
+	bool ProcessPaths(const std::string first_path, MountParameters& params,
+	                  bool path_relative_to_last_config);
+
 	void MountLocal(MountParameters& params, const std::string& local_path);
 
 	bool MountImageFat(MountParameters& params);

--- a/src/dos/programs/mount.h
+++ b/src/dos/programs/mount.h
@@ -80,7 +80,7 @@ private:
 	void MountLocal(MountParameters& params, const std::string& local_path);
 
 	bool MountImageFat(MountParameters& params);
-	bool MountImageIso(MountParameters& params);
+	bool MountImageIso(const MountParameters& params);
 	bool MountImageRaw(MountParameters& params);
 
 	void WriteMountStatus(const std::string& image_type,

--- a/src/dos/programs/mount.h
+++ b/src/dos/programs/mount.h
@@ -29,10 +29,14 @@ struct MountParameters {
 	bool is_ide               = false;
 	int8_t ide_index          = -1;
 	bool is_second_cable_slot = false;
+
 	// Defaulting to Hard Disk prevents obscure issues in games like Hyperspace 
 	uint8_t mediaid           = MediaId::HardDisk;
+
 	// 0-3 vs A-Z
 	bool is_drive_number = false;
+
+	bool is_image_mode = false;
 };
 
 class MOUNT final : public Program {
@@ -68,8 +72,10 @@ private:
 	                              bool is_relative_to_last_config) const;
 	std::string GetDosMappedHostPath(const std::string& dos_path) const;
 
-	bool ProcessPaths(const std::string first_path, MountParameters& params,
+	void ProcessPaths(const std::string first_path, MountParameters& params,
 	                  bool path_relative_to_last_config);
+
+	bool MountPaths(MountParameters& params);
 
 	void MountLocal(MountParameters& params, const std::string& local_path);
 

--- a/src/dos/programs/mount.h
+++ b/src/dos/programs/mount.h
@@ -14,13 +14,25 @@
 #include <string>
 #include <vector>
 
+enum class MountType {
+	FloppyImage,
+	HardDiskImage,
+	CdRomImage,
+	Directory,
+	Overlay
+};
+
+enum class MountFileSystemType { Fat16, Iso, None };
+
 // Struct to hold all parameters required for a mount operation
 struct MountParameters {
-	char drive                     = '\0';
+	char drive                 = '\0';
+	MountType type             = MountType::Directory;
+	MountFileSystemType fstype = MountFileSystemType::Fat16;
+
 	std::vector<std::string> paths = {};
-	std::string type               = "dir";
-	std::string fstype             = "fat";
-	std::string label              = "";
+
+	std::string label = "";
 
 	// Geometry: [0]=BytesPerSector, [1]=Sectors, [2]=Heads, [3]=Cylinders
 	std::array<uint16_t, 4> sizes = {0, 0, 0, 0};

--- a/src/shell/shell_misc.cpp
+++ b/src/shell/shell_misc.cpp
@@ -596,7 +596,7 @@ static void run_binary_executable(const std::string_view fullname,
 	               std::string(fullname).c_str(),
 	               fullname.size() + 1);
 
-	/* HACK: Store full commandline for mount and imgmount */
+	/* HACK: Store full commandline for MOUNT */
 	full_arguments.assign(args);
 
 	/* Fill the command line */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ add_executable(dosbox_tests
     math_utils_tests.cpp
     messages_adjust_tests.cpp
     mixer_tests.cpp
+    mount_tests.cpp
     port_containers_tests.cpp
     program_mixer_tests.cpp
     rect_tests.cpp

--- a/tests/dos_files_tests.cpp
+++ b/tests/dos_files_tests.cpp
@@ -1,23 +1,6 @@
 // SPDX-FileCopyrightText:  2020-2025 The DOSBox Staging Team
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-/* This sample shows how to write a simple unit test for dosbox-staging using
- * Google C++ testing framework.
- *
- * Read Google Test Primer for reference of most available features, macros,
- * and guidance about writing unit tests:
- *
- * https://github.com/google/googletest/blob/master/googletest/docs/primer.md#googletest-primer
- */
-
-/* Include necessary header files; order of headers should be as follows:
- *
- * 1. Header declaring functions/classes being tested
- * 2. <gtest/gtest.h>, which declares the testing framework
- * 3. Additional system headers (if needed)
- * 4. Additional dosbox-staging headers (if needed)
- */
-
 #include "dos/dos.h"
 
 #include <iterator>

--- a/tests/dosbox_test_fixture.h
+++ b/tests/dosbox_test_fixture.h
@@ -9,6 +9,7 @@
 
 #include <gtest/gtest.h>
 
+#include "audio/mixer.h"
 #include "config/config.h"
 #include "cpu/cpu.h"
 #include "dos/dos.h"
@@ -47,6 +48,7 @@ public:
 
 		DOSBOX_Init();
 		CPU_Init();
+		MIXER_Init();
 		BIOS_Init();
 		SERIAL_Init();
 		DOS_Init();
@@ -59,6 +61,7 @@ public:
 		SERIAL_Destroy();
 		BIOS_Destroy();
 		CPU_Destroy();
+		MIXER_Destroy();
 		DOSBOX_Destroy();
 
 		control = {};

--- a/tests/drives_tests.cpp
+++ b/tests/drives_tests.cpp
@@ -1,23 +1,6 @@
 // SPDX-FileCopyrightText:  2020-2025 The DOSBox Staging Team
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-/* This sample shows how to write a simple unit test for dosbox-staging using
- * Google C++ testing framework.
- *
- * Read Google Test Primer for reference of most available features, macros,
- * and guidance about writing unit tests:
- *
- * https://github.com/google/googletest/blob/master/googletest/docs/primer.md#googletest-primer
- */
-
-/* Include necessary header files; order of headers should be as follows:
- *
- * 1. Header declaring functions/classes being tested
- * 2. <gtest/gtest.h>, which declares the testing framework
- * 3. Additional system headers (if needed)
- * 4. Additional dosbox-staging headers (if needed)
- */
-
 #include "dos/drives.h"
 
 #include <gtest/gtest.h>
@@ -31,8 +14,6 @@ std::string run_Set_Label(char const * const input, bool cdrom) {
         " Input: " << input << " Output: " << output << '\n';
     return std::string(output);
 }
-
-// Open anonymous namespace (this is Google Test requirement)
 
 namespace {
 

--- a/tests/files/dosbox-staging-tests.conf
+++ b/tests/files/dosbox-staging-tests.conf
@@ -23,3 +23,6 @@ gui         = on
 misc        = on
 io          = on
 pci         = on
+
+[mixer]
+nosound = on

--- a/tests/mount_tests.cpp
+++ b/tests/mount_tests.cpp
@@ -211,8 +211,8 @@ TEST_F(MountTest, MountsPlainDirectoryWithDefaults)
 
 	ASSERT_TRUE(result.has_value());
 
-	EXPECT_EQ(result->type, "dir");
-	EXPECT_EQ(result->fstype, "fat");
+	EXPECT_EQ(result->type, MountType::Directory);
+	EXPECT_EQ(result->fstype, MountFileSystemType::Fat16);
 	EXPECT_EQ(result->mediaid, MediaId::HardDisk);
 
 	EXPECT_EQ(result->drive, 'L');
@@ -236,8 +236,8 @@ TEST_F(MountTest, DirectoryMountOnDriveA_UsesFloppyMediaId)
 
 	ASSERT_TRUE(result.has_value());
 
-	EXPECT_EQ(result->type, "dir");
-	EXPECT_EQ(result->fstype, "fat");
+	EXPECT_EQ(result->type, MountType::Directory);
+	EXPECT_EQ(result->fstype, MountFileSystemType::Fat16);
 	EXPECT_EQ(result->mediaid, MediaId::Floppy1_44MB);
 
 	EXPECT_EQ(result->sizes[0], 512);
@@ -252,8 +252,8 @@ TEST_F(MountTest, DirectoryMountReadOnly)
 
 	ASSERT_TRUE(result.has_value());
 
-	EXPECT_EQ(result->type, "dir");
-	EXPECT_EQ(result->fstype, "fat");
+	EXPECT_EQ(result->type, MountType::Directory);
+	EXPECT_EQ(result->fstype, MountFileSystemType::Fat16);
 	EXPECT_EQ(result->mediaid, MediaId::HardDisk);
 
 	EXPECT_TRUE(result->roflag);
@@ -270,8 +270,8 @@ TEST_F(MountTest, DirectoryMountWithExplicitLabelIsNotOverwritten)
 
 	ASSERT_TRUE(result.has_value());
 
-	EXPECT_EQ(result->type, "dir");
-	EXPECT_EQ(result->fstype, "fat");
+	EXPECT_EQ(result->type, MountType::Directory);
+	EXPECT_EQ(result->fstype, MountFileSystemType::Fat16);
 	EXPECT_EQ(result->mediaid, MediaId::HardDisk);
 
 	EXPECT_EQ(result->sizes[0], 512);
@@ -291,8 +291,8 @@ TEST_F(MountTest, OverlayMountsOnTopOfExistingDrive)
 
 	ASSERT_TRUE(result.has_value());
 
-	EXPECT_EQ(result->type, "overlay");
-	EXPECT_EQ(result->fstype, "fat");
+	EXPECT_EQ(result->type, MountType::Overlay);
+	EXPECT_EQ(result->fstype, MountFileSystemType::Fat16);
 	EXPECT_EQ(result->mediaid, MediaId::HardDisk);
 
 	EXPECT_EQ(result->drive, 'O');
@@ -317,8 +317,8 @@ TEST_F(MountTest, FloppyDefaultsGeometryAndMediaId)
 
 	ASSERT_TRUE(result.has_value());
 
-	EXPECT_EQ(result->type, "floppy");
-	EXPECT_EQ(result->fstype, "fat");
+	EXPECT_EQ(result->type, MountType::FloppyImage);
+	EXPECT_EQ(result->fstype, MountFileSystemType::Fat16);
 	EXPECT_EQ(result->mediaid, MediaId::Floppy1_44MB);
 
 	EXPECT_EQ(result->sizes[0], 512);
@@ -333,8 +333,8 @@ TEST_F(MountTest, IsoDefaultsGeometryAndFstype)
 
 	ASSERT_TRUE(result.has_value());
 
-	EXPECT_EQ(result->type, "iso");
-	EXPECT_EQ(result->fstype, "iso");
+	EXPECT_EQ(result->type, MountType::CdRomImage);
+	EXPECT_EQ(result->fstype, MountFileSystemType::Iso);
 	EXPECT_EQ(result->mediaid, MediaId::HardDisk);
 
 	EXPECT_EQ(result->sizes[0], 2048);
@@ -350,8 +350,8 @@ TEST_F(MountTest, ExplicitSizeOverridesDefaults)
 
 	ASSERT_TRUE(result.has_value());
 
-	EXPECT_EQ(result->type, "hdd");
-	EXPECT_EQ(result->fstype, "none");
+	EXPECT_EQ(result->type, MountType::HardDiskImage);
+	EXPECT_EQ(result->fstype, MountFileSystemType::None);
 	EXPECT_EQ(result->mediaid, MediaId::HardDisk);
 
 	EXPECT_EQ(result->sizes[0], 512);
@@ -368,8 +368,8 @@ TEST_F(MountTest, ExplicitChsOverridesExplicitSize)
 
 	ASSERT_TRUE(result.has_value());
 
-	EXPECT_EQ(result->type, "hdd");
-	EXPECT_EQ(result->fstype, "none");
+	EXPECT_EQ(result->type, MountType::HardDiskImage);
+	EXPECT_EQ(result->fstype, MountFileSystemType::None);
 	EXPECT_EQ(result->mediaid, MediaId::HardDisk);
 
 	EXPECT_EQ(result->sizes[0], 512);
@@ -384,8 +384,8 @@ TEST_F(MountTest, FreesizeOverridesDirDefaults)
 
 	ASSERT_TRUE(result.has_value());
 
-	EXPECT_EQ(result->type, "dir");
-	EXPECT_EQ(result->fstype, "fat");
+	EXPECT_EQ(result->type, MountType::Directory);
+	EXPECT_EQ(result->fstype, MountFileSystemType::Fat16);
 	EXPECT_EQ(result->mediaid, MediaId::HardDisk);
 
 	// total_size_cyl stays 32765 (100MB free is under the ~250MB
@@ -403,8 +403,8 @@ TEST_F(MountTest, FreesizeForFloppyIsInKbNotMb)
 
 	ASSERT_TRUE(result.has_value());
 
-	EXPECT_EQ(result->type, "floppy");
-	EXPECT_EQ(result->fstype, "none");
+	EXPECT_EQ(result->type, MountType::FloppyImage);
+	EXPECT_EQ(result->fstype, MountFileSystemType::None);
 	EXPECT_EQ(result->mediaid, MediaId::Floppy1_44MB);
 
 	EXPECT_EQ(result->sizes[0], 512);
@@ -426,8 +426,8 @@ TEST_F(MountTest, DriveNumberForcesNoneFstypeWhenNotExplicit)
 	EXPECT_TRUE(result->is_drive_number);
 	EXPECT_EQ(result->drive, '0');
 
-	EXPECT_EQ(result->type, "hdd");
-	EXPECT_EQ(result->fstype, "none");
+	EXPECT_EQ(result->type, MountType::HardDiskImage);
+	EXPECT_EQ(result->fstype, MountFileSystemType::None);
 	EXPECT_EQ(result->mediaid, MediaId::HardDisk);
 
 	// MountImageFat() will autodetect the HDD image's geometry if sizes
@@ -452,8 +452,8 @@ TEST_F(MountTest, LetterAtoDRemapsToDriveNumberWithFsNone)
 	// C -> drive number 2
 	EXPECT_EQ(result->drive, '2');
 
-	EXPECT_EQ(result->type, "hdd");
-	EXPECT_EQ(result->fstype, "none");
+	EXPECT_EQ(result->type, MountType::HardDiskImage);
+	EXPECT_EQ(result->fstype, MountFileSystemType::None);
 	EXPECT_EQ(result->mediaid, MediaId::HardDisk);
 
 	// MountImageFat() will autodetect the HDD image's geometry if sizes
@@ -473,7 +473,7 @@ TEST_F(MountTest, CdromAliasesToIso)
 	const auto result = Mount("R " + P("image.iso") + " -t cdrom");
 
 	ASSERT_TRUE(result.has_value());
-	EXPECT_EQ(result->type, "iso");
+	EXPECT_EQ(result->type, MountType::CdRomImage);
 }
 
 TEST_F(MountTest, FddAliasesToFloppy)
@@ -481,7 +481,7 @@ TEST_F(MountTest, FddAliasesToFloppy)
 	const auto result = Mount("B " + P("raw.dat") + " -t fdd");
 
 	ASSERT_TRUE(result.has_value());
-	EXPECT_EQ(result->type, "floppy");
+	EXPECT_EQ(result->type, MountType::FloppyImage);
 }
 
 // ---------------------------------------------------------------------
@@ -501,8 +501,8 @@ TEST_F(MountTest, IdeFlagSetWithoutInvokingCableSlotLookupForNonIsoType)
 	EXPECT_EQ(result->ide_index, -1);
 	EXPECT_FALSE(result->is_second_cable_slot);
 
-	EXPECT_EQ(result->type, "hdd");
-	EXPECT_EQ(result->fstype, "none");
+	EXPECT_EQ(result->type, MountType::HardDiskImage);
+	EXPECT_EQ(result->fstype, MountFileSystemType::None);
 	EXPECT_EQ(result->mediaid, MediaId::HardDisk);
 
 	EXPECT_EQ(result->sizes[0], 512);
@@ -524,8 +524,8 @@ TEST_F(MountTest, ImplicitImageModeAutoDetectsIsoFromExtension)
 	ASSERT_TRUE(result.has_value());
 
 	ASSERT_EQ(result->paths.size(), 1);
-	EXPECT_EQ(result->type, "iso");
-	EXPECT_EQ(result->fstype, "iso");
+	EXPECT_EQ(result->type, MountType::CdRomImage);
+	EXPECT_EQ(result->fstype, MountFileSystemType::Iso);
 }
 
 TEST_F(MountTest, AutoDetectsHddTypeFromImgExtension)
@@ -533,7 +533,7 @@ TEST_F(MountTest, AutoDetectsHddTypeFromImgExtension)
 	const auto result = Mount("U " + P("image.img"));
 
 	ASSERT_TRUE(result.has_value());
-	EXPECT_EQ(result->type, "hdd");
+	EXPECT_EQ(result->type, MountType::HardDiskImage);
 }
 
 TEST_F(MountTest, ExplicitTypeOverridesExtensionAutoDetection)
@@ -541,7 +541,7 @@ TEST_F(MountTest, ExplicitTypeOverridesExtensionAutoDetection)
 	const auto result = Mount("V " + P("image.img") + " -t iso");
 
 	ASSERT_TRUE(result.has_value());
-	EXPECT_EQ(result->type, "iso");
+	EXPECT_EQ(result->type, MountType::CdRomImage);
 }
 
 TEST_F(MountTest, MultipleExplicitPathsArePreservedInOrder)
@@ -592,7 +592,7 @@ TEST_F(MountTest, DirectoryOverridesExplicitFloppyTypeAndSetsFloppyLabel)
 	const auto result = Mount("T " + P("plain_dir") + " -t floppy");
 
 	ASSERT_TRUE(result.has_value());
-	EXPECT_EQ(result->type, "floppy");
+	EXPECT_EQ(result->type, MountType::FloppyImage);
 	EXPECT_EQ(result->label, "T_FLOPPY");
 }
 
@@ -646,8 +646,8 @@ TEST_F(MountTest, AutoDetectsIsoFromCueExtension)
 
 	ASSERT_TRUE(result.has_value());
 
-	EXPECT_EQ(result->type, "iso");
-	EXPECT_EQ(result->fstype, "iso");
+	EXPECT_EQ(result->type, MountType::CdRomImage);
+	EXPECT_EQ(result->fstype, MountFileSystemType::Iso);
 	EXPECT_EQ(result->mediaid, MediaId::HardDisk);
 
 	EXPECT_EQ(result->sizes[0], 2048);
@@ -662,8 +662,8 @@ TEST_F(MountTest, AutoDetectsIsoFromBinExtension)
 
 	ASSERT_TRUE(result.has_value());
 
-	EXPECT_EQ(result->type, "iso");
-	EXPECT_EQ(result->fstype, "iso");
+	EXPECT_EQ(result->type, MountType::CdRomImage);
+	EXPECT_EQ(result->fstype, MountFileSystemType::Iso);
 	EXPECT_EQ(result->mediaid, MediaId::HardDisk);
 
 	EXPECT_EQ(result->sizes[0], 2048);
@@ -678,8 +678,8 @@ TEST_F(MountTest, AutoDetectsIsoFromMdsExtension)
 
 	ASSERT_TRUE(result.has_value());
 
-	EXPECT_EQ(result->type, "iso");
-	EXPECT_EQ(result->fstype, "iso");
+	EXPECT_EQ(result->type, MountType::CdRomImage);
+	EXPECT_EQ(result->fstype, MountFileSystemType::Iso);
 	EXPECT_EQ(result->mediaid, MediaId::HardDisk);
 
 	EXPECT_EQ(result->sizes[0], 2048);
@@ -694,8 +694,8 @@ TEST_F(MountTest, AutoDetectsIsoFromCcdExtension)
 
 	ASSERT_TRUE(result.has_value());
 
-	EXPECT_EQ(result->type, "iso");
-	EXPECT_EQ(result->fstype, "iso");
+	EXPECT_EQ(result->type, MountType::CdRomImage);
+	EXPECT_EQ(result->fstype, MountFileSystemType::Iso);
 	EXPECT_EQ(result->mediaid, MediaId::HardDisk);
 
 	EXPECT_EQ(result->sizes[0], 2048);
@@ -710,8 +710,8 @@ TEST_F(MountTest, AutoDetectsHddFromImgExtension)
 
 	ASSERT_TRUE(result.has_value());
 
-	EXPECT_EQ(result->type, "hdd");
-	EXPECT_EQ(result->fstype, "fat");
+	EXPECT_EQ(result->type, MountType::HardDiskImage);
+	EXPECT_EQ(result->fstype, MountFileSystemType::Fat16);
 	EXPECT_EQ(result->mediaid, MediaId::HardDisk);
 
 	// MountImageFat() will autodetect the HDD image's geometry if sizes
@@ -732,8 +732,8 @@ TEST_F(MountTest, AutoDetectsHddFromImaExtension)
 
 	ASSERT_TRUE(result.has_value());
 
-	EXPECT_EQ(result->type, "hdd");
-	EXPECT_EQ(result->fstype, "fat");
+	EXPECT_EQ(result->type, MountType::HardDiskImage);
+	EXPECT_EQ(result->fstype, MountFileSystemType::Fat16);
 	EXPECT_EQ(result->mediaid, MediaId::HardDisk);
 
 	// MountImageFat() will autodetect the HDD image's geometry if sizes
@@ -750,8 +750,8 @@ TEST_F(MountTest, AutoDetectsHddFromVhdExtension)
 
 	ASSERT_TRUE(result.has_value());
 
-	EXPECT_EQ(result->type, "hdd");
-	EXPECT_EQ(result->fstype, "fat");
+	EXPECT_EQ(result->type, MountType::HardDiskImage);
+	EXPECT_EQ(result->fstype, MountFileSystemType::Fat16);
 	EXPECT_EQ(result->mediaid, MediaId::HardDisk);
 
 	// MountImageFat() will autodetect the HDD image's geometry if sizes
@@ -792,8 +792,8 @@ TEST_F(MountTest, ExplicitSizeOverridesFreesize)
 
 	ASSERT_TRUE(result.has_value());
 
-	EXPECT_EQ(result->type, "dir");
-	EXPECT_EQ(result->fstype, "fat");
+	EXPECT_EQ(result->type, MountType::Directory);
+	EXPECT_EQ(result->fstype, MountFileSystemType::Fat16);
 	EXPECT_EQ(result->mediaid, MediaId::HardDisk);
 
 	EXPECT_EQ(result->sizes[0], 512);
@@ -809,8 +809,8 @@ TEST_F(MountTest, ChsOverridesFreesize)
 
 	ASSERT_TRUE(result.has_value());
 
-	EXPECT_EQ(result->type, "dir");
-	EXPECT_EQ(result->fstype, "fat");
+	EXPECT_EQ(result->type, MountType::Directory);
+	EXPECT_EQ(result->fstype, MountFileSystemType::Fat16);
 	EXPECT_EQ(result->mediaid, MediaId::HardDisk);
 
 	EXPECT_EQ(result->sizes[0], 512);
@@ -826,8 +826,8 @@ TEST_F(MountTest, ChsOverridesSizeRegardlessOfArgumentOrder)
 
 	ASSERT_TRUE(result.has_value());
 
-	EXPECT_EQ(result->type, "hdd");
-	EXPECT_EQ(result->fstype, "none");
+	EXPECT_EQ(result->type, MountType::HardDiskImage);
+	EXPECT_EQ(result->fstype, MountFileSystemType::None);
 	EXPECT_EQ(result->mediaid, MediaId::HardDisk);
 
 	EXPECT_EQ(result->sizes[0], 512);
@@ -846,8 +846,8 @@ TEST_F(MountTest, ExplicitIsoTypeOverridesImgExtension)
 
 	ASSERT_TRUE(result.has_value());
 
-	EXPECT_EQ(result->type, "iso");
-	EXPECT_EQ(result->fstype, "iso");
+	EXPECT_EQ(result->type, MountType::CdRomImage);
+	EXPECT_EQ(result->fstype, MountFileSystemType::Iso);
 	EXPECT_EQ(result->mediaid, MediaId::HardDisk);
 
 	EXPECT_EQ(result->sizes[0], 2048);
@@ -863,8 +863,8 @@ TEST_F(MountTest, ExplicitHddTypeKeepsFatFilesystem)
 
 	ASSERT_TRUE(result.has_value());
 
-	EXPECT_EQ(result->type, "hdd");
-	EXPECT_EQ(result->fstype, "fat");
+	EXPECT_EQ(result->type, MountType::HardDiskImage);
+	EXPECT_EQ(result->fstype, MountFileSystemType::Fat16);
 	EXPECT_EQ(result->mediaid, MediaId::HardDisk);
 
 	EXPECT_EQ(result->sizes[0], 512);
@@ -883,8 +883,8 @@ TEST_F(MountTest, IsoExtensionOverridesExplicitFatFs)
 
 	ASSERT_TRUE(result.has_value());
 
-	EXPECT_EQ(result->type, "iso");
-	EXPECT_EQ(result->fstype, "iso");
+	EXPECT_EQ(result->type, MountType::CdRomImage);
+	EXPECT_EQ(result->fstype, MountFileSystemType::Iso);
 	EXPECT_EQ(result->mediaid, MediaId::HardDisk);
 }
 
@@ -902,8 +902,8 @@ TEST_F(MountTest, ExplicitIsoFsIsPreservedForFloppyType)
 
 	ASSERT_TRUE(result.has_value());
 
-	EXPECT_EQ(result->type, "floppy");
-	EXPECT_EQ(result->fstype, "iso");
+	EXPECT_EQ(result->type, MountType::FloppyImage);
+	EXPECT_EQ(result->fstype, MountFileSystemType::Iso);
 
 	// MediaId promotion only happens for floppy+fat.
 	EXPECT_EQ(result->mediaid, MediaId::Floppy1_44MB);
@@ -915,8 +915,8 @@ TEST_F(MountTest, ExplicitIsoTypeOverridesFloppyExtension)
 
 	ASSERT_TRUE(result.has_value());
 
-	EXPECT_EQ(result->type, "iso");
-	EXPECT_EQ(result->fstype, "iso");
+	EXPECT_EQ(result->type, MountType::CdRomImage);
+	EXPECT_EQ(result->fstype, MountFileSystemType::Iso);
 	EXPECT_EQ(result->mediaid, MediaId::HardDisk);
 
 	EXPECT_EQ(result->sizes[0], 2048);
@@ -931,8 +931,8 @@ TEST_F(MountTest, ExplicitFloppyTypeOverridesIsoExtension)
 
 	ASSERT_TRUE(result.has_value());
 
-	EXPECT_EQ(result->type, "floppy");
-	EXPECT_EQ(result->fstype, "fat");
+	EXPECT_EQ(result->type, MountType::FloppyImage);
+	EXPECT_EQ(result->fstype, MountFileSystemType::Fat16);
 
 	// Pin down whatever the parser currently does.
 	EXPECT_EQ(result->mediaid, MediaId::Floppy1_44MB);
@@ -944,8 +944,8 @@ TEST_F(MountTest, ExplicitIsoFilesystemWithoutType)
 
 	ASSERT_TRUE(result.has_value());
 
-	EXPECT_EQ(result->type, "hdd");
-	EXPECT_EQ(result->fstype, "iso");
+	EXPECT_EQ(result->type, MountType::HardDiskImage);
+	EXPECT_EQ(result->fstype, MountFileSystemType::Iso);
 	EXPECT_EQ(result->mediaid, MediaId::HardDisk);
 }
 
@@ -955,8 +955,8 @@ TEST_F(MountTest, ExplicitFatFilesystemWithoutType)
 
 	ASSERT_TRUE(result.has_value());
 
-	EXPECT_EQ(result->type, "hdd");
-	EXPECT_EQ(result->fstype, "fat");
+	EXPECT_EQ(result->type, MountType::HardDiskImage);
+	EXPECT_EQ(result->fstype, MountFileSystemType::Fat16);
 	EXPECT_EQ(result->mediaid, MediaId::HardDisk);
 }
 
@@ -966,8 +966,8 @@ TEST_F(MountTest, ExplicitIsoFilesystemOnIsoImage)
 
 	ASSERT_TRUE(result.has_value());
 
-	EXPECT_EQ(result->type, "iso");
-	EXPECT_EQ(result->fstype, "iso");
+	EXPECT_EQ(result->type, MountType::CdRomImage);
+	EXPECT_EQ(result->fstype, MountFileSystemType::Iso);
 	EXPECT_EQ(result->mediaid, MediaId::HardDisk);
 }
 
@@ -981,8 +981,8 @@ TEST_F(MountTest, SizeAcceptedForIsoMount)
 
 	ASSERT_TRUE(result.has_value());
 
-	EXPECT_EQ(result->type, "iso");
-	EXPECT_EQ(result->fstype, "iso");
+	EXPECT_EQ(result->type, MountType::CdRomImage);
+	EXPECT_EQ(result->fstype, MountFileSystemType::Iso);
 	EXPECT_EQ(result->mediaid, MediaId::HardDisk);
 
 	EXPECT_EQ(result->sizes[0], 512);
@@ -997,8 +997,8 @@ TEST_F(MountTest, ChsAcceptedForIsoMount)
 
 	ASSERT_TRUE(result.has_value());
 
-	EXPECT_EQ(result->type, "iso");
-	EXPECT_EQ(result->fstype, "iso");
+	EXPECT_EQ(result->type, MountType::CdRomImage);
+	EXPECT_EQ(result->fstype, MountFileSystemType::Iso);
 	EXPECT_EQ(result->mediaid, MediaId::HardDisk);
 
 	EXPECT_EQ(result->sizes[0], 512);
@@ -1026,8 +1026,8 @@ TEST_F(MountTest, FirstImageControlsAutoDetection)
 
 	ASSERT_TRUE(result.has_value());
 
-	EXPECT_EQ(result->type, "hdd");
-	EXPECT_EQ(result->fstype, "fat");
+	EXPECT_EQ(result->type, MountType::HardDiskImage);
+	EXPECT_EQ(result->fstype, MountFileSystemType::Fat16);
 	EXPECT_EQ(result->mediaid, MediaId::HardDisk);
 
 	ASSERT_EQ(result->paths.size(), 2);
@@ -1039,8 +1039,8 @@ TEST_F(MountTest, FirstImageControlsAutoDetectionReverseOrder)
 
 	ASSERT_TRUE(result.has_value());
 
-	EXPECT_EQ(result->type, "iso");
-	EXPECT_EQ(result->fstype, "iso");
+	EXPECT_EQ(result->type, MountType::CdRomImage);
+	EXPECT_EQ(result->fstype, MountFileSystemType::Iso);
 	EXPECT_EQ(result->mediaid, MediaId::HardDisk);
 
 	ASSERT_EQ(result->paths.size(), 2);
@@ -1052,8 +1052,8 @@ TEST_F(MountTest, FirstIsoImageControlsAutoDetection)
 
 	ASSERT_TRUE(result.has_value());
 
-	EXPECT_EQ(result->type, "iso");
-	EXPECT_EQ(result->fstype, "iso");
+	EXPECT_EQ(result->type, MountType::CdRomImage);
+	EXPECT_EQ(result->fstype, MountFileSystemType::Iso);
 	EXPECT_EQ(result->mediaid, MediaId::HardDisk);
 
 	ASSERT_EQ(result->paths.size(), 2);
@@ -1070,8 +1070,8 @@ TEST_F(MountTest, IdeFlagDoesNotAllocateControllerForNonIsoType)
 
 	ASSERT_TRUE(result.has_value());
 
-	EXPECT_EQ(result->type, "hdd");
-	EXPECT_EQ(result->fstype, "iso");
+	EXPECT_EQ(result->type, MountType::HardDiskImage);
+	EXPECT_EQ(result->fstype, MountFileSystemType::Iso);
 	EXPECT_EQ(result->mediaid, MediaId::HardDisk);
 
 	EXPECT_TRUE(result->is_ide);
@@ -1089,8 +1089,8 @@ TEST_F(MountTest, ExplicitSizeWithIsoImage)
 
 	ASSERT_TRUE(result.has_value());
 
-	EXPECT_EQ(result->type, "iso");
-	EXPECT_EQ(result->fstype, "iso");
+	EXPECT_EQ(result->type, MountType::CdRomImage);
+	EXPECT_EQ(result->fstype, MountFileSystemType::Iso);
 	EXPECT_EQ(result->mediaid, MediaId::HardDisk);
 
 	// Pin down whether ISO defaults or explicit size wins.
@@ -1102,8 +1102,8 @@ TEST_F(MountTest, ExplicitChsWithIsoImage)
 
 	ASSERT_TRUE(result.has_value());
 
-	EXPECT_EQ(result->type, "iso");
-	EXPECT_EQ(result->fstype, "iso");
+	EXPECT_EQ(result->type, MountType::CdRomImage);
+	EXPECT_EQ(result->fstype, MountFileSystemType::Iso);
 }
 
 // ---------------------------------------------------------------------
@@ -1190,7 +1190,7 @@ TEST_F(MountTest, DuplicateFilesystemFirstWins)
 
 	ASSERT_TRUE(result.has_value());
 
-	EXPECT_EQ(result->fstype, "fat");
+	EXPECT_EQ(result->fstype, MountFileSystemType::Fat16);
 }
 
 TEST_F(MountTest, DuplicateTypeFirstWins)
@@ -1201,8 +1201,8 @@ TEST_F(MountTest, DuplicateTypeFirstWins)
 
 	ASSERT_TRUE(result.has_value());
 
-	EXPECT_EQ(result->type, "floppy");
-	EXPECT_EQ(result->fstype, "fat");
+	EXPECT_EQ(result->type, MountType::FloppyImage);
+	EXPECT_EQ(result->fstype, MountFileSystemType::Fat16);
 	EXPECT_EQ(result->mediaid, MediaId::Floppy1_44MB);
 }
 

--- a/tests/mount_tests.cpp
+++ b/tests/mount_tests.cpp
@@ -430,10 +430,16 @@ TEST_F(MountTest, DriveNumberForcesNoneFstypeWhenNotExplicit)
 	EXPECT_EQ(result->fstype, "none");
 	EXPECT_EQ(result->mediaid, MediaId::HardDisk);
 
-	EXPECT_EQ(result->sizes[0], 512);
-	EXPECT_EQ(result->sizes[1], 32);
-	EXPECT_EQ(result->sizes[2], 32765);
-	EXPECT_EQ(result->sizes[3], 16000);
+	// MountImageFat() will autodetect the HDD image's geometry if sizes
+	// contains all zeroes.
+	//
+	// We're not testing the autodetection logic here; we'd need to write a
+	// valid HDD image for that in the test setup. Maybe later.
+	//
+	EXPECT_EQ(result->sizes[0], 0);
+	EXPECT_EQ(result->sizes[1], 0);
+	EXPECT_EQ(result->sizes[2], 0);
+	EXPECT_EQ(result->sizes[3], 0);
 }
 
 TEST_F(MountTest, LetterAtoDRemapsToDriveNumberWithFsNone)
@@ -443,16 +449,19 @@ TEST_F(MountTest, LetterAtoDRemapsToDriveNumberWithFsNone)
 	ASSERT_TRUE(result.has_value());
 	EXPECT_TRUE(result->is_drive_number);
 
-	EXPECT_EQ(result->drive, '2'); // C -> drive number 2
-	                               //
+	// C -> drive number 2
+	EXPECT_EQ(result->drive, '2');
+
 	EXPECT_EQ(result->type, "hdd");
 	EXPECT_EQ(result->fstype, "none");
 	EXPECT_EQ(result->mediaid, MediaId::HardDisk);
 
-	EXPECT_EQ(result->sizes[0], 512);
-	EXPECT_EQ(result->sizes[1], 32);
-	EXPECT_EQ(result->sizes[2], 32765);
-	EXPECT_EQ(result->sizes[3], 16000);
+	// MountImageFat() will autodetect the HDD image's geometry if sizes
+	// contains all zeroes.
+	EXPECT_EQ(result->sizes[0], 0);
+	EXPECT_EQ(result->sizes[1], 0);
+	EXPECT_EQ(result->sizes[2], 0);
+	EXPECT_EQ(result->sizes[3], 0);
 }
 
 // ---------------------------------------------------------------------
@@ -636,8 +645,15 @@ TEST_F(MountTest, AutoDetectsIsoFromCueExtension)
 	const auto result = Mount("E " + P("image.cue"));
 
 	ASSERT_TRUE(result.has_value());
+
 	EXPECT_EQ(result->type, "iso");
 	EXPECT_EQ(result->fstype, "iso");
+	EXPECT_EQ(result->mediaid, MediaId::HardDisk);
+
+	EXPECT_EQ(result->sizes[0], 2048);
+	EXPECT_EQ(result->sizes[1], 1);
+	EXPECT_EQ(result->sizes[2], 65535);
+	EXPECT_EQ(result->sizes[3], 0);
 }
 
 TEST_F(MountTest, AutoDetectsIsoFromBinExtension)
@@ -645,8 +661,15 @@ TEST_F(MountTest, AutoDetectsIsoFromBinExtension)
 	const auto result = Mount("E " + P("image.bin"));
 
 	ASSERT_TRUE(result.has_value());
+
 	EXPECT_EQ(result->type, "iso");
 	EXPECT_EQ(result->fstype, "iso");
+	EXPECT_EQ(result->mediaid, MediaId::HardDisk);
+
+	EXPECT_EQ(result->sizes[0], 2048);
+	EXPECT_EQ(result->sizes[1], 1);
+	EXPECT_EQ(result->sizes[2], 65535);
+	EXPECT_EQ(result->sizes[3], 0);
 }
 
 TEST_F(MountTest, AutoDetectsIsoFromMdsExtension)
@@ -654,8 +677,15 @@ TEST_F(MountTest, AutoDetectsIsoFromMdsExtension)
 	const auto result = Mount("E " + P("image.mds"));
 
 	ASSERT_TRUE(result.has_value());
+
 	EXPECT_EQ(result->type, "iso");
 	EXPECT_EQ(result->fstype, "iso");
+	EXPECT_EQ(result->mediaid, MediaId::HardDisk);
+
+	EXPECT_EQ(result->sizes[0], 2048);
+	EXPECT_EQ(result->sizes[1], 1);
+	EXPECT_EQ(result->sizes[2], 65535);
+	EXPECT_EQ(result->sizes[3], 0);
 }
 
 TEST_F(MountTest, AutoDetectsIsoFromCcdExtension)
@@ -663,8 +693,37 @@ TEST_F(MountTest, AutoDetectsIsoFromCcdExtension)
 	const auto result = Mount("E " + P("image.ccd"));
 
 	ASSERT_TRUE(result.has_value());
+
 	EXPECT_EQ(result->type, "iso");
 	EXPECT_EQ(result->fstype, "iso");
+	EXPECT_EQ(result->mediaid, MediaId::HardDisk);
+
+	EXPECT_EQ(result->sizes[0], 2048);
+	EXPECT_EQ(result->sizes[1], 1);
+	EXPECT_EQ(result->sizes[2], 65535);
+	EXPECT_EQ(result->sizes[3], 0);
+}
+
+TEST_F(MountTest, AutoDetectsHddFromImgExtension)
+{
+	const auto result = Mount("E " + P("image.img"));
+
+	ASSERT_TRUE(result.has_value());
+
+	EXPECT_EQ(result->type, "hdd");
+	EXPECT_EQ(result->fstype, "fat");
+	EXPECT_EQ(result->mediaid, MediaId::HardDisk);
+
+	// MountImageFat() will autodetect the HDD image's geometry if sizes
+	// contains all zeroes.
+	//
+	// We're not testing the autodetection logic here; we'd need to write a
+	// valid HDD image for that in the test setup. Maybe later.
+	//
+	EXPECT_EQ(result->sizes[0], 0);
+	EXPECT_EQ(result->sizes[1], 0);
+	EXPECT_EQ(result->sizes[2], 0);
+	EXPECT_EQ(result->sizes[3], 0);
 }
 
 TEST_F(MountTest, AutoDetectsHddFromImaExtension)
@@ -672,8 +731,17 @@ TEST_F(MountTest, AutoDetectsHddFromImaExtension)
 	const auto result = Mount("E " + P("image.ima"));
 
 	ASSERT_TRUE(result.has_value());
+
 	EXPECT_EQ(result->type, "hdd");
 	EXPECT_EQ(result->fstype, "fat");
+	EXPECT_EQ(result->mediaid, MediaId::HardDisk);
+
+	// MountImageFat() will autodetect the HDD image's geometry if sizes
+	// contains all zeroes.
+	EXPECT_EQ(result->sizes[0], 0);
+	EXPECT_EQ(result->sizes[1], 0);
+	EXPECT_EQ(result->sizes[2], 0);
+	EXPECT_EQ(result->sizes[3], 0);
 }
 
 TEST_F(MountTest, AutoDetectsHddFromVhdExtension)
@@ -681,8 +749,17 @@ TEST_F(MountTest, AutoDetectsHddFromVhdExtension)
 	const auto result = Mount("F " + P("image.vhd"));
 
 	ASSERT_TRUE(result.has_value());
+
 	EXPECT_EQ(result->type, "hdd");
 	EXPECT_EQ(result->fstype, "fat");
+	EXPECT_EQ(result->mediaid, MediaId::HardDisk);
+
+	// MountImageFat() will autodetect the HDD image's geometry if sizes
+	// contains all zeroes.
+	EXPECT_EQ(result->sizes[0], 0);
+	EXPECT_EQ(result->sizes[1], 0);
+	EXPECT_EQ(result->sizes[2], 0);
+	EXPECT_EQ(result->sizes[3], 0);
 }
 
 // ---------------------------------------------------------------------

--- a/tests/mount_tests.cpp
+++ b/tests/mount_tests.cpp
@@ -1,0 +1,1132 @@
+// SPDX-FileCopyrightText:  2026-2026 The DOSBox Staging Team
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "dos/programs/mount.h"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <filesystem>
+#include <fstream>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "dosbox_test_fixture.h"
+
+namespace {
+
+namespace std_fs = std::filesystem;
+
+class MountTest : public DOSBoxTestFixture {
+protected:
+	static std_fs::path test_file_path;
+
+	static void write_file(const std_fs::path& path,
+	                       size_t num_bytes = 1024, char fill = 0)
+	{
+		std::ofstream out(path, std::ios::binary | std::ios::trunc);
+		std::vector<char> buf(num_bytes, fill);
+		out.write(buf.data(), static_cast<std::streamsize>(buf.size()));
+	}
+
+	void SetUp() override
+	{
+		DOSBoxTestFixture::SetUp();
+
+		std_fs::create_directories(test_file_path);
+		std_fs::create_directories(test_file_path / "plain_dir");
+		std_fs::create_directories(test_file_path / "overlay_base");
+		std_fs::create_directories(test_file_path / "overlay_layer");
+
+		write_file(test_file_path / "plain_dir" / "readme.txt", 16, 'x');
+
+		// Generic image-ish files. None need valid boot-sector bytes
+		// or filesystem content: every test either supplies explicit
+		// -chs/-size (skipping the "autosize" file-probing path
+		// entirely) or uses a type where that path isn't taken.
+
+		write_file(test_file_path / "image.iso", 2048 * 4);
+		write_file(test_file_path / "image.img", 4096);
+		write_file(test_file_path / "bootable.img", 65536);
+		write_file(test_file_path / "raw.dat", 1440 * 1024);
+
+		write_file(test_file_path / "disk1.img", 512);
+		write_file(test_file_path / "disk02.img", 512);
+		write_file(test_file_path / "disk03.img", 512);
+
+		write_file(test_file_path / "image.cue", 2048);
+		write_file(test_file_path / "image.bin", 2048);
+		write_file(test_file_path / "image.mds", 2048);
+		write_file(test_file_path / "image.ccd", 2048);
+		write_file(test_file_path / "image.ima", 2048);
+		write_file(test_file_path / "image.vhd", 2048);
+
+		write_file(test_file_path / "image.flac", 2048);
+		write_file(test_file_path / "image.opus", 2048);
+		write_file(test_file_path / "image.ogg", 2048);
+		write_file(test_file_path / "image.mp3", 2048);
+		write_file(test_file_path / "image.wav", 2048);
+
+		write_file(test_file_path / "noextfile", 2048);
+	}
+
+	void TearDown() override
+	{
+		DOSBoxTestFixture::TearDown();
+	}
+
+	// Runs once after all tests in this suite.
+	static void TearDownTestSuite()
+	{
+		std::error_code ec;
+		std_fs::remove_all(test_file_path, ec);
+	}
+
+	static std::string P(const std::string& name)
+	{
+		return (test_file_path / name).string();
+	}
+
+	static std::optional<MountParameters> Mount(const std::string& command_params)
+	{
+		auto cmd     = new CommandLine("Z:\\MOUNT.COM", command_params);
+		auto program = new MOUNT();
+		return program->ProcessArguments(cmd);
+	}
+};
+
+// Use unique test file paths otherwise when when run tests in parallell
+// chunks with the -j option (e.g. -j 16) the teardown and the setup steps of
+// two chunks can overlap and cause test failures.
+//
+std_fs::path MountTest::test_file_path = [] {
+	const auto now = duration_cast<std::chrono::nanoseconds>(
+	                         std::chrono::system_clock::now().time_since_epoch())
+	                         .count();
+
+	// Anchored to this source file's location rather than the
+	// process's CWD
+	return std_fs::path(__FILE__).parent_path() /
+	       (std::to_string(now) + "_mount_test_files");
+}();
+
+// ---------------------------------------------------------------------
+// Error paths: ProcessArguments() must return std::nullopt.
+// ---------------------------------------------------------------------
+
+TEST_F(MountTest, RejectsUnknownType)
+{
+	const auto result = Mount("C " + P("plain_dir") + " -t bogus");
+	EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(MountTest, RejectsInvalidChsFormat)
+{
+	const auto result = Mount("C " + P("bootable.img") + " -t hdd -chs notnumbers");
+	EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(MountTest, RejectsMissingPath)
+{
+	const auto result = Mount("C");
+	EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(MountTest, RejectsDriveTokenTooLong)
+{
+	const auto result = Mount("WWW " + P("plain_dir"));
+	EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(MountTest, RejectsSecondCharNotColon)
+{
+	const auto result = Mount("WQ " + P("plain_dir"));
+	EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(MountTest, RejectsOutOfRangeDriveNumber)
+{
+	// Only digits '0'-'3' are valid drive numbers.
+	const auto result = Mount("4 " + P("bootable.img"));
+	EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(MountTest, RejectsBootableLetterOutsideAtoD)
+{
+	// -fs none forces the A-D -> 0-3 remap in ParseDrive; the switch's
+	// default case rejects any other letter.
+	const auto result = Mount("E " + P("bootable.img") + " -fs none");
+	EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(MountTest, RejectsNonexistentPath)
+{
+	// Not a directory or regular file -> PROGRAM_MOUNT_ERROR_2.
+	const auto result = Mount("G " + P("does_not_exist_at_all"));
+	EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(MountTest, RejectsOverlayWithoutMountedBase)
+{
+	const auto result = Mount("E " + P("overlay_layer") + " -t overlay");
+	EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(MountTest, WildcardMatchingNothingFallsBackToLiteralPath)
+{
+	// A glob that matches no files does NOT cause ProcessArguments() to
+	// fail. AddWildcardPaths() expansion comes up empty, so ProcessPaths()
+	// falls back to treating the literal, unexpanded glob string itself as
+	// the single path. Whether that literal "path" turns out to be openable
+	// is left to MountImage().
+	const auto result = Mount("F " + P("nomatch_*.img") + " -t floppy");
+
+	ASSERT_TRUE(result.has_value());
+	ASSERT_EQ(result->paths.size(), 1);
+	EXPECT_NE(result->paths[0].find("nomatch_*.img"), std::string::npos);
+}
+
+TEST_F(MountTest, RejectsAlreadyMountedDrive)
+{
+	// Mounts and re-mounts the same letter within one test.
+	const auto first = Mount("J " + P("plain_dir"));
+	ASSERT_TRUE(first.has_value());
+
+	const auto second = Mount("J " + P("overlay_layer"));
+	EXPECT_FALSE(second.has_value());
+}
+
+// ---------------------------------------------------------------------
+// Directory / overlay mounts (MountLocal() path).
+//
+// Note `params.paths` is NOT populated for this branch (it's only used for
+// image mounts) so these tests check the fields MountLocal() itself consumes
+// or mutates (drive, type, sizes, roflag, label, mediaid).
+// ---------------------------------------------------------------------
+
+TEST_F(MountTest, MountsPlainDirectoryWithDefaults)
+{
+	const auto result = Mount("L " + P("plain_dir"));
+
+	ASSERT_TRUE(result.has_value());
+
+	EXPECT_EQ(result->type, "dir");
+	EXPECT_EQ(result->fstype, "fat");
+	EXPECT_EQ(result->mediaid, MediaId::HardDisk);
+
+	EXPECT_EQ(result->drive, 'L');
+	EXPECT_FALSE(result->is_drive_number);
+	EXPECT_FALSE(result->roflag);
+
+	// Default "dir" geometry from ParseGeometry
+	EXPECT_EQ(result->sizes[0], 512);
+	EXPECT_EQ(result->sizes[1], 32);
+	EXPECT_EQ(result->sizes[2], 32765);
+	EXPECT_EQ(result->sizes[3], 16000);
+
+	// MountLocal mutates params.label to "<drive>_DRIVE" when none given
+	EXPECT_EQ(result->label, "L_DRIVE");
+}
+
+TEST_F(MountTest, DirectoryMountOnDriveA_UsesFloppyMediaId)
+{
+	// ParseGeometry special-cases drive A/B for dir/overlay mounts.
+	const auto result = Mount("A " + P("plain_dir"));
+
+	ASSERT_TRUE(result.has_value());
+
+	EXPECT_EQ(result->type, "dir");
+	EXPECT_EQ(result->fstype, "fat");
+	EXPECT_EQ(result->mediaid, MediaId::Floppy1_44MB);
+
+	EXPECT_EQ(result->sizes[0], 512);
+	EXPECT_EQ(result->sizes[1], 32);
+	EXPECT_EQ(result->sizes[2], 32765);
+	EXPECT_EQ(result->sizes[3], 16000);
+}
+
+TEST_F(MountTest, DirectoryMountReadOnly)
+{
+	const auto result = Mount("M " + P("plain_dir") + " -ro");
+
+	ASSERT_TRUE(result.has_value());
+
+	EXPECT_EQ(result->type, "dir");
+	EXPECT_EQ(result->fstype, "fat");
+	EXPECT_EQ(result->mediaid, MediaId::HardDisk);
+
+	EXPECT_TRUE(result->roflag);
+
+	EXPECT_EQ(result->sizes[0], 512);
+	EXPECT_EQ(result->sizes[1], 32);
+	EXPECT_EQ(result->sizes[2], 32765);
+	EXPECT_EQ(result->sizes[3], 16000);
+}
+
+TEST_F(MountTest, DirectoryMountWithExplicitLabelIsNotOverwritten)
+{
+	const auto result = Mount("N " + P("plain_dir") + " -label MYLABEL");
+
+	ASSERT_TRUE(result.has_value());
+
+	EXPECT_EQ(result->type, "dir");
+	EXPECT_EQ(result->fstype, "fat");
+	EXPECT_EQ(result->mediaid, MediaId::HardDisk);
+
+	EXPECT_EQ(result->sizes[0], 512);
+	EXPECT_EQ(result->sizes[1], 32);
+	EXPECT_EQ(result->sizes[2], 32765);
+	EXPECT_EQ(result->sizes[3], 16000);
+
+	EXPECT_EQ(result->label, "MYLABEL");
+}
+
+TEST_F(MountTest, OverlayMountsOnTopOfExistingDrive)
+{
+	const auto base = Mount("O " + P("overlay_base"));
+	ASSERT_TRUE(base.has_value());
+
+	const auto result = Mount("O " + P("overlay_layer") + " -t overlay");
+
+	ASSERT_TRUE(result.has_value());
+
+	EXPECT_EQ(result->type, "overlay");
+	EXPECT_EQ(result->fstype, "fat");
+	EXPECT_EQ(result->mediaid, MediaId::HardDisk);
+
+	EXPECT_EQ(result->drive, 'O');
+	EXPECT_EQ(result->label, "O_DRIVE");
+
+	EXPECT_EQ(result->sizes[0], 512);
+	EXPECT_EQ(result->sizes[1], 32);
+	EXPECT_EQ(result->sizes[2], 32765);
+	EXPECT_EQ(result->sizes[3], 16000);
+}
+
+// ---------------------------------------------------------------------
+// Geometry parsing (ParseGeometry)
+// ---------------------------------------------------------------------
+
+TEST_F(MountTest, FloppyDefaultsGeometryAndMediaId)
+{
+	// -t floppy is an "explicit image type", so this hits the image
+	// branch via a regular file, but the geometry defaults come from
+	// `ParseGeometry()` regardless of that branch.
+	const auto result = Mount("B " + P("raw.dat") + " -t floppy");
+
+	ASSERT_TRUE(result.has_value());
+
+	EXPECT_EQ(result->type, "floppy");
+	EXPECT_EQ(result->fstype, "fat");
+	EXPECT_EQ(result->mediaid, MediaId::Floppy1_44MB);
+
+	EXPECT_EQ(result->sizes[0], 512);
+	EXPECT_EQ(result->sizes[1], 1);
+	EXPECT_EQ(result->sizes[2], 2880);
+	EXPECT_EQ(result->sizes[3], 2880);
+}
+
+TEST_F(MountTest, IsoDefaultsGeometryAndFstype)
+{
+	const auto result = Mount("P " + P("image.iso") + " -t iso");
+
+	ASSERT_TRUE(result.has_value());
+
+	EXPECT_EQ(result->type, "iso");
+	EXPECT_EQ(result->fstype, "iso");
+	EXPECT_EQ(result->mediaid, MediaId::HardDisk);
+
+	EXPECT_EQ(result->sizes[0], 2048);
+	EXPECT_EQ(result->sizes[1], 1);
+	EXPECT_EQ(result->sizes[2], 65535);
+	EXPECT_EQ(result->sizes[3], 0);
+}
+
+TEST_F(MountTest, ExplicitSizeOverridesDefaults)
+{
+	const auto result = Mount("1 " + P("bootable.img") +
+	                          " -t hdd -size 512,63,16,100");
+
+	ASSERT_TRUE(result.has_value());
+
+	EXPECT_EQ(result->type, "hdd");
+	EXPECT_EQ(result->fstype, "none");
+	EXPECT_EQ(result->mediaid, MediaId::HardDisk);
+
+	EXPECT_EQ(result->sizes[0], 512);
+	EXPECT_EQ(result->sizes[1], 63);
+	EXPECT_EQ(result->sizes[2], 16);
+	EXPECT_EQ(result->sizes[3], 100);
+}
+
+TEST_F(MountTest, ExplicitChsOverridesExplicitSize)
+{
+	// -chs is parsed after -size in ParseGeometry, so it should win.
+	const auto result = Mount("2 " + P("bootable.img") +
+	                          " -t hdd -size 512,63,16,50 -chs 200,16,63");
+
+	ASSERT_TRUE(result.has_value());
+
+	EXPECT_EQ(result->type, "hdd");
+	EXPECT_EQ(result->fstype, "none");
+	EXPECT_EQ(result->mediaid, MediaId::HardDisk);
+
+	EXPECT_EQ(result->sizes[0], 512);
+	EXPECT_EQ(result->sizes[1], 63);  // sectors
+	EXPECT_EQ(result->sizes[2], 16);  // heads
+	EXPECT_EQ(result->sizes[3], 200); // cylinders
+}
+
+TEST_F(MountTest, FreesizeOverridesDirDefaults)
+{
+	const auto result = Mount("Q " + P("plain_dir") + " -freesize 100");
+
+	ASSERT_TRUE(result.has_value());
+
+	EXPECT_EQ(result->type, "dir");
+	EXPECT_EQ(result->fstype, "fat");
+	EXPECT_EQ(result->mediaid, MediaId::HardDisk);
+
+	// total_size_cyl stays 32765 (100MB free is under the ~250MB
+	// implied default); free_size_cyl = 100*1024*1024/(512*32) = 6400.
+	EXPECT_EQ(result->sizes[0], 512);
+	EXPECT_EQ(result->sizes[1], 32);
+	EXPECT_EQ(result->sizes[2], 32765);
+	EXPECT_EQ(result->sizes[3], 6400);
+}
+
+TEST_F(MountTest, FreesizeForFloppyIsInKbNotMb)
+{
+	const auto result = Mount("D " + P("raw.dat") +
+	                          " -t floppy -fs none -freesize 720");
+
+	ASSERT_TRUE(result.has_value());
+
+	EXPECT_EQ(result->type, "floppy");
+	EXPECT_EQ(result->fstype, "none");
+	EXPECT_EQ(result->mediaid, MediaId::Floppy1_44MB);
+
+	EXPECT_EQ(result->sizes[0], 512);
+	EXPECT_EQ(result->sizes[1], 1);
+	EXPECT_EQ(result->sizes[2], 2880);
+	EXPECT_EQ(result->sizes[3], 720 * 1024 / 512);
+}
+
+// ---------------------------------------------------------------------
+// Drive parsing (ParseDrive)
+// ---------------------------------------------------------------------
+
+TEST_F(MountTest, DriveNumberForcesNoneFstypeWhenNotExplicit)
+{
+	const auto result = Mount("0 " + P("bootable.img"));
+
+	ASSERT_TRUE(result.has_value());
+
+	EXPECT_TRUE(result->is_drive_number);
+	EXPECT_EQ(result->drive, '0');
+
+	EXPECT_EQ(result->type, "hdd");
+	EXPECT_EQ(result->fstype, "none");
+	EXPECT_EQ(result->mediaid, MediaId::HardDisk);
+
+	EXPECT_EQ(result->sizes[0], 512);
+	EXPECT_EQ(result->sizes[1], 32);
+	EXPECT_EQ(result->sizes[2], 32765);
+	EXPECT_EQ(result->sizes[3], 16000);
+}
+
+TEST_F(MountTest, LetterAtoDRemapsToDriveNumberWithFsNone)
+{
+	const auto result = Mount("C " + P("bootable.img") + " -fs none");
+
+	ASSERT_TRUE(result.has_value());
+	EXPECT_TRUE(result->is_drive_number);
+
+	EXPECT_EQ(result->drive, '2'); // C -> drive number 2
+	                               //
+	EXPECT_EQ(result->type, "hdd");
+	EXPECT_EQ(result->fstype, "none");
+	EXPECT_EQ(result->mediaid, MediaId::HardDisk);
+
+	EXPECT_EQ(result->sizes[0], 512);
+	EXPECT_EQ(result->sizes[1], 32);
+	EXPECT_EQ(result->sizes[2], 32765);
+	EXPECT_EQ(result->sizes[3], 16000);
+}
+
+// ---------------------------------------------------------------------
+// -t flag aliasing
+// ---------------------------------------------------------------------
+
+TEST_F(MountTest, CdromAliasesToIso)
+{
+	const auto result = Mount("R " + P("image.iso") + " -t cdrom");
+
+	ASSERT_TRUE(result.has_value());
+	EXPECT_EQ(result->type, "iso");
+}
+
+TEST_F(MountTest, FddAliasesToFloppy)
+{
+	const auto result = Mount("B " + P("raw.dat") + " -t fdd");
+
+	ASSERT_TRUE(result.has_value());
+	EXPECT_EQ(result->type, "floppy");
+}
+
+// ---------------------------------------------------------------------
+// -ide flag
+// ---------------------------------------------------------------------
+
+TEST_F(MountTest, IdeFlagSetWithoutInvokingCableSlotLookupForNonIsoType)
+{
+	const auto result = Mount("3 " + P("bootable.img") +
+	                          " -t hdd -size 512,63,16,100 -ide");
+
+	ASSERT_TRUE(result.has_value());
+
+	EXPECT_TRUE(result->is_ide);
+	// ide_index/is_second_cable_slot are only touched by
+	// IDE_Get_Next_Cable_Slot, which the source only calls for -t iso.
+	EXPECT_EQ(result->ide_index, -1);
+	EXPECT_FALSE(result->is_second_cable_slot);
+
+	EXPECT_EQ(result->type, "hdd");
+	EXPECT_EQ(result->fstype, "none");
+	EXPECT_EQ(result->mediaid, MediaId::HardDisk);
+
+	EXPECT_EQ(result->sizes[0], 512);
+	EXPECT_EQ(result->sizes[1], 63);
+	EXPECT_EQ(result->sizes[2], 16);
+	EXPECT_EQ(result->sizes[3], 100);
+}
+
+// ---------------------------------------------------------------------
+// Image-mode path collection (ProcessPaths)
+// ---------------------------------------------------------------------
+
+TEST_F(MountTest, ImplicitImageModeAutoDetectsIsoFromExtension)
+{
+	// No -t given; a plain existing regular file still triggers image
+	// mode, and the ".iso" extension auto-sets type+fstype.
+	const auto result = Mount("S " + P("image.iso"));
+
+	ASSERT_TRUE(result.has_value());
+
+	ASSERT_EQ(result->paths.size(), 1);
+	EXPECT_EQ(result->type, "iso");
+	EXPECT_EQ(result->fstype, "iso");
+}
+
+TEST_F(MountTest, AutoDetectsHddTypeFromImgExtension)
+{
+	const auto result = Mount("U " + P("image.img"));
+
+	ASSERT_TRUE(result.has_value());
+	EXPECT_EQ(result->type, "hdd");
+}
+
+TEST_F(MountTest, ExplicitTypeOverridesExtensionAutoDetection)
+{
+	const auto result = Mount("V " + P("image.img") + " -t iso");
+
+	ASSERT_TRUE(result.has_value());
+	EXPECT_EQ(result->type, "iso");
+}
+
+TEST_F(MountTest, MultipleExplicitPathsArePreservedInOrder)
+{
+	const auto result = Mount("W " + P("disk03.img") + " " + P("disk1.img") +
+	                          " " + P("disk02.img") + " -t floppy");
+
+	ASSERT_TRUE(result.has_value());
+
+	ASSERT_EQ(result->paths.size(), 3);
+	EXPECT_NE(result->paths[0].find("disk03.img"), std::string::npos);
+	EXPECT_NE(result->paths[1].find("disk1.img"), std::string::npos);
+	EXPECT_NE(result->paths[2].find("disk02.img"), std::string::npos);
+}
+
+TEST_F(MountTest, WildcardExpandsToMatchingFileSetUsingNaturalSort)
+{
+	const auto result = Mount("K " + P("disk*.img") + " -t floppy");
+
+	ASSERT_TRUE(result.has_value());
+	ASSERT_EQ(result->paths.size(), 3);
+
+	for (const auto* expected : {"disk1.img", "disk02.img", "disk03.img"}) {
+		const bool found = std::any_of(result->paths.begin(),
+		                               result->paths.end(),
+		                               [&](const std::string& p) {
+			                               return p.find(expected) !=
+			                                      std::string::npos;
+		                               });
+		EXPECT_TRUE(found) << "missing " << expected;
+	}
+}
+
+TEST_F(MountTest, FloppyMediaIdSetWhenTypeFloppyAndFstypeFat)
+{
+	const auto result = Mount("H " + P("raw.dat") + " -t floppy -fs fat");
+
+	ASSERT_TRUE(result.has_value());
+	EXPECT_EQ(result->mediaid, MediaId::Floppy1_44MB);
+}
+
+// ---------------------------------------------------------------------
+// Various edge cases
+// ---------------------------------------------------------------------
+
+TEST_F(MountTest, DirectoryOverridesExplicitFloppyTypeAndSetsFloppyLabel)
+{
+	const auto result = Mount("T " + P("plain_dir") + " -t floppy");
+
+	ASSERT_TRUE(result.has_value());
+	EXPECT_EQ(result->type, "floppy");
+	EXPECT_EQ(result->label, "T_FLOPPY");
+}
+
+TEST_F(MountTest,
+       RawHddDriveNumberMissingGeometrySucceedsAtParseLayerDespiteInternalFailure)
+{
+	// MountImageRaw() internally detects the missing geometry and
+	// returns false, but ProcessPaths() ignores that return value on
+	// every image-mount branch, so ProcessArguments() still returns a
+	// populated MountParameters.
+	const auto result = Mount("2 " + P("raw.dat") + " -t hdd -fs none");
+
+	ASSERT_TRUE(result.has_value());
+
+	EXPECT_EQ(result->sizes[0], 0);
+	EXPECT_EQ(result->sizes[1], 0);
+	EXPECT_EQ(result->sizes[2], 0);
+	EXPECT_EQ(result->sizes[3], 0);
+}
+
+TEST_F(MountTest, ResolvesPathThroughAlreadyMountedDosDrive)
+{
+	// First mount a real directory to a drive letter, then reference
+	// that drive's virtual path as the *source* path for a second
+	// mount, exercising GetDosMappedHostPath's fallback branch in
+	// ProcessPaths (stat on the host fails, so it checks whether the
+	// path maps through an existing Local drive instead).
+	const auto base = Mount("I " + P("plain_dir"));
+	ASSERT_TRUE(base.has_value());
+
+	const auto via_dos_path = Mount("J I:\\");
+	ASSERT_TRUE(via_dos_path.has_value());
+	EXPECT_EQ(via_dos_path->drive, 'J');
+}
+
+TEST_F(MountTest, IdeFlagAsStringValueAlsoSetsIsIde)
+{
+	const auto result = Mount("3 " + P("bootable.img") +
+	                          " -t hdd -size 512,63,16,100 -ide 1");
+	ASSERT_TRUE(result.has_value());
+	EXPECT_TRUE(result->is_ide);
+}
+
+// ---------------------------------------------------------------------
+// Extension-based auto-detection when no -t is given
+// ---------------------------------------------------------------------
+
+TEST_F(MountTest, AutoDetectsIsoFromCueExtension)
+{
+	const auto result = Mount("E " + P("image.cue"));
+
+	ASSERT_TRUE(result.has_value());
+	EXPECT_EQ(result->type, "iso");
+	EXPECT_EQ(result->fstype, "iso");
+}
+
+TEST_F(MountTest, AutoDetectsIsoFromBinExtension)
+{
+	const auto result = Mount("E " + P("image.bin"));
+
+	ASSERT_TRUE(result.has_value());
+	EXPECT_EQ(result->type, "iso");
+	EXPECT_EQ(result->fstype, "iso");
+}
+
+TEST_F(MountTest, AutoDetectsIsoFromMdsExtension)
+{
+	const auto result = Mount("E " + P("image.mds"));
+
+	ASSERT_TRUE(result.has_value());
+	EXPECT_EQ(result->type, "iso");
+	EXPECT_EQ(result->fstype, "iso");
+}
+
+TEST_F(MountTest, AutoDetectsIsoFromCcdExtension)
+{
+	const auto result = Mount("E " + P("image.ccd"));
+
+	ASSERT_TRUE(result.has_value());
+	EXPECT_EQ(result->type, "iso");
+	EXPECT_EQ(result->fstype, "iso");
+}
+
+TEST_F(MountTest, AutoDetectsHddFromImaExtension)
+{
+	const auto result = Mount("E " + P("image.ima"));
+
+	ASSERT_TRUE(result.has_value());
+	EXPECT_EQ(result->type, "hdd");
+	EXPECT_EQ(result->fstype, "fat");
+}
+
+TEST_F(MountTest, AutoDetectsHddFromVhdExtension)
+{
+	const auto result = Mount("F " + P("image.vhd"));
+
+	ASSERT_TRUE(result.has_value());
+	EXPECT_EQ(result->type, "hdd");
+	EXPECT_EQ(result->fstype, "fat");
+}
+
+// ---------------------------------------------------------------------
+// Known-crashing combinations
+// ---------------------------------------------------------------------
+
+/* TODO this test only passes in debug mode; fix this at some point
+
+TEST_F(MountTest, DriveNumberWithExplicitFatFstypeCrashesOnDriveIndex)
+{
+        // MountImageFat() calls drive_index() on params.drive, which is a
+        // digit character ('1') when is_drive_number is true and -fs fat
+        // is given explicitly. drive_index() asserts drive_letter is 'A'-'Z',
+        // so this combination currently aborts the process. Pinning that
+        // behaviour rather than hiding it.
+        EXPECT_DEATH(Mount("1 " + P("bootable.img") +
+                           " -fs fat -t hdd -size 512,63,16,100"),
+                     "drive_letter");
+}
+*/
+
+// ---------------------------------------------------------------------
+// Option precedence
+// ---------------------------------------------------------------------
+
+TEST_F(MountTest, ExplicitSizeOverridesFreesize)
+{
+	const auto result = Mount("X " + P("plain_dir") +
+	                          " -freesize 100 -size 512,63,16,42");
+
+	ASSERT_TRUE(result.has_value());
+
+	EXPECT_EQ(result->type, "dir");
+	EXPECT_EQ(result->fstype, "fat");
+	EXPECT_EQ(result->mediaid, MediaId::HardDisk);
+
+	EXPECT_EQ(result->sizes[0], 512);
+	EXPECT_EQ(result->sizes[1], 63);
+	EXPECT_EQ(result->sizes[2], 16);
+	EXPECT_EQ(result->sizes[3], 42);
+}
+
+TEST_F(MountTest, ChsOverridesFreesize)
+{
+	const auto result = Mount("X " + P("plain_dir") +
+	                          " -freesize 100 -chs 200,16,63");
+
+	ASSERT_TRUE(result.has_value());
+
+	EXPECT_EQ(result->type, "dir");
+	EXPECT_EQ(result->fstype, "fat");
+	EXPECT_EQ(result->mediaid, MediaId::HardDisk);
+
+	EXPECT_EQ(result->sizes[0], 512);
+	EXPECT_EQ(result->sizes[1], 63);
+	EXPECT_EQ(result->sizes[2], 16);
+	EXPECT_EQ(result->sizes[3], 200);
+}
+
+TEST_F(MountTest, ChsOverridesSizeRegardlessOfArgumentOrder)
+{
+	const auto result = Mount("1 " + P("bootable.img") +
+	                          " -chs 200,16,63 -size 512,63,16,50 -t hdd");
+
+	ASSERT_TRUE(result.has_value());
+
+	EXPECT_EQ(result->type, "hdd");
+	EXPECT_EQ(result->fstype, "none");
+	EXPECT_EQ(result->mediaid, MediaId::HardDisk);
+
+	EXPECT_EQ(result->sizes[0], 512);
+	EXPECT_EQ(result->sizes[1], 63);
+	EXPECT_EQ(result->sizes[2], 16);
+	EXPECT_EQ(result->sizes[3], 200);
+}
+
+// ---------------------------------------------------------------------
+// Auto-detection precedence
+// ---------------------------------------------------------------------
+
+TEST_F(MountTest, ExplicitIsoTypeOverridesImgExtension)
+{
+	const auto result = Mount("X " + P("image.img") + " -t iso");
+
+	ASSERT_TRUE(result.has_value());
+
+	EXPECT_EQ(result->type, "iso");
+	EXPECT_EQ(result->fstype, "iso");
+	EXPECT_EQ(result->mediaid, MediaId::HardDisk);
+
+	EXPECT_EQ(result->sizes[0], 2048);
+	EXPECT_EQ(result->sizes[1], 1);
+	EXPECT_EQ(result->sizes[2], 65535);
+	EXPECT_EQ(result->sizes[3], 0);
+}
+
+TEST_F(MountTest, ExplicitHddTypeKeepsFatFilesystem)
+{
+	const auto result = Mount("X " + P("image.iso") +
+	                          " -t hdd -size 512,63,16,100");
+
+	ASSERT_TRUE(result.has_value());
+
+	EXPECT_EQ(result->type, "hdd");
+	EXPECT_EQ(result->fstype, "fat");
+	EXPECT_EQ(result->mediaid, MediaId::HardDisk);
+
+	EXPECT_EQ(result->sizes[0], 512);
+	EXPECT_EQ(result->sizes[1], 63);
+	EXPECT_EQ(result->sizes[2], 16);
+	EXPECT_EQ(result->sizes[3], 100);
+}
+
+// ---------------------------------------------------------------------
+// Explicit -fs interactions
+// ---------------------------------------------------------------------
+
+TEST_F(MountTest, IsoExtensionOverridesExplicitFatFs)
+{
+	const auto result = Mount("X " + P("image.iso") + " -fs fat");
+
+	ASSERT_TRUE(result.has_value());
+
+	EXPECT_EQ(result->type, "iso");
+	EXPECT_EQ(result->fstype, "iso");
+	EXPECT_EQ(result->mediaid, MediaId::HardDisk);
+}
+
+TEST_F(MountTest, IsoTypeRejectsNoneFilesystem)
+{
+	const auto result = Mount("X " + P("image.iso") + " -t iso -fs none");
+
+	EXPECT_FALSE(result.has_value());
+}
+
+// TODO seems wrong; should be rejected
+TEST_F(MountTest, ExplicitIsoFsIsPreservedForFloppyType)
+{
+	const auto result = Mount("A " + P("raw.dat") + " -t floppy -fs iso");
+
+	ASSERT_TRUE(result.has_value());
+
+	EXPECT_EQ(result->type, "floppy");
+	EXPECT_EQ(result->fstype, "iso");
+
+	// MediaId promotion only happens for floppy+fat.
+	EXPECT_EQ(result->mediaid, MediaId::Floppy1_44MB);
+}
+
+TEST_F(MountTest, ExplicitIsoTypeOverridesFloppyExtension)
+{
+	const auto result = Mount("D " + P("bootable.img") + " -t iso");
+
+	ASSERT_TRUE(result.has_value());
+
+	EXPECT_EQ(result->type, "iso");
+	EXPECT_EQ(result->fstype, "iso");
+	EXPECT_EQ(result->mediaid, MediaId::HardDisk);
+
+	EXPECT_EQ(result->sizes[0], 2048);
+	EXPECT_EQ(result->sizes[1], 1);
+	EXPECT_EQ(result->sizes[2], 65535);
+	EXPECT_EQ(result->sizes[3], 0);
+}
+
+TEST_F(MountTest, ExplicitFloppyTypeOverridesIsoExtension)
+{
+	const auto result = Mount("A " + P("image.iso") + " -t floppy");
+
+	ASSERT_TRUE(result.has_value());
+
+	EXPECT_EQ(result->type, "floppy");
+	EXPECT_EQ(result->fstype, "fat");
+
+	// Pin down whatever the parser currently does.
+	EXPECT_EQ(result->mediaid, MediaId::Floppy1_44MB);
+}
+
+TEST_F(MountTest, ExplicitIsoFilesystemWithoutType)
+{
+	const auto result = Mount("D " + P("bootable.img") + " -fs iso");
+
+	ASSERT_TRUE(result.has_value());
+
+	EXPECT_EQ(result->type, "hdd");
+	EXPECT_EQ(result->fstype, "iso");
+	EXPECT_EQ(result->mediaid, MediaId::HardDisk);
+}
+
+TEST_F(MountTest, ExplicitFatFilesystemWithoutType)
+{
+	const auto result = Mount("D " + P("bootable.img") + " -fs fat");
+
+	ASSERT_TRUE(result.has_value());
+
+	EXPECT_EQ(result->type, "hdd");
+	EXPECT_EQ(result->fstype, "fat");
+	EXPECT_EQ(result->mediaid, MediaId::HardDisk);
+}
+
+TEST_F(MountTest, ExplicitIsoFilesystemOnIsoImage)
+{
+	const auto result = Mount("D " + P("image.iso") + " -fs iso");
+
+	ASSERT_TRUE(result.has_value());
+
+	EXPECT_EQ(result->type, "iso");
+	EXPECT_EQ(result->fstype, "iso");
+	EXPECT_EQ(result->mediaid, MediaId::HardDisk);
+}
+
+// ---------------------------------------------------------------------
+// Image geometry oddities
+// ---------------------------------------------------------------------
+
+TEST_F(MountTest, SizeAcceptedForIsoMount)
+{
+	const auto result = Mount("X " + P("image.iso") + " -t iso -size 512,63,16,99");
+
+	ASSERT_TRUE(result.has_value());
+
+	EXPECT_EQ(result->type, "iso");
+	EXPECT_EQ(result->fstype, "iso");
+	EXPECT_EQ(result->mediaid, MediaId::HardDisk);
+
+	EXPECT_EQ(result->sizes[0], 512);
+	EXPECT_EQ(result->sizes[1], 63);
+	EXPECT_EQ(result->sizes[2], 16);
+	EXPECT_EQ(result->sizes[3], 99);
+}
+
+TEST_F(MountTest, ChsAcceptedForIsoMount)
+{
+	const auto result = Mount("X " + P("image.iso") + " -t iso -chs 123,8,17");
+
+	ASSERT_TRUE(result.has_value());
+
+	EXPECT_EQ(result->type, "iso");
+	EXPECT_EQ(result->fstype, "iso");
+	EXPECT_EQ(result->mediaid, MediaId::HardDisk);
+
+	EXPECT_EQ(result->sizes[0], 512);
+	EXPECT_EQ(result->sizes[1], 17);
+	EXPECT_EQ(result->sizes[2], 8);
+	EXPECT_EQ(result->sizes[3], 123);
+}
+
+TEST_F(MountTest, FreesizeMutatesGeometryForImageMount)
+{
+	const auto result = Mount("1 " + P("bootable.img") + " -t hdd -freesize 50");
+
+	ASSERT_TRUE(result.has_value());
+
+	EXPECT_NE(result->sizes[3], 0);
+}
+
+// ---------------------------------------------------------------------
+// Multiple image behaviour
+// ---------------------------------------------------------------------
+
+TEST_F(MountTest, FirstImageControlsAutoDetection)
+{
+	const auto result = Mount("X " + P("image.img") + " " + P("image.iso"));
+
+	ASSERT_TRUE(result.has_value());
+
+	EXPECT_EQ(result->type, "hdd");
+	EXPECT_EQ(result->fstype, "fat");
+	EXPECT_EQ(result->mediaid, MediaId::HardDisk);
+
+	ASSERT_EQ(result->paths.size(), 2);
+}
+
+TEST_F(MountTest, FirstImageControlsAutoDetectionReverseOrder)
+{
+	const auto result = Mount("X " + P("image.iso") + " " + P("image.img"));
+
+	ASSERT_TRUE(result.has_value());
+
+	EXPECT_EQ(result->type, "iso");
+	EXPECT_EQ(result->fstype, "iso");
+	EXPECT_EQ(result->mediaid, MediaId::HardDisk);
+
+	ASSERT_EQ(result->paths.size(), 2);
+}
+
+TEST_F(MountTest, FirstIsoImageControlsAutoDetection)
+{
+	const auto result = Mount("D " + P("image.iso") + " " + P("bootable.img"));
+
+	ASSERT_TRUE(result.has_value());
+
+	EXPECT_EQ(result->type, "iso");
+	EXPECT_EQ(result->fstype, "iso");
+	EXPECT_EQ(result->mediaid, MediaId::HardDisk);
+
+	ASSERT_EQ(result->paths.size(), 2);
+}
+
+// ---------------------------------------------------------------------
+// IDE interactions
+// ---------------------------------------------------------------------
+
+TEST_F(MountTest, IdeFlagDoesNotAllocateControllerForNonIsoType)
+{
+	const auto result = Mount("D " + P("bootable.img") +
+	                          " -t hdd -fs iso -ide -size 512,63,16,100");
+
+	ASSERT_TRUE(result.has_value());
+
+	EXPECT_EQ(result->type, "hdd");
+	EXPECT_EQ(result->fstype, "iso");
+	EXPECT_EQ(result->mediaid, MediaId::HardDisk);
+
+	EXPECT_TRUE(result->is_ide);
+	EXPECT_EQ(result->ide_index, -1);
+	EXPECT_FALSE(result->is_second_cable_slot);
+}
+
+// ---------------------------------------------------------------------
+// Geometry precedence with ISO images
+// ---------------------------------------------------------------------
+
+TEST_F(MountTest, ExplicitSizeWithIsoImage)
+{
+	const auto result = Mount("D " + P("image.iso") + " -size 512,63,16,99");
+
+	ASSERT_TRUE(result.has_value());
+
+	EXPECT_EQ(result->type, "iso");
+	EXPECT_EQ(result->fstype, "iso");
+	EXPECT_EQ(result->mediaid, MediaId::HardDisk);
+
+	// Pin down whether ISO defaults or explicit size wins.
+}
+
+TEST_F(MountTest, ExplicitChsWithIsoImage)
+{
+	const auto result = Mount("D " + P("image.iso") + " -chs 123,8,17");
+
+	ASSERT_TRUE(result.has_value());
+
+	EXPECT_EQ(result->type, "iso");
+	EXPECT_EQ(result->fstype, "iso");
+}
+
+// ---------------------------------------------------------------------
+// Miscellaneous parser state
+// ---------------------------------------------------------------------
+
+TEST_F(MountTest, LabelPreservedForIsoMount)
+{
+	const auto result = Mount("D " + P("image.iso") + " -label MYDISC");
+
+	ASSERT_TRUE(result.has_value());
+
+	EXPECT_EQ(result->label, "MYDISC");
+}
+
+TEST_F(MountTest, ReadOnlyPreservedForIsoMount)
+{
+	const auto result = Mount("D " + P("image.iso") + " -ro");
+
+	ASSERT_TRUE(result.has_value());
+
+	EXPECT_TRUE(result->roflag);
+}
+
+TEST_F(MountTest, ReadOnlyPreservedForDirectoryMount)
+{
+	const auto result = Mount("D " + P("plain_dir") + " -ro");
+
+	ASSERT_TRUE(result.has_value());
+
+	EXPECT_TRUE(result->roflag);
+}
+
+// ---------------------------------------------------------------------
+// Duplicate option precedence
+// ---------------------------------------------------------------------
+
+TEST_F(MountTest, DuplicateLabelFirstWins)
+{
+	const auto result = Mount("X " + P("image.img") +
+	                          " -label FIRST"
+	                          " -label SECOND");
+
+	ASSERT_TRUE(result.has_value());
+
+	EXPECT_EQ(result->label, "FIRST");
+}
+
+TEST_F(MountTest, DuplicateSizeFirstWins)
+{
+	const auto result = Mount("X " + P("image.img") +
+	                          " -size 1,2,3,4"
+	                          " -size 5,6,7,8");
+
+	ASSERT_TRUE(result.has_value());
+
+	EXPECT_EQ(result->sizes[0], 1);
+	EXPECT_EQ(result->sizes[1], 2);
+	EXPECT_EQ(result->sizes[2], 3);
+	EXPECT_EQ(result->sizes[3], 4);
+}
+
+TEST_F(MountTest, DuplicateChsFirstWins)
+{
+	const auto result = Mount("X " + P("image.img") +
+	                          " -chs 100,17,8"
+	                          " -chs 200,63,16");
+
+	ASSERT_TRUE(result.has_value());
+
+	// CHS is normalized into the size array:
+	// sector size, sectors/track, heads, cylinders.
+	EXPECT_EQ(result->sizes[0], 512);
+	EXPECT_EQ(result->sizes[1], 8);
+	EXPECT_EQ(result->sizes[2], 17);
+	EXPECT_EQ(result->sizes[3], 100);
+}
+
+TEST_F(MountTest, DuplicateFilesystemFirstWins)
+{
+	const auto result = Mount("X " + P("image.img") +
+	                          " -fs fat"
+	                          " -fs iso");
+
+	ASSERT_TRUE(result.has_value());
+
+	EXPECT_EQ(result->fstype, "fat");
+}
+
+TEST_F(MountTest, DuplicateTypeFirstWins)
+{
+	const auto result = Mount("X " + P("image.img") +
+	                          " -t floppy"
+	                          " -t iso");
+
+	ASSERT_TRUE(result.has_value());
+
+	EXPECT_EQ(result->type, "floppy");
+	EXPECT_EQ(result->fstype, "fat");
+	EXPECT_EQ(result->mediaid, MediaId::Floppy1_44MB);
+}
+
+} // namespace

--- a/tests/shell_cmds_tests.cpp
+++ b/tests/shell_cmds_tests.cpp
@@ -1,23 +1,6 @@
 // SPDX-FileCopyrightText:  2020-2026 The DOSBox Staging Team
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-/* This sample shows how to write a simple unit test for dosbox-staging using
- * Google C++ testing framework.
- *
- * Read Google Test Primer for reference of most available features, macros,
- * and guidance about writing unit tests:
- *
- * https://github.com/google/googletest/blob/master/googletest/docs/primer.md#googletest-primer
- */
-
-/* Include necessary header files; order of headers should be as follows:
- *
- * 1. Header declaring functions/classes being tested
- * 2. <gtest/gtest.h>, which declares the testing framework
- * 3. Additional system headers (if needed)
- * 4. Additional dosbox-staging headers (if needed)
- */
-
 #include "shell/shell.h"
 
 #include <string>

--- a/tests/shell_redirection_tests.cpp
+++ b/tests/shell_redirection_tests.cpp
@@ -1,23 +1,6 @@
 // SPDX-FileCopyrightText:  2020-2025 The DOSBox Staging Team
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-/* This sample shows how to write a simple unit test for dosbox-staging using
- * Google C++ testing framework.
- *
- * Read Google Test Primer for reference of most available features, macros,
- * and guidance about writing unit tests:
- *
- * https://github.com/google/googletest/blob/master/googletest/docs/primer.md#googletest-primer
- */
-
-/* Include necessary header files; order of headers should be as follows:
- *
- * 1. Header declaring functions/classes being tested
- * 2. <gtest/gtest.h>, which declares the testing framework
- * 3. Additional system headers (if needed)
- * 4. Additional dosbox-staging headers (if needed)
- */
-
 #include "shell/shell.h"
 
 #include <string>


### PR DESCRIPTION
# Description

Booting into real MS-DOS from a HDD image works fine in 0.82.2 with the following config:

```ini
[autoexec]
imgmount c c_drive.img
boot -l c
```

But it does not in 0.83-RC1:

<img width="854" height="276" alt="image" src="https://github.com/user-attachments/assets/f957be3c-50bd-4eea-b940-ef0c33f8d6ab" />

It turns out that's because during the MOUNT & IMGMOUNT merging exercise we have introduced some subtle regressions to the file extension based mount type auto-detection logic. The above example works if I specify the type explicitly with `-t hdd` (so `imgmount c c_drive.img -t hdd`).

After this fix, we're back in business with the above config:

<img width="850" height="206" alt="image" src="https://github.com/user-attachments/assets/57f246a3-5af8-4c3b-ac28-c126569c7271" />

As always, I got a lot more than what I bargained for — the mount implementation is a mess, so I started untangling it, but it's a big job, and I introduced _more_ bugs in the process. So I switched gears and started adding comprehensive unit tests to pin down the behaviour, and I'm only including this rather minimal regression fix here. 

Probably half of those tests pin down bugs — the idea is as we improve things, we'll update the tests (re-pin them). Many things are broken, e.g. extension based mount type detection, but the good news is they seem to be broken in 0.82.2 too... 😆 Job for later in the 0.84 timeframe, and specifying explicit types with `-t` seems to work fine.

## Related issues

- https://github.com/dosbox-staging/dosbox-staging/pull/4683

## Release notes

None, 0.83 regression

# Manual testing

- Booting into real MS-DOS from a HDD image works with all the belong IMGMOUNT/MOUNT variations:

	```ini
	[autoexec]
	imgmount c c_drive.img
	#imgmount c c_drive.img -t hdd
	#mount c c_drive.img
	#mount c c_drive.img -t hdd
	boot -l c
	```

- The following result in various errors:

	```
	mount c c_drive.img -t iso
	mount c c_drive.img -t floppy
	mount c c_drive.img -t overlay
	mount c c_drive.img -t asdf
	mount c c_drive.img -t
	```

- Automounting `drives/c` empty folder and with content works.

- **King's Quest I** (PCjr booter version)
  - `boot floppy/disk.img` works

- **Azrael's Tear** (BIN/CUE automount, no CD audio tracks)

- **Warcraft II** (IMG/CUE automount, has CD audio tracks)
  - CD audio plays

- **11th Hour** (4 CD BIN/CUE images automounted as D:, no audio tracks)
  - Cmd+F4 disk switching works
  - MOUNT command lists the 4 images mounted as D:
  - Volume label is correct
  - Game works
  - Also tested with `MOUNT D cd/*.cue -t iso`
  - `MOUNT D cd/*.cue` **without** `-t iso` does not work -- _broken in 0.82.2 too; will fix on 0.84.0 later_

- **The Secret of Monkey Island** (BIN/CUE, manual mount, has CD audio tracks)
  - CD audio plays
  - Also tested with IMGMOUNT, MOUNT, with and without `-t iso`

- **Realms of the Haunting** (4 ISOs automounted as D:, E:, F:, and G:)
  - MOUNT command lists the 4 images mounted as D:, E:, F: and G:
  - Volume labels are correct (ROTH1 - ROTH4)
  - Game works
  - Also tested with IMGMOUNT, MOUNT; works with `-t iso`, but doesn't work without it -- _broken in 0.82.2 too; will fix on 0.84.0 later_

## Summary of pre-existing bugs (also present in 0.82.2)

- `MOUNT D blah.iso` does NOT work without `-t iso`
- But `MOUNT D blah.cue` DOES work without `-t iso` (so it seems for `.iso` files autodetection works, but not for `.cue` files)
- Wildcard mounts are consistently broken without `-t iso`, e.g. `MOUNT D *.cue`

The change has been manually tested on:

- [ ] Windows
- [x] macOS
- [ ] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

- [x] I am a human, I have read and understood the [project's policy on the use of generative AI tools](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md#policy-on-the-use-of-generative-ai-tools), and I have acted in accordance to it.

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my work (especially important for AI-assisted contributions).
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [x] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

