### PR TITLE
build: Fix 0.83 system-library packaging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -539,6 +539,7 @@ if(LIBATOMIC)
 endif()
 
 target_link_libraries(libdosboxcommon PRIVATE
+  $<IF:$<TARGET_EXISTS:SDL2::SDL2>,SDL2::SDL2,SDL2::SDL2-static>
   $<IF:$<TARGET_EXISTS:iir::iir>,iir::iir,iir::iir_static>
   loguru
   libdecoders

--- a/cmake/add_install_rules.cmake
+++ b/cmake/add_install_rules.cmake
@@ -41,7 +41,7 @@ function(add_install_rules)
     endforeach()
 
     # Bundle the resources
-    install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/${RESOURCE_COPY_PATH}"
+    install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/${RESOURCE_COPY_PATH}/"
             DESTINATION "${INSTALL_DIR_RESOURCES}")
 
     # Bundle required licenses

--- a/src/gui/render/opengl_renderer.cpp
+++ b/src/gui/render/opengl_renderer.cpp
@@ -93,7 +93,7 @@ SDL_Window* OpenGlRenderer::CreateSdlWindow(const int x, const int y,
 	auto flags = sdl_window_flags;
 	flags |= SDL_WINDOW_OPENGL;
 
-#ifdef MACOSX
+#if defined(MACOSX) && defined(SDL_HINT_MAC_COLOR_SPACE)
 	SDL_SetHint(SDL_HINT_MAC_COLOR_SPACE, "displayp3");
 #endif
 

--- a/src/gui/render/sdl_renderer.cpp
+++ b/src/gui/render/sdl_renderer.cpp
@@ -23,7 +23,7 @@ SdlRenderer::SdlRenderer(const int x, const int y, const int width,
 {
 	auto flags = sdl_window_flags | OpenGlDriverCrashWorkaround(render_driver);
 
-#ifdef MACOSX
+#if defined(MACOSX) && defined(SDL_HINT_MAC_COLOR_SPACE)
 	SDL_SetHint(SDL_HINT_MAC_COLOR_SPACE, "srgb");
 #endif
 

--- a/src/libs/decoders/CMakeLists.txt
+++ b/src/libs/decoders/CMakeLists.txt
@@ -20,7 +20,7 @@ if(USE_SYSTEM_LIBS)
     libdecoders PRIVATE ${OPUSFILE_CFLAGS_OTHER}
   )
   target_link_libraries(
-    libdecoders PRIVATE ${OPUSFILE_LIBRARIES}
+    libdecoders PRIVATE PkgConfig::OPUSFILE
   )
 else()
   find_package(OpusFile REQUIRED)

--- a/src/libs/manymouse/CMakeLists.txt
+++ b/src/libs/manymouse/CMakeLists.txt
@@ -14,4 +14,8 @@ if(C_MANYMOUSE)
     $<IF:$<BOOL:${SUPPORT_XINPUT2}>,${X11_Xinput_LIB},>
   )
 
+  if (DOSBOX_PLATFORM_MACOS)
+    target_link_libraries(libmanymouse PRIVATE ${IOKit_LIBRARIES})
+  endif()
+
 endif()

--- a/src/midi/CMakeLists.txt
+++ b/src/midi/CMakeLists.txt
@@ -24,3 +24,7 @@ if (C_COREMIDI)
   target_link_libraries(libdosboxcommon PRIVATE "-framework CoreFoundation")
   target_link_libraries(libdosboxcommon PRIVATE "-framework CoreMIDI")
 endif()
+
+if (C_COREAUDIO)
+  target_link_libraries(libdosboxcommon PRIVATE "-framework AudioToolbox")
+endif()


### PR DESCRIPTION
Fixes #5045.

Link SDL to `libdosboxcommon`, use the imported OpusFile pkg-config target, and link the macOS AudioToolbox and IOKit frameworks where needed. Guard the optional color-space hint so an unpatched system SDL can build both renderers. Install the contents of the resource directory at the configured data path on Linux.

Targets `release/0.83.x`; main has already migrated to SDL3. The changes build v0.83.0 with Homebrew system libraries on macOS arm64, and `--version` and `--list-shaders` run with networking disabled.

Checked the CMake Linux install rules: the shader files now land directly under the configured data directory instead of an extra `resources` directory.
