### PR TITLE
Remove weird stdout & stderr redirection to a file on Windows

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -469,39 +469,6 @@ static void handle_cli_set_commands(const std::vector<std::string>& set_args)
 	}
 }
 
-#if defined(WIN32) && !(C_DEBUGGER)
-static void apply_windows_debugger_workaround(const bool is_console_disabled)
-{
-	// Can't disable the console with debugger enabled
-	if (is_console_disabled) {
-		FreeConsole();
-		// Redirect standard input and standard output
-		//
-		if (freopen(STDOUT_FILE, "w", stdout) == NULL) {
-			// No stdout so don't write messages
-			no_stdout = true;
-		}
-		freopen(STDERR_FILE, "w", stderr);
-
-		// Line buffered
-		setvbuf(stdout, NULL, _IOLBF, BUFSIZ);
-		// No buffering
-		setvbuf(stderr, NULL, _IONBF, BUFSIZ);
-
-	} else {
-		if (AllocConsole()) {
-			fclose(stdin);
-			fclose(stdout);
-			fclose(stderr);
-			freopen("CONIN$", "r", stdin);
-			freopen("CONOUT$", "w", stdout);
-			freopen("CONOUT$", "w", stderr);
-		}
-		SetConsoleTitle("DOSBox Status Window");
-	}
-}
-#endif
-
 static void maybe_create_resource_directories()
 {
 	auto try_create_resource_dir = [](std_fs::path const& dir) {
@@ -663,10 +630,6 @@ int main(int argc, char* argv[])
 			// Exit to the command line
 			return *return_code;
 		}
-
-#if defined(WIN32) && !(C_DEBUGGER)
-		apply_windows_debugger_workaround(arguments->noconsole);
-#endif
 
 #if defined(WIN32)
 		SetConsoleCtrlHandler((PHANDLER_ROUTINE)console_event_handler, TRUE);


### PR DESCRIPTION
# Description

This doesn't seem to serve any useful purpose, and it doesn't seem to have much to do with the debugger. Probably some old stale code.

Removing this fixes a crash on Windows when Staging is installed to Program Files (so we don't have write access to the program folder), the console window is disabled, AND some library writes to stderr/stdout.

## Related issues

- Fixes https://github.com/dosbox-staging/dosbox-staging/issues/4974


# Release notes

Not worth mentioning.

# Manual testing

None.

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [ ] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

- [x] I am a human, I have read and understood the [project's policy on the use of generative AI tools](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md#policy-on-the-use-of-generative-ai-tools), and I have acted in accordance to it.

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my work (especially important for AI-assisted contributions).
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

