### PR TITLE
Use `MountType` as backing field for automount parameters type

### DIFF
--- a/src/dos/CMakeLists.txt
+++ b/src/dos/CMakeLists.txt
@@ -25,6 +25,7 @@ target_sources(libdosboxcommon PRIVATE
   drive_overlay.cpp
   drive_virtual.cpp
   drives.cpp
+  mount.cpp
   programs.cpp
 
   programs/attrib.cpp

--- a/src/dos/mount.cpp
+++ b/src/dos/mount.cpp
@@ -1,0 +1,39 @@
+#include "dos/mount.h"
+#include "misc/support.h"
+
+#include <optional>
+#include <string>
+
+std::string to_string(const MountType& mount_type)
+{
+	switch (mount_type) {
+	case MountType::Directory: return "dir";
+	case MountType::Overlay: return "overlay";
+	case MountType::FloppyImage: return "floppy";
+	case MountType::CdRomImage: return "iso";
+	case MountType::HardDiskImage: return "hdd";
+	default: assertm(false, "Invalid mount type format"); return {};
+	}
+}
+
+std::optional<MountType> parse_mount_type(const std::string& s)
+{
+	if (s == "floppy" || s == "fdd") {
+		return MountType::FloppyImage;
+
+	} else if (s == "hdd") {
+		return MountType::HardDiskImage;
+
+	} else if (s == "iso" || s == "cdrom") {
+		return MountType::CdRomImage;
+
+	} else if (s == "dir") {
+		return MountType::Directory;
+
+	} else if (s == "overlay") {
+		return MountType::Overlay;
+
+	} else {
+		return {};
+	}
+}

--- a/src/dos/mount.h
+++ b/src/dos/mount.h
@@ -1,0 +1,23 @@
+//
+// Created by farsil on 19/08/2026.
+//
+
+#ifndef DOSBOX_DOS_MOUNT_H
+#define DOSBOX_DOS_MOUNT_H
+
+#include <optional>
+#include <string>
+
+enum class MountType {
+	FloppyImage,
+	HardDiskImage,
+	CdRomImage,
+	Directory,
+	Overlay
+};
+
+std::string to_string(const MountType& mount_type);
+
+std::optional<MountType> parse_mount_type(const std::string& s);
+
+#endif // DOSBOX_DOS_MOUNT_H

--- a/src/dos/programs/mount.cpp
+++ b/src/dos/programs/mount.cpp
@@ -13,6 +13,7 @@
 #include "config/config.h"
 #include "dos/cdrom.h"
 #include "dos/drives.h"
+#include "dos/mount.h"
 #include "gui/mapper.h"
 #include "hardware/ide.h"
 #include "ints/bios_disk.h"
@@ -551,28 +552,6 @@ bool MOUNT::HandleUnmount()
 	}
 
 	return false;
-}
-
-static std::optional<MountType> parse_mount_type(const std::string s)
-{
-	if (s == "floppy" || s == "fdd") {
-		return MountType::FloppyImage;
-
-	} else if (s == "hdd") {
-		return MountType::HardDiskImage;
-
-	} else if (s == "iso" || s == "cdrom") {
-		return MountType::CdRomImage;
-
-	} else if (s == "dir") {
-		return MountType::Directory;
-
-	} else if (s == "overlay") {
-		return MountType::Overlay;
-
-	} else {
-		return {};
-	}
 }
 
 static std::optional<MountFileSystemType> parse_file_system_type(const std::string s)

--- a/src/dos/programs/mount.h
+++ b/src/dos/programs/mount.h
@@ -6,6 +6,7 @@
 #define DOSBOX_PROGRAM_MOUNT_H
 
 #include "dos/dos.h"
+#include "dos/mount.h"
 #include "dos/programs.h"
 #include "shell/command_line.h"
 
@@ -13,14 +14,6 @@
 #include <optional>
 #include <string>
 #include <vector>
-
-enum class MountType {
-	FloppyImage,
-	HardDiskImage,
-	CdRomImage,
-	Directory,
-	Overlay
-};
 
 enum class MountFileSystemType { Fat16, Iso, None };
 

--- a/src/shell/autoexec.cpp
+++ b/src/shell/autoexec.cpp
@@ -4,16 +4,17 @@
 
 #include "shell/autoexec.h"
 
-#include "utils/checks.h"
 #include "config/config.h"
+#include "config/setup.h"
+#include "dos/mount.h"
 #include "dosbox.h"
-#include "utils/fs_utils.h"
 #include "hardware/input/keyboard.h"
 #include "hardware/input/mouse.h"
-#include "config/setup.h"
-#include "shell/shell.h"
-#include "utils/string_utils.h"
 #include "misc/unicode.h"
+#include "shell/shell.h"
+#include "utils/checks.h"
+#include "utils/fs_utils.h"
+#include "utils/string_utils.h"
 
 #include <algorithm>
 #include <iostream>
@@ -254,12 +255,12 @@ private:
 };
 
 struct AutoMountSettings {
-	std::string override_drive = {};
-	std::string type           = {};
-	std::string label          = {};
-	bool readonly              = false;
-	std::string path           = {};
-	bool verbose               = false;
+	std::string override_drive    = {};
+	std::optional<MountType> type = {};
+	std::string label             = {};
+	bool readonly                 = false;
+	std::string path              = {};
+	bool verbose                  = false;
 };
 
 AutoExecModule::AutoExecModule(Section* configuration)
@@ -517,13 +518,16 @@ static std::unique_ptr<Config> specify_drive_conf()
 
 	// Define the [drive] section
 	const AutoMountSettings defaults = {};
+	const auto default_type          = defaults.type.has_value()
+	                                         ? to_string(defaults.type.value())
+	                                         : "";
 
 	const auto prop = conf->AddSection("drive");
 
 	// Define the allowed keys and types
 	constexpr auto OnStartup = Property::Changeable::OnlyAtStart;
 
-	prop->AddString("type", OnStartup, defaults.type.c_str())
+	prop->AddString("type", OnStartup, default_type.c_str())
 	        ->SetValues({"dir", "floppy", "cdrom", "iso", "overlay"});
 
 	prop->AddString("label", OnStartup, defaults.label.c_str());
@@ -571,19 +575,19 @@ static std::optional<AutoMountSettings> parse_drive_conf(const char dir_letter,
 		LOG_ERR("AUTOMOUNT: The override_drive setting can be left empty or a drive letter from 'a' to 'y'");
 	}
 
-	const auto type = section->GetString("type");
+	const auto type = parse_mount_type(section->GetString("type"));
 
-	if (type == "floppy" && dir_letter >= 'c') {
+	if (type == MountType::FloppyImage && dir_letter >= 'c') {
 		LOG_ERR("AUTOMOUNT: %s: setting 'type = %s' is invalid",
 		        conf_path.string().c_str(),
-		        type.c_str());
+		        to_string(type.value()).c_str());
 		LOG_ERR("AUTOMOUNT: Type can be set to 'floppy' only for drive letters 'a' or 'b'");
 
-	} else if ((type == "cdrom" || type == "iso") &&
+	} else if (type == MountType::CdRomImage &&
 	           (dir_letter == 'a' || dir_letter == 'b')) {
 		LOG_ERR("AUTOMOUNT: %s: setting 'type = %s' is invalid",
 		        conf_path.string().c_str(),
-		        type.c_str());
+		        to_string(type.value()).c_str());
 		LOG_ERR("AUTOMOUNT: Type can be set to 'cdrom' only for drive letters 'c' to 'y'");
 
 	} else {
@@ -639,8 +643,8 @@ static std::string build_auto_mount_dir_command(
 	command += " " + Quote + simplify_path(drive_path).string() + Quote;
 
 	if (settings.has_value()) {
-		if (!settings->type.empty()) {
-			command += " -t " + settings->type;
+		if (settings->type.has_value()) {
+			command += " -t " + to_string(settings->type.value());
 		}
 
 		if (!settings->label.empty()) {
@@ -726,13 +730,13 @@ static std::string build_auto_mount_command(const char dir_letter,
                                             const std_fs::path& drive_path,
                                             const std::optional<AutoMountSettings>& settings)
 {
-	std::set<std::string_view, std::less<>> image_type = {"cdrom", "iso"};
+	auto image_type                         = MountType::CdRomImage;
 	std::vector<std::string_view> image_ext = {".iso", ".cue", ".mds"};
 	auto build_auto_mount_images_command = build_auto_mount_cd_images_command;
 
 	// Look for floppy images when dir_letter matches a floppy drive
 	if (dir_letter == 'a' || dir_letter == 'b') {
-		image_type                  = {"floppy"};
+		image_type                  = MountType::FloppyImage;
 		image_ext                   = {".img", ".ima"};
 		build_auto_mount_images_command = build_auto_mount_floppy_images_command;
 	}
@@ -743,7 +747,7 @@ static std::string build_auto_mount_command(const char dir_letter,
 	// Use images for the drive mount if some have been found, and if the
 	// drive type is unset or matches the image type
 	if (!image_paths.empty() &&
-	    (settings->type.empty() || image_type.contains(settings->type))) {
+	    (!settings->type.has_value() || image_type == settings->type)) {
 		return build_auto_mount_images_command(dir_letter, image_paths, settings);
 	}
 

--- a/src/shell/autoexec.cpp
+++ b/src/shell/autoexec.cpp
@@ -528,7 +528,7 @@ static std::unique_ptr<Config> specify_drive_conf()
 	constexpr auto OnStartup = Property::Changeable::OnlyAtStart;
 
 	prop->AddString("type", OnStartup, default_type.c_str())
-	        ->SetValues({"dir", "floppy", "cdrom", "iso", "overlay"});
+	        ->SetValues({"dir", "floppy", "fdd", "cdrom", "iso", "overlay"});
 
 	prop->AddString("label", OnStartup, defaults.label.c_str());
 	prop->AddString("path", OnStartup, defaults.path.c_str());


### PR DESCRIPTION
# Description

This PR completes the `MountType` enumeration refactor by using it in the automount settings.


# Manual testing

I ran a dosbox staging instance with my test automount setup:

    Three floppy images on A
    Two cd-rom images on D
    MDS CD-Rom image on E
    Hard Disk image on C

Automounting uses mount internally. Everything works like nothing changed :)

The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [x] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

- [x] I am a human, I have read and understood the [project's policy on the use of generative AI tools](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md#policy-on-the-use-of-generative-ai-tools), and I have acted in accordance to it.

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my work (especially important for AI-assisted contributions).
- [x] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [ ] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [x] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

