### PR TITLE
Update context menu icon references in installer script

### DIFF
--- a/extras/windows-installer/DOSBox-Staging-setup.iss
+++ b/extras/windows-installer/DOSBox-Staging-setup.iss
@@ -88,7 +88,7 @@ Root: HKA; Subkey: "Software\{#DOSBoxAppInternal}"; ValueType: string; ValueName
 
 ; Add context menu entry when right-clicking on a folder
 Root: HKA; Subkey: "Software\Classes\Directory\shell\{#DOSBoxAppInternal}"; ValueType: string; ValueName: ""; ValueData: "Open with {#DOSBoxAppName}"; Check: WizardIsTaskSelected('contextmenu'); Flags: uninsdeletevalue
-Root: HKA; Subkey: "Software\Classes\Directory\shell\{#DOSBoxAppInternal}"; ValueType: string; ValueName: "Icon"; ValueData: """{app}\{#DOSBoxAppExeConsoleName}"",0"; Check: WizardIsTaskSelected('contextmenu'); Flags: uninsdeletekey
+Root: HKA; Subkey: "Software\Classes\Directory\shell\{#DOSBoxAppInternal}"; ValueType: string; ValueName: "Icon"; ValueData: """{app}\{#DOSBoxAppExeName}"",0"; Check: WizardIsTaskSelected('contextmenu'); Flags: uninsdeletekey
 Root: HKA; Subkey: "Software\Classes\Directory\shell\{#DOSBoxAppInternal}\command"; ValueType: string; ValueName: ""; ValueData: """{app}\{#DOSBoxAppExeConsoleName}"" --working-dir ""%v"""; Check: WizardIsTaskSelected('contextmenu'); Flags: uninsdeletekey
 
 Root: HKA; Subkey: "Software\Classes\Directory\shell\{#DOSBoxAppInternal}"; ValueType: none; Check: not WizardIsTaskSelected('contextmenu'); Flags: deletekey
@@ -96,7 +96,7 @@ Root: HKA; Subkey: "Software\Classes\Directory\shell\{#DOSBoxAppInternal}\comman
 
 ; Add context menu when right-clicking on an empty area within a folder
 Root: HKA; Subkey: "Software\Classes\Directory\Background\shell\{#DOSBoxAppInternal}"; ValueType: string; ValueName: ""; ValueData: "Open with {#DOSBoxAppName}"; Check: WizardIsTaskSelected('contextmenu'); Flags: uninsdeletevalue
-Root: HKA; Subkey: "Software\Classes\Directory\Background\shell\{#DOSBoxAppInternal}"; ValueType: string; ValueName: "Icon"; ValueData: """{app}\{#DOSBoxAppExeConsoleName}"",0"; Check: WizardIsTaskSelected('contextmenu'); Flags: uninsdeletekey
+Root: HKA; Subkey: "Software\Classes\Directory\Background\shell\{#DOSBoxAppInternal}"; ValueType: string; ValueName: "Icon"; ValueData: """{app}\{#DOSBoxAppExeName}"",0"; Check: WizardIsTaskSelected('contextmenu'); Flags: uninsdeletekey
 Root: HKA; Subkey: "Software\Classes\Directory\Background\shell\{#DOSBoxAppInternal}\command"; ValueType: string; ValueName: ""; ValueData: """{app}\{#DOSBoxAppExeConsoleName}"" --working-dir ""%v"""; Check: WizardIsTaskSelected('contextmenu'); Flags: uninsdeletekey
 
 Root: HKA; Subkey: "Software\Classes\Directory\Background\shell\{#DOSBoxAppInternal}"; ValueType: none; Check: not WizardIsTaskSelected('contextmenu'); Flags: deletekey
@@ -104,7 +104,7 @@ Root: HKA; Subkey: "Software\Classes\Directory\Background\shell\{#DOSBoxAppInter
 
 ; Add context menu when right-clicking on `.conf` extension
 Root: HKA; Subkey: "Software\Classes\SystemFileAssociations\.conf\shell\Open with {#DOSBoxAppName}"; ValueType: none; ValueName: ""; ValueData: ""; Check: WizardIsTaskSelected('contextmenu'); Flags: uninsdeletevalue
-Root: HKA; Subkey: "Software\Classes\SystemFileAssociations\.conf\shell\Open with {#DOSBoxAppName}"; ValueType: string; ValueName: "Icon"; ValueData: """{app}\{#DOSBoxAppExeConsoleName}"",0"; Check: WizardIsTaskSelected('contextmenu'); Flags: uninsdeletekey
+Root: HKA; Subkey: "Software\Classes\SystemFileAssociations\.conf\shell\Open with {#DOSBoxAppName}"; ValueType: string; ValueName: "Icon"; ValueData: """{app}\{#DOSBoxAppExeName}"",0"; Check: WizardIsTaskSelected('contextmenu'); Flags: uninsdeletekey
 Root: HKA; Subkey: "Software\Classes\SystemFileAssociations\.conf\shell\Open with {#DOSBoxAppName}\command"; ValueType: string; ValueName: ""; ValueData: """{app}\{#DOSBoxAppExeConsoleName}"" -conf ""%1"""; Check: WizardIsTaskSelected('contextmenu'); Flags: uninsdeletekey
 
 Root: HKA; Subkey: "Software\Classes\SystemFileAssociations\.conf\shell\Open with {#DOSBoxAppName}"; ValueType: none; Check: not WizardIsTaskSelected('contextmenu'); Flags: deletekey


### PR DESCRIPTION
# Description

Modifies the Windows installer script.
The registry entries that define the shell extension corresponding to the "Open with Dosbox Staging" context menu entries now have the Icon value set to the icon of dosbox.exe, not dosbox_with_console.bat, so that the Dosbox icon is used.


## Related issues

Fixes #5033


# Manual testing

Tested the registry change to work as intended, but did not test installer script compilation.