### PR TITLE
Update macos.md - 0.82.2 runs on macOS 11

### DIFF
--- a/website/docs/releases/macos.md
+++ b/website/docs/releases/macos.md
@@ -52,7 +52,7 @@ instructions]() when launching DOSBox Staging for the first time.
 
 ## Older releases
 
-- [DOSBox Staging 0.82.2 Universal Binary (dmg)][0_82_2] (macOS 14 or newer)
+- [DOSBox Staging 0.82.2 Universal Binary (dmg)][0_82_2] (macOS 11 or newer)
   <br>
   <small>
   sha256: 3b83bb63a7314212b207ae19b82ffd15<wbr>bac6ddc3a2e96d65a425343b4e9bd4a2

--- a/website/docs/releases/macos.md
+++ b/website/docs/releases/macos.md
@@ -22,7 +22,7 @@ sha256: d8a771adfb8010fa6b5f7fb5351abfba<wbr>659273ad01c89f03675a92bdbdae8167
 
 </section>
 
-DOSBos Staging requires **macOS 14 (Sonoma) or later**, and supports both
+DOSBos Staging requires **macOS 12 (Monterey) or later**, and supports both
 Intel and Apple silicon Macs.
 
 Read our the [0.83.0 release notes](release-notes/0.83.0.md) to learn about
@@ -31,7 +31,7 @@ the changes and improvements introduced by this release.
 
 ## System requirements
 
-The latest release is compatible with **macOS 14 (Sonoma) or later** and
+The latest release is compatible with **macOS 12 (Monterey) or later** and
 supports both 64-bit Intel and Apple silicon Macs.
 
 
@@ -47,7 +47,7 @@ are designed with developers and testers in mind.
 
 For releases before 0.81.0 and the [development snapshot
 builds](development-builds.md), you'll need to do follow [these
-instructions]() when launching DOSBox Staging for the first time.
+instructions](../0.83/manual/using-dosbox-staging/starting.md#apple-gatekeeper) when launching DOSBox Staging for the first time.
 
 
 ## Older releases


### PR DESCRIPTION
# Description

At `release/0.83.x` Updated macOS releases page to show macOS11 for 0.82.2
At `main` ("the next release (current work-in-progress alpha release)" = 0.84?) it also has to be done, but this branch seems to be older than 0.83.x, so I didn't touch it.

## Related issues

Fixes #5037

# Checklist

- [x] I am a human, I have read and understood the [project's policy on the use of generative AI tools](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md#policy-on-the-use-of-generative-ai-tools), and I have acted in accordance to it.

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-staging/dosbox-staging/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my work (especially important for AI-assisted contributions).
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [ ] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-staging/dosbox-staging/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [x] made corresponding changes to the documentation or the website according to the [documentation guidelines](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md).
- [ ] [locally verified](https://github.com/dosbox-staging/dosbox-staging/blob/main/docs/DOCUMENTATION.md#previewing-documentation-changes-locally) my website or documentation changes.

