### PR TITLE
Fix mount geometry option parsing

### DIFF
--- a/src/dos/programs/mount.cpp
+++ b/src/dos/programs/mount.cpp
@@ -602,12 +602,31 @@ static std::optional<MountFileSystemType> parse_file_system_type(const std::stri
 //
 //   params.label  (from the -label option)
 //
-bool MOUNT::ParseArguments(MountParameters& params, bool& explicit_fs,
-                           bool& path_relative_to_last_config)
+// Also extracts the raw geometry option strings into `geometry` (from the
+// -size, -freesize and -chs options). All options must be consumed here,
+// before ProcessPaths() collects the remaining arguments as image paths.
+//
+bool MOUNT::ParseArguments(MountParameters& params, GeometryArgs& geometry,
+                           bool& explicit_fs, bool& path_relative_to_last_config)
 {
 	if (cmd->FindExist("-pr", true)) {
 		path_relative_to_last_config = true;
 	}
+
+	// The geometry options can only be interpreted once the mount type is
+	// known, which ProcessPaths() may still auto-detect from the paths.
+	auto extract_option =
+	        [&](const std::string& option) -> std::optional<std::string> {
+		std::string value = {};
+		if (cmd->FindString(option, value, true)) {
+			return value;
+		}
+		return {};
+	};
+
+	geometry.size     = extract_option("-size");
+	geometry.freesize = extract_option("-freesize");
+	geometry.chs      = extract_option("-chs");
 
 	// Default is "dir" if the -t option is not provided
 	std::string type_str = "dir";
@@ -667,7 +686,7 @@ bool MOUNT::ParseArguments(MountParameters& params, bool& explicit_fs,
 //   params.mediaid
 //   params.sizes
 //
-bool MOUNT::ParseGeometry(MountParameters& params)
+bool MOUNT::ParseGeometry(MountParameters& params, const GeometryArgs& geometry)
 {
 	std::string str_size = "";
 	std::string str_chs  = "";
@@ -717,10 +736,11 @@ bool MOUNT::ParseGeometry(MountParameters& params)
 	// Parse the free space in mb (kb for floppies)
 	std::string mb_size;
 
-	if (cmd->FindString("-freesize", mb_size, true)) {
+	if (geometry.freesize) {
 
 		char teststr[1024];
-		uint16_t freesize = static_cast<uint16_t>(atoi(mb_size.c_str()));
+		auto freesize = static_cast<uint16_t>(
+		        atoi(geometry.freesize->c_str()));
 
 		if (params.type == MountType::FloppyImage) {
 			// freesize in kb
@@ -748,7 +768,9 @@ bool MOUNT::ParseGeometry(MountParameters& params)
 	}
 
 	// Parse -size
-	cmd->FindString("-size", str_size, true);
+	if (geometry.size) {
+		str_size = *geometry.size;
+	}
 
 	// Apply str_size string to sizes array
 	if (!str_size.empty()) {
@@ -778,7 +800,9 @@ bool MOUNT::ParseGeometry(MountParameters& params)
 	}
 
 	// Parse -chs C,H,S
-	if (cmd->FindString("-chs", str_chs, true)) {
+	if (geometry.chs) {
+		str_chs = *geometry.chs;
+
 		int cmd_cylinders = 0;
 		int cmd_heads     = 0;
 		int cmd_sectors   = 0;
@@ -1343,11 +1367,12 @@ std::optional<MountParameters> MOUNT::ProcessArguments(CommandLine* cmd)
 
 	MountParameters params;
 
+	GeometryArgs geometry             = {};
 	bool explicit_fs                  = false;
 	bool path_relative_to_last_config = false;
 
 	// Parse command line arguments
-	if (!ParseArguments(params, explicit_fs, path_relative_to_last_config)) {
+	if (!ParseArguments(params, geometry, explicit_fs, path_relative_to_last_config)) {
 		return {};
 	}
 
@@ -1364,7 +1389,7 @@ std::optional<MountParameters> MOUNT::ProcessArguments(CommandLine* cmd)
 	ProcessPaths(first_path, params, path_relative_to_last_config);
 
 	// Check drive geometry and types, abort if not valid
-	if (!ParseGeometry(params)) {
+	if (!ParseGeometry(params, geometry)) {
 		return {};
 	}
 

--- a/src/dos/programs/mount.cpp
+++ b/src/dos/programs/mount.cpp
@@ -603,34 +603,38 @@ static std::optional<MountFileSystemType> parse_file_system_type(const std::stri
 //   params.label  (from the -label option)
 //
 // Also extracts the raw geometry option strings into `geometry` (from the
-// -size, -freesize and -chs options). All options must be consumed here,
-// before ProcessPaths() collects the remaining arguments as image paths.
+// -size, -freesize and -chs options). Every option must be consumed here,
+// including repeated ones, because ProcessPaths() collects whatever is left
+// on the command line as image paths.
 //
 bool MOUNT::ParseArguments(MountParameters& params, GeometryArgs& geometry,
                            bool& explicit_fs, bool& path_relative_to_last_config)
 {
-	if (cmd->FindExist("-pr", true)) {
-		path_relative_to_last_config = true;
-	}
+	// Consumes all occurrences of an option that takes a value and returns
+	// the first one; repeats are dropped so they can't be picked up as
+	// image paths later on.
+	auto extract_option = [&](const std::string& option) {
+		std::optional<std::string> first_value = {};
+
+		std::string value = {};
+		while (cmd->FindString(option, value, true)) {
+			if (!first_value) {
+				first_value = value;
+			}
+		}
+		return first_value;
+	};
+
+	path_relative_to_last_config = cmd->FindExistRemoveAll("-pr");
 
 	// The geometry options can only be interpreted once the mount type is
 	// known, which ProcessPaths() may still auto-detect from the paths.
-	auto extract_option =
-	        [&](const std::string& option) -> std::optional<std::string> {
-		std::string value = {};
-		if (cmd->FindString(option, value, true)) {
-			return value;
-		}
-		return {};
-	};
-
 	geometry.size     = extract_option("-size");
 	geometry.freesize = extract_option("-freesize");
 	geometry.chs      = extract_option("-chs");
 
 	// Default is "dir" if the -t option is not provided
-	std::string type_str = "dir";
-	cmd->FindString("-t", type_str, true);
+	const auto type_str = extract_option("-t").value_or("dir");
 
 	const auto maybe_mount_type = parse_mount_type(type_str);
 	if (!maybe_mount_type) {
@@ -642,13 +646,15 @@ bool MOUNT::ParseArguments(MountParameters& params, GeometryArgs& geometry,
 	}
 	params.type = *maybe_mount_type;
 
-	params.roflag = cmd->FindExist("-ro", true);
+	params.roflag = cmd->FindExistRemoveAll("-ro");
 
 	// Parse -fs (filesystem type)
 	// Default is "fat" if the -fs option is not provided
-	std::string fstype_str = "fat";
+	const auto maybe_fstype_str = extract_option("-fs");
 
-	explicit_fs = cmd->FindString("-fs", fstype_str, true);
+	explicit_fs = maybe_fstype_str.has_value();
+
+	const auto fstype_str = maybe_fstype_str.value_or("fat");
 
 	const auto maybe_fs_type = parse_file_system_type(fstype_str);
 	if (!maybe_fs_type) {
@@ -666,20 +672,41 @@ bool MOUNT::ParseArguments(MountParameters& params, GeometryArgs& geometry,
 		}
 	}
 
-	// Parse -ide
-	std::string ide_value = {};
+	// Parse -ide, which can be given with or without a value
+	const auto has_ide_value = extract_option("-ide").has_value();
 
-	params.is_ide = cmd->FindString("-ide", ide_value, true) ||
-	                cmd->FindExist("-ide", true);
+	params.is_ide = cmd->FindExistRemoveAll("-ide") || has_ide_value;
 
 	if (params.is_ide && (params.type == MountType::CdRomImage)) {
 		IDE_Get_Next_Cable_Slot(params.ide_index, params.is_second_cable_slot);
 	}
 
 	// Label
-	cmd->FindString("-label", params.label, true);
+	params.label = extract_option("-label").value_or("");
 
 	return true;
+}
+
+// Anything still starting with a dash once ParseArguments() has run is an
+// option we don't know about. Reporting it beats letting ProcessPaths()
+// collect it as an image path, which fails much later with a confusing
+// "can't create drive from file" message.
+//
+bool MOUNT::HasUnknownOptions()
+{
+	auto unknown_option_found = false;
+
+	std::string arg = {};
+	for (auto i = 1u; cmd->FindCommand(i, arg); ++i) {
+		if (arg.starts_with('-')) {
+			NOTIFY_DisplayWarning(Notification::Source::Console,
+			                      "MOUNT",
+			                      "PROGRAM_MOUNT_UNKNOWN_OPTION",
+			                      arg.c_str());
+			unknown_option_found = true;
+		}
+	}
+	return unknown_option_found;
 }
 
 // Sets:
@@ -1383,6 +1410,10 @@ std::optional<MountParameters> MOUNT::ProcessArguments(CommandLine* cmd)
 		return {};
 	}
 
+	if (HasUnknownOptions()) {
+		return {};
+	}
+
 	// Resolve host paths, wildcard path arguments, auto-detect mount types,
 	// and determine whether we're dealing with image or directory/overlay
 	// mounts.
@@ -1499,6 +1530,7 @@ void MOUNT::AddMessages()
 	        "%s isn't a directory or valid image file.\n");
 
 	MSG_Add("PROGRAM_MOUNT_ILL_TYPE", "Illegal type %s");
+	MSG_Add("PROGRAM_MOUNT_UNKNOWN_OPTION", "Unknown option: %s\n");
 	MSG_Add("PROGRAM_MOUNT_ALREADY_MOUNTED", "Drive %c already mounted with %s\n");
 	MSG_Add("PROGRAM_MOUNT_UMOUNT_NOT_MOUNTED", "Drive %c isn't mounted.\n");
 

--- a/src/dos/programs/mount.h
+++ b/src/dos/programs/mount.h
@@ -24,6 +24,16 @@ enum class MountType {
 
 enum class MountFileSystemType { Fat16, Iso, None };
 
+// Raw geometry option strings, as given on the command line. These are
+// extracted before the path arguments are processed so they are not mistaken
+// for image paths, but can only be interpreted afterwards because their
+// meaning depends on the auto-detected mount type.
+struct GeometryArgs {
+	std::optional<std::string> size     = {};
+	std::optional<std::string> freesize = {};
+	std::optional<std::string> chs      = {};
+};
+
 // Struct to hold all parameters required for a mount operation
 struct MountParameters {
 	char drive                 = '\0';
@@ -75,9 +85,9 @@ private:
 	void ShowUsage();
 
 	bool HandleUnmount();
-	bool ParseArguments(MountParameters& params, bool& explicit_fs,
-	                    bool& path_relative_to_last_config);
-	bool ParseGeometry(MountParameters& params);
+	bool ParseArguments(MountParameters& params, GeometryArgs& geometry,
+	                    bool& explicit_fs, bool& path_relative_to_last_config);
+	bool ParseGeometry(MountParameters& params, const GeometryArgs& geometry);
 	bool ParseDrive(MountParameters& params, bool explicit_fs);
 
 	std::string ApplyRelativePath(const std::string& path,

--- a/src/dos/programs/mount.h
+++ b/src/dos/programs/mount.h
@@ -88,6 +88,7 @@ private:
 	bool ParseArguments(MountParameters& params, GeometryArgs& geometry,
 	                    bool& explicit_fs, bool& path_relative_to_last_config);
 	bool ParseGeometry(MountParameters& params, const GeometryArgs& geometry);
+	bool HasUnknownOptions();
 	bool ParseDrive(MountParameters& params, bool explicit_fs);
 
 	std::string ApplyRelativePath(const std::string& path,

--- a/tests/mount_tests.cpp
+++ b/tests/mount_tests.cpp
@@ -133,6 +133,60 @@ TEST_F(MountTest, RejectsMissingPath)
 	EXPECT_FALSE(result.has_value());
 }
 
+TEST_F(MountTest, RejectsUnknownOption)
+{
+	// Unrecognised options used to be collected as image paths and only
+	// failed later with a baffling "can't create drive from file".
+	const auto result = Mount("C " + P("image.img") + " -t hdd -bogus");
+	EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(MountTest, RejectsMisspelledOption)
+{
+	const auto result = Mount("C " + P("image.img") + " -t hdd -siz 512,63,16,81");
+	EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(MountTest, RejectsUnknownOptionBeforePath)
+{
+	const auto result = Mount("C -bogus " + P("image.img") + " -t hdd");
+	EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(MountTest, RejectsUnknownOptionOnDirectoryMount)
+{
+	const auto result = Mount("C " + P("plain_dir") + " -bogus");
+	EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(MountTest, AcceptsEveryKnownOptionTogether)
+{
+	// Guards the unknown-option check against false positives: every
+	// option MOUNT understands must be consumed by ParseArguments(), so
+	// adding one without consuming it fails here rather than surfacing as
+	// a mysterious mount failure. -ide goes last because it may be given
+	// without a value.
+	const auto result = Mount("C " + P("image.img") +
+	                          " -t hdd -fs fat -ro -label MYLABEL"
+	                          " -size 512,63,16,81 -freesize 10"
+	                          " -chs 100,16,63 -pr -ide");
+
+	ASSERT_TRUE(result.has_value());
+
+	ASSERT_EQ(result->paths.size(), 1);
+	EXPECT_EQ(result->type, MountType::HardDiskImage);
+	EXPECT_EQ(result->fstype, MountFileSystemType::Fat16);
+	EXPECT_EQ(result->label, "MYLABEL");
+	EXPECT_TRUE(result->roflag);
+	EXPECT_TRUE(result->is_ide);
+
+	// -chs takes precedence over -size and -freesize
+	EXPECT_EQ(result->sizes[0], 512);
+	EXPECT_EQ(result->sizes[1], 63);
+	EXPECT_EQ(result->sizes[2], 16);
+	EXPECT_EQ(result->sizes[3], 100);
+}
+
 TEST_F(MountTest, RejectsDriveTokenTooLong)
 {
 	const auto result = Mount("WWW " + P("plain_dir"));
@@ -1191,6 +1245,9 @@ TEST_F(MountTest, DuplicateLabelFirstWins)
 
 	ASSERT_TRUE(result.has_value());
 
+	// Repeats must not be left behind as image paths
+	ASSERT_EQ(result->paths.size(), 1);
+
 	EXPECT_EQ(result->label, "FIRST");
 }
 
@@ -1201,6 +1258,9 @@ TEST_F(MountTest, DuplicateSizeFirstWins)
 	                          " -size 5,6,7,8");
 
 	ASSERT_TRUE(result.has_value());
+
+	// Repeats must not be left behind as image paths
+	ASSERT_EQ(result->paths.size(), 1);
 
 	EXPECT_EQ(result->sizes[0], 1);
 	EXPECT_EQ(result->sizes[1], 2);
@@ -1215,6 +1275,9 @@ TEST_F(MountTest, DuplicateChsFirstWins)
 	                          " -chs 200,63,16");
 
 	ASSERT_TRUE(result.has_value());
+
+	// Repeats must not be left behind as image paths
+	ASSERT_EQ(result->paths.size(), 1);
 
 	// CHS is normalized into the size array:
 	// sector size, sectors/track, heads, cylinders.
@@ -1232,6 +1295,9 @@ TEST_F(MountTest, DuplicateFilesystemFirstWins)
 
 	ASSERT_TRUE(result.has_value());
 
+	// Repeats must not be left behind as image paths
+	ASSERT_EQ(result->paths.size(), 1);
+
 	EXPECT_EQ(result->fstype, MountFileSystemType::Fat16);
 }
 
@@ -1242,6 +1308,9 @@ TEST_F(MountTest, DuplicateTypeFirstWins)
 	                          " -t iso");
 
 	ASSERT_TRUE(result.has_value());
+
+	// Repeats must not be left behind as image paths
+	ASSERT_EQ(result->paths.size(), 1);
 
 	EXPECT_EQ(result->type, MountType::FloppyImage);
 	EXPECT_EQ(result->fstype, MountFileSystemType::Fat16);

--- a/tests/mount_tests.cpp
+++ b/tests/mount_tests.cpp
@@ -583,6 +583,48 @@ TEST_F(MountTest, FloppyMediaIdSetWhenTypeFloppyAndFstypeFat)
 	EXPECT_EQ(result->mediaid, MediaId::Floppy1_44MB);
 }
 
+TEST_F(MountTest, GeometryOptionsAreNotCollectedAsImagePaths)
+{
+	// Regression test for #5025: the geometry options are parsed after the
+	// image paths are collected, so they must still be removed from the
+	// command line beforehand. Otherwise "-size" and "512,63,16,81" are
+	// mounted as additional images and the mount fails with
+	// "Can't create drive from file".
+	const auto result = Mount("C " + P("image.img") + " -size 512,63,16,81");
+
+	ASSERT_TRUE(result.has_value());
+
+	ASSERT_EQ(result->paths.size(), 1);
+	EXPECT_NE(result->paths[0].find("image.img"), std::string::npos);
+
+	EXPECT_EQ(result->sizes[0], 512);
+	EXPECT_EQ(result->sizes[1], 63);
+	EXPECT_EQ(result->sizes[2], 16);
+	EXPECT_EQ(result->sizes[3], 81);
+}
+
+TEST_F(MountTest, ChsOptionIsNotCollectedAsImagePath)
+{
+	const auto result = Mount("C " + P("image.img") + " -chs 200,16,63");
+
+	ASSERT_TRUE(result.has_value());
+
+	ASSERT_EQ(result->paths.size(), 1);
+	EXPECT_NE(result->paths[0].find("image.img"), std::string::npos);
+
+	EXPECT_EQ(result->sizes[3], 200);
+}
+
+TEST_F(MountTest, FreesizeOptionIsNotCollectedAsImagePath)
+{
+	const auto result = Mount("C " + P("image.img") + " -t hdd -freesize 100");
+
+	ASSERT_TRUE(result.has_value());
+
+	ASSERT_EQ(result->paths.size(), 1);
+	EXPECT_NE(result->paths[0].find("image.img"), std::string::npos);
+}
+
 // ---------------------------------------------------------------------
 // Various edge cases
 // ---------------------------------------------------------------------


### PR DESCRIPTION
# Description

This PR consumes all mount parameters before running MOUNT::ProcessPaths() . ParseArguments() now also extracts the raw -size/-freesize/-chs strings into a small GeometryArgs struct. ParseGeometry() interprets them afterwards.

In addition to the reported trigger, another condition was found that caused tokens to survive and get into ProcessPaths(). A comprehensive fix includes rejecting incorrect arguments instead of silently ignoring them. 

## Related issues

#5025

# Release notes

Note: Unknown or incorrect mount parameters are now rejected with an error message. In previous versions they were silently ignored.

# Manual testing

```
makeimg hdd.img -t hd_40mb -fat 16
makeimg floppy.img -t fd_1440kb -label MYDISK

imgmount c hdd.img -size 512,63,16,81
mount c hdd.img -t hdd -size 512,63,16,81
mount c hdd.img -t hdd -chs 81,16,63
mount a floppy.img -t floppy -size 512,18,2,80
mount d game.iso -t iso -size 2048,1,65535,0
mount c -size 512,63,16,81 hdd.img -t hdd
```

All six printed Can't create drive from file. on 0.83.0 and no drive appeared. Now each prints FAT image hdd.img mounted as C drive (or the A: / CD-ROM equivalent).

```
mount c hdd.img -t hdd -siz 512,63,16,81
mount c hdd.img -t hdd -size 512,63,16,81 -bogus
mount d gamedir -bogus
```
Expect "Unknown option: -siz" / "Unknown option: -bogus" and no mount. On 0.83.0 the first two gave the same misleading "Can't create drive from file." 
The third silently succeeded, ignoring the typo.

```
mount c hdd.img -t hdd -size 512,63,16,81 -size 512,63,16,81
mount c hdd.img -t hdd -chs 81,16,63 -chs 81,16,63
mount c hdd.img -t hdd -t hdd
```
Repeats now mount normally, first value winning. All three failed on 0.83.0.


The change has been manually tested on:

- [ ] Windows
- [ ] macOS
- [X] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

- [X] I am a human, I have read and understood the [project's policy on the use of generative AI tools](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md#policy-on-the-use-of-generative-ai-tools), and I have acted in accordance to it.

I have:

- [X] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [X] performed a self-review of my work (especially important for AI-assisted contributions).
- [X] commented on the particularly hard-to-understand areas of my code.
- [X] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [X] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [X] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [X] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [X] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [X] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mount command-line parsing for repeated options, preserving the first value while preventing duplicates from being treated as image paths.
  * Correctly recognizes geometry settings such as size, free space, and cylinder/head/sector values, including precedence for CHS settings.
  * Rejects unknown, misspelled, or misplaced options with a warning instead of proceeding incorrectly.

* **Tests**
  * Added coverage for recognized options, invalid options, duplicate values, and geometry parsing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->