### PR TITLE
Use default unity gain for GUS audio samples

### DIFF
--- a/src/hardware/audio/gus.cpp
+++ b/src/hardware/audio/gus.cpp
@@ -377,11 +377,6 @@ Gus::Gus(const io_port_t port_pref, const uint8_t dma_pref, const uint8_t irq_pr
 	channel->SetResampleMethod(ResampleMethod::ZeroOrderHoldAndResample);
 	channel->SetZeroOrderHoldUpsamplerTargetRate(GusOutputSampleRate);
 
-	// GUS is prone to accumulating beyond the 16-bit range so we scale back
-	// by RMS.
-	constexpr auto rms_squared = static_cast<float>(M_SQRT1_2);
-	channel->Set0dbScalar(rms_squared);
-
 	SetFilter(filter_prefs);
 
 	ms_per_render = MillisInSecond / channel->GetSampleRate();


### PR DESCRIPTION
# Description

@johnnovak did some deep investigation and the `rms_squared` gain was incorrect for the GUS channel. This PR reverts to default hardware-correct unity gain.

# Release notes
## Authentic Gravis Ultrasound output volume emulation

Previously, the Gravis Ultrasound's master output volume was scaled down as more hardware channels became active, to reduce the risk of clipping. This wasn't accurate to real hardware: the GUS simply sums all mixer channel outputs into a 16-bit accumulator, and clipping prevention is left to the composer or programmer --- some even drove output into clipping deliberately, as an artistic choice, for a harder sound. Note also that minor clipping is often barely audible.

We've removed this scaling, making the output louder and more consistent across programs. Leave the `GUS` mixer channel volume at 100 for authentic clipping behavior, and turn down the `MASTER` channel if it's too loud. Alternatively, lower the `GUS` channel's volume for more headroom, though this might yield less authentic results --- the choice is yours.

# Manual testing

Ran Future Crew Unreal and Second Reality with GUS vs. SB compared using a dB SPL meter iOS app. GUS now has parity with SB.

The change has been manually tested on:

- [ ] Windows
- [x] macOS
- [ ] Linux


# Checklist

- [x] I am a human, I have read and understood the [project's policy on the use of generative AI tools](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md#policy-on-the-use-of-generative-ai-tools), and I have acted in accordance to it.

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my work (especially important for AI-assisted contributions).
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [x] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

