### PR TITLE
Adjust default GUS channel mixer volume

### DIFF
--- a/src/hardware/audio/gus.cpp
+++ b/src/hardware/audio/gus.cpp
@@ -5,6 +5,7 @@
 #include "private/gus.h"
 
 #include <array>
+#include <cmath>
 #include <iomanip>
 #include <memory>
 #include <string>
@@ -380,7 +381,9 @@ Gus::Gus(const io_port_t port_pref, const uint8_t dma_pref, const uint8_t irq_pr
 	// GUS is prone to accumulating beyond the 16-bit range so we scale back
 	// by RMS.
 	constexpr auto rms_squared = static_cast<float>(M_SQRT1_2);
+	constexpr auto default_gain = 1.0f / rms_squared;
 	channel->Set0dbScalar(rms_squared);
+	channel->SetUserVolume({default_gain, default_gain});
 
 	SetFilter(filter_prefs);
 


### PR DESCRIPTION
# Description
As pointed out by @GranMinigun, default GUS volume is noticeably lower than SB. This is due to an across-the-board gain attenuation to mitigate sample values that exceed the 16-bit max.

This minimal change boosts the GUS mixer channel default volume to compensate.

# Release notes
(Need anything here @johnnovak?)

# Manual testing
Future Crew Unreal:

dBSPL average (iOS dB meter app):
branch: 64.7 (SB), 65.1 (GUS)
main: 64.8 (SB), 62.2 (GUS)

The change has been manually tested on:

- [ ] Windows
- [x] macOS
- [ ] Linux


# Checklist

- [x] I am a human, I have read and understood the [project's policy on the use of generative AI tools](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md#policy-on-the-use-of-generative-ai-tools), and I have acted in accordance to it.

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my work (especially important for AI-assisted contributions).
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

