### PR TITLE
Bump vcpkg baseline & fix failing CI actions

### DIFF
--- a/.github/actions/setup-vcpkg/action.yml
+++ b/.github/actions/setup-vcpkg/action.yml
@@ -46,13 +46,25 @@ runs:
         $baseline = (Get-Content .\vcpkg.json | ConvertFrom-Json)."builtin-baseline"
         Write-Output "DOSBOX_VCPKG_BASELINE=${baseline}" >> $Env:GITHUB_ENV
 
-    - name: Checkout VCPKG to baseline
+    - name: Create vcpkg downloads directory
+      shell: bash
+      run: mkdir -p "${VCPKG_DOWNLOADS}"
+
+    - name: Checkout vcpkg to baseline
       shell: bash
       run: |
         cd "${VCPKG_ROOT}"
         git reset --hard
         git fetch
         git checkout "$DOSBOX_VCPKG_BASELINE"
+
+    - name: Bootstrap vcpkg
+      shell: bash
+      run: "${VCPKG_ROOT}/bootstrap-vcpkg.sh"
+
+    - name: Print vcpkg version
+      shell: bash
+      run: "${VCPKG_ROOT}/vcpkg version"
 
     - name: Get vcpkg commit
       shell: bash
@@ -102,18 +114,6 @@ runs:
       with:
         path: ${{ env.VCPKG_DOWNLOADS }}
         key:  ${{ steps.vcpkg_downloads_cache_key.outputs.cacheKey }}
-
-    - name: Create downloads cache directory
-      if: ${{ steps.vcpkg_downloads_cache.outputs.cache-hit != 'true' && runner.os != 'Windows'}}
-      shell: bash
-      run: |
-        mkdir -p "${VCPKG_DOWNLOADS}"
-
-    - name: Create downloads cache directory (Windows)
-      if: ${{ steps.vcpkg_downloads_cache.outputs.cache-hit != 'true' && runner.os == 'Windows'}}
-      shell: pwsh
-      run: |
-        New-Item -Path "${Env:VCPKG_DOWNLOADS}" -ItemType Directory -Force
 
     # 'true' = cache hit; 'false' = miss.
     - name:  Report vcpkg cache status

--- a/.github/actions/setup-vcpkg/action.yml
+++ b/.github/actions/setup-vcpkg/action.yml
@@ -28,23 +28,21 @@ runs:
     # - vcpkg_bin_cache: compiled output cache
     #
     - name: Set vcpkg env variables
-      if: ${{ runner.os != 'Windows'}}
       shell: bash
       run: |
-        echo "VCPKG_ROOT=${VCPKG_INSTALLATION_ROOT}" >> $GITHUB_ENV
-        echo "VCPKG_DOWNLOADS=${{ github.workspace }}/vcpkg_downloads" >> $GITHUB_ENV
-        echo "VCPKG_DEFAULT_BINARY_CACHE=${{ github.workspace }}/vcpkg_bin_cache" >> $GITHUB_ENV
-        echo "DOSBOX_VCPKG_BASELINE=$(jq -r .\"builtin-baseline\" ./vcpkg.json)" >> $GITHUB_ENV
-
-    - name: Set vcpkg cache env variable (Windows)
-      if: ${{ runner.os == 'Windows'}}
-      shell: pwsh
-      run: |
-        Write-Output "VCPKG_ROOT=$Env:VCPKG_INSTALLATION_ROOT" >> $Env:GITHUB_ENV
-        Write-Output "VCPKG_DOWNLOADS=C:\vcpkg_downloads" >> $Env:GITHUB_ENV
-        Write-Output "VCPKG_DEFAULT_BINARY_CACHE=C:\vcpkg_bin_cache" >> $Env:GITHUB_ENV
-        $baseline = (Get-Content .\vcpkg.json | ConvertFrom-Json)."builtin-baseline"
-        Write-Output "DOSBOX_VCPKG_BASELINE=${baseline}" >> $Env:GITHUB_ENV
+        echo "VCPKG_ROOT=${VCPKG_INSTALLATION_ROOT}" >> "$GITHUB_ENV"
+        if [ "$RUNNER_OS" = "Windows" ]; then
+          # Short, drive-root paths to stay under Windows' MAX_PATH limit --
+          # vcpkg build trees nest deeply.
+          echo "VCPKG_DOWNLOADS=C:\\vcpkg_downloads" >> "$GITHUB_ENV"
+          echo "VCPKG_DEFAULT_BINARY_CACHE=C:\\vcpkg_bin_cache" >> "$GITHUB_ENV"
+          echo "VCPKG_EXE=${VCPKG_INSTALLATION_ROOT}/vcpkg.exe" >> "$GITHUB_ENV"
+        else
+          echo "VCPKG_DOWNLOADS=${{ github.workspace }}/vcpkg_downloads" >> "$GITHUB_ENV"
+          echo "VCPKG_DEFAULT_BINARY_CACHE=${{ github.workspace }}/vcpkg_bin_cache" >> "$GITHUB_ENV"
+          echo "VCPKG_EXE=${VCPKG_INSTALLATION_ROOT}/vcpkg" >> "$GITHUB_ENV"
+        fi
+        echo "DOSBOX_VCPKG_BASELINE=$(jq -r .\"builtin-baseline\" ./vcpkg.json)" >> "$GITHUB_ENV"
 
     - name: Create vcpkg downloads directory
       shell: bash
@@ -88,16 +86,9 @@ runs:
         key:  ${{ steps.vcpkg_bin_cache_key.outputs.cacheKey }}
 
     - name: Create binary cache directory
-      if: ${{ steps.vcpkg_bin_cache.outputs.cache-hit != 'true' && runner.os != 'Windows'}}
+      if: ${{ steps.vcpkg_bin_cache.outputs.cache-hit != 'true' }}
       shell: bash
-      run: |
-        mkdir "${VCPKG_DEFAULT_BINARY_CACHE}"
-
-    - name: Create binary cache directory (Windows)
-      if: ${{ steps.vcpkg_bin_cache.outputs.cache-hit != 'true' && runner.os == 'Windows'}}
-      shell: pwsh
-      run: |
-        New-Item -Path "${Env:VCPKG_DEFAULT_BINARY_CACHE}" -ItemType Directory
+      run: mkdir -p "${VCPKG_DEFAULT_BINARY_CACHE}"
 
     # Per-OS key: downloads/tools/ has platform-specific binaries.
     # Compiler/ImageVersion are intentionally omitted -- tarballs are

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -49,6 +49,7 @@ jobs:
       - name: Install markdownlint
         run: |
           ruby --version
+          sudo gem install uri
           sudo gem install mdl
 
       - name: Run markdownlint

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -34,5 +34,5 @@
       "host": true
     }
   ],
-  "builtin-baseline": "10ceb139a610ebf3c6aa49cdc4a4b7f3db5d3f2b"
+  "builtin-baseline": "9e593bb18ea69cc5095e012465dcd675a822ed0d"
 }


### PR DESCRIPTION

# Description

Also fixing some vcpkg CI setup issues that the baseline bump highlighted (I was getting errors after the bump as vcpkg _itself_ also had to be updated).

`markdownlint` also broke — see the last commit for details.

Library upgrades:

```
- fluidsynth  2.5.4 -> 2.5.5
- gtest       1.17.0#2 -> 1.17.0#3
- libmt32emu  2.8.2#1 -> 2.8.3
- pkgconf     2.5.1#4 -> 3.0.3
- sdl3        3.4.10#1 -> 3.4.12
- sdl3-image  3.4.4 -> 3.4.4#1
```

# Manual testing

Staging started up on macOS, SDL 3.4.12 version was logged.

The change has been manually tested on:

- [ ] Windows
- [x] macOS
- [ ] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

- [x] I am a human, I have read and understood the [project's policy on the use of generative AI tools](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md#policy-on-the-use-of-generative-ai-tools), and I have acted in accordance to it.

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my work (especially important for AI-assisted contributions).
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

