### PR TITLE
docs: Rewrite vcpkg build tools paragraph

### DIFF
--- a/docs/build-linux.md
+++ b/docs/build-linux.md
@@ -125,13 +125,11 @@ Release build:
 
 ### Installing build tools
 
-- for Ubuntu:
+Refer to the [official vcpkg documentation](https://learn.microsoft.com/en-us/vcpkg/concepts/supported-hosts#dependencies)
+for installation instructions of the build tools required by vcpkg. 
 
-```shell
-sudo apt-get install git build-essential pkg-config cmake curl ninja-build \
-             autoconf autoconf-archive automake bison libtool libgl1-mesa-dev \
-             libsdl3-dev python3-venv
-```
+On Linux systems the C++ compiler is usually available through some meta-package
+(`build-essential` for Debian-based systems, `base-devel` for Arch, etc.).
 
 ### Install the vcpkg tool
 


### PR DESCRIPTION
# Description

This PR rewrites the "Installing build tools" paragraph in the vcpkg docs. It now points to the official documentation and adds a note for linux users, mostly for beginners: the official doc mentions a generic "C++ compiler", which usually means `gcc`, but it's probably better they install the whole base development suite.

# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

- [x] I am a human, I have read and understood the [project's policy on the use of generative AI tools](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md#policy-on-the-use-of-generative-ai-tools), and I have acted in accordance to it.

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [ ] performed a self-review of my work (especially important for AI-assisted contributions).
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [ ] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [x] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

