### PR TITLE
Fix cycles display in the window's titlebar for "unreal mode" programs

### DIFF
--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -250,8 +250,6 @@ static void set_modern_cycles_config(const CpuMode mode)
 	}
 }
 
-static bool is_protected_mode_program = false;
-
 void CPU_RestoreRealModeCyclesConfig()
 {
 	if (cpu.pmode || (!last_auto_determine_mode.auto_core &&
@@ -272,7 +270,6 @@ void CPU_RestoreRealModeCyclesConfig()
 			set_modern_cycles_config(CpuMode::Real);
 		}
 
-		is_protected_mode_program = false;
 		TITLEBAR_NotifyCyclesChanged();
 	}
 #if C_DYNAMIC_X86 || C_DYNREC
@@ -2175,12 +2172,12 @@ void CPU_SET_CRX(Bitu cr, Bitu value)
 			LOG(LOG_CPU, LOG_NORMAL)("Protected mode");
 			PAGING_Enable((value & CR0_PAGING) > 0);
 
+			TITLEBAR_NotifyCyclesChanged();
+
 			if (!auto_determine_mode.auto_core &&
 			    !auto_determine_mode.auto_cycles) {
 				break;
 			}
-
-			is_protected_mode_program = true;
 
 #if C_DYNAMIC_X86
 			if (auto_determine_mode.auto_core) {
@@ -2226,6 +2223,8 @@ void CPU_SET_CRX(Bitu cr, Bitu value)
 
 			PAGING_Enable(false);
 			LOG(LOG_CPU, LOG_NORMAL)("Real mode");
+
+			TITLEBAR_NotifyCyclesChanged();
 		}
 		break;
 	}
@@ -3136,7 +3135,7 @@ std::string CPU_GetCyclesConfigAsString()
 			}
 		};
 
-		if (is_protected_mode_program) {
+		if (cpu.pmode) {
 			if (conf.protected_mode_auto) {
 				// 'cpu_cycles' controls both real and protected
 				// mode


### PR DESCRIPTION
# Description

Replaces the earlier version of this PR that switched the titlebar display to the live `cpu.pmode` state and notified the titlebar on every CR0 PE transition in `CPU_SET_CRX()`. Testing showed the demo [Sunflower](https://www.pouet.net/prod.php?which=85) that rapidly alternates between real and protected mode for its entire runtime became unusable: the title string rapidly alternated between the two cycles values.

The original problem that the revised PR fixes (now correctly): the demo [no! by NoooN](https://www.pouet.net/prod.php?which=1159) showing the protected mode cycles value, but the value not changing when using the cycles increase/decrease hotkeys.

## Revised fix

In modern cycles mode, the titlebar cycles display derived the real/protected mode decision from a separately maintained flag (`is_protected_mode_program`) while the cycles hotkeys derived it from the live `cpu.pmode` state. Both could disagree with the cycles config _actually_ in effect, which is latched: it is applied on the first protected mode entry and only restored on program exit, surviving temporary switches back to real mode. As it turns out both mechanisms were wrong for modern cycles mode as they diverged from the legacy behaviour (note we only wanted to change how cycles is _configured_, **not** the pmode/realmode cycles behaviour!)

The old `cycles` setting always used this latch semantics, which has an interesting side effect: "unreal mode" programs (typically demos) that start in protected mode then switch back to real mode and stay there for the entire duration of the program (e.g. the demo [no! by NoooN](https://www.pouet.net/prod.php?which=1159)) effectively use the protected mode cycles settings as that's what gets latched at startup. This is a known original DOSBox quirk and it's fine; we don't want to change as it might have unintended consequences for programs that switch between real and pmode in various ways during runtime. Not worth messing around with it for the sake of a few demos.

The proper fix is to track the mode whose cycles config was last applied in `set_modern_cycles_config()` and derive both the titlebar display and the hotkeys from it. This mirrors the latch semantics of the legacy cycles mode, where both are derived from the effective config ('CPU_CycleAutoAdjust'), and guarantees the displayed and adjusted values always match the config in effect.

# Manual testing

- [no! by NoooN](https://www.pouet.net/prod.php?which=1159) — "unreal mode" demo (real mode demo with protected mode "excursions" at startup): after the startup excursion, the protected mode config is latched in and governs the demo's speed. Cycles increase/decrease hotkeys correctly adjust the protected mode cycles value shown in the titlebar, and the demo slows down/speeds up accordingly.

- [Sunflower](https://www.pouet.net/prod.php?which=85)  — protected mode demo that rapidly alternates between real and protected mode for its entire runtime (probably when dealing with XMS memory via real mode calls). The titlebar correctly shown the protected mode cycles value, cycles increase/decrease hotkeys correctly adjust the this value, and the demo slows down/speeds up accordingly.

The change has been manually tested on:

- [ ] Windows
- [x] macOS
- [ ] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

- [x] I am a human, I have read and understood the [project's policy on the use of generative AI tools](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md#policy-on-the-use-of-generative-ai-tools), and I have acted in accordance to it.

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my work (especially important for AI-assisted contributions).
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [x] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cycle configuration is now preserved when switching into or out of protected mode.
  * Modern cycle hotkeys and status displays consistently reflect the currently selected cycle configuration.
  * Cycle settings no longer unexpectedly change or become inconsistent during protected-mode transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->