### PR TITLE
Fix keyboard layout mapping for Croatian

### DIFF
--- a/src/misc/host_locale_win32.cpp
+++ b/src/misc/host_locale_win32.cpp
@@ -90,6 +90,8 @@ static const std::unordered_map<std::string, KeyboardLayoutMaybeCodepage> WinToD
 	// Canadian (dual-layer, QWERTY)
 	{ "00000c0c", { "cf445" }      }, // Canadian French (Legacy)
 	{ "00011009", { "cf445" }      }, // Canadian Multilingual Standard
+	// Croatian (QWERTZ)
+	{ "0000041a", { "hr" }         }, // Croatian
 	// Czech (QWERTZ)
 	{ "00000405", { "cz" }         }, // Czech
 	// Czech (programmers, QWERTY)
@@ -225,7 +227,6 @@ static const std::unordered_map<std::string, KeyboardLayoutMaybeCodepage> WinToD
 	{ "0000046e", { "sf" }         }, // Luxembourgish
 	// Slovenian (QWERTZ)
 	{ "00000424", { "si" }         }, // Slovenian
-	{ "0000041a", { "si" }         }, // Standard
 	// Slovak (QWERTZ)
 	{ "0000041b", { "sk" }         }, // Slovak
 	// Albanian (deadkeys, QWERTZ)


### PR DESCRIPTION
## Description

Fixes keyboard layout mapping so that KLID `0000041a` correctly points to `hr` (Croatian).

## Related issues

Fixes issue #5031

Tested on Windows, should not affect anything else.

